### PR TITLE
feat: add list_instances, NIM validation, and phase fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,7 +292,7 @@ version: "1.0"
 
 commands:
   network:
-    phases: ["setup", "teardown"]
+    phases: ["setup", "test", "teardown"]
     steps:
       - name: create_network
         phase: setup

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -87,7 +87,7 @@ version: "1.0"
 commands:
   network:
     # Phases execute in this order
-    phases: ["setup", "teardown"]
+    phases: ["setup", "test", "teardown"]
 
     steps:
       # Step 1: Create VPC (setup phase)
@@ -101,9 +101,9 @@ commands:
           - "{{region}}"
         timeout: 300
 
-      # Step 2: Run tests (setup phase)
+      # Step 2: Run tests (test phase)
       - name: test_connectivity
-        phase: setup
+        phase: test
         command: "python ./scripts/test_connectivity.py"
         args:
           - "--vpc-id"
@@ -147,13 +147,13 @@ Each platform defines phases and steps:
 ```yaml
 commands:
   network:
-    phases: ["setup", "teardown"]    # Execution order
-    steps: [...]                      # Steps grouped by phase
+    phases: ["setup", "test", "teardown"]    # Execution order
+    steps: [...]                              # Steps grouped by phase
 ```
 
 | Field | Required | Description |
 | ----- | -------- | ----------- |
-| `phases` | No | Ordered list of phases (default: `["setup", "teardown"]`) |
+| `phases` | No | Ordered list of phases (default: `["setup", "test", "teardown"]`) |
 | `steps` | Yes | List of step configurations |
 | `skip` | No | Skip this entire platform |
 

--- a/docs/guides/external-validation-guide.md
+++ b/docs/guides/external-validation-guide.md
@@ -111,7 +111,7 @@ version: "1.0"
 
 commands:
   myplatform:
-    phases: ["setup", "teardown"]
+    phases: ["setup", "test", "teardown"]
     steps:
       - name: launch_instance
         phase: setup

--- a/docs/guides/local-development.md
+++ b/docs/guides/local-development.md
@@ -97,10 +97,10 @@ version: "1.0"
 
 commands:
   network:
-    phases: ["setup", "teardown"]
+    phases: ["setup", "test", "teardown"]
     steps:
       - name: my_test
-        phase: setup
+        phase: test
         command: "python ./my_script.py"
         args: ["--region", "{{region}}"]
         timeout: 300

--- a/isvctl/configs/aws-control-plane.yaml
+++ b/isvctl/configs/aws-control-plane.yaml
@@ -24,7 +24,7 @@ version: "1.0"
 
 commands:
   control_plane:
-    phases: ["setup", "teardown"]
+    phases: ["setup", "test", "teardown"]
     steps:
       # =======================================================================
       # SETUP: API Health Check
@@ -54,7 +54,7 @@ commands:
       # TEST: Access Key Lifecycle - ISVP-173, 174
       # =======================================================================
       - name: test_access_key
-        phase: setup
+        phase: test
         command: "python3 ./stubs/aws/control-plane/test_access_key.py"
         args:
           - "--access-key-id"
@@ -71,7 +71,7 @@ commands:
         timeout: 120
 
       - name: disable_access_key
-        phase: setup
+        phase: test
         command: "python3 ./stubs/aws/control-plane/disable_access_key.py"
         args:
           - "--username"
@@ -81,7 +81,7 @@ commands:
         timeout: 60
 
       - name: verify_key_rejected
-        phase: setup
+        phase: test
         command: "python3 ./stubs/aws/control-plane/verify_key_rejected.py"
         args:
           - "--access-key-id"
@@ -101,7 +101,7 @@ commands:
       # TEST: Tenant Lifecycle - ISVP-175 to 179
       # =======================================================================
       - name: list_tenants
-        phase: setup
+        phase: test
         command: "python3 ./stubs/aws/control-plane/list_tenants.py"
         args:
           - "--region"
@@ -111,7 +111,7 @@ commands:
         timeout: 60
 
       - name: get_tenant
-        phase: setup
+        phase: test
         command: "python3 ./stubs/aws/control-plane/get_tenant.py"
         args:
           - "--group-name"

--- a/isvctl/configs/aws-iso.yaml
+++ b/isvctl/configs/aws-iso.yaml
@@ -40,7 +40,7 @@ version: "1.0"
 # =============================================================================
 commands:
   iso:
-    phases: ["setup", "teardown"]
+    phases: ["setup", "test", "teardown"]
     steps:
       # Step 1: Upload VMDK and import as AMI (long-running: 15-60 min)
       - name: upload_image
@@ -57,7 +57,7 @@ commands:
 
       # Step 2: Launch GPU instance from imported image
       - name: launch_instance
-        phase: setup
+        phase: test
         command: "python3 ./stubs/aws/iso/launch_instance.py"
         args:
           - "--ami-id"

--- a/isvctl/configs/aws-network.yaml
+++ b/isvctl/configs/aws-network.yaml
@@ -27,7 +27,7 @@ version: "1.0"
 
 commands:
   network:
-    phases: ["setup", "teardown"]
+    phases: ["setup", "test", "teardown"]
     steps:
       # =====================================================================
       # Setup: Create shared VPC for connectivity tests
@@ -51,7 +51,7 @@ commands:
       # Self-contained - creates and cleans up its own VPC
       # =====================================================================
       - name: vpc_crud
-        phase: setup
+        phase: test
         command: "python3 ./stubs/aws/network/vpc_crud_test.py"
         args:
           - "--region"
@@ -67,7 +67,7 @@ commands:
       # Self-contained - creates and cleans up its own VPC
       # =====================================================================
       - name: subnet_config
-        phase: setup
+        phase: test
         command: "python3 ./stubs/aws/network/subnet_test.py"
         args:
           - "--region"
@@ -85,7 +85,7 @@ commands:
       # Self-contained - creates and cleans up its own VPCs
       # =====================================================================
       - name: vpc_isolation
-        phase: setup
+        phase: test
         command: "python3 ./stubs/aws/network/isolation_test.py"
         args:
           - "--region"
@@ -103,7 +103,7 @@ commands:
       # Self-contained - creates and cleans up its own VPC
       # =====================================================================
       - name: security_blocking
-        phase: setup
+        phase: test
         command: "python3 ./stubs/aws/network/security_test.py"
         args:
           - "--region"
@@ -119,7 +119,7 @@ commands:
       # Tests network connectivity via SSM
       # =====================================================================
       - name: connectivity_test
-        phase: setup
+        phase: test
         command: "python3 ./stubs/aws/network/test_connectivity.py"
         args:
           - "--vpc-id"
@@ -139,7 +139,7 @@ commands:
       # Self-contained - creates and cleans up its own VPC
       # =====================================================================
       - name: traffic_validation
-        phase: setup
+        phase: test
         command: "python3 ./stubs/aws/network/traffic_test.py"
         args:
           - "--region"

--- a/isvctl/configs/aws-vm.yaml
+++ b/isvctl/configs/aws-vm.yaml
@@ -6,17 +6,24 @@
 #
 # Steps:
 #   1. launch_instance - boto3: Provisions EC2, outputs IP/key
-#   2. reboot_instance - boto3: Reboots EC2, validates recovery
-#   3. teardown - boto3: Terminates EC2
+#   2. list_instances - boto3: Lists instances in VPC
+#   3. reboot_instance - boto3: Reboots EC2, validates recovery
+#   4. deploy_nim - paramiko: Deploys NIM container via SSH
+#   5. teardown_nim - paramiko: Stops NIM container via SSH
+#   6. teardown - boto3: Terminates EC2
 #
 # Validations (in tests.validations):
 #   - InstanceStateCheck - verifies instance running
+#   - InstanceListCheck - verifies instances in VPC
 #   - InstanceRebootCheck - verifies reboot succeeded (uptime, SSH, state)
 #   - SshConnectivityCheck - paramiko: test SSH
 #   - SshGpuCheck - paramiko + nvidia-smi: test GPU
 #   - SshVcpuPinningCheck - paramiko: verify vCPU pinning and NUMA affinity
 #   - SshPciBusCheck - paramiko: verify PCI bus config for GPUs
 #   - SshHostSoftwareCheck - paramiko: verify kernel, libvirt, SBIOS, NVIDIA drivers
+#   - SshNimHealthCheck - paramiko + curl: verify NIM health endpoint
+#   - SshNimInferenceCheck - paramiko + curl: verify NIM inference
+#   - SshNimModelCheck - paramiko + curl: verify NIM model listing
 #
 # Validation timing is inferred from step's phase.
 #
@@ -27,7 +34,7 @@ version: "1.0"
 
 commands:
   vm:
-    phases: ["setup", "teardown"]
+    phases: ["setup", "test", "teardown"]
     steps:
       # AWS-specific: Launch instance (boto3)
       - name: launch_instance
@@ -44,7 +51,7 @@ commands:
 
       # AWS-specific: List instances in VPC (boto3)
       - name: list_instances
-        phase: setup
+        phase: test
         command: "python3 ./stubs/aws/vm/list_instances.py"
         args:
           - "--vpc-id"
@@ -57,7 +64,7 @@ commands:
 
       # AWS-specific: Reboot instance and validate recovery (boto3)
       - name: reboot_instance
-        phase: setup
+        phase: test
         command: "python3 ./stubs/aws/vm/reboot_instance.py"
         args:
           - "--instance-id"
@@ -69,6 +76,28 @@ commands:
           - "--public-ip"
           - "{{steps.launch_instance.public_ip}}"
         timeout: 600
+
+      # Shared: Deploy NIM container via SSH (paramiko)
+      - name: deploy_nim
+        phase: test
+        command: "python3 ./stubs/common/deploy_nim.py"
+        args:
+          - "--host"
+          - "{{steps.launch_instance.public_ip}}"
+          - "--key-file"
+          - "{{steps.launch_instance.key_file}}"
+        timeout: 1800
+
+      # Shared: Teardown NIM container via SSH (paramiko)
+      - name: teardown_nim
+        phase: teardown
+        command: "python3 ./stubs/common/teardown_nim.py"
+        args:
+          - "--host"
+          - "{{steps.launch_instance.public_ip}}"
+          - "--key-file"
+          - "{{steps.launch_instance.key_file}}"
+        timeout: 120
 
       # AWS-specific: Teardown (boto3)
       - name: teardown
@@ -166,6 +195,29 @@ tests:
         - SshPciBusCheck:
             expected_gpus: 1
         - SshHostSoftwareCheck: {}
+
+    # --- NIM validations ---
+    nim_health:
+      step: deploy_nim
+      checks:
+        - SshNimHealthCheck: {}
+
+    nim_models:
+      step: deploy_nim
+      checks:
+        - SshNimModelCheck: {}
+
+    nim_inference:
+      step: deploy_nim
+      checks:
+        - SshNimInferenceCheck:
+            prompt: "What is CUDA?"
+            max_tokens: 50
+
+    nim_teardown:
+      step: teardown_nim
+      checks:
+        - StepSuccessCheck: {}
 
     teardown_checks:
       step: teardown

--- a/isvctl/configs/aws-vm.yaml
+++ b/isvctl/configs/aws-vm.yaml
@@ -42,6 +42,19 @@ commands:
           - "{{region}}"
         timeout: 600
 
+      # AWS-specific: List instances in VPC (boto3)
+      - name: list_instances
+        phase: setup
+        command: "python3 ./stubs/aws/vm/list_instances.py"
+        args:
+          - "--vpc-id"
+          - "{{steps.launch_instance.vpc_id}}"
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 120
+
       # AWS-specific: Reboot instance and validate recovery (boto3)
       - name: reboot_instance
         phase: setup
@@ -86,6 +99,12 @@ tests:
       checks:
         - InstanceStateCheck:
             expected_state: "running"
+
+    list_instances:
+      step: list_instances
+      checks:
+        - InstanceListCheck:
+            min_count: 1
 
     ssh:
       step: launch_instance

--- a/isvctl/configs/stubs/aws/control-plane/docs/aws-control-plane.md
+++ b/isvctl/configs/stubs/aws/control-plane/docs/aws-control-plane.md
@@ -315,10 +315,6 @@ Missing permissions. Ensure your credentials have the IAM permissions listed abo
 
 Access key operations may take 5-20 seconds to propagate. The scripts include retry logic with exponential backoff.
 
-## Cost Considerations
-
-**Estimated Cost**: ~$0 - All operations use free tier IAM and Resource Groups APIs.
-
 ## Related Documentation
 
 - [Configuration Guide](../../../../../docs/guides/configuration.md) - Step-based configuration reference

--- a/isvctl/configs/stubs/aws/iso/docs/aws-iso.md
+++ b/isvctl/configs/stubs/aws/iso/docs/aws-iso.md
@@ -220,7 +220,7 @@ version: "1.0"
 
 commands:
   iso:
-    phases: ["setup", "teardown"]
+    phases: ["setup", "test", "teardown"]
     steps:
       # Step 1: Upload VMDK and import as AMI
       - name: upload_image
@@ -237,7 +237,7 @@ commands:
 
       # Step 2: Launch GPU instance from imported AMI
       - name: launch_instance
-        phase: setup
+        phase: test
         command: "python3 ./stubs/aws/iso/launch_instance.py"
         args:
           - "--ami-id"

--- a/isvctl/configs/stubs/aws/network/docs/aws-network.md
+++ b/isvctl/configs/stubs/aws/network/docs/aws-network.md
@@ -392,19 +392,6 @@ Increase timeout in config:
   timeout: 1200  # 20 minutes
 ```
 
-## Cost Considerations
-
-| Resource | Duration | Cost |
-|----------|----------|------|
-| VPC, Subnets, SGs, NACLs | Seconds | Free |
-| Internet Gateway | ~5-7 min | Free |
-| IAM Role/Profile | ~5-7 min | Free |
-| t3.micro instances | ~8-10 min | ~$0.03 |
-
-**Total estimated cost per full test run**: < $0.05
-
-All resources are automatically cleaned up after tests.
-
 ## Related Documentation
 
 - [Configuration Guide](../../../../../docs/guides/configuration.md)

--- a/isvctl/configs/stubs/aws/vm/docs/aws-vm.md
+++ b/isvctl/configs/stubs/aws/vm/docs/aws-vm.md
@@ -1,389 +1,101 @@
 # AWS VM (VM-as-a-Service) Validation Guide
 
-This guide provides a walkthrough for validating AWS EC2 VM-as-a-Service capabilities using the ISV validation framework.
+Validates AWS EC2 VM-as-a-Service capabilities using the ISV validation framework.
 
 ## Overview
 
 The AWS VM validation tests verify:
 
-1. **Instance Lifecycle** - Instance provisioning, state verification
-2. **SSH Access** - Remote configuration access via SSH
-3. **Host OS Validation** - OS image and driver checks
+1. **Instance Lifecycle** - Provisioning, state verification, instance listing
+2. **SSH Access** - Remote connectivity via SSH
+3. **Host OS Validation** - OS image, kernel, libvirt/QEMU, SBIOS, NVIDIA drivers
 4. **GPU Tests** - GPU visibility, stress workloads
 5. **vCPU Pinning** - vCPU count, NUMA topology, CPU-GPU locality
 6. **PCI Bus Config** - PCIe link speed/width, IOMMU groups, BAR memory
-7. **Host Software Stack** - Linux kernel, libvirt/QEMU, SBIOS, NVIDIA drivers
-8. **Reboot Resilience** - Instance reboot, recovery, full host OS persistence
+7. **Reboot Resilience** - Instance reboot, recovery, full host OS persistence
+8. **NIM Inference** - NIM container deployment, health, model listing, inference (optional)
 
 ## Architecture
 
-### Step-Based Architecture
+Scripts perform cloud/SSH operations and output JSON. Validations assert on the JSON.
 
-```text
-┌────────────────────────────────────────────────────────────────────────────────────┐
-│  Scripts (AWS-Specific - boto3)                                                    │
-│  ┌──────────────────────────┐ ┌──────────────────────────┐ ┌────────────────────┐  │
-│  │   launch_instance.py     │ │   reboot_instance.py     │ │   teardown.py      │  │
-│  │                          │ │                          │ │                    │  │
-│  │ - Find GPU AMI           │ │ - Verify running         │ │ - Terminate inst.  │  │
-│  │ - Create key pair        │ │ - Capture pre-uptime     │ │ - Delete key pair  │  │
-│  │ - Create security group  │ │ - Reboot via EC2 API     │ │ - Delete sec. grp  │  │
-│  │ - Launch EC2 instance    │ │ - Wait for status OK     │ │ - Output JSON      │  │
-│  │ - Wait for running       │ │ - Wait for SSH           │ │                    │  │
-│  │ - Output JSON            │ │ - Confirm uptime reset   │ │                    │  │
-│  │                          │ │ - Output JSON            │ │                    │  │
-│  └──────────────────────────┘ └──────────────────────────┘ └────────────────────┘  │
-│  ┌──────────────────────────┐                                                      │
-│  │   list_instances.py      │                                                      │
-│  │                          │                                                      │
-│  │ - Filter by VPC ID       │                                                      │
-│  │ - Verify target instance │                                                      │
-│  │ - Output JSON            │                                                      │
-│  └──────────────────────────┘                                                      │
-└────────────────────────────────────────────────────────────────────────────────────┘
-                                   │
-                                   ▼
-┌────────────────────────────────────────────────────────────────────────────────────┐
-│  Validations (Platform-Agnostic)                                                   │
-│                                                                                    │
-│  Instance          SSH / OS           GPU                Host OS                   │
-│  ┌───────────────┐  ┌──────────────┐  ┌──────────────┐  ┌───────────────────────┐  │
-│  │ InstanceState │  │SshConnectiv. │  │ SshGpuCheck  │  │ SshVcpuPinningCheck   │  │
-│  │    Check      │  │    Check     │  │              │  │ SshPciBusCheck        │  │
-│  │ InstanceReboot│  │ SshOsCheck   │  │ SshGpuStress │  │ SshHostSoftwareCheck  │  │
-│  │    Check      │  │              │  │    Check     │  │  (kernel, libvirt,    │  │
-│  │ InstanceList  │  │              │  │              │  │   SBIOS, drivers)     │  │
-│  │    Check      │  │              │  │              │  │                       │  │
-│  │ StepSuccess   │  │              │  │              │  │                       │  │
-│  │    Check      │  │              │  │              │  │                       │  │
-│  └───────────────┘  └──────────────┘  └──────────────┘  └───────────────────────┘  │
-└────────────────────────────────────────────────────────────────────────────────────┘
+```
+Config (YAML) -> Script (boto3/paramiko) -> JSON output -> Validations (assertions)
 ```
 
-### Test Flow
+### Steps
 
-```text
-┌───────────────────────────────────────────────────────────────────┐
-│  uv run isvctl test run -f isvctl/configs/aws-vm.yaml             │
-└───────────────────────────────────────────────────────────────────┘
-                                   │
-                                   ▼
-┌────────────────────────────────────────────────────────────────────┐
-│  1. launch_instance (SETUP phase)                                  │
-│  ┌─────────────────────────────────────────────────────────────┐   │
-│  │ Find GPU AMI ─▶ Create Key Pair ─▶ Create SG ─▶ Launch EC2  │   │
-│  │                                                             │   │
-│  │ Output: {instance_id, public_ip, key_file, state, ...}      │   │
-│  └─────────────────────────────────────────────────────────────┘   │
-│                                                                    │
-│  Validations: InstanceStateCheck, SshConnectivityCheck, SshOsCheck,│
-│               SshGpuCheck, SshVcpuPinningCheck, SshPciBusCheck,    │
-│               SshHostSoftwareCheck, SshGpuStressCheck              │
-└────────────────────────────────────────────────────────────────────┘
-                                   │
-                                   ▼
-┌────────────────────────────────────────────────────────────────────┐
-│  2. list_instances (SETUP phase)                                   │
-│  ┌─────────────────────────────────────────────────────────────┐   │
-│  │ Filter by VPC ID ─▶ Verify target instance in list          │   │
-│  │                                                             │   │
-│  │ Output: {instances, count, found_target, target_instance}   │   │
-│  └─────────────────────────────────────────────────────────────┘   │
-│                                                                    │
-│  Validations: InstanceListCheck                                    │
-└────────────────────────────────────────────────────────────────────┘
-                                   │
-                                   ▼
-┌────────────────────────────────────────────────────────────────────┐
-│  3. reboot_instance (SETUP phase)                                  │
-│  ┌─────────────────────────────────────────────────────────────┐   │
-│  │ Verify Running ─▶ Reboot EC2 API ─▶ Wait Status OK ─▶ SSH   │   │
-│  │                                                             │   │
-│  │ Output: {instance_id, state, ssh_ready, uptime_seconds,     │   │
-│  │          reboot_confirmed, ...}                             │   │
-│  └─────────────────────────────────────────────────────────────┘   │
-│                                                                    │
-│  Validations: InstanceRebootCheck, InstanceStateCheck,             │
-│               SshConnectivityCheck, SshOsCheck, SshGpuCheck,       │
-│               SshVcpuPinningCheck, SshPciBusCheck,                 │
-│               SshHostSoftwareCheck                                 │
-└────────────────────────────────────────────────────────────────────┘
-                                   │
-                                   ▼
-┌────────────────────────────────────────────────────────────────────┐
-│  4. teardown (TEARDOWN phase)                                      │
-│  ┌─────────────────────────────────────────────────────────────┐   │
-│  │ Terminate Instance ─▶ Delete Key Pair ─▶ Delete SG          │   │
-│  │                                                             │   │
-│  │ Output: {success, deleted: {instances, key_pairs, ...}}     │   │
-│  └─────────────────────────────────────────────────────────────┘   │
-│                                                                    │
-│  Validations: StepSuccessCheck                                     │
-└────────────────────────────────────────────────────────────────────┘
-```
+| # | Step | Phase | Script | Description |
+|---|------|-------|--------|-------------|
+| 1 | `launch_instance` | setup | `stubs/aws/vm/launch_instance.py` | Provision EC2 GPU instance |
+| 2 | `list_instances` | test | `stubs/aws/vm/list_instances.py` | List instances in VPC |
+| 3 | `reboot_instance` | test | `stubs/aws/vm/reboot_instance.py` | Reboot and validate recovery |
+| 4 | `deploy_nim` | test | `stubs/common/deploy_nim.py` | Deploy NIM container via SSH (skipped if no NGC key) |
+| 5 | `teardown_nim` | teardown | `stubs/common/teardown_nim.py` | Stop NIM container |
+| 6 | `teardown` | teardown | `stubs/aws/vm/teardown.py` | Terminate instance, delete key pair + SG |
+
+Only `launch_instance` is in the **setup** phase. If any test step fails, teardown still runs
+to prevent resource leaks. NIM steps are shared and reusable across VMaaS and BMaaS.
+
+### Validations
+
+| Validation | Step | Description |
+|------------|------|-------------|
+| `InstanceStateCheck` | launch_instance, reboot_instance | Verify instance is running |
+| `InstanceListCheck` | list_instances | Verify instances in VPC, target found |
+| `SshConnectivityCheck` | launch_instance, reboot_instance | SSH connectivity and command execution |
+| `SshOsCheck` | launch_instance, reboot_instance | Verify OS type |
+| `SshGpuCheck` | launch_instance, reboot_instance | GPU visibility via nvidia-smi |
+| `SshVcpuPinningCheck` | launch_instance, reboot_instance | vCPU count, NUMA topology, CPU-GPU locality |
+| `SshPciBusCheck` | launch_instance, reboot_instance | PCI GPU enumeration, PCIe link, IOMMU, BAR memory |
+| `SshHostSoftwareCheck` | launch_instance, reboot_instance | Kernel, libvirt/QEMU, SBIOS, NVIDIA drivers |
+| `SshGpuStressCheck` | launch_instance | GPU stress test (excluded by default) |
+| `InstanceRebootCheck` | reboot_instance | Reboot API call, state recovery, SSH, uptime reset |
+| `SshNimHealthCheck` | deploy_nim | NIM `/v1/health/ready` (skipped if no NGC key) |
+| `SshNimModelCheck` | deploy_nim | NIM `/v1/models` returns expected model |
+| `SshNimInferenceCheck` | deploy_nim | Chat completion request and response validation |
+| `StepSuccessCheck` | teardown | Teardown completed successfully |
 
 ## Prerequisites
 
-### Required Tools
-
-- AWS CLI v2 (`aws`)
-- Python 3.12+ with boto3, paramiko
-- uv package manager
+- AWS CLI v2, Python 3.12+ with boto3/paramiko, uv package manager
+- AWS credentials with EC2 permissions (RunInstances, TerminateInstances, CreateKeyPair, etc.)
+- `NGC_NIM_API_KEY` environment variable (optional, for NIM tests)
 
 ```bash
-# Verify installation
 aws --version
 uv run python -c "import boto3, paramiko; print('OK')"
 ```
 
-### AWS Credentials
-
-```bash
-# Option 1: IAM User credentials
-export AWS_ACCESS_KEY_ID=AKIA...
-export AWS_SECRET_ACCESS_KEY=...
-export AWS_REGION=us-west-2
-
-# Option 2: STS temporary credentials (recommended)
-export AWS_ACCESS_KEY_ID=ASIA...
-export AWS_SECRET_ACCESS_KEY=...
-export AWS_SESSION_TOKEN=...
-export AWS_REGION=us-west-2
-```
-
-### Required IAM Permissions
-
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:RunInstances", "ec2:TerminateInstances", "ec2:DescribeInstances",
-        "ec2:DescribeInstanceStatus", "ec2:RebootInstances",
-        "ec2:CreateKeyPair", "ec2:DeleteKeyPair", "ec2:DescribeKeyPairs",
-        "ec2:CreateSecurityGroup", "ec2:DeleteSecurityGroup",
-        "ec2:AuthorizeSecurityGroupIngress", "ec2:DescribeSecurityGroups",
-        "ec2:DescribeVpcs", "ec2:DescribeSubnets",
-        "ec2:CreateTags", "ec2:DescribeImages", "ec2:DescribeAvailabilityZones",
-        "ec2:DescribeInstanceTypeOfferings",
-        "sts:GetCallerIdentity"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-```
-
----
-
 ## Quick Start
 
-### 1. Install Dependencies
-
 ```bash
-cd ISV-NCP-Validation-Suite
-uv sync
-```
+# 1. Install
+cd ISV-NCP-Validation-Suite && uv sync
 
-### 2. Configure AWS Credentials
-
-```bash
+# 2. Configure credentials
 export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
 export AWS_REGION=us-west-2
-```
+export NGC_NIM_API_KEY=...  # optional, for NIM tests
 
-### 3. Run Tests
-
-```bash
-# Run all tests - instance auto-provisioned
+# 3. Run all tests
 uv run isvctl test run -f isvctl/configs/aws-vm.yaml
 
-# Verbose output
-uv run isvctl test run -f isvctl/configs/aws-vm.yaml -v
-```
-
-### 4. Run Specific Tests
-
-```bash
-# Run only SSH tests
+# 4. Run specific tests
 uv run isvctl test run -f isvctl/configs/aws-vm.yaml -- -k "Ssh"
-
-# Run only GPU tests
-uv run isvctl test run -f isvctl/configs/aws-vm.yaml -- -m "gpu"
-
-# Run only host OS checks (vCPU pinning, PCI bus, software stack)
-uv run isvctl test run -f isvctl/configs/aws-vm.yaml -- -k "Vcpu or PciBus or HostSoftware"
-
-# Run only reboot validations
 uv run isvctl test run -f isvctl/configs/aws-vm.yaml -- -k "reboot"
-
-# Exclude workload tests (stress tests)
+uv run isvctl test run -f isvctl/configs/aws-vm.yaml -- -k "Nim"
+uv run isvctl test run -f isvctl/configs/aws-vm.yaml -- -m "gpu"
 uv run isvctl test run -f isvctl/configs/aws-vm.yaml -- -m "not workload"
+uv run isvctl test run -f isvctl/configs/aws-vm.yaml -v -- -v -s  # verbose
 ```
-
-See the [Validation Details](#validation-details) section below for full usage docs on each check.
-
----
 
 ## Configuration
 
-### aws-vm.yaml Structure
+Full config: [`isvctl/configs/aws-vm.yaml`](../../../aws-vm.yaml)
 
-```yaml
-version: "1.0"
-
-commands:
-  vm:
-    phases: ["setup", "teardown"]
-    steps:
-      # Step 1: Launch EC2 GPU instance
-      - name: launch_instance
-        phase: setup
-        command: "python3 ./stubs/aws/vm/launch_instance.py"
-        args:
-          - "--name"
-          - "isv-test-gpu"
-          - "--instance-type"
-          - "{{instance_type}}"
-          - "--region"
-          - "{{region}}"
-        timeout: 600
-
-      # Step 2: List instances in VPC and verify target
-      - name: list_instances
-        phase: setup
-        command: "python3 ./stubs/aws/vm/list_instances.py"
-        args:
-          - "--vpc-id"
-          - "{{steps.launch_instance.vpc_id}}"
-          - "--instance-id"
-          - "{{steps.launch_instance.instance_id}}"
-          - "--region"
-          - "{{region}}"
-        timeout: 120
-
-      # Step 3: Reboot instance and validate recovery
-      - name: reboot_instance
-        phase: setup
-        command: "python3 ./stubs/aws/vm/reboot_instance.py"
-        args:
-          - "--instance-id"
-          - "{{steps.launch_instance.instance_id}}"
-          - "--region"
-          - "{{region}}"
-          - "--key-file"
-          - "{{steps.launch_instance.key_file}}"
-          - "--public-ip"
-          - "{{steps.launch_instance.public_ip}}"
-        timeout: 600
-
-      # Step 4: Teardown resources
-      - name: teardown
-        phase: teardown
-        command: "python3 ./stubs/aws/vm/teardown.py"
-        args:
-          - "--instance-id"
-          - "{{steps.launch_instance.instance_id}}"
-          - "--delete-key-pair"
-          - "--delete-security-group"
-        timeout: 600
-
-tests:
-  platform: vm
-  cluster_name: "aws-vm-validation"
-
-  settings:
-    region: "us-west-2"
-    instance_type: "g5.xlarge"
-
-  validations:
-    setup_checks:
-      step: launch_instance
-      checks:
-        - InstanceStateCheck:
-            expected_state: "running"
-
-    list_instances:
-      step: list_instances
-      checks:
-        - InstanceListCheck:
-            min_count: 1
-
-    ssh:
-      step: launch_instance
-      checks:
-        - SshConnectivityCheck: {}
-        - SshOsCheck:
-            expected_os: "ubuntu"
-
-    gpu:
-      step: launch_instance
-      checks:
-        - SshGpuCheck:
-            expected_gpus: 1
-
-    host_os:
-      step: launch_instance
-      checks:
-        - SshVcpuPinningCheck: {}
-        - SshPciBusCheck:
-            expected_gpus: 1
-        - SshHostSoftwareCheck: {}
-
-    gpu_workload:
-      step: launch_instance
-      checks:
-        - SshGpuStressCheck:
-            duration: 60
-
-    # Reboot validations
-    reboot_checks:
-      step: reboot_instance
-      checks:
-        - InstanceRebootCheck:
-            max_uptime: 600
-
-    reboot_state:
-      step: reboot_instance
-      checks:
-        - InstanceStateCheck:
-            expected_state: "running"
-
-    reboot_ssh:
-      step: reboot_instance
-      checks:
-        - SshConnectivityCheck: {}
-        - SshOsCheck:
-            expected_os: "ubuntu"
-
-    reboot_gpu:
-      step: reboot_instance
-      checks:
-        - SshGpuCheck:
-            expected_gpus: 1
-
-    reboot_host_os:
-      step: reboot_instance
-      checks:
-        - SshVcpuPinningCheck: {}
-        - SshPciBusCheck:
-            expected_gpus: 1
-        - SshHostSoftwareCheck: {}
-
-    teardown_checks:
-      step: teardown
-      checks:
-        - StepSuccessCheck: {}
-
-  exclude:
-    markers:
-      - workload  # Exclude stress test by default
-```
-
-### Settings Reference
+### Settings
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
@@ -401,213 +113,82 @@ tests:
 | g4dn.xlarge | 1 | T4 |
 | p4d.24xlarge | 8 | A100 |
 
+### Test Duration
+
+| Phase | Duration | Description |
+|-------|----------|-------------|
+| Launch Instance | 3-5 min | Create key, SG, launch EC2, wait for running |
+| SSH + GPU + Host OS | ~2 min | All SSH-based validations |
+| Reboot + Revalidation | 3-7 min | Reboot via API, re-run SSH/GPU/host OS checks |
+| NIM Deploy | 5-20 min | Pull image, start container, wait for health (first run) |
+| NIM Validation | ~30s | Health, models, inference checks |
+| Teardown | ~1 min | Terminate instance, delete resources |
+| **Total** | **15-35 min** | Full test cycle (with NIM) |
+
 ---
 
-## Validations
+## Validation Details
 
-### Validation Types
-
-| Validation | Category | Description |
-|------------|----------|-------------|
-| `InstanceStateCheck` | setup_checks, reboot_state | Verify instance is in expected state (running) |
-| `InstanceListCheck` | list_instances | Verify instances exist in VPC and target instance is present |
-| `SshConnectivityCheck` | ssh, reboot_ssh | Test SSH connectivity and command execution |
-| `SshOsCheck` | ssh, reboot_ssh | Verify OS type (ubuntu, etc.) |
-| `SshGpuCheck` | gpu, reboot_gpu | Verify GPU visibility via nvidia-smi |
-| `SshVcpuPinningCheck` | host_os, reboot_host_os | Verify vCPU count, online status, NUMA topology, CPU affinity, GPU-NUMA locality |
-| `SshPciBusCheck` | host_os, reboot_host_os | Verify PCI GPU enumeration, PCIe link speed/width, IOMMU groups, BAR memory, ACS |
-| `SshHostSoftwareCheck` | host_os, reboot_host_os | Verify Linux kernel, libvirt/QEMU/KVM, SBIOS (vendor/version/date), NVIDIA driver |
-| `SshGpuStressCheck` | gpu_workload | Run GPU stress test (excluded by default) |
-| `InstanceRebootCheck` | reboot_checks | Verify reboot succeeded: API call, state recovery, SSH restored, uptime reset |
-| `StepSuccessCheck` | teardown_checks | Verify teardown completed successfully |
-
-### Validation Details
-
-Each validation SSHs into the host and runs a series of subtests. All checks report
+Each validation SSHs into the host and runs subtests. All checks report
 subtest-level results so you can pinpoint exactly what passed or failed.
 
----
+### SshVcpuPinningCheck
 
-#### SshVcpuPinningCheck
-
-Validates that vCPUs are correctly provisioned, online, and topologically sane.
-
-**Subtests:**
+Validates vCPU provisioning, online status, and NUMA topology.
 
 | Subtest | What it checks |
 |---------|---------------|
-| `vcpu_count` | vCPU count from `nproc` matches `expected_vcpus` (if set) |
-| `vcpu_online` | All vCPUs are online (`/sys/devices/system/cpu/online`) |
-| `cpu_affinity` | CPU affinity mask of PID 1 (should span all vCPUs) |
-| `numa_topology` | All NUMA nodes have CPUs assigned, no empty nodes |
-| `numa_node{N}` | Per-node detail: which CPUs, how many cores |
+| `vcpu_count` | vCPU count matches `expected_vcpus` (if set) |
+| `vcpu_online` | All vCPUs are online |
+| `cpu_affinity` | CPU affinity mask of PID 1 spans all vCPUs |
+| `numa_topology` | All NUMA nodes have CPUs assigned |
 | `gpu{N}_numa` | GPU PCI device NUMA node (GPU-CPU locality) |
-
-**Config parameters:**
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `expected_vcpus` | int | *(auto-detect)* | Fail if vCPU count doesn't match |
 
-**Usage examples:**
+### SshPciBusCheck
 
-```yaml
-# Auto-detect (report what's found)
-- SshVcpuPinningCheck: {}
-
-# Enforce 4 vCPUs (for g5.xlarge)
-- SshVcpuPinningCheck:
-    expected_vcpus: 4
-
-# Enforce 16 vCPUs (for g5.4xlarge)
-- SshVcpuPinningCheck:
-    expected_vcpus: 16
-```
-
-**Sample output:**
-
-```text
-[PASS] vcpu_count      : 4 vCPUs
-[PASS] vcpu_online     : Online: 0-3 (4/4)
-[PASS] cpu_affinity    : pid 1's current affinity mask: f
-[PASS] numa_topology   : 1 NUMA node(s), all populated: True
-[PASS] numa_node0      : node0: CPUs 0-3 (4 cores)
-[PASS] gpu0_numa       : GPU 0 (00000000:00:1E.0) -> NUMA node 0
-```
-
----
-
-#### SshPciBusCheck
-
-Validates that the PCI bus is correctly configured for GPU passthrough.
-
-**Subtests:**
+Validates PCI bus configuration for GPU passthrough.
 
 | Subtest | What it checks |
 |---------|---------------|
-| `pci_gpu_count` | NVIDIA GPU devices on PCI bus (`lspci`) match expected count |
-| `pci_dev_{N}` | Per-device BDF address and description |
-| `pcie_link_gpu{N}` | PCIe generation (current/max) and link width (current/max) |
+| `pci_gpu_count` | NVIDIA GPU devices on PCI bus match expected count |
+| `pcie_link_gpu{N}` | PCIe generation and link width (current/max) |
 | `iommu_groups` | IOMMU group assignment for GPU devices |
-| `gpu{N}_bar_mem` | GPU BAR memory region mapped correctly |
+| `gpu{N}_bar_mem` | GPU BAR memory region |
 | `acs` | PCI Access Control Services status |
-
-**Config parameters:**
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `expected_gpus` | int | `1` | Expected number of GPU PCI devices |
 | `expected_link_width` | string | *(none)* | Expected PCIe link width, e.g. `"x16"` |
 
-**Usage examples:**
+### SshHostSoftwareCheck
 
-```yaml
-# Default (1 GPU, report link info)
-- SshPciBusCheck:
-    expected_gpus: 1
+Validates the full software stack: kernel, libvirt/QEMU, SBIOS, NVIDIA drivers.
 
-# Multi-GPU instance, enforce x16 link
-- SshPciBusCheck:
-    expected_gpus: 4
-    expected_link_width: "x16"
-```
-
-**Sample output:**
-
-```text
-[PASS] pci_gpu_count    : 1 GPU PCI device(s) (expected 1)
-[PASS] pci_dev_0        : 00:1e.0: 3D controller: NVIDIA Corporation GA102GL [A10G]
-[PASS] pcie_link_gpu0   : GPU 0: Gen4/4, x16/x16
-[PASS] iommu_groups     : 0000:00:1e.0 -> IOMMU group 17
-[PASS] gpu0_bar_mem     : GPU 0 (00:1E.0): 23028 MiB
-[PASS] acs              : ACS info not available (OK for cloud VMs)
-```
-
----
-
-#### SshHostSoftwareCheck
-
-Validates the full software stack: Linux kernel, libvirt/QEMU, System BIOS, and NVIDIA drivers.
-
-**Subtests:**
-
-| Subtest | Category | What it checks |
-|---------|----------|---------------|
-| `kernel_version` | Kernel | `uname -r`, optionally matches expected version |
-| `kernel_build` | Kernel | Kernel build string (`uname -v`) |
-| `kernel_modules` | Kernel | GPU/virt modules loaded: `nvidia`, `kvm`, `vfio`, `vhost` |
-| `libvirt` | Virtualization | `libvirtd --version`, optionally matches expected |
-| `qemu` | Virtualization | QEMU/qemu-kvm version |
-| `kvm` | Virtualization | `/dev/kvm` hardware virtualization support |
-| `virsh` | Virtualization | `virsh version --daemon` hypervisor API |
-| `bios_vendor` | SBIOS | BIOS vendor via `dmidecode` / sysfs |
-| `bios_version` | SBIOS | BIOS firmware version |
-| `bios_date` | SBIOS | BIOS release date |
-| `system_product` | SBIOS | System product / platform name |
-| `boot_mode` | SBIOS | UEFI vs Legacy BIOS |
-| `nvidia_driver` | NVIDIA | Driver version from `nvidia-smi` |
-| `cuda_version` | NVIDIA | CUDA runtime version |
-| `nvidia_module` | NVIDIA | Kernel module version (`/sys/module/nvidia/version`) |
-| `nvidia_persistence` | NVIDIA | Persistence mode on/off |
-
-**Config parameters:**
+| Subtest | What it checks |
+|---------|---------------|
+| `kernel_version` | `uname -r` |
+| `kernel_modules` | GPU/virt modules: `nvidia`, `kvm`, `vfio`, `vhost` |
+| `libvirt`, `qemu`, `kvm` | Virtualization stack |
+| `bios_vendor`, `bios_version`, `bios_date` | System BIOS via `dmidecode` |
+| `nvidia_driver`, `cuda_version` | NVIDIA driver and CUDA versions |
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `expected_kernel` | string | *(none)* | Kernel version substring to enforce (e.g. `"6.5"`) |
-| `expected_driver_version` | string | *(none)* | NVIDIA driver version substring (e.g. `"550"`) |
-| `expected_libvirt_version` | string | *(none)* | libvirt version substring (e.g. `"10.0"`) |
-| `expected_bios_vendor` | string | *(none)* | BIOS vendor name (e.g. `"Amazon"`, `"Dell"`) |
+| `expected_kernel` | string | *(none)* | Kernel version substring to enforce |
+| `expected_driver_version` | string | *(none)* | NVIDIA driver version substring |
+| `expected_libvirt_version` | string | *(none)* | libvirt version substring |
+| `expected_bios_vendor` | string | *(none)* | BIOS vendor name |
 
 When no `expected_*` parameter is set, the check **reports** the value without failing.
-When set, it **enforces** the value and fails if there's a mismatch.
 
-**Usage examples:**
-
-```yaml
-# Report-only mode (discover what's installed)
-- SshHostSoftwareCheck: {}
-
-# Enforce specific versions
-- SshHostSoftwareCheck:
-    expected_kernel: "6.5"
-    expected_driver_version: "550"
-
-# Full enforcement (bare-metal / on-prem)
-- SshHostSoftwareCheck:
-    expected_kernel: "6.8"
-    expected_driver_version: "550"
-    expected_libvirt_version: "10.0"
-    expected_bios_vendor: "Dell Inc."
-```
-
-**Sample output:**
-
-```text
-[PASS] kernel_version    : Kernel: 6.5.0-1024-aws
-[PASS] kernel_build      : #24~22.04.1-Ubuntu SMP Wed May 1 15:38:15 UTC 2024
-[PASS] kernel_modules    : Key modules: kvm, kvm_intel, nvidia, nvidia_drm, nvidia_modeset, nvidia_uvm
-[PASS] libvirt           : libvirt not installed (OK for bare metal/cloud)
-[PASS] qemu              : QEMU not installed (OK for bare metal/cloud)
-[PASS] kvm               : KVM not available
-[PASS] bios_vendor       : BIOS vendor: Amazon EC2
-[PASS] bios_version      : BIOS version: 1.0
-[PASS] bios_date         : BIOS date: 10/16/2017
-[PASS] system_product    : Platform: c5.xlarge
-[PASS] boot_mode         : Boot mode: UEFI
-[PASS] nvidia_driver     : NVIDIA Driver: 550.54.15
-[PASS] cuda_version      : CUDA: 12.4
-[PASS] nvidia_module     : nvidia.ko: 550.54.15
-[PASS] nvidia_persistence : Persistence mode: Enabled
-```
-
----
-
-#### InstanceRebootCheck
+### InstanceRebootCheck
 
 Validates that an EC2 instance rebooted successfully and fully recovered.
-
-**Subtests (checked in order):**
 
 | Check | Fails if |
 |-------|----------|
@@ -615,82 +196,16 @@ Validates that an EC2 instance rebooted successfully and fully recovered.
 | `state` | Instance is not `"running"` after reboot |
 | `ssh_ready` | SSH connectivity not restored |
 | `uptime_seconds` | Uptime exceeds `max_uptime` (reboot didn't happen) |
-| `reboot_confirmed` | Pre/post uptime comparison shows no reset |
-
-**Config parameters:**
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `max_uptime` | int | `600` | Max uptime in seconds to consider reboot confirmed |
 
-**Usage examples:**
-
-```yaml
-# Default (600s max uptime)
-- InstanceRebootCheck: {}
-
-# Stricter: reboot must result in <5 min uptime
-- InstanceRebootCheck:
-    max_uptime: 300
-```
-
----
-
-### Running Specific Validations
-
-```bash
-# Run all validations
-uv run isvctl test run -f isvctl/configs/aws-vm.yaml
-
-# Run only host OS checks (vCPU, PCI, software stack)
-uv run isvctl test run -f isvctl/configs/aws-vm.yaml -- -k "Vcpu or PciBus or HostSoftware"
-
-# Run only vCPU pinning
-uv run isvctl test run -f isvctl/configs/aws-vm.yaml -- -k "VcpuPinning"
-
-# Run only PCI bus checks
-uv run isvctl test run -f isvctl/configs/aws-vm.yaml -- -k "PciBus"
-
-# Run only host software stack (kernel, libvirt, SBIOS, driver)
-uv run isvctl test run -f isvctl/configs/aws-vm.yaml -- -k "HostSoftware"
-
-# Run only reboot validations
-uv run isvctl test run -f isvctl/configs/aws-vm.yaml -- -k "reboot"
-
-# Run only GPU checks
-uv run isvctl test run -f isvctl/configs/aws-vm.yaml -- -m "gpu"
-
-# Exclude stress tests
-uv run isvctl test run -f isvctl/configs/aws-vm.yaml -- -m "not workload"
-
-# Verbose output with full subtest details
-uv run isvctl test run -f isvctl/configs/aws-vm.yaml -v -- -v -s
-```
-
-### Validation Timing
-
-- **Default (no `phase`)**: Runs after setup steps complete
-- **`phase: teardown`**: Runs after teardown steps complete
-
-### Test Duration Summary
-
-| Phase | Duration | Description |
-|-------|----------|-------------|
-| Launch Instance | 3-5 min | Create key, SG, launch EC2, wait for running |
-| SSH Validation | ~30s | Connect and test commands |
-| GPU Validation | ~30s | Run nvidia-smi |
-| Host OS Checks | ~30-60s | vCPU pinning, PCI bus, kernel, libvirt, SBIOS, drivers |
-| GPU Stress | ~1-2 min | GPU stress test (excluded by default) |
-| Reboot Instance | 2-5 min | Reboot via API, wait for status checks, SSH |
-| Reboot Validation | ~1-2 min | Verify state, SSH, GPU, host OS after reboot |
-| Teardown | ~1 min | Terminate instance, delete resources |
-| **Total** | **8-15 min** | Full test cycle |
-
 ---
 
 ## Script Outputs
 
-### launch_instance.py Output
+### launch_instance.py
 
 ```json
 {
@@ -700,89 +215,73 @@ uv run isvctl test run -f isvctl/configs/aws-vm.yaml -v -- -v -s
   "public_ip": "54.1.2.3",
   "private_ip": "172.31.1.5",
   "state": "running",
-  "ami_id": "ami-0abc123",
-  "key_name": "isv-test-key-abc123",
-  "key_path": "/home/user/.ssh/isv-test-key-abc123.pem",
-  "security_group_id": "sg-0abc123",
+  "key_file": "/tmp/isv-test-key.pem",
+  "vpc_id": "vpc-0abc123",
   "ssh_user": "ubuntu"
 }
 ```
 
-### list_instances.py Output
+### list_instances.py
 
 ```json
 {
   "success": true,
   "platform": "vm",
-  "instances": [
-    {
-      "instance_id": "i-0abc123def456",
-      "instance_type": "g5.xlarge",
-      "state": "running",
-      "public_ip": "54.1.2.3",
-      "private_ip": "172.31.1.5",
-      "vpc_id": "vpc-0abc123"
-    }
-  ],
+  "instances": [{"instance_id": "i-0abc123", "state": "running", "vpc_id": "vpc-0abc123"}],
   "count": 1,
   "found_target": true,
-  "target_instance": "i-0abc123def456"
+  "target_instance": "i-0abc123"
 }
 ```
 
-**Key fields for validations:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `instances` | array | List of non-terminated instances in the VPC |
-| `count` | int | Number of instances returned |
-| `found_target` | bool | Whether the target instance ID was found in the list |
-| `target_instance` | string | The instance ID that was searched for |
-
-### reboot_instance.py Output
+### reboot_instance.py
 
 ```json
 {
   "success": true,
   "platform": "vm",
   "instance_id": "i-0abc123def456",
-  "region": "us-west-2",
   "state": "running",
-  "public_ip": "54.1.2.3",
-  "private_ip": "172.31.1.5",
-  "key_file": "/tmp/isv-test-key.pem",
-  "ssh_user": "ubuntu",
   "reboot_initiated": true,
   "ssh_ready": true,
-  "pre_reboot_uptime": 342.5,
   "uptime_seconds": 45.2,
   "reboot_confirmed": true
 }
 ```
 
-**Key fields for validations:**
+### deploy_nim.py
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `reboot_initiated` | bool | EC2 reboot API call succeeded |
-| `state` | string | Instance state after reboot (should be `"running"`) |
-| `ssh_ready` | bool | SSH connectivity restored after reboot |
-| `uptime_seconds` | float | System uptime after reboot (low = reboot confirmed) |
-| `reboot_confirmed` | bool | Uptime comparison confirms reboot occurred |
-| `pre_reboot_uptime` | float | System uptime before reboot (for comparison) |
+```json
+{
+  "success": true,
+  "platform": "vm",
+  "skipped": false,
+  "container_id": "ea20e03203fb",
+  "model": "meta/llama-3.2-1b-instruct",
+  "endpoint": "http://localhost:8000",
+  "port": 8000,
+  "health_ready": true,
+  "host": "54.1.2.3",
+  "key_file": "/tmp/isv-test-key.pem"
+}
+```
 
-### teardown.py Output
+When `NGC_NIM_API_KEY` is not set, returns `{"success": true, "skipped": true}`.
+
+### teardown_nim.py
+
+```json
+{"success": true, "platform": "vm", "container_removed": true}
+```
+
+### teardown.py
 
 ```json
 {
   "success": true,
   "platform": "vm",
   "resources_destroyed": true,
-  "deleted": {
-    "instances": ["i-0abc123def456"],
-    "security_groups": ["sg-0abc123"],
-    "key_pairs": ["isv-test-key-abc123"]
-  }
+  "deleted": {"instances": ["i-0abc123"], "security_groups": ["sg-0abc123"], "key_pairs": ["isv-test-key"]}
 }
 ```
 
@@ -793,132 +292,51 @@ uv run isvctl test run -f isvctl/configs/aws-vm.yaml -v -- -v -s
 ### Instance Not Starting
 
 ```bash
-# Check AWS limits
 aws service-quotas list-service-quotas --service-code ec2 --region us-west-2
-
-# Try smaller instance
-uv run isvctl test run -f isvctl/configs/aws-vm.yaml \
-  --set tests.settings.instance_type=g4dn.xlarge
 ```
 
 ### SSH Connection Failed
 
 ```bash
-# Check if instance has public IP
-aws ec2 describe-instances --instance-ids i-xxx \
-  --query 'Reservations[*].Instances[*].PublicIpAddress'
-
-# Check security group rules
-aws ec2 describe-security-groups --group-ids sg-xxx
-
-# Test SSH manually
-ssh -i ~/.ssh/isv-test-key-xxx.pem ubuntu@<public-ip>
+aws ec2 describe-instances --instance-ids i-xxx --query 'Reservations[*].Instances[*].PublicIpAddress'
+ssh -i /tmp/isv-test-key.pem ubuntu@<public-ip>
 ```
 
-### Reboot Validation Failed
+### Host OS Check Failed
 
 ```bash
-# Check instance state via AWS CLI
-aws ec2 describe-instances --instance-ids i-xxx \
-  --query 'Reservations[*].Instances[*].[State.Name]'
-
-# Check instance status checks
-aws ec2 describe-instance-status --instance-ids i-xxx \
-  --query 'InstanceStatuses[*].[InstanceStatus.Status,SystemStatus.Status]'
-
-# SSH in and check uptime manually
-ssh -i ~/.ssh/isv-test-key-xxx.pem ubuntu@<public-ip> "cat /proc/uptime"
-
-# Check system logs for reboot evidence
-ssh -i ~/.ssh/isv-test-key-xxx.pem ubuntu@<public-ip> "last reboot | head -5"
+ssh -i /tmp/isv-test-key.pem ubuntu@<public-ip>
+nproc && cat /sys/devices/system/cpu/online     # vCPU
+lspci -d 10de: -nn && nvidia-smi -q -d PCIE     # PCI
+uname -r && nvidia-smi                           # kernel + driver
+sudo dmidecode -s bios-vendor                    # SBIOS
 ```
 
-### Host OS Check Failed (vCPU / PCI / Software)
+### NIM Deployment Failed
 
 ```bash
-# SSH into instance for manual inspection
-ssh -i ~/.ssh/isv-test-key-xxx.pem ubuntu@<public-ip>
+# Check container status
+ssh -i /tmp/isv-test-key.pem ubuntu@<ip> "docker ps -a; docker logs isv-nim 2>&1 | tail -20"
 
-# --- vCPU Pinning ---
-nproc                                         # vCPU count
-cat /sys/devices/system/cpu/online            # Online CPUs
-taskset -p 1                                  # CPU affinity of init
-lscpu | grep NUMA                             # NUMA topology
-nvidia-smi --query-gpu=index,gpu_bus_id --format=csv,noheader  # GPU bus IDs
+# Check disk space (NIM images are 8-15GB)
+ssh -i /tmp/isv-test-key.pem ubuntu@<ip> "df -h / && docker system df"
 
-# --- PCI Bus ---
-lspci -d 10de: -nn                            # NVIDIA PCI devices
-nvidia-smi -q -d PCIE                         # PCIe link details
-find /sys/kernel/iommu_groups/ -type l        # IOMMU groups
-
-# --- Kernel & Drivers ---
-uname -r                                      # Kernel version
-uname -v                                      # Kernel build
-lsmod | grep -E 'nvidia|kvm|vfio'            # Key modules
-nvidia-smi                                    # Driver + CUDA
-cat /sys/module/nvidia/version                # Kernel module version
-
-# --- libvirt / QEMU ---
-libvirtd --version 2>/dev/null                # libvirt version
-qemu-system-x86_64 --version 2>/dev/null     # QEMU version
-test -c /dev/kvm && echo "KVM OK"            # KVM support
-
-# --- SBIOS ---
-sudo dmidecode -s bios-vendor                 # BIOS vendor
-sudo dmidecode -s bios-version                # BIOS version
-sudo dmidecode -s bios-release-date           # BIOS date
-sudo dmidecode -s system-product-name         # Platform
-test -d /sys/firmware/efi && echo "UEFI" || echo "Legacy"  # Boot mode
-```
-
-### GPU Not Detected
-
-```bash
-# SSH into instance
-ssh -i ~/.ssh/isv-test-key-xxx.pem ubuntu@<public-ip>
-
-# Check NVIDIA driver
-nvidia-smi
-
-# Check if using GPU AMI
-lsmod | grep nvidia
+# Test manually
+ssh -i /tmp/isv-test-key.pem ubuntu@<ip> "curl -sf http://localhost:8000/v1/models"
 ```
 
 ### Cleanup Failed Resources
 
 ```bash
-# List instances with ISV tags
-aws ec2 describe-instances \
-  --filters "Name=tag:Purpose,Values=isv-validation" \
+aws ec2 describe-instances --filters "Name=tag:Purpose,Values=isv-validation" \
   --query 'Reservations[*].Instances[*].[InstanceId,State.Name]'
-
-# Terminate orphaned instances
 aws ec2 terminate-instances --instance-ids i-xxx
-
-# Delete orphaned security groups
-aws ec2 delete-security-group --group-id sg-xxx
-
-# Delete orphaned key pairs
-aws ec2 delete-key-pair --key-name isv-test-key-xxx
 ```
-
----
-
-## Cost Considerations
-
-| Resource | Duration | Cost (approx) |
-|----------|----------|---------------|
-| g5.xlarge | 1 hour | $1.01 |
-| g4dn.xlarge | 1 hour | $0.53 |
-| t3.micro | 1 hour | $0.01 |
-
-**Tip:** The teardown phase cleans up all resources automatically. Use `--skip-destroy` flag in teardown.py to keep resources for debugging.
 
 ---
 
 ## Related Documentation
 
-- [AWS ISO Import Validation Guide](../../iso/docs/aws-iso.md) - VMDK/VHD import tests
 - [AWS EKS Validation Guide](../../eks/docs/aws-eks.md) - Kubernetes cluster tests
 - [AWS Network Validation Guide](../../network/docs/aws-network.md) - VPC and network tests
 - [Configuration Guide](../../../../../docs/guides/configuration.md) - Config file options

--- a/isvctl/configs/stubs/aws/vm/docs/aws-vm.md
+++ b/isvctl/configs/stubs/aws/vm/docs/aws-vm.md
@@ -40,14 +40,14 @@ The AWS VM validation tests verify:
 │  Validations (Platform-Agnostic)                                                   │
 │                                                                                    │
 │  Instance          SSH / OS           GPU                Host OS                   │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐  ┌───────────────────────┐   │
-│  │ InstanceState │  │SshConnectiv. │  │ SshGpuCheck  │  │ SshVcpuPinningCheck   │   │
-│  │    Check      │  │    Check     │  │              │  │ SshPciBusCheck        │   │
-│  │ InstanceReboot│  │ SshOsCheck   │  │SshGpuStress  │  │ SshHostSoftwareCheck  │   │
-│  │    Check      │  │              │  │    Check     │  │  (kernel, libvirt,    │   │
-│  │ StepSuccess   │  │              │  │              │  │   SBIOS, drivers)     │   │
-│  │    Check      │  │              │  │              │  │                       │   │
-│  └──────────────┘  └──────────────┘  └──────────────┘  └───────────────────────┘   │
+│  ┌───────────────┐  ┌──────────────┐  ┌──────────────┐  ┌───────────────────────┐  │
+│  │ InstanceState │  │SshConnectiv. │  │ SshGpuCheck  │  │ SshVcpuPinningCheck   │  │
+│  │    Check      │  │    Check     │  │              │  │ SshPciBusCheck        │  │
+│  │ InstanceReboot│  │ SshOsCheck   │  │ SshGpuStress │  │ SshHostSoftwareCheck  │  │
+│  │    Check      │  │              │  │    Check     │  │  (kernel, libvirt,    │  │
+│  │ StepSuccess   │  │              │  │              │  │   SBIOS, drivers)     │  │
+│  │    Check      │  │              │  │              │  │                       │  │
+│  └───────────────┘  └──────────────┘  └──────────────┘  └───────────────────────┘  │
 └────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -79,7 +79,7 @@ The AWS VM validation tests verify:
 │  │ Verify Running ─▶ Reboot EC2 API ─▶ Wait Status OK ─▶ SSH   │   │
 │  │                                                             │   │
 │  │ Output: {instance_id, state, ssh_ready, uptime_seconds,     │   │
-│  │          reboot_confirmed, ...}                              │   │
+│  │          reboot_confirmed, ...}                             │   │
 │  └─────────────────────────────────────────────────────────────┘   │
 │                                                                    │
 │  Validations: InstanceRebootCheck, InstanceStateCheck,             │

--- a/isvctl/configs/stubs/aws/vm/docs/aws-vm.md
+++ b/isvctl/configs/stubs/aws/vm/docs/aws-vm.md
@@ -33,6 +33,13 @@ The AWS VM validation tests verify:
 │  │ - Output JSON            │ │ - Confirm uptime reset   │ │                    │  │
 │  │                          │ │ - Output JSON            │ │                    │  │
 │  └──────────────────────────┘ └──────────────────────────┘ └────────────────────┘  │
+│  ┌──────────────────────────┐                                                      │
+│  │   list_instances.py      │                                                      │
+│  │                          │                                                      │
+│  │ - Filter by VPC ID       │                                                      │
+│  │ - Verify target instance │                                                      │
+│  │ - Output JSON            │                                                      │
+│  └──────────────────────────┘                                                      │
 └────────────────────────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼
@@ -45,7 +52,9 @@ The AWS VM validation tests verify:
 │  │    Check      │  │    Check     │  │              │  │ SshPciBusCheck        │  │
 │  │ InstanceReboot│  │ SshOsCheck   │  │ SshGpuStress │  │ SshHostSoftwareCheck  │  │
 │  │    Check      │  │              │  │    Check     │  │  (kernel, libvirt,    │  │
-│  │ StepSuccess   │  │              │  │              │  │   SBIOS, drivers)     │  │
+│  │ InstanceList  │  │              │  │              │  │   SBIOS, drivers)     │  │
+│  │    Check      │  │              │  │              │  │                       │  │
+│  │ StepSuccess   │  │              │  │              │  │                       │  │
 │  │    Check      │  │              │  │              │  │                       │  │
 │  └───────────────┘  └──────────────┘  └──────────────┘  └───────────────────────┘  │
 └────────────────────────────────────────────────────────────────────────────────────┘
@@ -74,7 +83,19 @@ The AWS VM validation tests verify:
                                    │
                                    ▼
 ┌────────────────────────────────────────────────────────────────────┐
-│  2. reboot_instance (SETUP phase)                                  │
+│  2. list_instances (SETUP phase)                                   │
+│  ┌─────────────────────────────────────────────────────────────┐   │
+│  │ Filter by VPC ID ─▶ Verify target instance in list          │   │
+│  │                                                             │   │
+│  │ Output: {instances, count, found_target, target_instance}   │   │
+│  └─────────────────────────────────────────────────────────────┘   │
+│                                                                    │
+│  Validations: InstanceListCheck                                    │
+└────────────────────────────────────────────────────────────────────┘
+                                   │
+                                   ▼
+┌────────────────────────────────────────────────────────────────────┐
+│  3. reboot_instance (SETUP phase)                                  │
 │  ┌─────────────────────────────────────────────────────────────┐   │
 │  │ Verify Running ─▶ Reboot EC2 API ─▶ Wait Status OK ─▶ SSH   │   │
 │  │                                                             │   │
@@ -90,7 +111,7 @@ The AWS VM validation tests verify:
                                    │
                                    ▼
 ┌────────────────────────────────────────────────────────────────────┐
-│  3. teardown (TEARDOWN phase)                                      │
+│  4. teardown (TEARDOWN phase)                                      │
 │  ┌─────────────────────────────────────────────────────────────┐   │
 │  │ Terminate Instance ─▶ Delete Key Pair ─▶ Delete SG          │   │
 │  │                                                             │   │
@@ -231,7 +252,20 @@ commands:
           - "{{region}}"
         timeout: 600
 
-      # Step 2: Reboot instance and validate recovery
+      # Step 2: List instances in VPC and verify target
+      - name: list_instances
+        phase: setup
+        command: "python3 ./stubs/aws/vm/list_instances.py"
+        args:
+          - "--vpc-id"
+          - "{{steps.launch_instance.vpc_id}}"
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 120
+
+      # Step 3: Reboot instance and validate recovery
       - name: reboot_instance
         phase: setup
         command: "python3 ./stubs/aws/vm/reboot_instance.py"
@@ -246,7 +280,7 @@ commands:
           - "{{steps.launch_instance.public_ip}}"
         timeout: 600
 
-      # Step 3: Teardown resources
+      # Step 4: Teardown resources
       - name: teardown
         phase: teardown
         command: "python3 ./stubs/aws/vm/teardown.py"
@@ -271,6 +305,12 @@ tests:
       checks:
         - InstanceStateCheck:
             expected_state: "running"
+
+    list_instances:
+      step: list_instances
+      checks:
+        - InstanceListCheck:
+            min_count: 1
 
     ssh:
       step: launch_instance
@@ -370,6 +410,7 @@ tests:
 | Validation | Category | Description |
 |------------|----------|-------------|
 | `InstanceStateCheck` | setup_checks, reboot_state | Verify instance is in expected state (running) |
+| `InstanceListCheck` | list_instances | Verify instances exist in VPC and target instance is present |
 | `SshConnectivityCheck` | ssh, reboot_ssh | Test SSH connectivity and command execution |
 | `SshOsCheck` | ssh, reboot_ssh | Verify OS type (ubuntu, etc.) |
 | `SshGpuCheck` | gpu, reboot_gpu | Verify GPU visibility via nvidia-smi |
@@ -666,6 +707,37 @@ uv run isvctl test run -f isvctl/configs/aws-vm.yaml -v -- -v -s
   "ssh_user": "ubuntu"
 }
 ```
+
+### list_instances.py Output
+
+```json
+{
+  "success": true,
+  "platform": "vm",
+  "instances": [
+    {
+      "instance_id": "i-0abc123def456",
+      "instance_type": "g5.xlarge",
+      "state": "running",
+      "public_ip": "54.1.2.3",
+      "private_ip": "172.31.1.5",
+      "vpc_id": "vpc-0abc123"
+    }
+  ],
+  "count": 1,
+  "found_target": true,
+  "target_instance": "i-0abc123def456"
+}
+```
+
+**Key fields for validations:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `instances` | array | List of non-terminated instances in the VPC |
+| `count` | int | Number of instances returned |
+| `found_target` | bool | Whether the target instance ID was found in the list |
+| `target_instance` | string | The instance ID that was searched for |
 
 ### reboot_instance.py Output
 

--- a/isvctl/configs/stubs/aws/vm/list_instances.py
+++ b/isvctl/configs/stubs/aws/vm/list_instances.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""List EC2 instances in a VPC.
+
+Usage:
+    python list_instances.py --vpc-id vpc-xxx --region us-west-2
+    python list_instances.py --vpc-id vpc-xxx --instance-id i-xxx
+
+Output JSON:
+{
+    "success": true,
+    "platform": "vm",
+    "instances": [
+        {
+            "instance_id": "i-xxx",
+            "instance_type": "g5.xlarge",
+            "state": "running",
+            "public_ip": "54.x.x.x",
+            "private_ip": "10.0.1.5",
+            "vpc_id": "vpc-xxx"
+        }
+    ],
+    "count": 1,
+    "found_target": true,
+    "target_instance": "i-xxx"
+}
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="List EC2 instances in a VPC")
+    parser.add_argument("--vpc-id", required=True, help="VPC ID to list instances for")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--instance-id", help="Target instance ID to verify exists in list")
+    args = parser.parse_args()
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "vm",
+        "instances": [],
+    }
+
+    try:
+        response = ec2.describe_instances(
+            Filters=[
+                {"Name": "vpc-id", "Values": [args.vpc_id]},
+            ]
+        )
+
+        for reservation in response.get("Reservations", []):
+            for instance in reservation.get("Instances", []):
+                state = instance["State"]["Name"]
+                if state == "terminated":
+                    continue
+                result["instances"].append(
+                    {
+                        "instance_id": instance["InstanceId"],
+                        "instance_type": instance.get("InstanceType", "unknown"),
+                        "state": state,
+                        "public_ip": instance.get("PublicIpAddress"),
+                        "private_ip": instance.get("PrivateIpAddress"),
+                        "vpc_id": instance.get("VpcId"),
+                    }
+                )
+
+        result["count"] = len(result["instances"])
+
+        if args.instance_id:
+            result["target_instance"] = args.instance_id
+            result["found_target"] = any(i["instance_id"] == args.instance_id for i in result["instances"])
+
+        result["success"] = True
+
+    except ClientError as e:
+        result["error"] = str(e)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/common/deploy_nim.py
+++ b/isvctl/configs/stubs/common/deploy_nim.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Deploy a NIM inference container on a remote host via SSH.
+
+Pulls and runs the NIM container with GPU support, waits for the health
+endpoint, and outputs connection details as JSON.
+
+Usage:
+    python deploy_nim.py --host 54.1.2.3 --key-file /tmp/key.pem
+    python deploy_nim.py --host 54.1.2.3 --key-file /tmp/key.pem --model meta/llama-3.2-1b-instruct
+    python deploy_nim.py --host 54.1.2.3 --key-file /tmp/key.pem --port 8000 --timeout 600
+
+Output JSON:
+{
+    "success": true,
+    "platform": "vm",
+    "container_id": "abc123...",
+    "container_name": "isv-nim",
+    "model": "meta/llama-3.2-3b-instruct",
+    "image": "nvcr.io/nim/meta/llama-3.2-3b-instruct:latest",
+    "endpoint": "http://localhost:8000",
+    "port": 8000,
+    "health_ready": true,
+    "host": "54.1.2.3",
+    "key_file": "/tmp/key.pem",
+    "ssh_user": "ubuntu"
+}
+
+Requires: paramiko
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Any
+
+import paramiko
+
+
+def ssh_connect(host: str, user: str, key_file: str) -> paramiko.SSHClient:
+    """Create SSH connection to remote host."""
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    client.connect(
+        hostname=host,
+        username=user,
+        key_filename=key_file,
+        timeout=30,
+        allow_agent=False,
+        look_for_keys=False,
+    )
+    return client
+
+
+def run_cmd(ssh: paramiko.SSHClient, command: str, timeout: int = 120) -> tuple[int, str, str]:
+    """Execute command via SSH and return (exit_code, stdout, stderr)."""
+    _, stdout, stderr = ssh.exec_command(command, timeout=timeout)
+    exit_code = stdout.channel.recv_exit_status()
+    return exit_code, stdout.read().decode(), stderr.read().decode()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Deploy NIM container on remote host")
+    parser.add_argument("--host", required=True, help="Remote host IP/hostname")
+    parser.add_argument("--key-file", required=True, help="SSH private key path")
+    parser.add_argument("--user", default="ubuntu", help="SSH username")
+    parser.add_argument("--model", default="meta/llama-3.2-1b-instruct", help="NIM model name")
+    parser.add_argument("--tag", default="latest", help="Container image tag")
+    parser.add_argument("--port", type=int, default=8000, help="Host port to expose NIM on")
+    parser.add_argument("--container-name", default="isv-nim", help="Docker container name")
+    parser.add_argument(
+        "--ngc-api-key",
+        default=os.environ.get("NGC_NIM_API_KEY", ""),
+        help="NGC API key for pulling NIM images",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="Seconds to wait for NIM health endpoint",
+    )
+    args = parser.parse_args()
+
+    image = f"nvcr.io/nim/{args.model}:{args.tag}"
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "vm",
+        "skipped": False,
+        "container_id": None,
+        "container_name": args.container_name,
+        "model": args.model,
+        "image": image,
+        "endpoint": f"http://localhost:{args.port}",
+        "port": args.port,
+        "health_ready": False,
+        "host": args.host,
+        "key_file": args.key_file,
+        "ssh_user": args.user,
+    }
+
+    if not args.ngc_api_key:
+        print("NGC_NIM_API_KEY not set, skipping NIM deployment", file=sys.stderr)
+        result["success"] = True
+        result["skipped"] = True
+        result["skip_reason"] = "NGC_NIM_API_KEY not set"
+        print(json.dumps(result, indent=2))
+        return 0
+
+    try:
+        ssh = ssh_connect(args.host, args.user, args.key_file)
+
+        # Log in to NGC registry
+        if args.ngc_api_key:
+            print("Logging in to NGC registry...", file=sys.stderr)
+            exit_code, _, stderr_out = run_cmd(
+                ssh,
+                f"echo '{args.ngc_api_key}' | docker login nvcr.io -u '$oauthtoken' --password-stdin 2>&1",
+            )
+            if exit_code != 0:
+                result["error"] = f"NGC login failed: {stderr_out}"
+                print(json.dumps(result, indent=2))
+                return 1
+        else:
+            print("Warning: NGC_NIM_API_KEY not set, skipping registry login", file=sys.stderr)
+
+        # Clean up previous containers/images to free disk space
+        run_cmd(ssh, f"docker rm -f {args.container_name} 2>/dev/null || true")
+        run_cmd(ssh, "docker system prune -af 2>/dev/null || true")
+
+        # Launch NIM container
+        print(f"Launching NIM container: {image}", file=sys.stderr)
+        docker_cmd = (
+            f"docker run -d --gpus all"
+            f" --name {args.container_name}"
+            f" -p {args.port}:8000"
+            f" -e NGC_API_KEY='{args.ngc_api_key}'"
+            f" {image}"
+        )
+        exit_code, stdout, stderr_out = run_cmd(ssh, docker_cmd, timeout=1200)
+        if exit_code != 0:
+            result["error"] = f"docker run failed: {stderr_out}"
+            print(json.dumps(result, indent=2))
+            return 1
+
+        container_id = stdout.strip()[:12]
+        result["container_id"] = container_id
+        print(f"Container started: {container_id}", file=sys.stderr)
+
+        # Poll health endpoint until ready
+        print(f"Waiting for NIM health endpoint (timeout: {args.timeout}s)...", file=sys.stderr)
+        deadline = time.time() + args.timeout
+        poll_interval = 10
+        while time.time() < deadline:
+            exit_code, stdout, _ = run_cmd(
+                ssh,
+                f"curl -sf http://localhost:{args.port}/v1/health/ready 2>/dev/null && echo OK || echo WAIT",
+            )
+            if "OK" in stdout:
+                result["health_ready"] = True
+                print("NIM is ready.", file=sys.stderr)
+                break
+            # Check container is still running
+            exit_code, stdout, _ = run_cmd(ssh, f"docker inspect -f '{{{{.State.Running}}}}' {args.container_name}")
+            if stdout.strip() != "true":
+                _, logs, _ = run_cmd(ssh, f"docker logs --tail 30 {args.container_name} 2>&1")
+                result["error"] = f"Container exited unexpectedly. Logs:\n{logs}"
+                print(json.dumps(result, indent=2))
+                return 1
+            time.sleep(poll_interval)
+        else:
+            _, logs, _ = run_cmd(ssh, f"docker logs --tail 30 {args.container_name} 2>&1")
+            result["error"] = f"Health endpoint not ready after {args.timeout}s. Logs:\n{logs}"
+            print(json.dumps(result, indent=2))
+            return 1
+
+        result["success"] = True
+        ssh.close()
+
+    except Exception as e:
+        result["error"] = str(e)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/common/deploy_nim.py
+++ b/isvctl/configs/stubs/common/deploy_nim.py
@@ -108,22 +108,20 @@ def main() -> int:
         print(json.dumps(result, indent=2))
         return 0
 
+    ssh = None
     try:
         ssh = ssh_connect(args.host, args.user, args.key_file)
 
         # Log in to NGC registry
-        if args.ngc_api_key:
-            print("Logging in to NGC registry...", file=sys.stderr)
-            exit_code, _, stderr_out = run_cmd(
-                ssh,
-                f"echo '{args.ngc_api_key}' | docker login nvcr.io -u '$oauthtoken' --password-stdin 2>&1",
-            )
-            if exit_code != 0:
-                result["error"] = f"NGC login failed: {stderr_out}"
-                print(json.dumps(result, indent=2))
-                return 1
-        else:
-            print("Warning: NGC_NIM_API_KEY not set, skipping registry login", file=sys.stderr)
+        print("Logging in to NGC registry...", file=sys.stderr)
+        exit_code, _, stderr_out = run_cmd(
+            ssh,
+            f"echo '{args.ngc_api_key}' | docker login nvcr.io -u '$oauthtoken' --password-stdin 2>&1",
+        )
+        if exit_code != 0:
+            result["error"] = f"NGC login failed: {stderr_out}"
+            print(json.dumps(result, indent=2))
+            return 1
 
         # Clean up previous containers/images to free disk space
         run_cmd(ssh, f"docker rm -f {args.container_name} 2>/dev/null || true")
@@ -176,10 +174,12 @@ def main() -> int:
             return 1
 
         result["success"] = True
-        ssh.close()
 
     except Exception as e:
         result["error"] = str(e)
+    finally:
+        if ssh:
+            ssh.close()
 
     print(json.dumps(result, indent=2))
     return 0 if result["success"] else 1

--- a/isvctl/configs/stubs/common/teardown_nim.py
+++ b/isvctl/configs/stubs/common/teardown_nim.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Tear down a NIM inference container on a remote host via SSH.
+
+Stops and removes the NIM container, optionally removes the image.
+
+Usage:
+    python teardown_nim.py --host 54.1.2.3 --key-file /tmp/key.pem
+    python teardown_nim.py --host 54.1.2.3 --key-file /tmp/key.pem --remove-image
+
+Output JSON:
+{
+    "success": true,
+    "platform": "vm",
+    "container_removed": true,
+    "image_removed": false,
+    "container_name": "isv-nim"
+}
+
+Requires: paramiko
+"""
+
+import argparse
+import json
+import sys
+from typing import Any
+
+import paramiko
+
+
+def ssh_connect(host: str, user: str, key_file: str) -> paramiko.SSHClient:
+    """Create SSH connection to remote host."""
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    client.connect(
+        hostname=host,
+        username=user,
+        key_filename=key_file,
+        timeout=30,
+        allow_agent=False,
+        look_for_keys=False,
+    )
+    return client
+
+
+def run_cmd(ssh: paramiko.SSHClient, command: str, timeout: int = 60) -> tuple[int, str, str]:
+    """Execute command via SSH and return (exit_code, stdout, stderr)."""
+    _, stdout, stderr = ssh.exec_command(command, timeout=timeout)
+    exit_code = stdout.channel.recv_exit_status()
+    return exit_code, stdout.read().decode(), stderr.read().decode()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Tear down NIM container on remote host")
+    parser.add_argument("--host", required=True, help="Remote host IP/hostname")
+    parser.add_argument("--key-file", required=True, help="SSH private key path")
+    parser.add_argument("--user", default="ubuntu", help="SSH username")
+    parser.add_argument("--container-name", default="isv-nim", help="Docker container name")
+    parser.add_argument("--remove-image", action="store_true", help="Also remove the container image")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "vm",
+        "container_removed": False,
+        "image_removed": False,
+        "container_name": args.container_name,
+    }
+
+    try:
+        ssh = ssh_connect(args.host, args.user, args.key_file)
+
+        # Get image name before removing container (for optional image removal)
+        image_name = None
+        if args.remove_image:
+            exit_code, stdout, _ = run_cmd(
+                ssh, f"docker inspect -f '{{{{.Config.Image}}}}' {args.container_name} 2>/dev/null"
+            )
+            if exit_code == 0:
+                image_name = stdout.strip()
+
+        # Stop and remove container
+        print(f"Stopping container: {args.container_name}", file=sys.stderr)
+        exit_code, _, stderr_out = run_cmd(ssh, f"docker rm -f {args.container_name} 2>&1")
+        result["container_removed"] = exit_code == 0 or "No such container" in stderr_out
+
+        # Optionally remove image
+        if args.remove_image and image_name:
+            print(f"Removing image: {image_name}", file=sys.stderr)
+            exit_code, _, _ = run_cmd(ssh, f"docker rmi {image_name} 2>&1", timeout=120)
+            result["image_removed"] = exit_code == 0
+
+        result["success"] = result["container_removed"]
+        ssh.close()
+
+    except Exception as e:
+        result["error"] = str(e)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/common/teardown_nim.py
+++ b/isvctl/configs/stubs/common/teardown_nim.py
@@ -66,31 +66,35 @@ def main() -> int:
         "container_name": args.container_name,
     }
 
+    ssh = None
     try:
         ssh = ssh_connect(args.host, args.user, args.key_file)
 
-        # Get image name before removing container (for optional image removal)
-        image_name = None
-        if args.remove_image:
-            exit_code, stdout, _ = run_cmd(
-                ssh, f"docker inspect -f '{{{{.Config.Image}}}}' {args.container_name} 2>/dev/null"
-            )
-            if exit_code == 0:
-                image_name = stdout.strip()
+        try:
+            # Get image name before removing container (for optional image removal)
+            image_name = None
+            if args.remove_image:
+                exit_code, stdout, _ = run_cmd(
+                    ssh, f"docker inspect -f '{{{{.Config.Image}}}}' {args.container_name} 2>/dev/null"
+                )
+                if exit_code == 0:
+                    image_name = stdout.strip()
 
-        # Stop and remove container
-        print(f"Stopping container: {args.container_name}", file=sys.stderr)
-        exit_code, _, stderr_out = run_cmd(ssh, f"docker rm -f {args.container_name} 2>&1")
-        result["container_removed"] = exit_code == 0 or "No such container" in stderr_out
+            # Stop and remove container
+            print(f"Stopping container: {args.container_name}", file=sys.stderr)
+            exit_code, _, stderr_out = run_cmd(ssh, f"docker rm -f {args.container_name} 2>&1")
+            result["container_removed"] = exit_code == 0 or "No such container" in stderr_out
 
-        # Optionally remove image
-        if args.remove_image and image_name:
-            print(f"Removing image: {image_name}", file=sys.stderr)
-            exit_code, _, _ = run_cmd(ssh, f"docker rmi {image_name} 2>&1", timeout=120)
-            result["image_removed"] = exit_code == 0
+            # Optionally remove image
+            if args.remove_image and image_name:
+                print(f"Removing image: {image_name}", file=sys.stderr)
+                exit_code, _, _ = run_cmd(ssh, f"docker rmi {image_name} 2>&1", timeout=120)
+                result["image_removed"] = exit_code == 0
 
-        result["success"] = result["container_removed"]
-        ssh.close()
+            result["success"] = result["container_removed"]
+        finally:
+            if ssh is not None and hasattr(ssh, "close"):
+                ssh.close()
 
     except Exception as e:
         result["error"] = str(e)

--- a/isvctl/src/isvctl/cli/test.py
+++ b/isvctl/src/isvctl/cli/test.py
@@ -367,14 +367,15 @@ def run(
                     # Handle case where name might be a dict (extract class name)
                     if isinstance(vr_name, dict):
                         vr_name = next(iter(vr_name.keys()), "unknown")
-                    vr_passed = vr.get("passed", False)
                     vr_message = vr.get("message", "")
                     vr_category = vr.get("category", "")
-                    if vr_passed:
+                    category_prefix = f"[{vr_category}] " if vr_category else ""
+                    if vr.get("skipped"):
+                        vr_status = typer.style("SKIPPED", fg=typer.colors.YELLOW)
+                    elif vr.get("passed", False):
                         vr_status = typer.style("PASSED", fg=typer.colors.GREEN)
                     else:
                         vr_status = typer.style("FAILED", fg=typer.colors.RED)
-                    category_prefix = f"[{vr_category}] " if vr_category else ""
                     typer.echo(f"  {category_prefix}{vr_name}: {vr_status} - {vr_message}")
 
     typer.echo("-" * 60)

--- a/isvctl/src/isvctl/config/output_schemas.py
+++ b/isvctl/src/isvctl/config/output_schemas.py
@@ -50,6 +50,10 @@ STEP_SCHEMA_MAPPING: dict[str, str | None] = {
     "run_test": "workload_result",
     "run_benchmark": "workload_result",
     "execute_workload": "workload_result",
+    # NIM deployment -> "nim_deploy" schema
+    "deploy_nim": "nim_deploy",
+    # NIM teardown -> "teardown" schema
+    "teardown_nim": "teardown",
     # Teardown operations -> "teardown" schema
     "teardown": "teardown",
     "cleanup": "teardown",
@@ -189,6 +193,24 @@ OUTPUT_SCHEMAS: dict[str, dict[str, Any]] = {
             "count": {"type": "integer", "description": "Number of instances"},
             "found_target": {"type": "boolean", "description": "Target instance was found"},
             "target_instance": {"type": "string", "description": "Target instance ID searched for"},
+        },
+        "additionalProperties": True,
+    },
+    "nim_deploy": {
+        "type": "object",
+        "required": ["success", "platform"],
+        "properties": {
+            **COMMON_PROPERTIES,
+            "container_id": {"type": ["string", "null"], "description": "Docker container ID"},
+            "container_name": {"type": "string", "description": "Docker container name"},
+            "model": {"type": "string", "description": "NIM model name"},
+            "image": {"type": "string", "description": "Container image used"},
+            "endpoint": {"type": "string", "description": "NIM endpoint URL"},
+            "port": {"type": "integer", "description": "Host port NIM is exposed on"},
+            "health_ready": {"type": "boolean", "description": "Whether health check passed"},
+            "host": {"type": "string", "description": "Remote host IP"},
+            "key_file": {"type": "string", "description": "SSH key file path"},
+            "ssh_user": {"type": "string", "description": "SSH username"},
         },
         "additionalProperties": True,
     },

--- a/isvctl/src/isvctl/config/output_schemas.py
+++ b/isvctl/src/isvctl/config/output_schemas.py
@@ -39,6 +39,8 @@ STEP_SCHEMA_MAPPING: dict[str, str | None] = {
     "create_instance": "instance",
     "provision_vm": "instance",
     "create_vm": "instance",
+    # Instance list operations -> "instance_list" schema
+    "list_instances": "instance_list",
     # GPU setup -> "gpu_setup" schema
     "install_gpu_operator": "gpu_setup",
     "setup_gpu": "gpu_setup",
@@ -161,6 +163,32 @@ OUTPUT_SCHEMAS: dict[str, dict[str, Any]] = {
             "instance_type": {"type": "string", "description": "Instance type/size"},
             "ssh_user": {"type": "string", "description": "SSH username"},
             "ssh_key_path": {"type": "string", "description": "Path to SSH private key"},
+        },
+        "additionalProperties": True,
+    },
+    "instance_list": {
+        "type": "object",
+        "required": ["success", "platform"],
+        "properties": {
+            **COMMON_PROPERTIES,
+            "instances": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "instance_id": {"type": "string"},
+                        "instance_type": {"type": "string"},
+                        "state": {"type": "string"},
+                        "public_ip": {"type": ["string", "null"]},
+                        "private_ip": {"type": ["string", "null"]},
+                        "vpc_id": {"type": "string"},
+                    },
+                },
+                "description": "List of instances in the VPC",
+            },
+            "count": {"type": "integer", "description": "Number of instances"},
+            "found_target": {"type": "boolean", "description": "Target instance was found"},
+            "target_instance": {"type": "string", "description": "Target instance ID searched for"},
         },
         "additionalProperties": True,
     },

--- a/isvctl/src/isvctl/config/schema.py
+++ b/isvctl/src/isvctl/config/schema.py
@@ -98,7 +98,7 @@ class PlatformCommands(BaseModel):
     Example:
        ```yaml
        network:
-         phases: ["setup", "teardown"]  # Defines execution order
+         phases: ["setup", "test", "teardown"]  # Defines execution order
          steps:
            - name: create_vpc
              phase: setup

--- a/isvtest/src/isvtest/tests/test_validations.py
+++ b/isvtest/src/isvtest/tests/test_validations.py
@@ -221,20 +221,31 @@ def test_validation(
     # Inject subtests fixture for nested test reporting
     validation._subtests = subtests
 
-    # Run the validation
-    result = validation.execute()
-
-    # Store result in memory for isvctl to retrieve after pytest completes
-    # Get category from validation_config (set by run_validations_via_pytest)
+    # Run the validation, capturing skips so they appear in the orchestration summary
     category = validation_config.get("_category", "")
+    try:
+        result = validation.execute()
+    except pytest.skip.Exception as exc:
+        skip_reason = str(exc)
+        _validation_results.append(
+            {
+                "name": validation_name,
+                "passed": True,
+                "skipped": True,
+                "message": skip_reason,
+                "category": category,
+            }
+        )
+        raise
+
     _validation_results.append(
         {
             "name": validation_name,
             "passed": result["passed"],
+            "skipped": False,
             "message": result["output"] if result["passed"] else result["error"],
             "category": category,
         }
     )
 
-    # Assert success
     assert result["passed"], f"Validation failed: {result['error']}\nOutput: {result['output']}"

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -33,6 +33,7 @@ from isvtest.validations.iam import (
 )
 from isvtest.validations.instance import (
     InstanceCreatedCheck,
+    InstanceListCheck,
     InstanceStateCheck,
 )
 from isvtest.validations.network import (
@@ -55,6 +56,7 @@ __all__ = [
     "FieldValueCheck",
     "GpuOperatorInstalledCheck",
     "InstanceCreatedCheck",
+    "InstanceListCheck",
     "InstanceStateCheck",
     "NetworkConnectivityCheck",
     "NetworkProvisionedCheck",

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -45,6 +45,11 @@ from isvtest.validations.network import (
     VpcCrudCheck,
     VpcIsolationCheck,
 )
+from isvtest.validations.nim import (
+    SshNimHealthCheck,
+    SshNimInferenceCheck,
+    SshNimModelCheck,
+)
 
 __all__ = [
     "AccessKeyAuthenticatedCheck",
@@ -64,6 +69,9 @@ __all__ = [
     "PerformanceCheck",
     "SchemaValidation",
     "SecurityBlockingCheck",
+    "SshNimHealthCheck",
+    "SshNimInferenceCheck",
+    "SshNimModelCheck",
     "StepSuccessCheck",
     "SubnetConfigCheck",
     "TenantCreatedCheck",

--- a/isvtest/src/isvtest/validations/instance.py
+++ b/isvtest/src/isvtest/validations/instance.py
@@ -144,3 +144,62 @@ class InstanceCreatedCheck(BaseValidation):
         self.set_passed(
             f"Instance {instance_id} created: type={instance_type}, public={public_ip}, private={private_ip}"
         )
+
+
+class InstanceListCheck(BaseValidation):
+    """Validate instance list from a VPC.
+
+    Checks that the instances list exists, is non-empty (or meets min_count),
+    validates required fields on each instance, and optionally verifies that
+    a target instance appears in the list.
+
+    Config:
+        step_output: The step output to check
+        min_count: Minimum number of instances expected (default: 1)
+
+    Step output:
+        instances: List of instance dicts
+        count: Number of instances
+        found_target: Whether target instance was found
+        target_instance: Target instance ID searched for
+    """
+
+    description: ClassVar[str] = "Check instance list from VPC"
+    markers: ClassVar[list[str]] = ["vm"]
+
+    REQUIRED_FIELDS = ("instance_id", "state", "vpc_id")
+
+    def run(self) -> None:
+        step_output = self.config.get("step_output", {})
+        min_count = self.config.get("min_count", 1)
+
+        instances = step_output.get("instances")
+        if instances is None:
+            self.set_failed("No 'instances' key in step output")
+            return
+
+        if len(instances) < min_count:
+            self.set_failed(f"Expected at least {min_count} instance(s), got {len(instances)}")
+            return
+
+        # Validate required fields on each instance
+        for i, inst in enumerate(instances):
+            for field in self.REQUIRED_FIELDS:
+                if not inst.get(field):
+                    self.set_failed(f"Instance at index {i} missing required field '{field}'")
+                    return
+
+        # Check target instance if specified
+        found_target = step_output.get("found_target")
+        target = step_output.get("target_instance")
+
+        if found_target is not None and target:
+            if not found_target:
+                self.set_failed(f"Target instance '{target}' not found in list")
+                return
+
+        count = step_output.get("count", len(instances))
+        msg = f"Listed {count} instance(s)"
+        if target and found_target:
+            msg += f", target '{target}' found"
+        self.set_passed(msg)

--- a/isvtest/src/isvtest/validations/nim.py
+++ b/isvtest/src/isvtest/validations/nim.py
@@ -1,0 +1,313 @@
+"""NIM inference validations (platform-agnostic).
+
+SSH-based validations for NIM containers running on any host.
+These work identically on VMaaS, BMaaS, or any SSH-accessible machine
+with a NIM container running.
+
+They consume connection details from step outputs:
+    host: "{{steps.deploy_nim.host}}"
+    key_file: "{{steps.deploy_nim.key_file}}"
+    user: "{{steps.deploy_nim.ssh_user}}"
+    port: "{{steps.deploy_nim.port}}"
+
+Requires paramiko: pip install paramiko
+"""
+
+from __future__ import annotations
+
+import json
+from typing import ClassVar
+
+import pytest
+
+from isvtest.core.ssh import (
+    get_failed_subtests,
+    get_ssh_client,
+    get_ssh_config,
+    run_ssh_command,
+)
+from isvtest.core.validation import BaseValidation
+
+
+def _get_nim_port(config: dict) -> int:
+    """Extract NIM port from config or step output."""
+    return config.get("port") or config.get("step_output", {}).get("port") or 8000
+
+
+def _is_nim_skipped(config: dict) -> str | None:
+    """Return skip reason if NIM deployment was skipped or missing, else None."""
+    step_output = config.get("step_output", {})
+    if step_output.get("skipped"):
+        return step_output.get("skip_reason", "NIM deployment was skipped")
+    if not step_output or not step_output.get("success"):
+        return "NIM deployment did not succeed"
+    return None
+
+
+class SshNimHealthCheck(BaseValidation):
+    """Check NIM container health endpoint via SSH.
+
+    Connects via SSH and curls the NIM /v1/health/ready endpoint.
+
+    Config:
+        host, key_file, user: SSH connection details (or from step_output)
+        port: NIM port on the host (default: 8000)
+    """
+
+    description: ClassVar[str] = "Validates NIM health endpoint"
+    timeout: ClassVar[int] = 120
+    markers: ClassVar[list[str]] = ["ssh", "gpu"]
+
+    def run(self) -> None:
+        skip_reason = _is_nim_skipped(self.config)
+        if skip_reason:
+            pytest.skip(skip_reason)
+
+        try:
+            import paramiko  # noqa: F401
+        except ImportError:
+            self.set_failed("paramiko not installed")
+            return
+
+        ssh_cfg = get_ssh_config(self.config, self.config.get("inventory", {}))
+        host = ssh_cfg["ssh_host"]
+        user = ssh_cfg["ssh_user"]
+        key_path = ssh_cfg["ssh_key_path"]
+        port = _get_nim_port(self.config)
+
+        if not host or not key_path:
+            self.set_failed("Missing host or key_file")
+            return
+
+        try:
+            ssh = get_ssh_client(host, user, key_path)
+
+            exit_code, stdout, _ = run_ssh_command(
+                ssh,
+                f"curl -sf http://localhost:{port}/v1/health/ready 2>/dev/null; echo $?",
+            )
+            healthy = exit_code == 0 and "0" in stdout.strip().split("\n")[-1]
+            self.report_subtest("health_ready", healthy, "NIM healthy" if healthy else "Health endpoint not ready")
+
+            ssh.close()
+
+            if healthy:
+                self.set_passed(f"NIM health check passed on {host}:{port}")
+            else:
+                self.set_failed(f"NIM health endpoint not ready on {host}:{port}")
+
+        except Exception as e:
+            self.set_failed(f"NIM health check failed: {e}")
+
+
+class SshNimInferenceCheck(BaseValidation):
+    """Run NIM inference test via SSH.
+
+    Sends a chat completion request to the NIM container and validates
+    the response contains generated content.
+
+    Config:
+        host, key_file, user: SSH connection details (or from step_output)
+        port: NIM port on the host (default: 8000)
+        prompt: Test prompt (default: "What is CUDA?")
+        model: Model name for the request (optional, auto-detected from /v1/models)
+        max_tokens: Max tokens in response (default: 50)
+    """
+
+    description: ClassVar[str] = "Validates NIM inference via chat completions"
+    timeout: ClassVar[int] = 300
+    markers: ClassVar[list[str]] = ["ssh", "gpu", "workload", "slow"]
+
+    def run(self) -> None:
+        skip_reason = _is_nim_skipped(self.config)
+        if skip_reason:
+            pytest.skip(skip_reason)
+
+        try:
+            import paramiko  # noqa: F401
+        except ImportError:
+            self.set_failed("paramiko not installed")
+            return
+
+        ssh_cfg = get_ssh_config(self.config, self.config.get("inventory", {}))
+        host = ssh_cfg["ssh_host"]
+        user = ssh_cfg["ssh_user"]
+        key_path = ssh_cfg["ssh_key_path"]
+        port = _get_nim_port(self.config)
+        prompt = self.config.get("prompt", "What is CUDA?")
+        max_tokens = self.config.get("max_tokens", 50)
+        model = self.config.get("model") or self.config.get("step_output", {}).get("model")
+
+        if not host or not key_path:
+            self.set_failed("Missing host or key_file")
+            return
+
+        try:
+            ssh = get_ssh_client(host, user, key_path)
+
+            # Auto-detect model name if not provided
+            if not model:
+                exit_code, stdout, _ = run_ssh_command(ssh, f"curl -sf http://localhost:{port}/v1/models 2>/dev/null")
+                if exit_code == 0 and stdout.strip():
+                    try:
+                        models_data = json.loads(stdout)
+                        model_list = models_data.get("data", [])
+                        if model_list:
+                            model = model_list[0].get("id", "")
+                    except json.JSONDecodeError:
+                        pass
+
+            if not model:
+                self.set_failed("Could not determine model name")
+                ssh.close()
+                return
+
+            self.report_subtest("model_detected", True, f"Model: {model}")
+
+            # Send chat completion request
+            payload = json.dumps(
+                {
+                    "model": model,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "max_tokens": max_tokens,
+                }
+            )
+            curl_cmd = (
+                f"curl -sf -X POST http://localhost:{port}/v1/chat/completions"
+                f" -H 'Content-Type: application/json'"
+                f" -d '{payload}'"
+            )
+            exit_code, stdout, stderr = run_ssh_command(ssh, curl_cmd)
+
+            if exit_code != 0 or not stdout.strip():
+                self.set_failed(f"Inference request failed: {stderr}")
+                ssh.close()
+                return
+
+            try:
+                response = json.loads(stdout)
+            except json.JSONDecodeError:
+                self.set_failed(f"Invalid JSON response: {stdout[:200]}")
+                ssh.close()
+                return
+
+            # Validate response structure
+            choices = response.get("choices", [])
+            has_choices = len(choices) > 0
+            self.report_subtest("has_choices", has_choices, f"{len(choices)} choice(s)")
+
+            if not has_choices:
+                self.set_failed("No choices in response")
+                ssh.close()
+                return
+
+            content = choices[0].get("message", {}).get("content", "")
+            has_content = len(content) > 0
+            self.report_subtest("has_content", has_content, f"Response: {content[:80]}...")
+
+            finish_reason = choices[0].get("finish_reason", "")
+            valid_finish = finish_reason in ("stop", "length")
+            self.report_subtest("finish_reason", valid_finish, f"finish_reason={finish_reason}")
+
+            # Check usage stats if present
+            usage = response.get("usage", {})
+            if usage:
+                tokens = usage.get("completion_tokens", 0)
+                self.report_subtest("tokens_generated", tokens > 0, f"{tokens} tokens")
+
+            ssh.close()
+
+            failed = get_failed_subtests(self._subtest_results)
+            if failed:
+                self.set_failed(f"Inference subtests failed: {', '.join(failed)}")
+            else:
+                self.set_passed(f"NIM inference OK on {host}:{port} (model={model})")
+
+        except Exception as e:
+            self.set_failed(f"NIM inference check failed: {e}")
+
+
+class SshNimModelCheck(BaseValidation):
+    """Check NIM /v1/models endpoint via SSH.
+
+    Validates the models endpoint returns at least one model and
+    optionally verifies a specific model name is present.
+
+    Config:
+        host, key_file, user: SSH connection details (or from step_output)
+        port: NIM port on the host (default: 8000)
+        expected_model: Model name substring to look for (optional)
+    """
+
+    description: ClassVar[str] = "Validates NIM model listing"
+    timeout: ClassVar[int] = 120
+    markers: ClassVar[list[str]] = ["ssh", "gpu"]
+
+    def run(self) -> None:
+        skip_reason = _is_nim_skipped(self.config)
+        if skip_reason:
+            pytest.skip(skip_reason)
+
+        try:
+            import paramiko  # noqa: F401
+        except ImportError:
+            self.set_failed("paramiko not installed")
+            return
+
+        ssh_cfg = get_ssh_config(self.config, self.config.get("inventory", {}))
+        host = ssh_cfg["ssh_host"]
+        user = ssh_cfg["ssh_user"]
+        key_path = ssh_cfg["ssh_key_path"]
+        port = _get_nim_port(self.config)
+        expected_model = self.config.get("expected_model")
+
+        if not host or not key_path:
+            self.set_failed("Missing host or key_file")
+            return
+
+        try:
+            ssh = get_ssh_client(host, user, key_path)
+
+            exit_code, stdout, stderr = run_ssh_command(ssh, f"curl -sf http://localhost:{port}/v1/models 2>/dev/null")
+            if exit_code != 0 or not stdout.strip():
+                self.set_failed(f"/v1/models request failed: {stderr}")
+                ssh.close()
+                return
+
+            try:
+                data = json.loads(stdout)
+            except json.JSONDecodeError:
+                self.set_failed(f"Invalid JSON from /v1/models: {stdout[:200]}")
+                ssh.close()
+                return
+
+            models = data.get("data", [])
+            has_models = len(models) > 0
+            self.report_subtest("has_models", has_models, f"{len(models)} model(s)")
+
+            if not has_models:
+                self.set_failed("No models returned")
+                ssh.close()
+                return
+
+            model_ids = [m.get("id", "") for m in models]
+            self.report_subtest("model_list", True, ", ".join(model_ids))
+
+            if expected_model:
+                found = any(expected_model in mid for mid in model_ids)
+                self.report_subtest(
+                    "expected_model",
+                    found,
+                    f"'{expected_model}' {'found' if found else 'not found'} in model list",
+                )
+
+            ssh.close()
+
+            failed = get_failed_subtests(self._subtest_results)
+            if failed:
+                self.set_failed(f"Model check subtests failed: {', '.join(failed)}")
+            else:
+                self.set_passed(f"NIM model check passed ({', '.join(model_ids)})")
+
+        except Exception as e:
+            self.set_failed(f"NIM model check failed: {e}")

--- a/isvtest/src/isvtest/validations/nim.py
+++ b/isvtest/src/isvtest/validations/nim.py
@@ -16,6 +16,7 @@ Requires paramiko: pip install paramiko
 from __future__ import annotations
 
 import json
+import shlex
 from typing import ClassVar
 
 import pytest
@@ -175,7 +176,7 @@ class SshNimInferenceCheck(BaseValidation):
             curl_cmd = (
                 f"curl -sf -X POST http://localhost:{port}/v1/chat/completions"
                 f" -H 'Content-Type: application/json'"
-                f" -d '{payload}'"
+                f" -d {shlex.quote(payload)}"
             )
             exit_code, stdout, stderr = run_ssh_command(ssh, curl_cmd)
 

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -1,10 +1,12 @@
 """Tests for validation module."""
 
-from unittest.mock import MagicMock
+import json
+from unittest.mock import MagicMock, patch
 
 from isvtest.core.runners import CommandResult
 from isvtest.core.validation import BaseValidation
 from isvtest.validations.instance import InstanceListCheck
+from isvtest.validations.nim import SshNimHealthCheck, SshNimInferenceCheck, SshNimModelCheck
 
 
 class ConcreteValidation(BaseValidation):
@@ -309,3 +311,264 @@ class TestInstanceListCheck:
         )
         result = v.execute()
         assert result["passed"] is True
+
+
+def _mock_ssh_run(responses: dict[str, tuple[int, str, str]]):
+    """Create a mock run_ssh_command that returns canned responses by substring match."""
+
+    def _run(ssh: MagicMock, command: str) -> tuple[int, str, str]:
+        for pattern, response in responses.items():
+            if pattern in command:
+                return response
+        return (1, "", "unknown command")
+
+    return _run
+
+
+def _nim_config(extra: dict | None = None) -> dict:
+    """Build a minimal NIM validation config with SSH details."""
+    cfg: dict = {
+        "step_output": {
+            "success": True,
+            "host": "10.0.0.1",
+            "key_file": "/tmp/test.pem",
+            "ssh_user": "ubuntu",
+            "port": 8000,
+        },
+    }
+    if extra:
+        cfg.update(extra)
+    return cfg
+
+
+class TestSshNimHealthCheck:
+    """Tests for SshNimHealthCheck validation."""
+
+    def test_skipped_when_nim_not_deployed(self) -> None:
+        """Test skip when deploy_nim was skipped."""
+        import pytest
+
+        v = SshNimHealthCheck(
+            config={
+                "step_output": {
+                    "skipped": True,
+                    "skip_reason": "NGC_NIM_API_KEY not set",
+                },
+            }
+        )
+        with pytest.raises(pytest.skip.Exception, match="NGC_NIM_API_KEY"):
+            v.execute()
+
+    @patch("isvtest.validations.nim.get_ssh_client")
+    @patch("isvtest.validations.nim.run_ssh_command")
+    def test_healthy(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Test passing when health endpoint returns OK."""
+        mock_ssh.return_value = MagicMock()
+        mock_run.return_value = (0, "\n0", "")
+
+        v = SshNimHealthCheck(config=_nim_config())
+        result = v.execute()
+        assert result["passed"] is True
+        assert "health check passed" in result["output"]
+
+    @patch("isvtest.validations.nim.get_ssh_client")
+    @patch("isvtest.validations.nim.run_ssh_command")
+    def test_unhealthy(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Test failure when health endpoint is not ready."""
+        mock_ssh.return_value = MagicMock()
+        mock_run.return_value = (1, "1", "")
+
+        v = SshNimHealthCheck(config=_nim_config())
+        result = v.execute()
+        assert result["passed"] is False
+        assert "not ready" in result["error"]
+
+    def test_missing_host(self) -> None:
+        """Test failure when host is missing but step succeeded."""
+        v = SshNimHealthCheck(config={"step_output": {"success": True}})
+        result = v.execute()
+        assert result["passed"] is False
+        assert "Missing host" in result["error"]
+
+    def test_skipped_when_step_failed(self) -> None:
+        """Test skip when deploy_nim step output is empty (timed out)."""
+        import pytest
+
+        v = SshNimHealthCheck(config={"step_output": {}})
+        with pytest.raises(pytest.skip.Exception, match="did not succeed"):
+            v.execute()
+
+
+class TestSshNimInferenceCheck:
+    """Tests for SshNimInferenceCheck validation."""
+
+    @patch("isvtest.validations.nim.get_ssh_client")
+    @patch("isvtest.validations.nim.run_ssh_command")
+    def test_successful_inference(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Test passing with valid inference response."""
+        mock_ssh.return_value = MagicMock()
+
+        models_response = json.dumps({"data": [{"id": "meta/llama-3.2-3b-instruct"}]})
+        inference_response = json.dumps(
+            {
+                "choices": [{"message": {"content": "CUDA is a platform..."}, "finish_reason": "stop"}],
+                "usage": {"completion_tokens": 10, "prompt_tokens": 5, "total_tokens": 15},
+            }
+        )
+
+        mock_run.side_effect = _mock_ssh_run(
+            {
+                "/v1/models": (0, models_response, ""),
+                "/v1/chat/completions": (0, inference_response, ""),
+            }
+        )
+
+        v = SshNimInferenceCheck(config=_nim_config())
+        result = v.execute()
+        assert result["passed"] is True
+        assert "inference OK" in result["output"]
+
+    @patch("isvtest.validations.nim.get_ssh_client")
+    @patch("isvtest.validations.nim.run_ssh_command")
+    def test_empty_choices(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Test failure when response has no choices."""
+        mock_ssh.return_value = MagicMock()
+
+        mock_run.side_effect = _mock_ssh_run(
+            {
+                "/v1/models": (0, json.dumps({"data": [{"id": "test-model"}]}), ""),
+                "/v1/chat/completions": (0, json.dumps({"choices": []}), ""),
+            }
+        )
+
+        v = SshNimInferenceCheck(config=_nim_config())
+        result = v.execute()
+        assert result["passed"] is False
+        assert "No choices" in result["error"]
+
+    @patch("isvtest.validations.nim.get_ssh_client")
+    @patch("isvtest.validations.nim.run_ssh_command")
+    def test_no_model_detected(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Test failure when no model can be detected."""
+        mock_ssh.return_value = MagicMock()
+        mock_run.return_value = (1, "", "error")
+
+        v = SshNimInferenceCheck(config=_nim_config())
+        result = v.execute()
+        assert result["passed"] is False
+        assert "Could not determine model" in result["error"]
+
+    @patch("isvtest.validations.nim.get_ssh_client")
+    @patch("isvtest.validations.nim.run_ssh_command")
+    def test_model_from_config(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Test that model can be specified directly in config."""
+        mock_ssh.return_value = MagicMock()
+
+        inference_response = json.dumps(
+            {
+                "choices": [{"message": {"content": "response"}, "finish_reason": "stop"}],
+            }
+        )
+
+        mock_run.side_effect = _mock_ssh_run(
+            {
+                "/v1/chat/completions": (0, inference_response, ""),
+            }
+        )
+
+        v = SshNimInferenceCheck(config=_nim_config({"model": "my-model"}))
+        result = v.execute()
+        assert result["passed"] is True
+
+    @patch("isvtest.validations.nim.get_ssh_client")
+    @patch("isvtest.validations.nim.run_ssh_command")
+    def test_invalid_json_response(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Test failure when inference returns invalid JSON."""
+        mock_ssh.return_value = MagicMock()
+
+        mock_run.side_effect = _mock_ssh_run(
+            {
+                "/v1/models": (0, json.dumps({"data": [{"id": "test-model"}]}), ""),
+                "/v1/chat/completions": (0, "not json", ""),
+            }
+        )
+
+        v = SshNimInferenceCheck(config=_nim_config())
+        result = v.execute()
+        assert result["passed"] is False
+        assert "Invalid JSON" in result["error"]
+
+
+class TestSshNimModelCheck:
+    """Tests for SshNimModelCheck validation."""
+
+    @patch("isvtest.validations.nim.get_ssh_client")
+    @patch("isvtest.validations.nim.run_ssh_command")
+    def test_models_returned(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Test passing when models are returned."""
+        mock_ssh.return_value = MagicMock()
+        mock_run.return_value = (
+            0,
+            json.dumps({"data": [{"id": "meta/llama-3.2-3b-instruct"}]}),
+            "",
+        )
+
+        v = SshNimModelCheck(config=_nim_config())
+        result = v.execute()
+        assert result["passed"] is True
+        assert "llama" in result["output"]
+
+    @patch("isvtest.validations.nim.get_ssh_client")
+    @patch("isvtest.validations.nim.run_ssh_command")
+    def test_no_models(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Test failure when no models are returned."""
+        mock_ssh.return_value = MagicMock()
+        mock_run.return_value = (0, json.dumps({"data": []}), "")
+
+        v = SshNimModelCheck(config=_nim_config())
+        result = v.execute()
+        assert result["passed"] is False
+        assert "No models" in result["error"]
+
+    @patch("isvtest.validations.nim.get_ssh_client")
+    @patch("isvtest.validations.nim.run_ssh_command")
+    def test_expected_model_found(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Test passing when expected model is found."""
+        mock_ssh.return_value = MagicMock()
+        mock_run.return_value = (
+            0,
+            json.dumps({"data": [{"id": "meta/llama-3.2-3b-instruct"}]}),
+            "",
+        )
+
+        v = SshNimModelCheck(config=_nim_config({"expected_model": "llama"}))
+        result = v.execute()
+        assert result["passed"] is True
+
+    @patch("isvtest.validations.nim.get_ssh_client")
+    @patch("isvtest.validations.nim.run_ssh_command")
+    def test_expected_model_not_found(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Test failure when expected model is not found."""
+        mock_ssh.return_value = MagicMock()
+        mock_run.return_value = (
+            0,
+            json.dumps({"data": [{"id": "meta/llama-3.2-3b-instruct"}]}),
+            "",
+        )
+
+        v = SshNimModelCheck(config=_nim_config({"expected_model": "mistral"}))
+        result = v.execute()
+        assert result["passed"] is False
+        assert "expected_model" in result["error"]
+
+    @patch("isvtest.validations.nim.get_ssh_client")
+    @patch("isvtest.validations.nim.run_ssh_command")
+    def test_request_failed(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Test failure when models endpoint is unreachable."""
+        mock_ssh.return_value = MagicMock()
+        mock_run.return_value = (1, "", "connection refused")
+
+        v = SshNimModelCheck(config=_nim_config())
+        result = v.execute()
+        assert result["passed"] is False
+        assert "failed" in result["error"]

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -3,8 +3,17 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from isvtest.core.runners import CommandResult
 from isvtest.core.validation import BaseValidation
+from isvtest.tests.test_validations import (
+    _validation_results,
+    clear_validation_results,
+)
+from isvtest.tests.test_validations import (
+    test_validation as run_validation_entry_point,
+)
 from isvtest.validations.instance import InstanceListCheck
 from isvtest.validations.nim import SshNimHealthCheck, SshNimInferenceCheck, SshNimModelCheck
 
@@ -572,3 +581,61 @@ class TestSshNimModelCheck:
         result = v.execute()
         assert result["passed"] is False
         assert "failed" in result["error"]
+
+
+class TestValidationResultCapture:
+    """Tests that test_validation() captures results in _validation_results.
+
+    Exercises the orchestration integration path: skipped, passed, and failed
+    validations must all appear in the in-memory results list so the
+    ORCHESTRATION RESULTS summary can display them.
+    """
+
+    def setup_method(self) -> None:
+        clear_validation_results()
+
+    def test_skipped_validation_captured(self) -> None:
+        """Skipped validations must appear in _validation_results with skipped=True."""
+        config = {
+            "step_output": {"skipped": True, "skip_reason": "NGC_NIM_API_KEY not set"},
+            "_category": "nim",
+        }
+        subtests = MagicMock()
+
+        with pytest.raises(pytest.skip.Exception):
+            run_validation_entry_point(SshNimHealthCheck, config, "SshNimHealthCheck", subtests)
+
+        assert len(_validation_results) == 1
+        r = _validation_results[0]
+        assert r["name"] == "SshNimHealthCheck"
+        assert r["skipped"] is True
+        assert r["passed"] is True
+        assert r["category"] == "nim"
+        assert "NGC_NIM_API_KEY" in r["message"]
+
+    def test_passed_validation_captured(self) -> None:
+        """Passed validations must appear with skipped=False."""
+        config = {"_category": "test_cat"}
+        subtests = MagicMock()
+
+        run_validation_entry_point(ConcreteValidation, config, "ConcreteValidation", subtests)
+
+        assert len(_validation_results) == 1
+        r = _validation_results[0]
+        assert r["name"] == "ConcreteValidation"
+        assert r["skipped"] is False
+        assert r["passed"] is True
+
+    def test_failed_validation_captured(self) -> None:
+        """Failed validations must appear with passed=False."""
+        config = {"_category": "test_cat"}
+        subtests = MagicMock()
+
+        with pytest.raises(AssertionError):
+            run_validation_entry_point(FailingValidation, config, "FailingValidation", subtests)
+
+        assert len(_validation_results) == 1
+        r = _validation_results[0]
+        assert r["name"] == "FailingValidation"
+        assert r["skipped"] is False
+        assert r["passed"] is False

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 from isvtest.core.runners import CommandResult
 from isvtest.core.validation import BaseValidation
+from isvtest.validations.instance import InstanceListCheck
 
 
 class ConcreteValidation(BaseValidation):
@@ -170,3 +171,141 @@ class TestBaseValidation:
         validation = ConcreteValidation()
         assert validation.log is not None
         assert validation.log.name == "ConcreteValidation"
+
+
+class TestInstanceListCheck:
+    """Tests for InstanceListCheck validation."""
+
+    def _make_instance(
+        self,
+        instance_id: str = "i-abc123",
+        state: str = "running",
+        vpc_id: str = "vpc-111",
+    ) -> dict:
+        return {
+            "instance_id": instance_id,
+            "instance_type": "g5.xlarge",
+            "state": state,
+            "public_ip": "54.0.0.1",
+            "private_ip": "10.0.0.1",
+            "vpc_id": vpc_id,
+        }
+
+    def test_valid_list(self) -> None:
+        """Test passing with a valid instance list."""
+        v = InstanceListCheck(
+            config={
+                "step_output": {
+                    "instances": [self._make_instance()],
+                    "count": 1,
+                },
+            }
+        )
+        result = v.execute()
+        assert result["passed"] is True
+        assert "Listed 1 instance(s)" in result["output"]
+
+    def test_found_target(self) -> None:
+        """Test passing when target instance is found."""
+        v = InstanceListCheck(
+            config={
+                "step_output": {
+                    "instances": [self._make_instance(instance_id="i-target")],
+                    "count": 1,
+                    "found_target": True,
+                    "target_instance": "i-target",
+                },
+            }
+        )
+        result = v.execute()
+        assert result["passed"] is True
+        assert "i-target" in result["output"]
+        assert "found" in result["output"]
+
+    def test_empty_list(self) -> None:
+        """Test failure with an empty instance list."""
+        v = InstanceListCheck(
+            config={
+                "step_output": {
+                    "instances": [],
+                    "count": 0,
+                },
+            }
+        )
+        result = v.execute()
+        assert result["passed"] is False
+        assert "at least 1" in result["error"]
+
+    def test_missing_instances_key(self) -> None:
+        """Test failure when instances key is missing."""
+        v = InstanceListCheck(
+            config={
+                "step_output": {
+                    "count": 0,
+                },
+            }
+        )
+        result = v.execute()
+        assert result["passed"] is False
+        assert "No 'instances' key" in result["error"]
+
+    def test_target_not_found(self) -> None:
+        """Test failure when target instance is not in the list."""
+        v = InstanceListCheck(
+            config={
+                "step_output": {
+                    "instances": [self._make_instance(instance_id="i-other")],
+                    "count": 1,
+                    "found_target": False,
+                    "target_instance": "i-target",
+                },
+            }
+        )
+        result = v.execute()
+        assert result["passed"] is False
+        assert "i-target" in result["error"]
+        assert "not found" in result["error"]
+
+    def test_missing_required_fields(self) -> None:
+        """Test failure when an instance is missing required fields."""
+        v = InstanceListCheck(
+            config={
+                "step_output": {
+                    "instances": [{"instance_type": "g5.xlarge"}],
+                    "count": 1,
+                },
+            }
+        )
+        result = v.execute()
+        assert result["passed"] is False
+        assert "missing required field" in result["error"]
+
+    def test_custom_min_count(self) -> None:
+        """Test failure when instance count is below custom min_count."""
+        v = InstanceListCheck(
+            config={
+                "step_output": {
+                    "instances": [self._make_instance()],
+                    "count": 1,
+                },
+                "min_count": 3,
+            }
+        )
+        result = v.execute()
+        assert result["passed"] is False
+        assert "at least 3" in result["error"]
+
+    def test_custom_min_count_satisfied(self) -> None:
+        """Test passing when custom min_count is satisfied."""
+        instances = [self._make_instance(instance_id=f"i-{i}") for i in range(3)]
+        v = InstanceListCheck(
+            config={
+                "step_output": {
+                    "instances": instances,
+                    "count": 3,
+                },
+                "min_count": 3,
+            }
+        )
+        result = v.execute()
+        assert result["passed"] is True


### PR DESCRIPTION
- Add `list_instances` step and `InstanceListCheck` validation for AWS VM
- Add composable NIM deployment and validation (health, models, inference) via SSH,
  reusable across VMaaS and BMaaS. Skips gracefully when NGC_NIM_API_KEY is not set.
- Fix all configs to use setup/test/teardown phases so teardown always runs
  even when test steps fail, preventing cloud resource leaks
- Streamline aws-vm.md documentation, remove cost sections from all docs

Closes #45
Closes #82