### PR TITLE
feat: add AWS Bare Metal (BMaaS) validation suite

### DIFF
--- a/isvctl/configs/aws-bm.yaml
+++ b/isvctl/configs/aws-bm.yaml
@@ -13,6 +13,18 @@
 # Test validations bind to describe_instance (test phase) so teardown
 # always runs even if tests fail.
 #
+# Dev workflow (reuse existing instance):
+#   # Run 1: launch + test, keep instance alive
+#   AWS_BM_SKIP_TEARDOWN=true uv run isvctl test run -f isvctl/configs/aws-bm.yaml
+#
+#   # Run 2+: reuse instance, iterate on tests
+#   AWS_BM_INSTANCE_ID=i-xxx AWS_BM_KEY_FILE=/tmp/isv-bm-test-key.pem \
+#     AWS_BM_SKIP_TEARDOWN=true uv run isvctl test run -f isvctl/configs/aws-bm.yaml
+#
+#   # Final: teardown
+#   AWS_BM_INSTANCE_ID=i-xxx AWS_BM_KEY_FILE=/tmp/isv-bm-test-key.pem \
+#     uv run isvctl test run -f isvctl/configs/aws-bm.yaml
+#
 # Usage:
 #   uv run isvctl test run -f isvctl/configs/aws-bm.yaml
 
@@ -23,6 +35,7 @@ commands:
     phases: ["setup", "test", "teardown"]
     steps:
       # Launch bare-metal GPU instance (boto3)
+      # Set AWS_BM_INSTANCE_ID + AWS_BM_KEY_FILE to reuse an existing instance
       - name: launch_instance
         phase: setup
         command: "python3 ./stubs/aws/bm/launch_instance.py"
@@ -49,6 +62,7 @@ commands:
         timeout: 120
 
       # Teardown bare-metal instance (boto3)
+      # Set AWS_BM_SKIP_TEARDOWN=true to keep the instance alive
       - name: teardown
         phase: teardown
         command: "python3 ./stubs/aws/bm/teardown.py"
@@ -59,6 +73,7 @@ commands:
           - "{{region}}"
           - "--delete-key-pair"
           - "--delete-security-group"
+          - "{{teardown_flag}}"
         timeout: 1800
 
 tests:
@@ -69,6 +84,7 @@ tests:
   settings:
     region: "us-west-2"
     instance_type: "g4dn.metal"
+    teardown_flag: "{{(env.AWS_BM_SKIP_TEARDOWN == 'true') | ternary('--skip-destroy', '')}}"
 
   validations:
     # Setup phase - only check provisioning succeeded

--- a/isvctl/configs/aws-bm.yaml
+++ b/isvctl/configs/aws-bm.yaml
@@ -223,12 +223,12 @@ tests:
       checks:
         - SshHostSoftwareCheck: {}
 
-    # Test phase: GPU stress workload
-    gpu_workload:
-      step: describe_instance
-      checks:
-        - SshGpuStressCheck:
-            duration: 60
+    # TODO: Add GPU stress test
+    # gpu_workload:
+    #   step: describe_instance
+    #   checks:
+    #     - SshGpuStressCheck:
+    #         duration: 60
 
     # Test phase: reboot validations
     reboot_checks:

--- a/isvctl/configs/aws-bm.yaml
+++ b/isvctl/configs/aws-bm.yaml
@@ -1,0 +1,114 @@
+# AWS Bare Metal (BMaaS) Validation Configuration
+#
+# Architecture:
+#   - Scripts (AWS-specific): launch_instance.py, describe_instance.py, teardown.py (use boto3)
+#   - Validations (platform-agnostic): Defined in tests.validations
+#
+# Steps:
+#   1. launch_instance - boto3: Provisions bare-metal EC2, outputs IP/key (setup)
+#   2. describe_instance - boto3: Describes instance state, passes SSH info (test)
+#   3. teardown - boto3: Terminates bare-metal EC2 (teardown)
+#
+# Validation timing is inferred from step's phase.
+# Test validations bind to describe_instance (test phase) so teardown
+# always runs even if tests fail.
+#
+# Usage:
+#   uv run isvctl test run -f isvctl/configs/aws-bm.yaml
+
+version: "1.0"
+
+commands:
+  bm:
+    phases: ["setup", "test", "teardown"]
+    steps:
+      # Launch bare-metal GPU instance (boto3)
+      - name: launch_instance
+        phase: setup
+        command: "python3 ./stubs/aws/bm/launch_instance.py"
+        args:
+          - "--name"
+          - "isv-bm-test-gpu"
+          - "--instance-type"
+          - "{{instance_type}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 1200
+
+      # Describe instance - test phase anchor for validations (boto3)
+      - name: describe_instance
+        phase: test
+        command: "python3 ./stubs/aws/bm/describe_instance.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+          - "--key-file"
+          - "{{steps.launch_instance.key_file}}"
+        timeout: 120
+
+      # Teardown bare-metal instance (boto3)
+      - name: teardown
+        phase: teardown
+        command: "python3 ./stubs/aws/bm/teardown.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+          - "--delete-key-pair"
+          - "--delete-security-group"
+        timeout: 1800
+
+tests:
+  platform: bm
+  cluster_name: "aws-bm-validation"
+  description: "AWS Bare Metal (BMaaS) validation tests"
+
+  settings:
+    region: "us-west-2"
+    instance_type: "g4dn.metal"
+
+  validations:
+    # Setup phase - only check provisioning succeeded
+    setup_checks:
+      step: launch_instance
+      checks:
+        - InstanceStateCheck:
+            expected_state: "running"
+
+    # Test phase - all validations bind to describe_instance
+    instance_info:
+      step: describe_instance
+      checks:
+        - InstanceStateCheck:
+            expected_state: "running"
+
+    ssh:
+      step: describe_instance
+      checks:
+        - SshConnectivityCheck: {}
+        - SshOsCheck:
+            expected_os: "ubuntu"
+
+    gpu:
+      step: describe_instance
+      checks:
+        - SshGpuCheck:
+            expected_gpus: 8
+
+    host_os:
+      step: describe_instance
+      checks:
+        - SshHostSoftwareCheck: {}
+
+    # Teardown phase
+    teardown_checks:
+      step: teardown
+      checks:
+        - StepSuccessCheck: {}
+
+  exclude:
+    markers:
+      - workload

--- a/isvctl/configs/aws-bm.yaml
+++ b/isvctl/configs/aws-bm.yaml
@@ -2,6 +2,7 @@
 #
 # Architecture:
 #   - Scripts (AWS-specific): launch_instance.py, describe_instance.py, teardown.py (use boto3)
+#   - Scripts (shared): deploy_nim.py, teardown_nim.py (paramiko)
 #   - Validations (platform-agnostic): Defined in tests.validations
 #
 # Steps:
@@ -9,7 +10,9 @@
 #   2. list_instances - Lists instances in VPC, verifies target exists (test)
 #   3. describe_instance - Describes instance state, passes SSH info (test)
 #   4. reboot_instance - Reboots instance, validates recovery (test)
-#   5. teardown - Terminates bare-metal EC2 (teardown)
+#   5. deploy_nim - Deploys NIM container via SSH (test)
+#   6. teardown_nim - Stops NIM container via SSH (teardown)
+#   7. teardown - Terminates bare-metal EC2 (teardown)
 #
 # Validation timing is inferred from step's phase.
 # Test validations bind to test-phase steps so teardown always runs
@@ -92,6 +95,28 @@ commands:
           - "--public-ip"
           - "{{steps.launch_instance.public_ip}}"
         timeout: 1800
+
+      # Deploy NIM container via SSH (shared script)
+      - name: deploy_nim
+        phase: test
+        command: "python3 ./stubs/common/deploy_nim.py"
+        args:
+          - "--host"
+          - "{{steps.launch_instance.public_ip}}"
+          - "--key-file"
+          - "{{steps.launch_instance.key_file}}"
+        timeout: 1800
+
+      # Teardown NIM container via SSH (shared script)
+      - name: teardown_nim
+        phase: teardown
+        command: "python3 ./stubs/common/teardown_nim.py"
+        args:
+          - "--host"
+          - "{{steps.launch_instance.public_ip}}"
+          - "--key-file"
+          - "{{steps.launch_instance.key_file}}"
+        timeout: 120
 
       # Teardown bare-metal instance (boto3)
       # Set AWS_BM_SKIP_TEARDOWN=true to keep the instance alive
@@ -199,12 +224,38 @@ tests:
       checks:
         - SshHostSoftwareCheck: {}
 
-    # Teardown phase
+    # Test phase: NIM inference validations
+    nim_health:
+      step: deploy_nim
+      checks:
+        - SshNimHealthCheck: {}
+
+    nim_models:
+      step: deploy_nim
+      checks:
+        - SshNimModelCheck: {}
+
+    nim_inference:
+      step: deploy_nim
+      checks:
+        - SshNimInferenceCheck:
+            prompt: "What is CUDA?"
+            max_tokens: 50
+
+    # Teardown phase: NIM cleanup
+    nim_teardown:
+      step: teardown_nim
+      checks:
+        - StepSuccessCheck: {}
+
+    # Teardown phase: instance cleanup + sanitization
     teardown_checks:
       step: teardown
       checks:
         - StepSuccessCheck: {}
+        - FieldValueCheck:
+            field: "resources_destroyed"
+            expected: true
 
   exclude:
-    markers:
-      - workload
+    markers: []

--- a/isvctl/configs/aws-bm.yaml
+++ b/isvctl/configs/aws-bm.yaml
@@ -5,13 +5,15 @@
 #   - Validations (platform-agnostic): Defined in tests.validations
 #
 # Steps:
-#   1. launch_instance - boto3: Provisions bare-metal EC2, outputs IP/key (setup)
-#   2. describe_instance - boto3: Describes instance state, passes SSH info (test)
-#   3. teardown - boto3: Terminates bare-metal EC2 (teardown)
+#   1. launch_instance - Provisions bare-metal EC2, outputs IP/key (setup)
+#   2. list_instances - Lists instances in VPC, verifies target exists (test)
+#   3. describe_instance - Describes instance state, passes SSH info (test)
+#   4. reboot_instance - Reboots instance, validates recovery (test)
+#   5. teardown - Terminates bare-metal EC2 (teardown)
 #
 # Validation timing is inferred from step's phase.
-# Test validations bind to describe_instance (test phase) so teardown
-# always runs even if tests fail.
+# Test validations bind to test-phase steps so teardown always runs
+# even if tests fail.
 #
 # Dev workflow (reuse existing instance):
 #   # Run 1: launch + test, keep instance alive
@@ -48,7 +50,21 @@ commands:
           - "{{region}}"
         timeout: 1200
 
-      # Describe instance - test phase anchor for validations (boto3)
+      # List instances in VPC - verifies instance is visible
+      # Reuses VM script (generic EC2 API)
+      - name: list_instances
+        phase: test
+        command: "python3 ./stubs/aws/vm/list_instances.py"
+        args:
+          - "--vpc-id"
+          - "{{steps.launch_instance.vpc_id}}"
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 120
+
+      # Describe instance - test phase anchor for SSH/GPU validations
       - name: describe_instance
         phase: test
         command: "python3 ./stubs/aws/bm/describe_instance.py"
@@ -60,6 +76,22 @@ commands:
           - "--key-file"
           - "{{steps.launch_instance.key_file}}"
         timeout: 120
+
+      # Reboot instance and validate recovery
+      # BM-specific: longer waits for hardware POST/BIOS/OS boot
+      - name: reboot_instance
+        phase: test
+        command: "python3 ./stubs/aws/bm/reboot_instance.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+          - "--key-file"
+          - "{{steps.launch_instance.key_file}}"
+          - "--public-ip"
+          - "{{steps.launch_instance.public_ip}}"
+        timeout: 1800
 
       # Teardown bare-metal instance (boto3)
       # Set AWS_BM_SKIP_TEARDOWN=true to keep the instance alive
@@ -94,13 +126,21 @@ tests:
         - InstanceStateCheck:
             expected_state: "running"
 
-    # Test phase - all validations bind to describe_instance
+    # Test phase: list instances
+    list_instances:
+      step: list_instances
+      checks:
+        - InstanceListCheck:
+            min_count: 1
+
+    # Test phase: instance info
     instance_info:
       step: describe_instance
       checks:
         - InstanceStateCheck:
             expected_state: "running"
 
+    # Test phase: SSH access
     ssh:
       step: describe_instance
       checks:
@@ -108,14 +148,54 @@ tests:
         - SshOsCheck:
             expected_os: "ubuntu"
 
+    # Test phase: GPU hardware
     gpu:
       step: describe_instance
       checks:
         - SshGpuCheck:
             expected_gpus: 8
 
+    # Test phase: host software stack
     host_os:
       step: describe_instance
+      checks:
+        - SshHostSoftwareCheck: {}
+
+    # Test phase: GPU stress workload
+    gpu_workload:
+      step: describe_instance
+      checks:
+        - SshGpuStressCheck:
+            duration: 60
+
+    # Test phase: reboot validations
+    reboot_checks:
+      step: reboot_instance
+      checks:
+        - InstanceRebootCheck:
+            max_uptime: 600
+
+    reboot_state:
+      step: reboot_instance
+      checks:
+        - InstanceStateCheck:
+            expected_state: "running"
+
+    reboot_ssh:
+      step: reboot_instance
+      checks:
+        - SshConnectivityCheck: {}
+        - SshOsCheck:
+            expected_os: "ubuntu"
+
+    reboot_gpu:
+      step: reboot_instance
+      checks:
+        - SshGpuCheck:
+            expected_gpus: 8
+
+    reboot_host_os:
+      step: reboot_instance
       checks:
         - SshHostSoftwareCheck: {}
 

--- a/isvctl/configs/aws-bm.yaml
+++ b/isvctl/configs/aws-bm.yaml
@@ -10,9 +10,11 @@
 #   2. list_instances - Lists instances in VPC, verifies target exists (test)
 #   3. describe_instance - Describes instance state, passes SSH info (test)
 #   4. reboot_instance - Reboots instance, validates recovery (test)
-#   5. deploy_nim - Deploys NIM container via SSH (test)
-#   6. teardown_nim - Stops NIM container via SSH (teardown)
-#   7. teardown - Terminates bare-metal EC2 (teardown)
+#   5. reinstall_instance - Reinstalls OS from stock AMI (test) [DEFERRED: AMI snapshot rotation on metal]
+#   6. deploy_nim - Deploys NIM container via SSH (test)
+#   7. teardown_nim - Stops NIM container via SSH (teardown)
+#   8. teardown - Terminates bare-metal EC2 (teardown)
+#   9. verify_teardown - Confirms instance terminated, resources deleted (teardown)
 #
 # Validation timing is inferred from step's phase.
 # Test validations bind to test-phase steps so teardown always runs
@@ -96,7 +98,27 @@ commands:
           - "{{steps.launch_instance.public_ip}}"
         timeout: 1800
 
+      # DEFERRED: Reinstall instance from stock OS (stop + swap root volume + start)
+      # AWS metal instances don't support CreateReplaceRootVolumeTask, and AMI
+      # snapshots can be rotated by Amazon, causing CreateVolume to fail.
+      # Needs: use latest AMI snapshot instead of original, and don't delete
+      # old volume until new one is attached.
+      # - name: reinstall_instance
+      #   phase: test
+      #   command: "python3 ./stubs/aws/bm/reinstall_instance.py"
+      #   args:
+      #     - "--instance-id"
+      #     - "{{steps.launch_instance.instance_id}}"
+      #     - "--region"
+      #     - "{{region}}"
+      #     - "--key-file"
+      #     - "{{steps.launch_instance.key_file}}"
+      #     - "--public-ip"
+      #     - "{{steps.launch_instance.public_ip}}"
+      #   timeout: 3600
+
       # Deploy NIM container via SSH (shared script)
+      # Requires NGC_NIM_API_KEY env var
       - name: deploy_nim
         phase: test
         command: "python3 ./stubs/common/deploy_nim.py"
@@ -132,6 +154,21 @@ commands:
           - "--delete-security-group"
           - "{{teardown_flag}}"
         timeout: 1800
+
+      # Post-teardown sanitization: verify instance terminated and resources deleted
+      - name: verify_teardown
+        phase: teardown
+        command: "python3 ./stubs/aws/bm/verify_terminated.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+          - "--security-group-id"
+          - "{{steps.launch_instance.security_group_id}}"
+          - "--key-name"
+          - "{{steps.launch_instance.key_name}}"
+        timeout: 120
 
 tests:
   platform: bm
@@ -224,6 +261,26 @@ tests:
       checks:
         - SshHostSoftwareCheck: {}
 
+    # DEFERRED: reinstall validations
+    # reinstall_state:
+    #   step: reinstall_instance
+    #   checks:
+    #     - InstanceStateCheck:
+    #         expected_state: "running"
+    #
+    # reinstall_ssh:
+    #   step: reinstall_instance
+    #   checks:
+    #     - SshConnectivityCheck: {}
+    #     - SshOsCheck:
+    #         expected_os: "ubuntu"
+    #
+    # reinstall_gpu:
+    #   step: reinstall_instance
+    #   checks:
+    #     - SshGpuCheck:
+    #         expected_gpus: 8
+
     # Test phase: NIM inference validations
     nim_health:
       step: deploy_nim
@@ -251,6 +308,12 @@ tests:
     # Teardown phase: instance cleanup
     teardown_checks:
       step: teardown
+      checks:
+        - StepSuccessCheck: {}
+
+    # Teardown phase: sanitization - verify resources actually deleted
+    sanitization:
+      step: verify_teardown
       checks:
         - StepSuccessCheck: {}
 

--- a/isvctl/configs/aws-bm.yaml
+++ b/isvctl/configs/aws-bm.yaml
@@ -248,14 +248,11 @@ tests:
       checks:
         - StepSuccessCheck: {}
 
-    # Teardown phase: instance cleanup + sanitization
+    # Teardown phase: instance cleanup
     teardown_checks:
       step: teardown
       checks:
         - StepSuccessCheck: {}
-        - FieldValueCheck:
-            field: "resources_destroyed"
-            expected: true
 
   exclude:
     markers: []

--- a/isvctl/configs/aws-eks.yaml
+++ b/isvctl/configs/aws-eks.yaml
@@ -118,6 +118,4 @@ tests:
           genai_perf_concurrency: 8
 
   exclude:
-    markers:
-      - slow
-      - workload
+    markers: []

--- a/isvctl/configs/aws-iso.yaml
+++ b/isvctl/configs/aws-iso.yaml
@@ -146,12 +146,12 @@ tests:
     #     - SshGpuCheck:
     #         expected_gpus: 1
 
-    # Optional: GPU stress test (excluded by default)
-    gpu_workload:
-      step: launch_instance
-      checks:
-        - SshGpuStressCheck:
-            duration: 60
+    # TODO: Add GPU stress test
+    # gpu_workload:
+    #   step: launch_instance
+    #   checks:
+    #     - SshGpuStressCheck:
+    #         duration: 60
 
     # Validate teardown succeeded
     teardown_checks:

--- a/isvctl/configs/aws-iso.yaml
+++ b/isvctl/configs/aws-iso.yaml
@@ -160,5 +160,4 @@ tests:
         - StepSuccessCheck: {}
 
   exclude:
-    markers:
-      - workload
+    markers: []

--- a/isvctl/configs/aws-vm.yaml
+++ b/isvctl/configs/aws-vm.yaml
@@ -156,11 +156,12 @@ tests:
             expected_gpus: 1
         - SshHostSoftwareCheck: {}
 
-    gpu_workload:
-      step: launch_instance
-      checks:
-        - SshGpuStressCheck:
-            duration: 60
+    # TODO: Add GPU stress test
+    # gpu_workload:
+    #   step: launch_instance
+    #   checks:
+    #     - SshGpuStressCheck:
+    #         duration: 60
 
     # --- Reboot validations ---
     reboot_checks:

--- a/isvctl/configs/aws-vm.yaml
+++ b/isvctl/configs/aws-vm.yaml
@@ -225,5 +225,4 @@ tests:
         - StepSuccessCheck: {}
 
   exclude:
-    markers:
-      - workload
+    markers: []

--- a/isvctl/configs/stubs/aws/bm/describe_instance.py
+++ b/isvctl/configs/stubs/aws/bm/describe_instance.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Describe a running AWS EC2 bare-metal instance.
+
+Lightweight test-phase step that fetches current instance state and
+passes through SSH connection info. Validations (SSH, GPU, host OS)
+bind to this step so they run in the test phase rather than setup,
+ensuring teardown always runs even if tests fail.
+
+Usage:
+    python describe_instance.py --instance-id i-xxx --region us-west-2 \
+        --key-file /tmp/key.pem
+
+Output JSON:
+{
+    "success": true,
+    "platform": "bm",
+    "instance_id": "i-xxx",
+    "instance_type": "g4dn.metal",
+    "state": "running",
+    "public_ip": "54.x.x.x",
+    "private_ip": "10.0.1.5",
+    "key_file": "/tmp/key.pem",
+    "ssh_user": "ubuntu"
+}
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+def main() -> int:
+    """Describe a bare-metal EC2 instance and return its current state.
+
+    Returns:
+        0 on success, 1 on failure
+    """
+    parser = argparse.ArgumentParser(description="Describe bare-metal EC2 instance")
+    parser.add_argument("--instance-id", required=True, help="EC2 instance ID")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--key-file", required=True, help="Path to SSH private key")
+    parser.add_argument("--ssh-user", default="ubuntu", help="SSH username")
+    args = parser.parse_args()
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "bm",
+        "instance_id": args.instance_id,
+        "region": args.region,
+        "key_file": args.key_file,
+        "ssh_user": args.ssh_user,
+    }
+
+    try:
+        instances = ec2.describe_instances(InstanceIds=[args.instance_id])
+        instance = instances["Reservations"][0]["Instances"][0]
+
+        result["state"] = instance["State"]["Name"]
+        result["instance_type"] = instance.get("InstanceType")
+        result["public_ip"] = instance.get("PublicIpAddress")
+        result["private_ip"] = instance.get("PrivateIpAddress")
+        result["vpc_id"] = instance.get("VpcId")
+        result["subnet_id"] = instance.get("SubnetId")
+        result["availability_zone"] = instance.get("Placement", {}).get("AvailabilityZone")
+        result["launch_time"] = instance.get("LaunchTime", "").isoformat() if instance.get("LaunchTime") else None
+        result["success"] = True
+
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "InvalidInstanceID.NotFound":
+            result["error"] = f"Instance {args.instance_id} not found"
+        else:
+            result["error"] = str(e)
+    except Exception as e:
+        result["error"] = str(e)
+
+    print(json.dumps(result, indent=2, default=str))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/aws/bm/docs/aws-bm.md
+++ b/isvctl/configs/stubs/aws/bm/docs/aws-bm.md
@@ -1,0 +1,146 @@
+# AWS Bare Metal (BMaaS) Validation Guide
+
+Validates AWS EC2 bare-metal GPU instances using the ISV validation framework.
+
+## Overview
+
+The AWS BM validation tests verify:
+
+1. **Instance Lifecycle** - Provisioning, state verification, instance listing, deletion
+2. **SSH Access** - Remote connectivity via SSH
+3. **Host OS Validation** - Kernel, BIOS, NVIDIA drivers
+4. **GPU Tests** - GPU visibility, stress workloads
+5. **Reboot Resilience** - Instance reboot, recovery, full host OS persistence
+6. **NIM Inference** - NIM container deployment, health, model listing, inference
+7. **Sanitization** - Resource cleanup verification after teardown
+
+## Prerequisites
+
+### Required Tools
+
+- AWS CLI v2 (`aws`)
+- Python 3.12+ with boto3, paramiko
+- uv package manager
+
+### AWS Credentials
+
+```bash
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_REGION=us-west-2
+```
+
+### Required IAM Permissions
+
+Same as VM validation. See [AWS VM Guide](../../vm/docs/aws-vm.md) for the full IAM policy.
+
+## Quick Start
+
+```bash
+# Run all tests (provisions g4dn.metal by default)
+uv run isvctl test run -f isvctl/configs/aws-bm.yaml
+
+# Verbose output
+uv run isvctl test run -f isvctl/configs/aws-bm.yaml -- -v -s
+
+# Run only SSH tests
+uv run isvctl test run -f isvctl/configs/aws-bm.yaml -- -k "Ssh"
+
+# Run only reboot validations
+uv run isvctl test run -f isvctl/configs/aws-bm.yaml -- -k "reboot"
+```
+
+## Dev Workflow (Instance Reuse)
+
+Bare-metal instances take ~3 min to provision and ~20 min to terminate.
+For fast iteration during development, you can keep the instance alive
+between runs.
+
+```bash
+# Run 1: launch + test, keep instance alive
+AWS_BM_SKIP_TEARDOWN=true uv run isvctl test run -f isvctl/configs/aws-bm.yaml -- -v -s
+
+# Run 2+: reuse existing instance (get instance ID from run 1 output)
+AWS_BM_INSTANCE_ID=i-xxx AWS_BM_KEY_FILE=/tmp/isv-bm-test-key.pem \
+  AWS_BM_SKIP_TEARDOWN=true uv run isvctl test run -f isvctl/configs/aws-bm.yaml -- -v -s
+
+# Final: teardown (unset skip flag)
+AWS_BM_INSTANCE_ID=i-xxx AWS_BM_KEY_FILE=/tmp/isv-bm-test-key.pem \
+  uv run isvctl test run -f isvctl/configs/aws-bm.yaml -- -v -s
+```
+
+## Settings
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `region` | string | `us-west-2` | AWS region |
+| `instance_type` | string | `g4dn.metal` | Bare-metal instance type |
+
+### Available Bare-Metal GPU Instance Types
+
+| Instance Type | GPUs | GPU Type | vCPUs | Memory |
+|---------------|------|----------|-------|--------|
+| g4dn.metal | 8 | T4 | 96 | 384 GiB |
+| g5g.metal | 2 | T4g | 64 | 128 GiB |
+
+## Test Duration
+
+| Phase | Duration | Description |
+|-------|----------|-------------|
+| Launch Instance | 3-5 min | Create key, SG, launch bare-metal EC2, wait for running |
+| List Instances | ~5s | Verify instance visible in VPC |
+| SSH/GPU/Host OS | ~30s | SSH connectivity, GPU, kernel, drivers |
+| Reboot Instance | 10-20 min | Reboot via API, wait for status checks, SSH |
+| NIM Deploy | 5-15 min | Pull + start NIM container |
+| NIM Validation | ~30s | Health, models, inference |
+| Teardown | 15-25 min | Terminate bare-metal instance, delete resources |
+| **Total** | **35-70 min** | Full test cycle |
+
+## Cost & Cleanup
+
+> **Warning**: These tests create AWS resources (EC2 bare-metal instances,
+> security groups, key pairs) that incur costs. Bare-metal instances are
+> significantly more expensive than regular VMs.
+>
+> Resources are automatically cleaned up during the teardown phase, but if
+> teardown fails or is skipped, you must manually delete them to avoid
+> ongoing charges.
+
+| Resource | Hourly Cost (approx) |
+|----------|---------------------|
+| g4dn.metal | $7.82 |
+| g5g.metal | $2.74 |
+
+### Checking for Orphaned Resources
+
+```bash
+# Find instances tagged by isvtest
+aws ec2 describe-instances \
+  --filters "Name=tag:CreatedBy,Values=isvtest" "Name=instance-state-name,Values=running,stopped" \
+  --query 'Reservations[*].Instances[*].[InstanceId,InstanceType,State.Name,Tags[?Key==`Name`].Value|[0]]' \
+  --output table
+
+# Terminate orphaned instances
+aws ec2 terminate-instances --instance-ids i-xxx
+
+# Find orphaned security groups
+aws ec2 describe-security-groups \
+  --filters "Name=group-name,Values=isv-bm-*" \
+  --query 'SecurityGroups[*].[GroupId,GroupName]' --output table
+
+# Delete orphaned security groups
+aws ec2 delete-security-group --group-id sg-xxx
+
+# Delete orphaned key pairs
+aws ec2 describe-key-pairs --filters "Name=key-name,Values=isv-bm-*" --output table
+aws ec2 delete-key-pair --key-name isv-bm-test-key
+```
+
+## Related Documentation
+
+- [AWS VM Validation Guide](../../vm/docs/aws-vm.md) - VM-as-a-Service tests
+- [AWS ISO Import Validation Guide](../../iso/docs/aws-iso.md) - VMDK/VHD import tests
+- [AWS EKS Validation Guide](../../eks/docs/aws-eks.md) - Kubernetes cluster tests
+- [AWS Network Validation Guide](../../network/docs/aws-network.md) - VPC and network tests
+- [Configuration Guide](../../../../../docs/guides/configuration.md) - Config file options
+- [isvctl Documentation](../../../../../docs/packages/isvctl.md) - CLI reference

--- a/isvctl/configs/stubs/aws/bm/docs/aws-bm.md
+++ b/isvctl/configs/stubs/aws/bm/docs/aws-bm.md
@@ -100,16 +100,9 @@ AWS_BM_INSTANCE_ID=i-xxx AWS_BM_KEY_FILE=/tmp/isv-bm-test-key.pem \
 
 > **Warning**: These tests create AWS resources (EC2 bare-metal instances,
 > security groups, key pairs) that incur costs. Bare-metal instances are
-> significantly more expensive than regular VMs.
->
-> Resources are automatically cleaned up during the teardown phase, but if
-> teardown fails or is skipped, you must manually delete them to avoid
-> ongoing charges.
-
-| Resource | Hourly Cost (approx) |
-|----------|---------------------|
-| g4dn.metal | $7.82 |
-| g5g.metal | $2.74 |
+> significantly more expensive than regular VMs. Resources are automatically
+> cleaned up during the teardown phase, but if teardown fails or is skipped,
+> you must manually delete them to avoid ongoing charges.
 
 ### Checking for Orphaned Resources
 

--- a/isvctl/configs/stubs/aws/bm/launch_instance.py
+++ b/isvctl/configs/stubs/aws/bm/launch_instance.py
@@ -2,21 +2,29 @@
 """Launch AWS EC2 bare-metal GPU instance for BMaaS testing.
 
 Similar to the VM launch script but targeted at bare-metal instance types
-(e.g. g5.metal, p4de.24xlarge, p5.48xlarge) which provide direct hardware
+(e.g. g4dn.metal, p4de.24xlarge, p5.48xlarge) which provide direct hardware
 access without a hypervisor.
 
 Reuses shared helpers from common/ec2.py for key pairs, security groups,
 and AZ-aware subnet selection.
 
+Instance reuse (dev workflow):
+    Set AWS_BM_INSTANCE_ID and AWS_BM_KEY_FILE env vars to skip launching
+    and describe an existing instance instead. This allows fast iteration
+    on validations without reprovisioning.
+
 Usage:
-    python launch_instance.py --name isv-bm-test --instance-type g5.metal --region us-west-2
+    python launch_instance.py --name isv-bm-test --instance-type g4dn.metal --region us-west-2
+
+    # Reuse existing instance:
+    AWS_BM_INSTANCE_ID=i-xxx AWS_BM_KEY_FILE=/tmp/key.pem python launch_instance.py
 
 Output JSON:
 {
     "success": true,
     "platform": "bm",
     "instance_id": "i-xxx",
-    "instance_type": "g5.metal",
+    "instance_type": "g4dn.metal",
     "public_ip": "54.x.x.x",
     "private_ip": "10.0.1.5",
     "state": "running",
@@ -94,10 +102,62 @@ def get_bare_metal_ami(ec2: Any, instance_type: str) -> str | None:
     return images[0]["ImageId"] if images else None
 
 
+def reuse_existing_instance(region: str) -> int:
+    """Describe an existing instance instead of launching a new one.
+
+    Used when AWS_BM_INSTANCE_ID and AWS_BM_KEY_FILE are set.
+
+    Args:
+        region: AWS region for the EC2 client.
+
+    Returns:
+        0 on success, 1 on failure
+    """
+    instance_id = os.environ["AWS_BM_INSTANCE_ID"]
+    key_file = os.environ["AWS_BM_KEY_FILE"]
+
+    print(f"Reusing existing instance {instance_id}", file=sys.stderr)
+
+    ec2 = boto3.client("ec2", region_name=region)
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "bm",
+        "instance_id": instance_id,
+        "region": region,
+        "key_file": key_file,
+        "reused": True,
+    }
+
+    try:
+        instances = ec2.describe_instances(InstanceIds=[instance_id])
+        instance = instances["Reservations"][0]["Instances"][0]
+
+        result["state"] = instance["State"]["Name"]
+        result["instance_type"] = instance.get("InstanceType")
+        result["public_ip"] = instance.get("PublicIpAddress")
+        result["private_ip"] = instance.get("PrivateIpAddress")
+        result["vpc_id"] = instance.get("VpcId")
+        result["subnet_id"] = instance.get("SubnetId")
+        result["key_name"] = instance.get("KeyName")
+        result["availability_zone"] = instance.get("Placement", {}).get("AvailabilityZone")
+        result["success"] = result["state"] == "running"
+
+        if not result["success"]:
+            result["error"] = f"Instance {instance_id} is {result['state']}, expected running"
+    except Exception as e:
+        result["error"] = str(e)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
 def main() -> int:
     """Launch a bare-metal GPU EC2 instance for BMaaS testing.
 
-    Creates key pair + security group, selects an appropriate AMI,
+    If AWS_BM_INSTANCE_ID and AWS_BM_KEY_FILE are set, skips launching
+    and describes the existing instance instead (dev workflow).
+
+    Otherwise, creates key pair + security group, selects an appropriate AMI,
     and launches the instance with subnet fallback logic. Waits for
     the instance to pass both running and status-ok checks (bare-metal
     instances take longer to fully boot).
@@ -120,6 +180,10 @@ def main() -> int:
         help="Root volume size in GiB (default: 200, larger for BM workloads)",
     )
     args = parser.parse_args()
+
+    # Reuse existing instance if env vars are set
+    if os.environ.get("AWS_BM_INSTANCE_ID") and os.environ.get("AWS_BM_KEY_FILE"):
+        return reuse_existing_instance(args.region)
 
     ec2 = boto3.client("ec2", region_name=args.region)
 
@@ -233,6 +297,16 @@ def main() -> int:
         result["vpc_id"] = vpc_id
         result["availability_zone"] = instance.get("Placement", {}).get("AvailabilityZone")
         result["success"] = True
+
+        print(
+            f"\n{'=' * 60}\n"
+            f"To reuse this instance on subsequent runs:\n\n"
+            f"  export AWS_BM_INSTANCE_ID={instance_id}\n"
+            f"  export AWS_BM_KEY_FILE={result['key_file']}\n"
+            f"  export AWS_BM_SKIP_TEARDOWN=true\n"
+            f"{'=' * 60}\n",
+            file=sys.stderr,
+        )
 
     except Exception as e:
         result["error"] = str(e)

--- a/isvctl/configs/stubs/aws/bm/launch_instance.py
+++ b/isvctl/configs/stubs/aws/bm/launch_instance.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Launch AWS EC2 bare-metal GPU instance for BMaaS testing.
+
+Similar to the VM launch script but targeted at bare-metal instance types
+(e.g. g5.metal, p4de.24xlarge, p5.48xlarge) which provide direct hardware
+access without a hypervisor.
+
+Reuses shared helpers from common/ec2.py for key pairs, security groups,
+and AZ-aware subnet selection.
+
+Usage:
+    python launch_instance.py --name isv-bm-test --instance-type g5.metal --region us-west-2
+
+Output JSON:
+{
+    "success": true,
+    "platform": "bm",
+    "instance_id": "i-xxx",
+    "instance_type": "g5.metal",
+    "public_ip": "54.x.x.x",
+    "private_ip": "10.0.1.5",
+    "state": "running",
+    "ami_id": "ami-xxx",
+    "key_name": "isv-bm-test-key",
+    "key_file": "/tmp/isv-bm-test-key.pem"
+}
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+
+import boto3
+from botocore.exceptions import ClientError
+from common.ec2 import (
+    create_key_pair,
+    create_security_group,
+    get_architecture_for_instance_type,
+    get_default_vpc_and_subnets,
+)
+
+
+def get_bare_metal_ami(ec2: Any, instance_type: str) -> str | None:
+    """Get appropriate AMI for a bare-metal GPU instance.
+
+    Bare-metal instances need AMIs that boot directly on hardware.
+    Deep Learning AMIs with NVIDIA drivers pre-installed are preferred.
+
+    Args:
+        ec2: boto3 EC2 client
+        instance_type: EC2 instance type (used to detect architecture)
+
+    Returns:
+        AMI ID or None if not found
+    """
+    architecture = get_architecture_for_instance_type(instance_type)
+
+    ami_patterns = [
+        "Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 22.04)*",
+        "Deep Learning Base GPU AMI (Ubuntu 22.04)*",
+        "Deep Learning AMI GPU PyTorch*Ubuntu 22.04*",
+    ]
+    fallback_pattern = (
+        "ubuntu/images/hvm-ssd-gp3/ubuntu-jammy-22.04-arm64-server-*"
+        if architecture == "arm64"
+        else "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
+    )
+
+    for pattern in ami_patterns:
+        response = ec2.describe_images(
+            Owners=["amazon"],
+            Filters=[
+                {"Name": "name", "Values": [pattern]},
+                {"Name": "state", "Values": ["available"]},
+                {"Name": "architecture", "Values": [architecture]},
+            ],
+        )
+        images = sorted(response["Images"], key=lambda x: x["CreationDate"], reverse=True)
+        if images:
+            return images[0]["ImageId"]
+
+    response = ec2.describe_images(
+        Owners=["amazon"],
+        Filters=[
+            {"Name": "name", "Values": [fallback_pattern]},
+            {"Name": "state", "Values": ["available"]},
+        ],
+    )
+    images = sorted(response["Images"], key=lambda x: x["CreationDate"], reverse=True)
+    return images[0]["ImageId"] if images else None
+
+
+def main() -> int:
+    """Launch a bare-metal GPU EC2 instance for BMaaS testing.
+
+    Creates key pair + security group, selects an appropriate AMI,
+    and launches the instance with subnet fallback logic. Waits for
+    the instance to pass both running and status-ok checks (bare-metal
+    instances take longer to fully boot).
+
+    Returns:
+        0 on success, 1 on failure
+    """
+    parser = argparse.ArgumentParser(description="Launch bare-metal GPU instance")
+    parser.add_argument("--name", default="isv-bm-test-gpu", help="Instance name")
+    parser.add_argument("--instance-type", default="g4dn.metal", help="EC2 bare-metal instance type")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--vpc-id", help="VPC ID (uses default if not specified)")
+    parser.add_argument("--subnet-id", help="Subnet ID (uses first subnet if not specified)")
+    parser.add_argument("--ami-id", help="AMI ID (auto-detects GPU AMI if not specified)")
+    parser.add_argument("--key-name", default="isv-bm-test-key", help="EC2 key pair name")
+    parser.add_argument(
+        "--volume-size",
+        type=int,
+        default=200,
+        help="Root volume size in GiB (default: 200, larger for BM workloads)",
+    )
+    args = parser.parse_args()
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "bm",
+        "instance_id": None,
+        "instance_type": args.instance_type,
+        "region": args.region,
+    }
+
+    try:
+        if args.vpc_id and args.subnet_id:
+            vpc_id = args.vpc_id
+            subnet_list = [args.subnet_id]
+        else:
+            vpc_id, subnet_list = get_default_vpc_and_subnets(ec2, args.instance_type)
+
+        key_file = create_key_pair(ec2, args.key_name)
+        result["key_name"] = args.key_name
+        result["key_file"] = key_file
+
+        sg_name = f"{args.name}-sg"
+        sg_id = create_security_group(ec2, vpc_id, sg_name)
+        result["security_group_id"] = sg_id
+
+        architecture = get_architecture_for_instance_type(args.instance_type)
+        result["architecture"] = architecture
+
+        ami_id = args.ami_id or get_bare_metal_ami(ec2, args.instance_type)
+        if not ami_id:
+            raise RuntimeError(f"Could not find suitable {architecture} AMI for bare-metal")
+        result["ami_id"] = ami_id
+
+        ami_info = ec2.describe_images(ImageIds=[ami_id])
+        if ami_info["Images"]:
+            result["ami_name"] = ami_info["Images"][0].get("Name", "unknown")
+            result["ami_architecture"] = ami_info["Images"][0].get("Architecture", "unknown")
+
+        last_error = None
+        instance_id = None
+
+        for subnet_id in subnet_list:
+            try:
+                response = ec2.run_instances(
+                    ImageId=ami_id,
+                    InstanceType=args.instance_type,
+                    MinCount=1,
+                    MaxCount=1,
+                    KeyName=args.key_name,
+                    SubnetId=subnet_id,
+                    SecurityGroupIds=[sg_id],
+                    TagSpecifications=[
+                        {
+                            "ResourceType": "instance",
+                            "Tags": [
+                                {"Key": "Name", "Value": args.name},
+                                {"Key": "Platform", "Value": "bare-metal"},
+                                {"Key": "CreatedBy", "Value": "isvtest"},
+                            ],
+                        }
+                    ],
+                    BlockDeviceMappings=[
+                        {
+                            "DeviceName": "/dev/sda1",
+                            "Ebs": {
+                                "VolumeSize": args.volume_size,
+                                "VolumeType": "gp3",
+                            },
+                        }
+                    ],
+                )
+                instance_id = response["Instances"][0]["InstanceId"]
+                result["subnet_id"] = subnet_id
+                break
+            except ClientError as e:
+                error_code = e.response["Error"]["Code"]
+                if error_code in ("Unsupported", "InsufficientInstanceCapacity"):
+                    last_error = e
+                    continue
+                raise
+
+        if not instance_id:
+            if last_error:
+                raise last_error
+            raise RuntimeError("Failed to launch bare-metal instance in any subnet")
+
+        result["instance_id"] = instance_id
+
+        # Bare-metal instances take longer to boot; use generous waiter config
+        print("Waiting for instance to reach running state...", file=sys.stderr)
+        waiter = ec2.get_waiter("instance_running")
+        waiter.wait(
+            InstanceIds=[instance_id],
+            WaiterConfig={"Delay": 15, "MaxAttempts": 60},
+        )
+
+        print("Waiting for instance status checks (bare-metal takes longer)...", file=sys.stderr)
+        status_waiter = ec2.get_waiter("instance_status_ok")
+        status_waiter.wait(
+            InstanceIds=[instance_id],
+            WaiterConfig={"Delay": 15, "MaxAttempts": 80},
+        )
+
+        instances = ec2.describe_instances(InstanceIds=[instance_id])
+        instance = instances["Reservations"][0]["Instances"][0]
+
+        result["public_ip"] = instance.get("PublicIpAddress")
+        result["private_ip"] = instance.get("PrivateIpAddress")
+        result["state"] = instance["State"]["Name"]
+        result["vpc_id"] = vpc_id
+        result["availability_zone"] = instance.get("Placement", {}).get("AvailabilityZone")
+        result["success"] = True
+
+    except Exception as e:
+        result["error"] = str(e)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/aws/bm/launch_instance.py
+++ b/isvctl/configs/stubs/aws/bm/launch_instance.py
@@ -38,9 +38,10 @@ import argparse
 import json
 import os
 import sys
+from pathlib import Path
 from typing import Any
 
-sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import boto3
 from botocore.exceptions import ClientError
@@ -297,16 +298,6 @@ def main() -> int:
         result["vpc_id"] = vpc_id
         result["availability_zone"] = instance.get("Placement", {}).get("AvailabilityZone")
         result["success"] = True
-
-        print(
-            f"\n{'=' * 60}\n"
-            f"To reuse this instance on subsequent runs:\n\n"
-            f"  export AWS_BM_INSTANCE_ID={instance_id}\n"
-            f"  export AWS_BM_KEY_FILE={result['key_file']}\n"
-            f"  export AWS_BM_SKIP_TEARDOWN=true\n"
-            f"{'=' * 60}\n",
-            file=sys.stderr,
-        )
 
     except Exception as e:
         result["error"] = str(e)

--- a/isvctl/configs/stubs/aws/bm/reboot_instance.py
+++ b/isvctl/configs/stubs/aws/bm/reboot_instance.py
@@ -32,6 +32,8 @@ import sys
 import time
 from typing import Any
 
+import boto3
+
 
 def wait_for_ssh(
     host: str,
@@ -142,8 +144,6 @@ def main() -> int:
         help="Seconds to wait after reboot API call before checking (default: 120)",
     )
     args = parser.parse_args()
-
-    import boto3
 
     ec2 = boto3.client("ec2", region_name=args.region)
 

--- a/isvctl/configs/stubs/aws/bm/reboot_instance.py
+++ b/isvctl/configs/stubs/aws/bm/reboot_instance.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Reboot AWS EC2 bare-metal instance and validate it comes back healthy.
+
+Same logic as the VM reboot script but with longer timeouts appropriate
+for bare-metal instances (hardware POST, BIOS, OS boot without hypervisor).
+
+Usage:
+    python reboot_instance.py --instance-id i-xxx --region us-west-2 \
+        --key-file /tmp/key.pem --public-ip 54.x.x.x
+
+Output JSON:
+{
+    "success": true,
+    "platform": "bm",
+    "instance_id": "i-xxx",
+    "state": "running",
+    "public_ip": "54.x.x.x",
+    "private_ip": "10.0.1.5",
+    "key_file": "/tmp/key.pem",
+    "ssh_user": "ubuntu",
+    "reboot_initiated": true,
+    "uptime_seconds": 45.2,
+    "ssh_ready": true
+}
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+def wait_for_ssh(
+    host: str,
+    user: str,
+    key_file: str,
+    max_attempts: int = 60,
+    interval: int = 15,
+) -> bool:
+    """Wait for SSH to become available on the host.
+
+    Bare-metal instances can take 10-15 min to fully reboot, so defaults
+    are more generous than the VM version (60 attempts x 15s = 15 min).
+
+    Args:
+        host: Public IP or hostname
+        user: SSH username
+        key_file: Path to SSH private key
+        max_attempts: Maximum number of connection attempts
+        interval: Seconds between attempts
+
+    Returns:
+        True if SSH is ready, False if timed out
+    """
+    for attempt in range(1, max_attempts + 1):
+        try:
+            result = subprocess.run(
+                [
+                    "ssh",
+                    "-o",
+                    "StrictHostKeyChecking=no",
+                    "-o",
+                    "ConnectTimeout=5",
+                    "-o",
+                    "BatchMode=yes",
+                    "-i",
+                    key_file,
+                    f"{user}@{host}",
+                    "exit 0",
+                ],
+                capture_output=True,
+                timeout=15,
+            )
+            if result.returncode == 0:
+                print(f"  SSH ready after attempt {attempt}", file=sys.stderr)
+                return True
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+
+        print(f"  Waiting for SSH... (attempt {attempt}/{max_attempts})", file=sys.stderr)
+        time.sleep(interval)
+
+    return False
+
+
+def get_uptime_via_ssh(host: str, user: str, key_file: str) -> float | None:
+    """Get system uptime in seconds via SSH.
+
+    Args:
+        host: Public IP or hostname
+        user: SSH username
+        key_file: Path to SSH private key
+
+    Returns:
+        Uptime in seconds, or None if command failed
+    """
+    try:
+        result = subprocess.run(
+            [
+                "ssh",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "ConnectTimeout=10",
+                "-o",
+                "BatchMode=yes",
+                "-i",
+                key_file,
+                f"{user}@{host}",
+                "cat /proc/uptime | cut -d' ' -f1",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            return float(result.stdout.strip())
+    except (subprocess.TimeoutExpired, ValueError, OSError):
+        pass
+    return None
+
+
+def main() -> int:
+    """Reboot a bare-metal EC2 instance and wait for it to come back healthy.
+
+    Returns:
+        0 on success, 1 on failure
+    """
+    parser = argparse.ArgumentParser(description="Reboot bare-metal EC2 instance")
+    parser.add_argument("--instance-id", required=True, help="EC2 instance ID")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--key-file", required=True, help="Path to SSH private key")
+    parser.add_argument("--public-ip", required=True, help="Instance public IP")
+    parser.add_argument("--ssh-user", default="ubuntu", help="SSH username")
+    parser.add_argument(
+        "--wait-before-check",
+        type=int,
+        default=120,
+        help="Seconds to wait after reboot API call before checking (default: 120)",
+    )
+    args = parser.parse_args()
+
+    import boto3
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "bm",
+        "instance_id": args.instance_id,
+        "region": args.region,
+        "key_file": args.key_file,
+        "ssh_user": args.ssh_user,
+        "reboot_initiated": False,
+        "ssh_ready": False,
+    }
+
+    try:
+        print("Verifying instance is running before reboot...", file=sys.stderr)
+        instances = ec2.describe_instances(InstanceIds=[args.instance_id])
+        instance = instances["Reservations"][0]["Instances"][0]
+        current_state = instance["State"]["Name"]
+
+        if current_state != "running":
+            result["error"] = f"Instance is {current_state}, expected running"
+            result["state"] = current_state
+            print(json.dumps(result, indent=2))
+            return 1
+
+        pre_uptime = get_uptime_via_ssh(args.public_ip, args.ssh_user, args.key_file)
+        if pre_uptime is not None:
+            result["pre_reboot_uptime"] = round(pre_uptime, 1)
+            print(f"  Pre-reboot uptime: {pre_uptime:.0f}s", file=sys.stderr)
+
+        print(f"Rebooting instance {args.instance_id}...", file=sys.stderr)
+        ec2.reboot_instances(InstanceIds=[args.instance_id])
+        result["reboot_initiated"] = True
+        print("  Reboot API call succeeded", file=sys.stderr)
+
+        print(
+            f"Waiting {args.wait_before_check}s for reboot to take effect...",
+            file=sys.stderr,
+        )
+        time.sleep(args.wait_before_check)
+
+        # Bare-metal status checks can take 5-10 min after reboot
+        print("Waiting for instance status checks (bare-metal takes longer)...", file=sys.stderr)
+        waiter = ec2.get_waiter("instance_status_ok")
+        waiter.wait(
+            InstanceIds=[args.instance_id],
+            WaiterConfig={"Delay": 15, "MaxAttempts": 60},
+        )
+        print("  Instance status checks passed", file=sys.stderr)
+
+        instances = ec2.describe_instances(InstanceIds=[args.instance_id])
+        instance = instances["Reservations"][0]["Instances"][0]
+
+        result["state"] = instance["State"]["Name"]
+        result["public_ip"] = instance.get("PublicIpAddress")
+        result["private_ip"] = instance.get("PrivateIpAddress")
+
+        public_ip = result["public_ip"] or args.public_ip
+
+        print("Waiting for SSH to be ready after reboot...", file=sys.stderr)
+        ssh_ready = wait_for_ssh(public_ip, args.ssh_user, args.key_file)
+        result["ssh_ready"] = ssh_ready
+
+        if not ssh_ready:
+            result["error"] = "SSH not ready after reboot"
+            print("WARNING: SSH did not become ready after reboot", file=sys.stderr)
+            print(json.dumps(result, indent=2))
+            return 1
+
+        post_uptime = get_uptime_via_ssh(public_ip, args.ssh_user, args.key_file)
+        if post_uptime is not None:
+            result["uptime_seconds"] = round(post_uptime, 1)
+            print(f"  Post-reboot uptime: {post_uptime:.0f}s", file=sys.stderr)
+
+            if pre_uptime is not None and post_uptime < pre_uptime:
+                result["reboot_confirmed"] = True
+                print("  Reboot confirmed (uptime reset)", file=sys.stderr)
+            elif pre_uptime is not None:
+                result["reboot_confirmed"] = False
+                print(
+                    f"  WARNING: Uptime did not decrease (pre={pre_uptime:.0f}s, post={post_uptime:.0f}s)",
+                    file=sys.stderr,
+                )
+            else:
+                result["reboot_confirmed"] = post_uptime < 600
+                print(
+                    f"  Reboot likely confirmed (uptime={post_uptime:.0f}s)",
+                    file=sys.stderr,
+                )
+
+        result["success"] = True
+        print("Reboot completed successfully!", file=sys.stderr)
+
+    except Exception as e:
+        result["error"] = str(e)
+        print(f"ERROR: {e}", file=sys.stderr)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/aws/bm/reinstall_instance.py
+++ b/isvctl/configs/stubs/aws/bm/reinstall_instance.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Reinstall a bare-metal EC2 instance from its configured stock OS.
+
+AWS does not support CreateReplaceRootVolumeTask on metal instances, so
+this script performs the equivalent manually:
+  1. Get the original AMI's root snapshot
+  2. Stop the instance
+  3. Detach the current root volume
+  4. Create a new volume from the AMI snapshot
+  5. Attach the new volume as root
+  6. Start the instance
+  7. Wait for status checks + SSH
+
+Usage:
+    python reinstall_instance.py --instance-id i-xxx --region us-west-2 \
+        --key-file /tmp/key.pem --public-ip 54.x.x.x
+
+Output JSON:
+{
+    "success": true,
+    "platform": "bm",
+    "instance_id": "i-xxx",
+    "state": "running",
+    "public_ip": "54.x.x.x",
+    "key_file": "/tmp/key.pem",
+    "ssh_user": "ubuntu",
+    "ssh_ready": true,
+    "reinstall_method": "root_volume_swap"
+}
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError, WaiterError
+
+
+def wait_for_ssh(
+    host: str,
+    user: str,
+    key_file: str,
+    max_attempts: int = 60,
+    interval: int = 15,
+) -> bool:
+    """Wait for SSH to become available on the host.
+
+    Args:
+        host: Public IP or hostname
+        user: SSH username
+        key_file: Path to SSH private key
+        max_attempts: Maximum number of connection attempts
+        interval: Seconds between attempts
+
+    Returns:
+        True if SSH is ready, False if timed out
+    """
+    for attempt in range(1, max_attempts + 1):
+        try:
+            result = subprocess.run(
+                [
+                    "ssh",
+                    "-o",
+                    "StrictHostKeyChecking=no",
+                    "-o",
+                    "ConnectTimeout=5",
+                    "-o",
+                    "BatchMode=yes",
+                    "-i",
+                    key_file,
+                    f"{user}@{host}",
+                    "exit 0",
+                ],
+                capture_output=True,
+                timeout=15,
+            )
+            if result.returncode == 0:
+                print(f"  SSH ready after attempt {attempt}", file=sys.stderr)
+                return True
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+
+        print(f"  Waiting for SSH... (attempt {attempt}/{max_attempts})", file=sys.stderr)
+        time.sleep(interval)
+
+    return False
+
+
+def get_ami_root_snapshot(ec2: Any, ami_id: str) -> tuple[str, str]:
+    """Get the root device snapshot ID and device name from an AMI.
+
+    Args:
+        ec2: boto3 EC2 client
+        ami_id: AMI ID to inspect
+
+    Returns:
+        Tuple of (snapshot_id, device_name)
+
+    Raises:
+        RuntimeError: If AMI not found or has no root snapshot
+    """
+    images = ec2.describe_images(ImageIds=[ami_id])
+    if not images["Images"]:
+        raise RuntimeError(f"AMI {ami_id} not found")
+
+    image = images["Images"][0]
+    root_device = image["RootDeviceName"]
+
+    for bdm in image.get("BlockDeviceMappings", []):
+        if bdm.get("DeviceName") == root_device and "Ebs" in bdm:
+            return bdm["Ebs"]["SnapshotId"], root_device
+
+    raise RuntimeError(f"No root snapshot found in AMI {ami_id}")
+
+
+def main() -> int:
+    """Reinstall a bare-metal instance by swapping its root volume.
+
+    Returns:
+        0 on success, 1 on failure
+    """
+    parser = argparse.ArgumentParser(description="Reinstall bare-metal instance from stock OS")
+    parser.add_argument("--instance-id", required=True, help="EC2 instance ID")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--key-file", required=True, help="Path to SSH private key")
+    parser.add_argument("--public-ip", required=True, help="Instance public IP")
+    parser.add_argument("--ssh-user", default="ubuntu", help="SSH username")
+    parser.add_argument("--ami-id", help="AMI ID to reinstall from (default: instance's current AMI)")
+    parser.add_argument(
+        "--volume-size",
+        type=int,
+        default=200,
+        help="New root volume size in GiB (default: 200)",
+    )
+    args = parser.parse_args()
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "bm",
+        "instance_id": args.instance_id,
+        "region": args.region,
+        "key_file": args.key_file,
+        "ssh_user": args.ssh_user,
+        "ssh_ready": False,
+        "reinstall_method": "root_volume_swap",
+    }
+
+    old_volume_id = None
+
+    try:
+        # Step 1: Get instance details
+        print("Getting instance details...", file=sys.stderr)
+        instances = ec2.describe_instances(InstanceIds=[args.instance_id])
+        instance = instances["Reservations"][0]["Instances"][0]
+
+        if instance["State"]["Name"] != "running":
+            result["error"] = f"Instance is {instance['State']['Name']}, expected running"
+            print(json.dumps(result, indent=2))
+            return 1
+
+        ami_id = args.ami_id or instance.get("ImageId")
+        if not ami_id:
+            result["error"] = "Cannot determine AMI ID for reinstall"
+            print(json.dumps(result, indent=2))
+            return 1
+
+        result["ami_id"] = ami_id
+        az = instance["Placement"]["AvailabilityZone"]
+        root_device = instance.get("RootDeviceName", "/dev/sda1")
+
+        # Find current root volume
+        for bdm in instance.get("BlockDeviceMappings", []):
+            if bdm.get("DeviceName") == root_device:
+                old_volume_id = bdm["Ebs"]["VolumeId"]
+                break
+
+        if not old_volume_id:
+            result["error"] = f"Cannot find root volume for device {root_device}"
+            print(json.dumps(result, indent=2))
+            return 1
+
+        print(f"  AMI: {ami_id}, Root device: {root_device}, Old volume: {old_volume_id}", file=sys.stderr)
+
+        # Step 2: Get AMI's root snapshot
+        print("Getting AMI root snapshot...", file=sys.stderr)
+        snapshot_id, _ = get_ami_root_snapshot(ec2, ami_id)
+        print(f"  Snapshot: {snapshot_id}", file=sys.stderr)
+
+        # Step 3: Stop the instance (bare-metal can take 15-20+ min)
+        print(f"Stopping instance {args.instance_id}...", file=sys.stderr)
+        ec2.stop_instances(InstanceIds=[args.instance_id])
+
+        waiter = ec2.get_waiter("instance_stopped")
+        try:
+            waiter.wait(
+                InstanceIds=[args.instance_id],
+                WaiterConfig={"Delay": 30, "MaxAttempts": 50},
+            )
+        except WaiterError:
+            # Check if it actually stopped despite waiter timeout
+            inst = ec2.describe_instances(InstanceIds=[args.instance_id])
+            state = inst["Reservations"][0]["Instances"][0]["State"]["Name"]
+            if state != "stopped":
+                raise RuntimeError(
+                    f"Instance failed to stop (state: {state}). Bare-metal instances can take 20+ min to stop."
+                )
+        print("  Instance stopped", file=sys.stderr)
+
+        # Step 4: Detach old root volume
+        print(f"Detaching old root volume {old_volume_id}...", file=sys.stderr)
+        ec2.detach_volume(VolumeId=old_volume_id, InstanceId=args.instance_id, Force=True)
+        vol_waiter = ec2.get_waiter("volume_available")
+        vol_waiter.wait(VolumeIds=[old_volume_id])
+        print("  Old volume detached", file=sys.stderr)
+
+        # Step 5: Create new volume from AMI snapshot
+        print(f"Creating new root volume from snapshot {snapshot_id}...", file=sys.stderr)
+        new_volume = ec2.create_volume(
+            SnapshotId=snapshot_id,
+            AvailabilityZone=az,
+            VolumeType="gp3",
+            Size=args.volume_size,
+            TagSpecifications=[
+                {
+                    "ResourceType": "volume",
+                    "Tags": [
+                        {"Key": "Name", "Value": f"reinstall-{args.instance_id}"},
+                        {"Key": "CreatedBy", "Value": "isvtest"},
+                    ],
+                }
+            ],
+        )
+        new_volume_id = new_volume["VolumeId"]
+        result["new_volume_id"] = new_volume_id
+        vol_waiter.wait(VolumeIds=[new_volume_id])
+        print(f"  New volume created: {new_volume_id}", file=sys.stderr)
+
+        # Step 6: Attach new volume as root
+        print(f"Attaching new volume as {root_device}...", file=sys.stderr)
+        ec2.attach_volume(
+            VolumeId=new_volume_id,
+            InstanceId=args.instance_id,
+            Device=root_device,
+        )
+        attach_waiter = ec2.get_waiter("volume_in_use")
+        attach_waiter.wait(VolumeIds=[new_volume_id])
+        print("  New volume attached", file=sys.stderr)
+
+        # Step 7: Delete old volume
+        print(f"Deleting old volume {old_volume_id}...", file=sys.stderr)
+        try:
+            ec2.delete_volume(VolumeId=old_volume_id)
+        except ClientError as e:
+            print(f"  Warning: could not delete old volume: {e}", file=sys.stderr)
+
+        # Step 8: Start the instance
+        print(f"Starting instance {args.instance_id}...", file=sys.stderr)
+        ec2.start_instances(InstanceIds=[args.instance_id])
+
+        run_waiter = ec2.get_waiter("instance_running")
+        run_waiter.wait(
+            InstanceIds=[args.instance_id],
+            WaiterConfig={"Delay": 15, "MaxAttempts": 60},
+        )
+
+        print("Waiting for instance status checks...", file=sys.stderr)
+        status_waiter = ec2.get_waiter("instance_status_ok")
+        status_waiter.wait(
+            InstanceIds=[args.instance_id],
+            WaiterConfig={"Delay": 15, "MaxAttempts": 80},
+        )
+        print("  Instance status checks passed", file=sys.stderr)
+
+        # Step 9: Get updated instance details
+        instances = ec2.describe_instances(InstanceIds=[args.instance_id])
+        instance = instances["Reservations"][0]["Instances"][0]
+
+        result["state"] = instance["State"]["Name"]
+        result["public_ip"] = instance.get("PublicIpAddress")
+        result["private_ip"] = instance.get("PrivateIpAddress")
+
+        public_ip = result["public_ip"] or args.public_ip
+
+        # Step 10: Wait for SSH
+        print("Waiting for SSH after reinstall...", file=sys.stderr)
+        ssh_ready = wait_for_ssh(public_ip, args.ssh_user, args.key_file)
+        result["ssh_ready"] = ssh_ready
+
+        if not ssh_ready:
+            result["error"] = "SSH not ready after reinstall"
+            print(json.dumps(result, indent=2))
+            return 1
+
+        result["success"] = True
+        print("Reinstall completed successfully!", file=sys.stderr)
+
+    except Exception as e:
+        result["error"] = str(e)
+        print(f"ERROR: {e}", file=sys.stderr)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/aws/bm/teardown.py
+++ b/isvctl/configs/stubs/aws/bm/teardown.py
@@ -58,6 +58,17 @@ def main() -> int:
     if args.skip_destroy:
         result["success"] = True
         result["message"] = "Destroy skipped (--skip-destroy flag)"
+        print(
+            f"\n{'=' * 60}\n"
+            f"Teardown skipped. Instance {args.instance_id} is still running.\n\n"
+            f"To rerun tests without reprovisioning:\n"
+            f"  export AWS_BM_INSTANCE_ID={args.instance_id}\n"
+            f"  export AWS_BM_KEY_FILE=<key_file_from_launch>\n"
+            f"  export AWS_BM_SKIP_TEARDOWN=true\n\n"
+            f"To teardown later, unset AWS_BM_SKIP_TEARDOWN and rerun.\n"
+            f"{'=' * 60}\n",
+            file=sys.stderr,
+        )
         print(json.dumps(result, indent=2))
         return 0
 

--- a/isvctl/configs/stubs/aws/bm/teardown.py
+++ b/isvctl/configs/stubs/aws/bm/teardown.py
@@ -57,17 +57,9 @@ def main() -> int:
 
     if args.skip_destroy:
         result["success"] = True
-        result["message"] = "Destroy skipped (--skip-destroy flag)"
-        print(
-            f"\n{'=' * 60}\n"
-            f"Teardown skipped. Instance {args.instance_id} is still running.\n\n"
-            f"To rerun tests without reprovisioning:\n"
-            f"  export AWS_BM_INSTANCE_ID={args.instance_id}\n"
-            f"  export AWS_BM_KEY_FILE=<key_file_from_launch>\n"
-            f"  export AWS_BM_SKIP_TEARDOWN=true\n\n"
-            f"To teardown later, unset AWS_BM_SKIP_TEARDOWN and rerun.\n"
-            f"{'=' * 60}\n",
-            file=sys.stderr,
+        result["message"] = (
+            f"Teardown skipped. Instance {args.instance_id} is still running. "
+            f"To teardown later, unset AWS_BM_SKIP_TEARDOWN and rerun."
         )
         print(json.dumps(result, indent=2))
         return 0

--- a/isvctl/configs/stubs/aws/bm/teardown.py
+++ b/isvctl/configs/stubs/aws/bm/teardown.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Teardown AWS EC2 bare-metal instance and associated resources.
+
+Mirrors the VM teardown script but sets platform to "bm". The actual
+EC2 API calls are identical (terminate, delete SG, delete key pair).
+
+Usage:
+    python teardown.py --instance-id i-xxx --region us-west-2
+
+Output JSON:
+{
+    "success": true,
+    "platform": "bm",
+    "resources_destroyed": true,
+    "deleted": {
+        "instances": ["i-xxx"],
+        "security_groups": ["sg-xxx"],
+        "key_pairs": ["key-name"]
+    }
+}
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import boto3
+from botocore.exceptions import ClientError, WaiterError
+
+
+def main() -> int:
+    """Terminate a bare-metal EC2 instance and clean up associated resources.
+
+    Returns:
+        0 on success, 1 on failure
+    """
+    parser = argparse.ArgumentParser(description="Teardown bare-metal EC2 instance")
+    parser.add_argument("--instance-id", required=True, help="EC2 instance ID")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--delete-key-pair", action="store_true", help="Also delete key pair")
+    parser.add_argument("--delete-security-group", action="store_true", help="Also delete security group")
+    parser.add_argument("--skip-destroy", action="store_true", help="Skip actual destroy")
+    args = parser.parse_args()
+
+    result = {
+        "success": False,
+        "platform": "bm",
+        "resources_destroyed": False,
+        "deleted": {
+            "instances": [],
+            "security_groups": [],
+            "key_pairs": [],
+        },
+    }
+
+    if args.skip_destroy:
+        result["success"] = True
+        result["message"] = "Destroy skipped (--skip-destroy flag)"
+        print(json.dumps(result, indent=2))
+        return 0
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+
+    sg_ids: list[str] = []
+    key_name: str | None = None
+
+    try:
+        instances = ec2.describe_instances(InstanceIds=[args.instance_id])
+        instance = instances["Reservations"][0]["Instances"][0]
+        sg_ids = [sg["GroupId"] for sg in instance.get("SecurityGroups", [])]
+        key_name = instance.get("KeyName")
+
+        print(f"Terminating instance {args.instance_id}...", file=sys.stderr)
+        ec2.terminate_instances(InstanceIds=[args.instance_id])
+        result["deleted"]["instances"].append(args.instance_id)
+
+        # Wait for termination -- bare-metal can take 15-20+ minutes.
+        # If the waiter times out, that's OK: the terminate call succeeded
+        # and AWS will finish it. We still proceed to clean up other resources.
+        try:
+            waiter = ec2.get_waiter("instance_terminated")
+            waiter.wait(
+                InstanceIds=[args.instance_id],
+                WaiterConfig={"Delay": 30, "MaxAttempts": 50},
+            )
+            print("  Instance terminated", file=sys.stderr)
+        except WaiterError:
+            print(
+                "  Waiter timed out, but terminate was initiated. AWS will finish asynchronously.",
+                file=sys.stderr,
+            )
+            result.setdefault("warnings", []).append("Termination waiter timed out; instance is still shutting down")
+
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "InvalidInstanceID.NotFound":
+            result["message"] = "Instance not found (already terminated)"
+        else:
+            result["error"] = str(e)
+            print(json.dumps(result, indent=2))
+            return 1
+    except Exception as e:
+        result["error"] = str(e)
+        print(json.dumps(result, indent=2))
+        return 1
+
+    # Always attempt SG and key pair cleanup, even if waiter timed out
+    if args.delete_security_group and sg_ids:
+        time.sleep(5)
+        for sg_id in sg_ids:
+            try:
+                sg_info = ec2.describe_security_groups(GroupIds=[sg_id])
+                if sg_info["SecurityGroups"] and sg_info["SecurityGroups"][0].get("GroupName") == "default":
+                    continue
+                ec2.delete_security_group(GroupId=sg_id)
+                result["deleted"]["security_groups"].append(sg_id)
+            except ClientError as e:
+                error_code = e.response["Error"]["Code"]
+                if error_code == "DependencyViolation":
+                    result.setdefault("warnings", []).append(
+                        f"SG {sg_id} still in use (instance shutting down); will be cleaned up by AWS"
+                    )
+                elif error_code not in ("InvalidGroup.NotFound", "CannotDelete"):
+                    result.setdefault("warnings", []).append(f"Could not delete SG {sg_id}: {e}")
+
+    if args.delete_key_pair and key_name:
+        try:
+            ec2.delete_key_pair(KeyName=key_name)
+            result["deleted"]["key_pairs"].append(key_name)
+            key_file = f"/tmp/{key_name}.pem"
+            if os.path.exists(key_file):
+                os.remove(key_file)
+        except ClientError as e:
+            result.setdefault("warnings", []).append(f"Could not delete key pair: {e}")
+
+    result["success"] = True
+    result["resources_destroyed"] = True
+    result["message"] = "Bare-metal instance teardown completed"
+
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/aws/bm/verify_terminated.py
+++ b/isvctl/configs/stubs/aws/bm/verify_terminated.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Verify an EC2 instance has been terminated after teardown.
+
+Post-teardown sanitization check: confirms the instance is in
+'terminated' state or no longer exists (already cleaned up by AWS).
+Also verifies that the associated security group and key pair have
+been removed.
+
+Usage:
+    python verify_terminated.py --instance-id i-xxx --region us-west-2
+
+Output JSON:
+{
+    "success": true,
+    "platform": "bm",
+    "instance_id": "i-xxx",
+    "state": "terminated",
+    "resources_destroyed": true,
+    "checks": {
+        "instance": "terminated",
+        "security_group": "deleted",
+        "key_pair": "deleted"
+    }
+}
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+def main() -> int:
+    """Verify instance and associated resources have been cleaned up.
+
+    Returns:
+        0 on success, 1 on failure
+    """
+    parser = argparse.ArgumentParser(description="Verify instance terminated")
+    parser.add_argument("--instance-id", required=True, help="EC2 instance ID")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--security-group-id", nargs="?", default=None, help="Security group ID to verify deleted")
+    parser.add_argument("--key-name", nargs="?", default=None, help="Key pair name to verify deleted")
+    args = parser.parse_args()
+
+    # Treat empty strings (from unresolved Jinja2 templates) as None
+    if args.security_group_id is not None and not args.security_group_id.strip():
+        args.security_group_id = None
+    if args.key_name is not None and not args.key_name.strip():
+        args.key_name = None
+
+    # Skip verification when teardown was intentionally skipped (dev workflow)
+    if os.environ.get("AWS_BM_SKIP_TEARDOWN") == "true":
+        print(
+            json.dumps(
+                {
+                    "success": True,
+                    "platform": "bm",
+                    "instance_id": args.instance_id,
+                    "message": "Verification skipped (AWS_BM_SKIP_TEARDOWN=true)",
+                    "checks": {},
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "bm",
+        "instance_id": args.instance_id,
+        "region": args.region,
+        "resources_destroyed": False,
+        "checks": {},
+    }
+
+    issues: list[str] = []
+
+    # Check instance state
+    try:
+        instances = ec2.describe_instances(InstanceIds=[args.instance_id])
+        instance = instances["Reservations"][0]["Instances"][0]
+        state = instance["State"]["Name"]
+        result["state"] = state
+
+        if state in ("terminated", "shutting-down"):
+            result["checks"]["instance"] = state
+        else:
+            result["checks"]["instance"] = state
+            issues.append(f"Instance {args.instance_id} is {state}, expected terminated")
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "InvalidInstanceID.NotFound":
+            result["state"] = "not_found"
+            result["checks"]["instance"] = "not_found"
+        else:
+            issues.append(f"Error checking instance: {e}")
+
+    # Check security group was deleted
+    if args.security_group_id:
+        try:
+            ec2.describe_security_groups(GroupIds=[args.security_group_id])
+            result["checks"]["security_group"] = "exists"
+            issues.append(f"Security group {args.security_group_id} still exists")
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "InvalidGroup.NotFound":
+                result["checks"]["security_group"] = "deleted"
+            else:
+                issues.append(f"Error checking SG: {e}")
+
+    # Check key pair was deleted
+    if args.key_name:
+        try:
+            ec2.describe_key_pairs(KeyNames=[args.key_name])
+            result["checks"]["key_pair"] = "exists"
+            issues.append(f"Key pair {args.key_name} still exists")
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "InvalidKeyPair.NotFound":
+                result["checks"]["key_pair"] = "deleted"
+            else:
+                issues.append(f"Error checking key pair: {e}")
+
+    if issues:
+        result["error"] = "; ".join(issues)
+    else:
+        result["success"] = True
+        result["resources_destroyed"] = True
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/aws/control-plane/docs/aws-control-plane.md
+++ b/isvctl/configs/stubs/aws/control-plane/docs/aws-control-plane.md
@@ -315,6 +315,12 @@ Missing permissions. Ensure your credentials have the IAM permissions listed abo
 
 Access key operations may take 5-20 seconds to propagate. The scripts include retry logic with exponential backoff.
 
+## Cost & Cleanup
+
+> **Note**: Control plane tests primarily use read-only API calls (DescribeInstances,
+> ListBuckets, GetCallerIdentity, etc.) and do not create billable resources.
+> No manual cleanup is required.
+
 ## Related Documentation
 
 - [Configuration Guide](../../../../../docs/guides/configuration.md) - Step-based configuration reference

--- a/isvctl/configs/stubs/aws/control-plane/docs/aws-control-plane.md
+++ b/isvctl/configs/stubs/aws/control-plane/docs/aws-control-plane.md
@@ -318,8 +318,13 @@ Access key operations may take 5-20 seconds to propagate. The scripts include re
 ## Cost & Cleanup
 
 > **Note**: Control plane tests primarily use read-only API calls (DescribeInstances,
-> ListBuckets, GetCallerIdentity, etc.) and do not create billable resources.
-> No manual cleanup is required.
+> ListBuckets, GetCallerIdentity, etc.). However, the Access Key Lifecycle and Tenant
+> Lifecycle tests create temporary resources—IAM users, access keys, and resource
+> groups—as part of their CRUD validations. These resources are free-tier/non-billable
+> and are automatically cleaned up during the teardown phase. If a test run is
+> interrupted before teardown completes, any leftover resources (prefixed with
+> `isv-access-key-test-` or `isv-tenant-test-`) can be safely deleted manually.
+> No long-lived billable resources are created.
 
 ## Related Documentation
 

--- a/isvctl/configs/stubs/aws/eks/docs/aws-eks.md
+++ b/isvctl/configs/stubs/aws/eks/docs/aws-eks.md
@@ -459,9 +459,9 @@ For running AWS VPC network validation tests (`-m network`), additional permissi
 ## Cost & Cleanup
 
 > **Warning**: These tests create AWS resources (EKS clusters, EC2 node groups,
-> VPCs, IAM roles) that incur significant costs. Resources are automatically
-> cleaned up during the teardown phase, but if teardown fails or is skipped,
-> you must manually delete them to avoid ongoing charges.
+> VPCs, IAM roles) that incur costs. Resources are automatically cleaned up
+> during the teardown phase, but if teardown fails or is skipped, you must
+> manually delete them to avoid ongoing charges.
 
 ```bash
 # Check for running EKS clusters
@@ -469,11 +469,6 @@ aws eks list-clusters --query 'clusters' --output table
 
 # Delete orphaned cluster
 aws eks delete-cluster --name isv-test-cluster
-
-# Check running costs
-aws ce get-cost-and-usage \
-  --time-period Start=$(date -d '-1 day' +%Y-%m-%d),End=$(date +%Y-%m-%d) \
-  --granularity DAILY --metrics BlendedCost
 ```
 
 ## Related Documentation

--- a/isvctl/configs/stubs/aws/eks/docs/aws-eks.md
+++ b/isvctl/configs/stubs/aws/eks/docs/aws-eks.md
@@ -456,6 +456,26 @@ For running AWS VPC network validation tests (`-m network`), additional permissi
 
 ---
 
+## Cost & Cleanup
+
+> **Warning**: These tests create AWS resources (EKS clusters, EC2 node groups,
+> VPCs, IAM roles) that incur significant costs. Resources are automatically
+> cleaned up during the teardown phase, but if teardown fails or is skipped,
+> you must manually delete them to avoid ongoing charges.
+
+```bash
+# Check for running EKS clusters
+aws eks list-clusters --query 'clusters' --output table
+
+# Delete orphaned cluster
+aws eks delete-cluster --name isv-test-cluster
+
+# Check running costs
+aws ce get-cost-and-usage \
+  --time-period Start=$(date -d '-1 day' +%Y-%m-%d),End=$(date +%Y-%m-%d) \
+  --granularity DAILY --metrics BlendedCost
+```
+
 ## Related Documentation
 
 - [Terraform Module README](../terraform/README.md) - Detailed Terraform configuration

--- a/isvctl/configs/stubs/aws/iam/docs/aws-iam.md
+++ b/isvctl/configs/stubs/aws/iam/docs/aws-iam.md
@@ -184,3 +184,17 @@ class AzureAdProvider:
         result = self.client.users.post(user)
         return CreateUserResult(success=True, user_id=result.id, ...)
 ```
+
+## Cost & Cleanup
+
+> **Note**: IAM tests create temporary IAM users and access keys which are
+> free-tier resources. The teardown phase automatically deletes them, but if
+> teardown fails, you should manually clean up to avoid orphaned credentials.
+
+```bash
+# Find orphaned test users
+aws iam list-users --query 'Users[?starts_with(UserName, `isv-test-`)].UserName' --output table
+
+# Delete orphaned user (detach policies and delete keys first)
+aws iam delete-user --user-name isv-test-user
+```

--- a/isvctl/configs/stubs/aws/iam/docs/aws-iam.md
+++ b/isvctl/configs/stubs/aws/iam/docs/aws-iam.md
@@ -195,6 +195,21 @@ class AzureAdProvider:
 # Find orphaned test users
 aws iam list-users --query 'Users[?starts_with(UserName, `isv-test-`)].UserName' --output table
 
-# Delete orphaned user (detach policies and delete keys first)
+# Detach managed policies
+aws iam list-attached-user-policies --user-name isv-test-user \
+  --query 'AttachedPolicies[].PolicyArn' --output text | tr '\t' '\n' | \
+  xargs -I {} aws iam detach-user-policy --user-name isv-test-user --policy-arn {}
+
+# Remove inline policies
+aws iam list-user-policies --user-name isv-test-user \
+  --query 'PolicyNames[]' --output text | tr '\t' '\n' | \
+  xargs -I {} aws iam delete-user-policy --user-name isv-test-user --policy-name {}
+
+# Delete access keys
+aws iam list-access-keys --user-name isv-test-user \
+  --query 'AccessKeyMetadata[].AccessKeyId' --output text | tr '\t' '\n' | \
+  xargs -I {} aws iam delete-access-key --user-name isv-test-user --access-key-id {}
+
+# Delete orphaned user
 aws iam delete-user --user-name isv-test-user
 ```

--- a/isvctl/configs/stubs/aws/iso/docs/aws-iso.md
+++ b/isvctl/configs/stubs/aws/iso/docs/aws-iso.md
@@ -387,7 +387,12 @@ uv run isvctl test run -f isvctl/configs/aws-iso.yaml -v
 
 ---
 
-## Cleanup
+## Cost & Cleanup
+
+> **Warning**: These tests create AWS resources (S3 buckets, EC2 instances, AMIs,
+> EBS snapshots, security groups) that incur costs. Resources are automatically
+> cleaned up during the teardown phase, but if teardown fails or is skipped,
+> you must manually delete them to avoid ongoing charges.
 
 Tests automatically clean up all resources, even on failure:
 

--- a/isvctl/configs/stubs/aws/network/docs/aws-network.md
+++ b/isvctl/configs/stubs/aws/network/docs/aws-network.md
@@ -395,7 +395,7 @@ Increase timeout in config:
 ## Cost & Cleanup
 
 > **Warning**: These tests create AWS resources (VPCs, subnets, security groups,
-> internet gateways, EC2 instances) that may incur costs. Resources are
+> internet gateways, EC2 instances) that incur costs. Resources are
 > automatically cleaned up during the teardown phase, but if teardown fails
 > or is skipped, you must manually delete them to avoid ongoing charges.
 

--- a/isvctl/configs/stubs/aws/network/docs/aws-network.md
+++ b/isvctl/configs/stubs/aws/network/docs/aws-network.md
@@ -404,8 +404,42 @@ Increase timeout in config:
 aws ec2 describe-vpcs --filters "Name=tag:CreatedBy,Values=isvtest" \
   --query 'Vpcs[*].[VpcId,Tags[?Key==`Name`].Value|[0],State]' --output table
 
-# Delete orphaned VPCs (delete dependent resources first)
-aws ec2 delete-vpc --vpc-id vpc-xxx
+# Delete orphaned VPCs (must remove dependent resources first — see below)
+VPC_ID="vpc-xxx"
+```
+
+`delete-vpc` fails with `DependencyViolation` if any resources still reference
+the VPC. Remove dependencies in this order before deleting:
+
+1. Terminate EC2 instances, load balancers, RDS/EFS mount targets (`terminate-instances`)
+2. Delete NAT Gateways and VPC Endpoints (`delete-nat-gateway`, `delete-vpc-endpoints`)
+3. Detach & delete remaining ENIs and release Elastic IPs (`delete-network-interface`)
+4. Detach & delete Internet/VPN Gateways (`detach-internet-gateway`, `delete-internet-gateway`)
+5. Delete peering/VPN connections (`delete-vpc-peering-connection`)
+6. Disassociate & delete custom route tables (`disassociate-route-table`, `delete-route-table`)
+7. Delete subnets (`delete-subnet`)
+8. Delete non-default security groups and NACLs (`delete-security-group`, `delete-network-acl`)
+
+> **Key check:** there must be **zero ENIs** remaining before `delete-vpc` succeeds.
+> Verify with: `aws ec2 describe-network-interfaces --filters Name=vpc-id,Values=$VPC_ID`
+
+```bash
+# Quick manual cleanup example
+VPC_ID="vpc-xxx"
+aws ec2 terminate-instances --instance-ids $(aws ec2 describe-instances \
+  --filters "Name=vpc-id,Values=$VPC_ID" --query 'Reservations[*].Instances[*].InstanceId' --output text)
+aws ec2 detach-internet-gateway --internet-gateway-id igw-xxx --vpc-id $VPC_ID
+aws ec2 delete-internet-gateway --internet-gateway-id igw-xxx
+aws ec2 delete-subnet --subnet-id subnet-xxx
+aws ec2 delete-security-group --group-id sg-xxx
+aws ec2 delete-vpc --vpc-id $VPC_ID
+```
+
+For automated cleanup, use the suite's teardown phase which handles the full
+dependency sequence via [`teardown_vpc.py`](../teardown_vpc.py):
+
+```bash
+uv run isvctl test run -f isvctl/configs/aws-network.yaml --phase teardown
 ```
 
 ## Related Documentation

--- a/isvctl/configs/stubs/aws/network/docs/aws-network.md
+++ b/isvctl/configs/stubs/aws/network/docs/aws-network.md
@@ -392,6 +392,22 @@ Increase timeout in config:
   timeout: 1200  # 20 minutes
 ```
 
+## Cost & Cleanup
+
+> **Warning**: These tests create AWS resources (VPCs, subnets, security groups,
+> internet gateways, EC2 instances) that may incur costs. Resources are
+> automatically cleaned up during the teardown phase, but if teardown fails
+> or is skipped, you must manually delete them to avoid ongoing charges.
+
+```bash
+# Find VPCs tagged by isvtest
+aws ec2 describe-vpcs --filters "Name=tag:CreatedBy,Values=isvtest" \
+  --query 'Vpcs[*].[VpcId,Tags[?Key==`Name`].Value|[0],State]' --output table
+
+# Delete orphaned VPCs (delete dependent resources first)
+aws ec2 delete-vpc --vpc-id vpc-xxx
+```
+
 ## Related Documentation
 
 - [Configuration Guide](../../../../../docs/guides/configuration.md)

--- a/isvctl/configs/stubs/aws/vm/docs/aws-vm.md
+++ b/isvctl/configs/stubs/aws/vm/docs/aws-vm.md
@@ -335,6 +335,30 @@ aws ec2 terminate-instances --instance-ids i-xxx
 
 ---
 
+## Cost & Cleanup
+
+> **Warning**: These tests create AWS resources (EC2 instances, security groups,
+> key pairs) that incur costs. Resources are automatically cleaned up during the
+> teardown phase, but if teardown fails or is skipped, you must manually delete
+> them to avoid ongoing charges.
+
+```bash
+# Find instances tagged by isvtest
+aws ec2 describe-instances \
+  --filters "Name=tag:CreatedBy,Values=isvtest" "Name=instance-state-name,Values=running,stopped" \
+  --query 'Reservations[*].Instances[*].[InstanceId,InstanceType,State.Name]' --output table
+
+# Terminate orphaned instances
+aws ec2 terminate-instances --instance-ids i-xxx
+
+# Find and delete orphaned security groups
+aws ec2 describe-security-groups --filters "Name=group-name,Values=isv-test-*" \
+  --query 'SecurityGroups[*].[GroupId,GroupName]' --output table
+
+# Delete orphaned key pairs
+aws ec2 delete-key-pair --key-name isv-test-key
+```
+
 ## Related Documentation
 
 - [AWS EKS Validation Guide](../../eks/docs/aws-eks.md) - Kubernetes cluster tests


### PR DESCRIPTION
## Summary

- Add end-to-end validation for AWS EC2 bare-metal GPU instances (BMaaS)
- New BM scripts: `launch_instance.py`, `describe_instance.py`, `reboot_instance.py`, `reinstall_instance.py`, `teardown.py`, `verify_terminated.py`
- New config `aws-bm.yaml` with 9 steps, 21 validations across setup/test/teardown phases
- Reuse existing shared code: `list_instances.py`, `deploy_nim.py`, `teardown_nim.py`, and all validation classes
- Dev workflow via `AWS_BM_INSTANCE_ID` / `AWS_BM_KEY_FILE` / `AWS_BM_SKIP_TEARDOWN` env vars
- Add "Cost & Cleanup" sections to all AWS docs

## Issues

Closes #49
Closes #51
Closes #52
Closes #53
Closes #54
Closes #56
Closes #57
Closes #61
Closes #64