### PR TITLE
chore: update AWS EKS teardown behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ See [Contributing](docs/contributing.md) for development setup and guidelines.
 
 | Variable | Description |
 | -------- | ----------- |
-| `NGC_NIM_API_KEY` | Required for NIM model benchmarks |
 | `ISV_SERVICE_ENDPOINT` | Required for ISV Lab Service uploads |
 | `ISV_SSA_ISSUER` | Required for ISV Lab Service uploads |
 | `ISV_CLIENT_ID` | Required for ISV Lab Service uploads |
 | `ISV_CLIENT_SECRET` | Required for ISV Lab Service uploads |
+| `NGC_NIM_API_KEY` | Required for NIM model benchmarks |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Templates are available for: [IAM](isvctl/configs/templates/iam.yaml) | [Network
 
 See the [Templates README](isvctl/configs/templates/README.md) for the full guide, and the [AWS Reference Implementation](docs/references/aws.md) as a working example.
 
+## Prerequisites
+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/) (Python package manager)
+
 ## Quick Start
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,6 +2,10 @@
 
 This guide covers installation and basic usage of NVIDIA ISV NCP Validation Suite.
 
+## Prerequisites
+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/) (Python package manager)
+
 ## Installation
 
 ### Local Development

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,11 +98,11 @@ See [Remote Deployment Guide](guides/remote-deployment.md) for details.
 | `AWS_ACCESS_KEY_ID` | AWS access key (for AWS tests) |
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key (for AWS tests) |
 | `AWS_REGION` | AWS region (default: us-west-2) |
-| `NGC_NIM_API_KEY` | Required for NIM model benchmarks |
 | `ISV_SERVICE_ENDPOINT` | Required for result upload to ISV Lab Service |
 | `ISV_SSA_ISSUER` | Required for result upload to ISV Lab Service |
 | `ISV_CLIENT_ID` | Required for result upload to ISV Lab Service |
 | `ISV_CLIENT_SECRET` | Required for result upload to ISV Lab Service |
+| `NGC_NIM_API_KEY` | Required for NIM model benchmarks |
 
 ## Next Steps
 

--- a/docs/guides/troubleshooting-started-tests.md
+++ b/docs/guides/troubleshooting-started-tests.md
@@ -1,6 +1,6 @@
 # Troubleshooting: Test Runs Stuck in STARTED
 
-This guide helps ISV Lab partners diagnose and fix test runs that never reach a terminal state (SUCCESS or FAILED) and remain **STARTED** in the [ISV Validation Labs portal](https://ncp-isv-validation-labs.nvidia.com/).
+This guide helps ISV Lab partners diagnose and fix test runs that never reach a terminal state (SUCCESS or FAILED) and remain **STARTED** in the [ISV Validation Labs portal](https://public.ncp-isv-validation-labs.nvidia.com/).
 
 ## Root cause (single RCA)
 

--- a/isvctl/configs/aws/eks.yaml
+++ b/isvctl/configs/aws/eks.yaml
@@ -11,13 +11,13 @@
 #   # Run tests only (skip setup/teardown)
 #   uv run isvctl test run -f isvctl/configs/aws/eks.yaml --phase test
 #
-#   # Teardown cluster
-#   AWS_TEARDOWN_ENABLED=true TF_AUTO_APPROVE=true uv run isvctl test run -f isvctl/configs/aws/eks.yaml --phase teardown
+#   # Skip teardown (preserve resources)
+#   AWS_SKIP_TEARDOWN=true TF_AUTO_APPROVE=true uv run isvctl test run -f isvctl/configs/aws/eks.yaml
 #
 # Environment Variables:
 #   - TF_AUTO_APPROVE: Set to "true" to skip Terraform approval prompts (default: false)
 #   - TF_VAR_*: Terraform variables (e.g., TF_VAR_region, TF_VAR_gpu_node_instance_types)
-#   - AWS_TEARDOWN_ENABLED: Set to "true" to enable teardown (default: false)
+#   - AWS_SKIP_TEARDOWN: Set to "true" to skip teardown and preserve resources (default: false)
 #   - NGC_NIM_API_KEY: NGC API key for NIM workloads
 #   - AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY: AWS credentials (if not using IAM roles)
 
@@ -48,7 +48,6 @@ commands:
         command: "../stubs/aws/eks/teardown.sh"
         timeout: 1800 # 30 min for Terraform destroy
         env:
-          AWS_TEARDOWN_ENABLED: "false"
           TF_AUTO_APPROVE: "true"
 
 # =============================================================================

--- a/isvctl/configs/stubs/aws/eks/docs/aws-eks.md
+++ b/isvctl/configs/stubs/aws/eks/docs/aws-eks.md
@@ -85,7 +85,7 @@ NGC_NIM_API_KEY=nvapi-XXXXX \
   uv run isvctl test run -f isvctl/configs/aws/eks.yaml
 ```
 
-> **Note**: By default, teardown is disabled to preserve resources. The setup phase is idempotent - if the cluster already exists, it will skip provisioning and just generate inventory. See [Teardown](#phase-3-teardown) for cleanup instructions.
+> **Note**: By default, teardown runs automatically to clean up resources. Set `AWS_SKIP_TEARDOWN=true` to preserve resources after testing. The setup phase is idempotent - if the cluster already exists, it will skip provisioning and just generate inventory. See [Teardown](#phase-3-teardown) for details.
 
 ---
 
@@ -191,8 +191,10 @@ The test phase runs validation checks and workloads.
 
 ```bash
 # Runs: setup -> test -> teardown
-# Teardown is disabled by default, so resources are preserved
 uv run isvctl test run -f isvctl/configs/aws/eks.yaml
+
+# To preserve resources, skip teardown:
+AWS_SKIP_TEARDOWN=true uv run isvctl test run -f isvctl/configs/aws/eks.yaml
 ```
 
 #### Run Phases Separately
@@ -207,7 +209,7 @@ uv run isvctl test run -f isvctl/configs/aws/eks.yaml --phase setup
 uv run isvctl test run -f isvctl/configs/aws/eks.yaml --phase test
 ```
 
-> **Note**: The `--phase` option only accepts one value at a time. To run setup and test together, omit `--phase` to run all phases (teardown is disabled by default).
+> **Note**: The `--phase` option only accepts one value at a time. To run setup and test together without teardown, use `AWS_SKIP_TEARDOWN=true` and omit `--phase`.
 
 #### Validation Categories
 
@@ -268,7 +270,7 @@ Results are saved to:
 
 ### Phase 3: Teardown
 
-> **Important**: Teardown is **disabled by default** to prevent accidental resource deletion.
+> **Important**: Teardown runs by default. Set `AWS_SKIP_TEARDOWN=true` to preserve resources.
 
 #### Check Current Resources
 
@@ -287,16 +289,15 @@ aws ce get-cost-and-usage \
 #### Destroy Infrastructure
 
 ```bash
-# Option 1: Via isvctl (recommended)
-AWS_TEARDOWN_ENABLED=true \
-  uv run isvctl test run -f isvctl/configs/aws/eks.yaml --phase teardown
+# Option 1: Via isvctl (recommended) - teardown runs by default
+uv run isvctl test run -f isvctl/configs/aws/eks.yaml --phase teardown
 
 # Option 2: Direct Terraform
 cd isvctl/configs/stubs/aws/eks/terraform
 terraform destroy
 ```
 
-When teardown is skipped, you'll see:
+When teardown is skipped (via `AWS_SKIP_TEARDOWN=true`), you'll see:
 
 ```text
 ========================================
@@ -306,9 +307,8 @@ When teardown is skipped, you'll see:
 AWS infrastructure was NOT destroyed.
 Your EKS cluster and resources are still running.
 
-To destroy resources, run with:
-  AWS_TEARDOWN_ENABLED=true TF_AUTO_APPROVE=true \
-    uv run isvctl test run -f isvctl/configs/aws/eks.yaml --phase teardown
+To destroy resources, run without AWS_SKIP_TEARDOWN:
+  uv run isvctl test run -f isvctl/configs/aws/eks.yaml --phase teardown
 ```
 
 ---
@@ -329,17 +329,11 @@ export TF_VAR_gpu_node_desired_size=1
 
 # Run all phases: setup -> test -> teardown
 # Setup detects existing cluster and skips provisioning if it exists
-# Teardown is disabled by default (AWS_TEARDOWN_ENABLED=false)
+# Teardown runs by default (set AWS_SKIP_TEARDOWN=true to preserve resources)
 echo "=== RUNNING VALIDATION (setup -> test -> teardown) ==="
 uv run isvctl test run -f isvctl/configs/aws/eks.yaml
 
-# Phase 3: Cleanup (optional - uncomment to destroy)
-# echo "=== DESTROYING INFRASTRUCTURE ==="
-# AWS_TEARDOWN_ENABLED=true uv run isvctl test run -f isvctl/configs/aws/eks.yaml --phase teardown
-
 echo "=== VALIDATION COMPLETE ==="
-echo "Remember to destroy resources when done:"
-echo "  AWS_TEARDOWN_ENABLED=true uv run isvctl test run -f isvctl/configs/aws/eks.yaml --phase teardown"
 ```
 
 ---

--- a/isvctl/configs/stubs/aws/eks/teardown.sh
+++ b/isvctl/configs/stubs/aws/eks/teardown.sh
@@ -2,7 +2,7 @@
 # AWS EKS Teardown Stub - Destroys AWS infrastructure using Terraform
 #
 # Environment Variables:
-#   - AWS_TEARDOWN_ENABLED: Set to "true" to enable teardown (default: false)
+#   - AWS_SKIP_TEARDOWN: Set to "true" to skip teardown and preserve resources (default: false)
 #   - TF_AUTO_APPROVE: Set to "true" to skip confirmation (default: false)
 #
 # Warning: This will permanently delete all AWS resources!
@@ -12,10 +12,9 @@ set -eo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
 
-# Safety check
-AWS_TEARDOWN_ENABLED="${AWS_TEARDOWN_ENABLED:-false}"
+AWS_SKIP_TEARDOWN="${AWS_SKIP_TEARDOWN:-false}"
 AWS_REGION="${AWS_REGION:-us-west-2}"
-if [ "$AWS_TEARDOWN_ENABLED" != "true" ]; then
+if [ "$AWS_SKIP_TEARDOWN" = "true" ]; then
     echo "" >&2
     echo "========================================" >&2
     echo "  TEARDOWN SKIPPED - Resources Preserved" >&2
@@ -24,21 +23,19 @@ if [ "$AWS_TEARDOWN_ENABLED" != "true" ]; then
     echo "AWS infrastructure was NOT destroyed." >&2
     echo "Your EKS cluster and resources are still running." >&2
     echo "" >&2
-    echo "To destroy resources, run with:" >&2
-    echo "  AWS_TEARDOWN_ENABLED=true TF_AUTO_APPROVE=true \\" >&2
-    echo "    uv run isvctl test run -f isvctl/configs/aws/eks.yaml --phase teardown" >&2
+    echo "To destroy resources, run without AWS_SKIP_TEARDOWN:" >&2
+    echo "  uv run isvctl test run -f isvctl/configs/aws/eks.yaml --phase teardown" >&2
     echo "" >&2
     echo "Or manually:" >&2
     echo "  cd isvctl/configs/stubs/aws/eks/terraform" >&2
     echo "  terraform destroy" >&2
     echo "" >&2
-    # Output JSON for orchestration framework
     cat << EOF
 {
   "success": true,
   "platform": "kubernetes",
   "skipped": true,
-  "message": "Teardown skipped (set AWS_TEARDOWN_ENABLED=true to enable)",
+  "message": "Teardown skipped (AWS_SKIP_TEARDOWN=true)",
   "aws": {
     "region": "${AWS_REGION}"
   }


### PR DESCRIPTION
## Summary

- Flip AWS EKS teardown default: teardown now runs automatically unless explicitly skipped with `AWS_SKIP_TEARDOWN=true` (replaces `AWS_TEARDOWN_ENABLED`), preventing ISVs from accidentally leaving resources running
- Add `uv` as a prerequisite in README and getting-started guide, since it's required before the first `uv sync` command

## Changes

### Teardown logic flip
- **`isvctl/configs/aws/eks.yaml`** — replaced `AWS_TEARDOWN_ENABLED` env var with `AWS_SKIP_TEARDOWN`, removed default override that disabled teardown
- **`isvctl/configs/stubs/aws/eks/teardown.sh`** — flipped guard condition to skip only when `AWS_SKIP_TEARDOWN=true`
- **`isvctl/configs/stubs/aws/eks/docs/aws-eks.md`** — updated all references and instructions

### Documentation
- **`README.md`** — added Prerequisites section with link to uv installation
- **`docs/getting-started.md`** — added Prerequisites section with link to uv installation