### PR TITLE
feat: add BMaaS workload and network validation tests

### DIFF
--- a/isvctl/configs/aws/bm.yaml
+++ b/isvctl/configs/aws/bm.yaml
@@ -10,7 +10,7 @@
 #   2. list_instances - Lists instances in VPC, verifies target exists (test)
 #   3. describe_instance - Describes instance state, passes SSH info (test)
 #   4. reboot_instance - Reboots instance, validates recovery (test)
-#   5. reinstall_instance - Reinstalls OS from stock AMI (test) [DEFERRED: AMI snapshot rotation on metal]
+#   5. reinstall_instance - Reinstalls OS from stock AMI (test) [skip: true, ~30-45 min on AWS metal]
 #   6. deploy_nim - Deploys NIM container via SSH (test)
 #   7. teardown_nim - Stops NIM container via SSH (teardown)
 #   8. teardown - Terminates bare-metal EC2 (teardown)
@@ -120,24 +120,24 @@ commands:
           - "{{steps.launch_instance.public_ip}}"
         timeout: 1800
 
-      # DEFERRED: Reinstall instance from stock OS (stop + swap root volume + start)
-      # AWS metal instances don't support CreateReplaceRootVolumeTask, and AMI
-      # snapshots can be rotated by Amazon, causing CreateVolume to fail.
-      # Needs: use latest AMI snapshot instead of original, and don't delete
-      # old volume until new one is attached.
-      # - name: reinstall_instance
-      #   phase: test
-      #   command: "python3 ../stubs/aws/bm/reinstall_instance.py"
-      #   args:
-      #     - "--instance-id"
-      #     - "{{steps.launch_instance.instance_id}}"
-      #     - "--region"
-      #     - "{{region}}"
-      #     - "--key-file"
-      #     - "{{steps.launch_instance.key_file}}"
-      #     - "--public-ip"
-      #     - "{{steps.launch_instance.public_ip}}"
-      #   timeout: 3600
+      # Reinstall instance from stock OS (stop + swap root volume + start)
+      # Skipped by default: ~30-45 min on AWS metal, and CreateReplaceRootVolumeTask
+      # is not supported. The script performs a manual root volume swap instead.
+      # Set skip: false to enable on platforms where reinstall is fast/supported.
+      - name: reinstall_instance
+        phase: test
+        skip: true
+        command: "python3 ../stubs/aws/bm/reinstall_instance.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+          - "--key-file"
+          - "{{steps.launch_instance.key_file}}"
+          - "--public-ip"
+          - "{{steps.launch_instance.public_ip}}"
+        timeout: 3600
 
       # Deploy NIM container via SSH (shared script)
       # Requires NGC_NIM_API_KEY env var
@@ -335,25 +335,25 @@ tests:
       checks:
         - SshHostSoftwareCheck: {}
 
-    # DEFERRED: reinstall validations
-    # reinstall_state:
-    #   step: reinstall_instance
-    #   checks:
-    #     - InstanceStateCheck:
-    #         expected_state: "running"
-    #
-    # reinstall_ssh:
-    #   step: reinstall_instance
-    #   checks:
-    #     - SshConnectivityCheck: {}
-    #     - SshOsCheck:
-    #         expected_os: "ubuntu"
-    #
-    # reinstall_gpu:
-    #   step: reinstall_instance
-    #   checks:
-    #     - SshGpuCheck:
-    #         expected_gpus: 8
+    # Reinstall validations (skipped when reinstall_instance step is skipped)
+    reinstall_state:
+      step: reinstall_instance
+      checks:
+        - InstanceStateCheck:
+            expected_state: "running"
+
+    reinstall_ssh:
+      step: reinstall_instance
+      checks:
+        - SshConnectivityCheck: {}
+        - SshOsCheck:
+            expected_os: "ubuntu"
+
+    reinstall_gpu:
+      step: reinstall_instance
+      checks:
+        - SshGpuCheck:
+            expected_gpus: 8
 
     # Test phase: NIM inference validations
     nim_health:

--- a/isvctl/configs/aws/bm.yaml
+++ b/isvctl/configs/aws/bm.yaml
@@ -262,12 +262,21 @@ tests:
         - FieldExistsCheck:
             fields: ["config_id", "config_name", "dry_run_passed"]
 
-    # TODO: Add GPU stress test
-    # gpu_workload:
-    #   step: describe_instance
-    #   checks:
-    #     - SshGpuStressCheck:
-    #         duration: 60
+    # GPU stress test - PyTorch matrix multiplications on all GPUs
+    gpu_stress:
+      step: describe_instance
+      checks:
+        - SshGpuStressCheck:
+            runtime: 30
+            memory_gb: 16
+            expected_gpus: 8
+
+    # NCCL AllReduce - validates GPU-to-GPU communication (NVLink/NVSwitch)
+    nccl:
+      step: describe_instance
+      checks:
+        - SshNcclCheck:
+            expected_gpus: 8
 
     # Test phase: reboot validations
     reboot_checks:

--- a/isvctl/configs/aws/bm.yaml
+++ b/isvctl/configs/aws/bm.yaml
@@ -85,7 +85,6 @@ commands:
       # Verify OS image installed on BM instance
       - name: verify_image
         phase: test
-        skip: true
         command: "python3 ../stubs/aws/image-registry/verify_image_installed.py"
         args:
           - "--instance-id"
@@ -97,7 +96,6 @@ commands:
       # Verify install config can provision BM
       - name: verify_config
         phase: test
-        skip: true
         command: "python3 ../stubs/aws/image-registry/verify_config_installable.py"
         args:
           - "--instance-id"
@@ -110,7 +108,6 @@ commands:
       # BM-specific: longer waits for hardware POST/BIOS/OS boot
       - name: reboot_instance
         phase: test
-        skip: true
         command: "python3 ../stubs/aws/bm/reboot_instance.py"
         args:
           - "--instance-id"
@@ -146,7 +143,6 @@ commands:
       # Requires NGC_NIM_API_KEY env var
       - name: deploy_nim
         phase: test
-        skip: true
         command: "python3 ../stubs/common/deploy_nim.py"
         args:
           - "--host"
@@ -158,7 +154,6 @@ commands:
       # Teardown NIM container via SSH (shared script)
       - name: teardown_nim
         phase: teardown
-        skip: true
         command: "python3 ../stubs/common/teardown_nim.py"
         args:
           - "--host"

--- a/isvctl/configs/aws/bm.yaml
+++ b/isvctl/configs/aws/bm.yaml
@@ -266,6 +266,14 @@ tests:
         - SshNcclCheck:
             expected_gpus: 8
 
+    # Training workload - validates full training stack (forward/backward/optimizer)
+    training:
+      step: describe_instance
+      checks:
+        - SshTrainingCheck:
+            steps: 50
+            expected_gpus: 8
+
     # Test phase: image registry validations
     image_installed:
       step: verify_image

--- a/isvctl/configs/aws/bm.yaml
+++ b/isvctl/configs/aws/bm.yaml
@@ -274,6 +274,24 @@ tests:
             steps: 50
             expected_gpus: 8
 
+    # Network / interconnect checks
+    nvlink:
+      step: describe_instance
+      checks:
+        - SshNvlinkCheck:
+            expected_gpus: 8
+
+    infiniband:
+      step: describe_instance
+      checks:
+        - SshInfiniBandCheck: {}
+
+    ethernet:
+      step: describe_instance
+      checks:
+        - SshEthernetCheck:
+            ping_target: "8.8.8.8"
+
     # Test phase: image registry validations
     image_installed:
       step: verify_image

--- a/isvctl/configs/aws/bm.yaml
+++ b/isvctl/configs/aws/bm.yaml
@@ -85,6 +85,7 @@ commands:
       # Verify OS image installed on BM instance
       - name: verify_image
         phase: test
+        skip: true
         command: "python3 ../stubs/aws/image-registry/verify_image_installed.py"
         args:
           - "--instance-id"
@@ -96,6 +97,7 @@ commands:
       # Verify install config can provision BM
       - name: verify_config
         phase: test
+        skip: true
         command: "python3 ../stubs/aws/image-registry/verify_config_installable.py"
         args:
           - "--instance-id"
@@ -108,6 +110,7 @@ commands:
       # BM-specific: longer waits for hardware POST/BIOS/OS boot
       - name: reboot_instance
         phase: test
+        skip: true
         command: "python3 ../stubs/aws/bm/reboot_instance.py"
         args:
           - "--instance-id"
@@ -143,6 +146,7 @@ commands:
       # Requires NGC_NIM_API_KEY env var
       - name: deploy_nim
         phase: test
+        skip: true
         command: "python3 ../stubs/common/deploy_nim.py"
         args:
           - "--host"
@@ -154,6 +158,7 @@ commands:
       # Teardown NIM container via SSH (shared script)
       - name: teardown_nim
         phase: teardown
+        skip: true
         command: "python3 ../stubs/common/teardown_nim.py"
         args:
           - "--host"
@@ -245,6 +250,22 @@ tests:
       checks:
         - SshHostSoftwareCheck: {}
 
+    # GPU stress test - PyTorch matrix multiplications on all GPUs
+    gpu_stress:
+      step: describe_instance
+      checks:
+        - SshGpuStressCheck:
+            runtime: 30
+            memory_gb: 16
+            expected_gpus: 8
+
+    # NCCL AllReduce - validates GPU-to-GPU communication (NVLink/NVSwitch)
+    nccl:
+      step: describe_instance
+      checks:
+        - SshNcclCheck:
+            expected_gpus: 8
+
     # Test phase: image registry validations
     image_installed:
       step: verify_image
@@ -261,22 +282,6 @@ tests:
         - StepSuccessCheck: {}
         - FieldExistsCheck:
             fields: ["config_id", "config_name", "dry_run_passed"]
-
-    # GPU stress test - PyTorch matrix multiplications on all GPUs
-    gpu_stress:
-      step: describe_instance
-      checks:
-        - SshGpuStressCheck:
-            runtime: 30
-            memory_gb: 16
-            expected_gpus: 8
-
-    # NCCL AllReduce - validates GPU-to-GPU communication (NVLink/NVSwitch)
-    nccl:
-      step: describe_instance
-      checks:
-        - SshNcclCheck:
-            expected_gpus: 8
 
     # Test phase: reboot validations
     reboot_checks:

--- a/isvctl/configs/templates/bm.yaml
+++ b/isvctl/configs/templates/bm.yaml
@@ -15,14 +15,15 @@
 #   fields, the validations pass regardless of which cloud you use.
 #
 # Steps:
-#   1. launch_instance    (setup)    - Provision bare-metal GPU instance
-#   2. list_instances     (test)     - List instances, verify target exists
-#   3. describe_instance  (test)     - Describe instance state + SSH info
-#   4. reboot_instance    (test)     - Reboot instance, validate recovery
-#   5. deploy_nim         (test)     - Deploy NIM container via SSH
-#   6. teardown_nim       (teardown) - Stop NIM container
-#   7. teardown           (teardown) - Terminate instance
-#   8. verify_teardown    (teardown) - Confirm resources deleted
+#   1. launch_instance      (setup)    - Provision bare-metal GPU instance
+#   2. list_instances       (test)     - List instances, verify target exists
+#   3. describe_instance    (test)     - Describe instance state + SSH info
+#   4. reboot_instance      (test)     - Reboot instance, validate recovery
+#   5. reinstall_instance   (test)     - Reinstall OS from stock image [skip: true by default]
+#   6. deploy_nim           (test)     - Deploy NIM container via SSH
+#   7. teardown_nim         (teardown) - Stop NIM container
+#   8. teardown             (teardown) - Terminate instance
+#   9. verify_teardown      (teardown) - Confirm resources deleted
 #
 # Dev workflow (reuse existing instance):
 #   # Run 1: launch + test, keep instance alive
@@ -135,7 +136,27 @@ commands:
           - "{{steps.launch_instance.public_ip}}"
         timeout: 1800
 
-      # ─── Step 5: Deploy NIM Container ─────────────────────────────
+      # ─── Step 5: Reinstall Instance ─────────────────────────────────
+      # Reinstall the node from its configured stock OS.
+      # Skipped by default: can be very slow depending on platform.
+      # Set skip: false and implement stubs/bm/reinstall_instance.py to enable.
+      # See ../aws/bm.yaml + stubs/aws/bm/reinstall_instance.py for reference.
+      - name: reinstall_instance
+        phase: test
+        skip: true
+        command: "python3 ./stubs/bm/reinstall_instance.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+          - "--key-file"
+          - "{{steps.launch_instance.key_file}}"
+          - "--public-ip"
+          - "{{steps.launch_instance.public_ip}}"
+        timeout: 3600
+
+      # ─── Step 6: Deploy NIM Container ─────────────────────────────
       - name: deploy_nim
         phase: test
         command: "python3 ./stubs/common/deploy_nim.py"
@@ -146,7 +167,7 @@ commands:
           - "{{steps.launch_instance.key_file}}"
         timeout: 1800
 
-      # ─── Step 6: Teardown NIM ─────────────────────────────────────
+      # ─── Step 7: Teardown NIM ─────────────────────────────────────
       - name: teardown_nim
         phase: teardown
         command: "python3 ./stubs/common/teardown_nim.py"
@@ -157,7 +178,7 @@ commands:
           - "{{steps.launch_instance.key_file}}"
         timeout: 120
 
-      # ─── Step 7: Teardown Instance ────────────────────────────────
+      # ─── Step 8: Teardown Instance ────────────────────────────────
       - name: teardown
         phase: teardown
         command: "python3 ./stubs/bm/teardown.py"
@@ -171,7 +192,7 @@ commands:
           - "{{teardown_flag}}"
         timeout: 1800
 
-      # ─── Step 8: Verify Teardown ──────────────────────────────────
+      # ─── Step 9: Verify Teardown ──────────────────────────────────
       # Post-teardown sanitization: verify instance terminated and
       # resources deleted.
       - name: verify_teardown
@@ -237,6 +258,44 @@ tests:
       checks:
         - SshHostSoftwareCheck: {}
 
+    # GPU stress test - PyTorch matrix multiplications on all GPUs
+    gpu_stress:
+      step: describe_instance
+      checks:
+        - SshGpuStressCheck:
+            runtime: 30
+            memory_gb: 16
+
+    # NCCL AllReduce - validates GPU-to-GPU communication (NVLink/NVSwitch)
+    nccl:
+      step: describe_instance
+      checks:
+        - SshNcclCheck: {}
+
+    # DDP training workload - validates full training stack
+    training:
+      step: describe_instance
+      checks:
+        - SshTrainingCheck:
+            steps: 50
+
+    # Network / interconnect checks
+    nvlink:
+      step: describe_instance
+      checks:
+        - SshNvlinkCheck: {}
+
+    infiniband:
+      step: describe_instance
+      checks:
+        - SshInfiniBandCheck: {}
+
+    ethernet:
+      step: describe_instance
+      checks:
+        - SshEthernetCheck:
+            ping_target: "8.8.8.8"
+
     reboot_checks:
       step: reboot_instance
       checks:
@@ -266,6 +325,25 @@ tests:
       step: reboot_instance
       checks:
         - SshHostSoftwareCheck: {}
+
+    # Reinstall validations (skipped when reinstall_instance step is skipped)
+    reinstall_state:
+      step: reinstall_instance
+      checks:
+        - InstanceStateCheck:
+            expected_state: "running"
+
+    reinstall_ssh:
+      step: reinstall_instance
+      checks:
+        - SshConnectivityCheck: {}
+        - SshOsCheck:
+            expected_os: "ubuntu"
+
+    reinstall_gpu:
+      step: reinstall_instance
+      checks:
+        - SshGpuCheck: {}
 
     nim_health:
       step: deploy_nim

--- a/isvctl/configs/templates/image-registry.yaml
+++ b/isvctl/configs/templates/image-registry.yaml
@@ -23,6 +23,10 @@
 #   5. install_config_bm      (test)     - Install OS config on bare-metal
 #   6. teardown               (teardown) - Clean up all resources
 #
+# Note: In the AWS reference implementation, the BM install/verify steps
+#   (install_image_bm, install_config_bm) are in ../aws/bm.yaml instead of
+#   here, as verify_image and verify_config steps within the BM lifecycle.
+#
 # Quick start:
 #   1. Copy this folder:  cp -r templates/ my-isv/
 #   2. Edit the stubs:    my-isv/stubs/image-registry/*.py

--- a/isvctl/configs/templates/kaas.yaml
+++ b/isvctl/configs/templates/kaas.yaml
@@ -111,6 +111,20 @@ tests:
           runtime: 30
       - K8sNimInferenceWorkload:
           timeout: 900
+      - K8sNimHelmWorkload-1b:
+          model: "meta/llama-3.2-1b-instruct"
+          model_tag: "latest"
+          gpu_count: 1
+          timeout: 900
+          genai_perf_requests: 100
+          genai_perf_concurrency: 4
+      - K8sNimHelmWorkload-3b:
+          model: "meta/llama-3.2-3b-instruct"
+          model_tag: "latest"
+          gpu_count: 1
+          timeout: 1800
+          genai_perf_requests: 200
+          genai_perf_concurrency: 8
 
   exclude:
     markers: []

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -238,9 +238,12 @@ class Orchestrator:
             step_phase = (step.phase or "setup").lower()
             steps_by_phase[step_phase].append(step)
 
-        # Register all step phases upfront so validation phase inference works
-        # even before a step has executed
+        # Register step phases upfront so validation phase inference works
+        # even before a step has executed. Skipped steps are excluded so
+        # their validations are also skipped automatically.
         for step in steps:
+            if step.skip:
+                continue
             step_phase = (step.phase or "setup").lower()
             self.context.set_step_phase(step.name, step_phase)
 

--- a/isvctl/src/isvctl/orchestrator/step_executor.py
+++ b/isvctl/src/isvctl/orchestrator/step_executor.py
@@ -204,7 +204,7 @@ class StepExecutor:
 
         for step in steps:
             if step.skip:
-                logger.info(f"Skipping step: {step.name}")
+                logger.info(f"Skipping step '{step.name}' (skip: true) and its validations")
                 results.add_step(
                     StepResult(
                         name=step.name,

--- a/isvtest/src/isvtest/main.py
+++ b/isvtest/src/isvtest/main.py
@@ -223,12 +223,15 @@ def _transform_validations_for_pytest(
                     params = {"phase": group_phase, **params}
 
                 # Determine validation phase (priority: explicit > infer from step > default)
+                # If a step is referenced but has no registered phase, it was skipped
                 if "phase" in params:
                     validation_phase = params["phase"]
                 elif "step" in params:
-                    # Infer from the step's phase
                     step_name = params["step"]
-                    validation_phase = step_phases.get(step_name, "test")
+                    if step_name not in step_phases:
+                        logger.info(f"Skipping validation '{name}' in [{category}]: step '{step_name}' is skipped")
+                        continue
+                    validation_phase = step_phases[step_name]
                 else:
                     validation_phase = "test"  # Default to test phase
 

--- a/isvtest/src/isvtest/validations/ssh.py
+++ b/isvtest/src/isvtest/validations/ssh.py
@@ -1446,6 +1446,306 @@ class SshTrainingCheck(BaseValidation):
             self.set_failed(f"Training check failed: {e}")
 
 
+# =============================================================================
+# Network / Interconnect Validations
+# =============================================================================
+
+
+class SshNvlinkCheck(BaseValidation):
+    """Validate NVLink topology and link status via SSH.
+
+    Checks that NVLink interconnects between GPUs are present and active
+    using ``nvidia-smi nvlink -s`` and ``nvidia-smi topo -m``.
+
+    Config:
+        host, key_file, user: SSH connection details
+        expected_gpus (int): Expected GPU count (optional)
+    """
+
+    description: ClassVar[str] = "NVLink topology and status via SSH"
+    timeout: ClassVar[int] = 120
+    markers: ClassVar[list[str]] = ["ssh", "gpu", "network"]
+
+    def run(self) -> None:
+        try:
+            import paramiko  # noqa: F401
+        except ImportError:
+            self.set_failed("paramiko not installed")
+            return
+
+        ssh_cfg = get_ssh_config(self.config, self.config.get("inventory", {}))
+        host = ssh_cfg["ssh_host"]
+        user = ssh_cfg["ssh_user"]
+        key_path = ssh_cfg["ssh_key_path"]
+
+        if not host or not key_path:
+            self.set_failed("Missing host or key_file")
+            return
+
+        expected_gpus = self.config.get("expected_gpus", ssh_cfg.get("gpu_count"))
+
+        try:
+            ssh = get_ssh_client(host, user, key_path, timeout=60)
+
+            # Check NVLink status per GPU
+            exit_code, stdout, _ = run_ssh_command(ssh, "nvidia-smi nvlink -s 2>/dev/null")
+            if exit_code != 0 or not stdout.strip():
+                # NVLink may not be available (e.g., consumer GPUs)
+                self.report_subtest("nvlink", True, "NVLink not available (OK for non-NVLink GPUs)")
+                self.set_passed(f"NVLink not available on {host} (skipped)")
+                ssh.close()
+                return
+
+            # Parse per-GPU NVLink status
+            # Format: "GPU 0: ..." followed by link lines
+            current_gpu = None
+            gpu_links: dict[str, list[str]] = {}
+            inactive_links: list[str] = []
+            for line in stdout.strip().splitlines():
+                gpu_match = re.match(r"GPU\s+(\d+):", line)
+                if gpu_match:
+                    current_gpu = gpu_match.group(1)
+                    gpu_links[current_gpu] = []
+                elif current_gpu is not None and line.strip():
+                    gpu_links[current_gpu].append(line.strip())
+                    if "inactive" in line.lower():
+                        inactive_links.append(f"GPU {current_gpu}: {line.strip()}")
+
+            for gpu_id, links in gpu_links.items():
+                active = [ln for ln in links if "inactive" not in ln.lower()]
+                link_ok = len(active) > 0
+                self.report_subtest(
+                    f"gpu{gpu_id}_nvlink",
+                    link_ok,
+                    f"GPU {gpu_id}: {len(active)} active link(s)",
+                )
+
+            if expected_gpus and len(gpu_links) < expected_gpus:
+                self.report_subtest(
+                    "gpu_count",
+                    False,
+                    f"NVLink on {len(gpu_links)} GPUs, expected {expected_gpus}",
+                )
+
+            # Get topology matrix for context
+            exit_code, stdout, _ = run_ssh_command(ssh, "nvidia-smi topo -m 2>/dev/null")
+            if exit_code == 0 and stdout.strip():
+                self.report_subtest("topology", True, "Topology matrix available")
+                self.log.info(f"GPU topology:\n{stdout.strip()}")
+
+            ssh.close()
+
+            failed = get_failed_subtests(self._subtest_results)
+            if failed:
+                self.set_failed(f"NVLink subtests failed: {', '.join(failed)}")
+            elif inactive_links:
+                self.set_failed(f"Inactive NVLink links detected: {'; '.join(inactive_links)}")
+            else:
+                self.set_passed(f"NVLink check on {host} OK ({len(gpu_links)} GPUs)")
+
+        except Exception as e:
+            self.set_failed(f"NVLink check failed: {e}")
+
+
+class SshInfiniBandCheck(BaseValidation):
+    """Validate InfiniBand interfaces via SSH.
+
+    Checks that IB ports are present and in Active state using ``ibstat``.
+
+    Config:
+        host, key_file, user: SSH connection details
+        expected_ports (int): Expected number of active IB ports (optional)
+    """
+
+    description: ClassVar[str] = "InfiniBand interface status via SSH"
+    timeout: ClassVar[int] = 120
+    markers: ClassVar[list[str]] = ["ssh", "network"]
+
+    def run(self) -> None:
+        try:
+            import paramiko  # noqa: F401
+        except ImportError:
+            self.set_failed("paramiko not installed")
+            return
+
+        ssh_cfg = get_ssh_config(self.config, self.config.get("inventory", {}))
+        host = ssh_cfg["ssh_host"]
+        user = ssh_cfg["ssh_user"]
+        key_path = ssh_cfg["ssh_key_path"]
+
+        if not host or not key_path:
+            self.set_failed("Missing host or key_file")
+            return
+
+        expected_ports = self.config.get("expected_ports")
+
+        try:
+            ssh = get_ssh_client(host, user, key_path, timeout=60)
+
+            # Check if ibstat is available
+            exit_code, stdout, _ = run_ssh_command(ssh, "ibstat 2>/dev/null")
+            if exit_code != 0 or not stdout.strip():
+                self.report_subtest("infiniband", True, "InfiniBand not available (OK if not expected)")
+                self.set_passed(f"InfiniBand not available on {host} (skipped)")
+                ssh.close()
+                return
+
+            # Parse ibstat output for CA (Channel Adapter) and port status
+            # Format: "CA 'mlx5_0'" ... "Port 1:" ... "State: Active"
+            current_ca = None
+            current_port = None
+            active_ports = 0
+            total_ports = 0
+            for line in stdout.strip().splitlines():
+                ca_match = re.match(r"\s*CA\s+'(\S+)'", line)
+                port_match = re.match(r"\s*Port\s+(\d+):", line)
+                state_match = re.match(r"\s*State:\s+(\S+)", line)
+
+                if ca_match:
+                    current_ca = ca_match.group(1)
+                elif port_match:
+                    current_port = port_match.group(1)
+                    total_ports += 1
+                elif state_match and current_ca and current_port:
+                    state = state_match.group(1)
+                    is_active = state == "Active"
+                    if is_active:
+                        active_ports += 1
+                    self.report_subtest(
+                        f"{current_ca}_port{current_port}",
+                        is_active,
+                        f"{current_ca} port {current_port}: {state}",
+                    )
+
+            if total_ports == 0:
+                self.report_subtest("ib_ports", False, "No IB ports found")
+                self.set_failed(f"No InfiniBand ports found on {host}")
+                ssh.close()
+                return
+
+            if expected_ports and active_ports < expected_ports:
+                self.report_subtest(
+                    "port_count",
+                    False,
+                    f"{active_ports} active ports, expected {expected_ports}",
+                )
+
+            ssh.close()
+
+            failed = get_failed_subtests(self._subtest_results)
+            if failed:
+                self.set_failed(f"InfiniBand subtests failed: {', '.join(failed)}")
+            else:
+                self.set_passed(f"InfiniBand check on {host} OK ({active_ports}/{total_ports} ports active)")
+
+        except Exception as e:
+            self.set_failed(f"InfiniBand check failed: {e}")
+
+
+class SshEthernetCheck(BaseValidation):
+    """Validate network interfaces and connectivity via SSH.
+
+    Checks that expected network interfaces are up and optionally
+    verifies connectivity to a target host via ping.
+
+    Config:
+        host, key_file, user: SSH connection details
+        expected_interfaces (list[str]): Interface names to check (optional, e.g. ["eth0", "ens5"])
+        ping_target (str): Host to ping for connectivity check (optional)
+    """
+
+    description: ClassVar[str] = "Ethernet interfaces and connectivity via SSH"
+    timeout: ClassVar[int] = 120
+    markers: ClassVar[list[str]] = ["ssh", "network"]
+
+    def run(self) -> None:
+        try:
+            import paramiko  # noqa: F401
+        except ImportError:
+            self.set_failed("paramiko not installed")
+            return
+
+        ssh_cfg = get_ssh_config(self.config, self.config.get("inventory", {}))
+        host = ssh_cfg["ssh_host"]
+        user = ssh_cfg["ssh_user"]
+        key_path = ssh_cfg["ssh_key_path"]
+
+        if not host or not key_path:
+            self.set_failed("Missing host or key_file")
+            return
+
+        expected_interfaces = self.config.get("expected_interfaces", [])
+        ping_target = self.config.get("ping_target")
+
+        try:
+            ssh = get_ssh_client(host, user, key_path, timeout=60)
+
+            # List all UP interfaces
+            exit_code, stdout, _ = run_ssh_command(
+                ssh,
+                "ip -o link show up | awk -F': ' '{print $2}' | grep -v lo",
+            )
+            if exit_code != 0:
+                self.set_failed(f"Cannot list network interfaces on {host}")
+                ssh.close()
+                return
+
+            up_interfaces = [iface.strip() for iface in stdout.strip().splitlines() if iface.strip()]
+            self.report_subtest(
+                "interfaces_up",
+                len(up_interfaces) > 0,
+                f"{len(up_interfaces)} interface(s) up: {', '.join(up_interfaces[:10])}",
+            )
+
+            # Check expected interfaces if specified
+            for iface in expected_interfaces:
+                found = iface in up_interfaces
+                self.report_subtest(
+                    f"iface_{iface}",
+                    found,
+                    f"{iface}: {'UP' if found else 'NOT FOUND'}",
+                )
+
+            # Get interface details (IP addresses)
+            exit_code, stdout, _ = run_ssh_command(
+                ssh,
+                "ip -o addr show | grep -v '127.0.0.1' | grep -v '::1' | awk '{print $2, $3, $4}'",
+            )
+            if exit_code == 0 and stdout.strip():
+                addr_idx = 0
+                for line in stdout.strip().splitlines()[:10]:
+                    parts = line.split()
+                    if len(parts) >= 3:
+                        iface, family, addr = parts[0], parts[1], parts[2]
+                        self.report_subtest(
+                            f"addr_{addr_idx}_{iface}",
+                            True,
+                            f"{iface} ({family}): {addr}",
+                        )
+                        addr_idx += 1
+
+            # Ping test if target specified
+            if ping_target:
+                exit_code, stdout, _ = run_ssh_command(ssh, f"ping -c 3 -W 5 {ping_target} 2>&1")
+                ping_ok = exit_code == 0 and "0% packet loss" in stdout
+                self.report_subtest(
+                    "ping",
+                    ping_ok,
+                    f"Ping {ping_target}: {'OK' if ping_ok else 'FAILED'}",
+                )
+
+            ssh.close()
+
+            failed = get_failed_subtests(self._subtest_results)
+            if failed:
+                self.set_failed(f"Ethernet subtests failed: {', '.join(failed)}")
+            else:
+                self.set_passed(f"Ethernet check on {host} OK ({len(up_interfaces)} interfaces up)")
+
+        except Exception as e:
+            self.set_failed(f"Ethernet check failed: {e}")
+
+
 class SshContainerRuntimeCheck(BaseValidation):
     """Container runtime and NVIDIA Docker check.
 

--- a/isvtest/src/isvtest/validations/ssh.py
+++ b/isvtest/src/isvtest/validations/ssh.py
@@ -1286,12 +1286,17 @@ class SshNcclCheck(BaseValidation):
 
 
 class SshTrainingCheck(BaseValidation):
-    """Run a PyTorch training workload via SSH.
+    """Run a DDP PyTorch training workload via SSH.
 
-    Validates the full training stack (forward, backward, optimizer) by
-    training a small MLP on synthetic data inside a Docker container.
-    Verifies that loss computation, gradient backpropagation, and weight
-    updates work correctly on each GPU.
+    Validates the full distributed training stack by running a small MLP
+    with DistributedDataParallel across all GPUs.  Uses ``torchrun`` to
+    launch one process per GPU, with NCCL gradient synchronisation every
+    step -- the same communication path real training workloads use.
+
+    Validates:
+      - Forward / backward / optimizer work on every GPU
+      - NCCL gradient sync completes without error
+      - Weights stay identical across all ranks (DDP invariant)
 
     Config:
         host, key_file, user: SSH connection details
@@ -1303,7 +1308,7 @@ class SshTrainingCheck(BaseValidation):
         expected_gpus (int): Expected GPU count (optional)
     """
 
-    description: ClassVar[str] = "PyTorch training workload via SSH"
+    description: ClassVar[str] = "DDP training workload via SSH"
     timeout: ClassVar[int] = 900
     markers: ClassVar[list[str]] = ["ssh", "gpu", "workload"]
 
@@ -1342,22 +1347,36 @@ class SshTrainingCheck(BaseValidation):
                 container_runtime = _detect_ssh_container_runtime(ssh)
                 self.log.info(f"Auto-detected runtime: {container_runtime}")
 
+            # Detect GPU count for torchrun --nproc_per_node
+            exit_code, stdout_gpu, _ = run_ssh_command(ssh, "nvidia-smi --query-gpu=name --format=csv,noheader | wc -l")
+            if exit_code != 0 or not stdout_gpu.strip().isdigit():
+                self.set_failed(f"Cannot detect GPU count on {host}")
+                ssh.close()
+                return
+            gpu_count = int(stdout_gpu.strip())
+            if expected_gpus:
+                gpu_count = int(expected_gpus)
+
             script_b64 = base64.b64encode(script_path.read_bytes()).decode()
-            decode_and_run = f"echo {script_b64} | base64 -d | python3"
+            # torchrun needs a file path, not stdin
+            write_and_run = (
+                f"echo {script_b64} | base64 -d > /tmp/_isv_train.py && "
+                f"torchrun --nproc_per_node={gpu_count} /tmp/_isv_train.py"
+            )
             env_vars = f"TRAIN_STEPS={steps} TRAIN_BATCH_SIZE={batch_size} TRAIN_HIDDEN_SIZE={hidden_size}"
 
             if container_runtime == "python":
-                cmd = f"bash -c '{env_vars} {decode_and_run}'"
+                cmd = f"bash -c '{env_vars} {write_and_run}'"
             else:
                 cmd = (
-                    f"docker run --rm --gpus all "
+                    f"docker run --rm --gpus all --ipc=host "
                     f"-e TRAIN_STEPS={steps} -e TRAIN_BATCH_SIZE={batch_size} "
                     f"-e TRAIN_HIDDEN_SIZE={hidden_size} "
-                    f"{image} bash -c '{decode_and_run}'"
+                    f"{image} bash -c '{write_and_run}'"
                 )
 
             self.log.info(
-                f"Running training on {host}: steps={steps}, "
+                f"Running DDP training on {host}: {gpu_count} GPUs, steps={steps}, "
                 f"batch={batch_size}, hidden={hidden_size}, mode={container_runtime}"
             )
 
@@ -1380,35 +1399,41 @@ class SshTrainingCheck(BaseValidation):
                 )
                 return
 
-            # Parse per-GPU results
+            # Parse per-GPU results (DDP format includes synced field)
             gpu_lines = re.findall(
                 r"GPU (\d+): loss ([\d.]+) -> ([\d.]+) "
-                r"\(decreased=(True|False), grads=(True|False)\)",
+                r"\(decreased=(True|False), grads=(True|False), synced=(True|False)\)",
                 output,
             )
-            for gpu_id, first, last, decreased, grads in gpu_lines:
+            for gpu_id, first, last, decreased, grads, synced in gpu_lines:
                 grad_ok = grads == "True"
+                sync_ok = synced == "True"
                 self.report_subtest(
                     f"gpu{gpu_id}_grads",
                     grad_ok,
                     f"GPU {gpu_id}: loss {first} -> {last}, grads={grads}",
+                )
+                self.report_subtest(
+                    f"gpu{gpu_id}_sync",
+                    sync_ok,
+                    f"GPU {gpu_id}: weights synced={synced}",
                 )
 
             # Parse SUCCESS line
             match = re.search(r"SUCCESS:.*trained (\d+) steps on (\d+) GPU", output)
             if match:
                 trained_steps = int(match.group(1))
-                gpu_count = int(match.group(2))
+                result_gpus = int(match.group(2))
                 self.report_subtest("steps", trained_steps > 0, f"{trained_steps} steps completed")
-                self.report_subtest("gpu_count", True, f"{gpu_count} GPU(s) trained")
+                self.report_subtest("ddp", True, f"DDP on {result_gpus} GPU(s)")
 
-                if expected_gpus and gpu_count < expected_gpus:
+                if expected_gpus and result_gpus < expected_gpus:
                     self.report_subtest(
                         "gpu_count_check",
                         False,
-                        f"Expected {expected_gpus} GPUs, got {gpu_count}",
+                        f"Expected {expected_gpus} GPUs, got {result_gpus}",
                     )
-                    self.set_failed(f"GPU count mismatch: expected {expected_gpus}, got {gpu_count}")
+                    self.set_failed(f"GPU count mismatch: expected {expected_gpus}, got {result_gpus}")
                     return
 
             failed = get_failed_subtests(self._subtest_results)

--- a/isvtest/src/isvtest/validations/ssh.py
+++ b/isvtest/src/isvtest/validations/ssh.py
@@ -1285,6 +1285,142 @@ class SshNcclCheck(BaseValidation):
             self.set_failed(f"NCCL test failed: {e}")
 
 
+class SshTrainingCheck(BaseValidation):
+    """Run a PyTorch training workload via SSH.
+
+    Validates the full training stack (forward, backward, optimizer) by
+    training a small MLP on synthetic data inside a Docker container.
+    Verifies that loss computation, gradient backpropagation, and weight
+    updates work correctly on each GPU.
+
+    Config:
+        host, key_file, user: SSH connection details
+        steps (int): Number of training steps (default: 50)
+        batch_size (int): Training batch size (default: 64)
+        hidden_size (int): Hidden layer size (default: 2048)
+        image (str): PyTorch container image (default: nvcr.io/nvidia/pytorch:25.04-py3)
+        container_runtime (str): "docker" or "python" (default: auto-detect)
+        expected_gpus (int): Expected GPU count (optional)
+    """
+
+    description: ClassVar[str] = "PyTorch training workload via SSH"
+    timeout: ClassVar[int] = 900
+    markers: ClassVar[list[str]] = ["ssh", "gpu", "workload"]
+
+    def run(self) -> None:
+        try:
+            import paramiko  # noqa: F401
+        except ImportError:
+            self.set_failed("paramiko not installed")
+            return
+
+        ssh_cfg = get_ssh_config(self.config, self.config.get("inventory", {}))
+        host = ssh_cfg["ssh_host"]
+        user = ssh_cfg["ssh_user"]
+        key_path = ssh_cfg["ssh_key_path"]
+
+        if not host or not key_path:
+            self.set_failed("Missing host or key_file")
+            return
+
+        steps = self.config.get("steps", 50)
+        batch_size = self.config.get("batch_size", 64)
+        hidden_size = self.config.get("hidden_size", 2048)
+        image = self.config.get("image", "nvcr.io/nvidia/pytorch:25.04-py3")
+        container_runtime = self.config.get("container_runtime")
+        expected_gpus = self.config.get("expected_gpus", ssh_cfg.get("gpu_count"))
+
+        script_path = Path(__file__).parent.parent / "workloads" / "scripts" / "gpu_train_torch.py"
+        if not script_path.exists():
+            self.set_failed(f"Training script not found: {script_path}")
+            return
+
+        try:
+            ssh = get_ssh_client(host, user, key_path, timeout=60)
+
+            if not container_runtime:
+                container_runtime = _detect_ssh_container_runtime(ssh)
+                self.log.info(f"Auto-detected runtime: {container_runtime}")
+
+            script_b64 = base64.b64encode(script_path.read_bytes()).decode()
+            decode_and_run = f"echo {script_b64} | base64 -d | python3"
+            env_vars = f"TRAIN_STEPS={steps} TRAIN_BATCH_SIZE={batch_size} TRAIN_HIDDEN_SIZE={hidden_size}"
+
+            if container_runtime == "python":
+                cmd = f"bash -c '{env_vars} {decode_and_run}'"
+            else:
+                cmd = (
+                    f"docker run --rm --gpus all "
+                    f"-e TRAIN_STEPS={steps} -e TRAIN_BATCH_SIZE={batch_size} "
+                    f"-e TRAIN_HIDDEN_SIZE={hidden_size} "
+                    f"{image} bash -c '{decode_and_run}'"
+                )
+
+            self.log.info(
+                f"Running training on {host}: steps={steps}, "
+                f"batch={batch_size}, hidden={hidden_size}, mode={container_runtime}"
+            )
+
+            _, stdout, stderr = run_ssh_command(ssh, cmd)
+            ssh.close()
+
+            output = f"{stdout}\n{stderr}".strip()
+            self.log.debug(f"Training output:\n{output[:2000]}")
+
+            if "FAILURE:" in output:
+                self.report_subtest("training", False, output.strip())
+                self.set_failed(f"Training failed on {host}: {output.strip()}")
+                return
+
+            if "SUCCESS:" not in output:
+                self.report_subtest("training", False, "SUCCESS marker not found")
+                self.set_failed(
+                    f"Training did not complete on {host}",
+                    output=output[-500:],
+                )
+                return
+
+            # Parse per-GPU results
+            gpu_lines = re.findall(
+                r"GPU (\d+): loss ([\d.]+) -> ([\d.]+) "
+                r"\(decreased=(True|False), grads=(True|False)\)",
+                output,
+            )
+            for gpu_id, first, last, decreased, grads in gpu_lines:
+                grad_ok = grads == "True"
+                self.report_subtest(
+                    f"gpu{gpu_id}_grads",
+                    grad_ok,
+                    f"GPU {gpu_id}: loss {first} -> {last}, grads={grads}",
+                )
+
+            # Parse SUCCESS line
+            match = re.search(r"SUCCESS:.*trained (\d+) steps on (\d+) GPU", output)
+            if match:
+                trained_steps = int(match.group(1))
+                gpu_count = int(match.group(2))
+                self.report_subtest("steps", trained_steps > 0, f"{trained_steps} steps completed")
+                self.report_subtest("gpu_count", True, f"{gpu_count} GPU(s) trained")
+
+                if expected_gpus and gpu_count < expected_gpus:
+                    self.report_subtest(
+                        "gpu_count_check",
+                        False,
+                        f"Expected {expected_gpus} GPUs, got {gpu_count}",
+                    )
+                    self.set_failed(f"GPU count mismatch: expected {expected_gpus}, got {gpu_count}")
+                    return
+
+            failed = get_failed_subtests(self._subtest_results)
+            if failed:
+                self.set_failed(f"Training subtests failed: {', '.join(failed)}")
+            else:
+                self.set_passed(f"Training passed on {host}: {output.strip().splitlines()[-1]}")
+
+        except Exception as e:
+            self.set_failed(f"Training check failed: {e}")
+
+
 class SshContainerRuntimeCheck(BaseValidation):
     """Container runtime and NVIDIA Docker check.
 

--- a/isvtest/src/isvtest/validations/ssh.py
+++ b/isvtest/src/isvtest/validations/ssh.py
@@ -13,8 +13,14 @@ Requires paramiko: pip install paramiko
 
 from __future__ import annotations
 
+import base64
 import os
-from typing import ClassVar
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    import paramiko
 
 from isvtest.core.ssh import (
     get_failed_subtests,
@@ -1001,23 +1007,282 @@ class SshDriverCheck(BaseValidation):
 # =============================================================================
 
 
-# FIXME: The test is a placeholder, we should have better approach.
-class SshGpuStressCheck(BaseValidation):
-    """Run GPU stress test via SSH.
+def _detect_ssh_container_runtime(ssh: paramiko.SSHClient) -> str:
+    """Detect available container runtime on a remote host via SSH.
 
-    Works on any platform with SSH + PyTorch.
+    Checks for Docker with NVIDIA GPU support. Falls back to "python"
+    if Docker is not available or the NVIDIA runtime is not configured.
+
+    Args:
+        ssh: Connected paramiko SSHClient instance
+
+    Returns:
+        "docker" if Docker + NVIDIA runtime works, otherwise "python"
+    """
+    exit_code, stdout, _ = run_ssh_command(
+        ssh,
+        "docker info --format '{{.Runtimes}}' 2>/dev/null",
+    )
+    if exit_code != 0:
+        return "python"
+    if "nvidia" not in stdout.lower():
+        return "python"
+    return "docker"
+
+
+class SshGpuStressCheck(BaseValidation):
+    """Run GPU stress test via SSH using PyTorch matrix multiplications.
+
+    Runs the same gpu_stress_torch.py script used by Slurm/K8s workloads,
+    but executed remotely over SSH inside a Docker container (or directly
+    with system Python if container_runtime is "python").
 
     Config:
         host, key_file, user: SSH connection details
-        duration: Stress test duration in seconds (default: 60)
+        runtime (int): Stress duration in seconds (default: 30)
+        memory_gb (int): Target GPU memory usage in GB (default: 16)
+        image (str): PyTorch container image (default: nvcr.io/nvidia/pytorch:25.04-py3)
+        container_runtime (str): "docker" or "python" (default: "docker")
+        expected_gpus (int): Expected GPU count to validate (optional)
     """
 
     description: ClassVar[str] = "GPU stress test via SSH"
-    timeout: ClassVar[int] = 600
+    timeout: ClassVar[int] = 900
     markers: ClassVar[list[str]] = ["ssh", "gpu", "workload"]
 
     def run(self) -> None:
-        self.set_passed("GPU stress completed (placeholder)")
+        try:
+            import paramiko  # noqa: F401
+        except ImportError:
+            self.set_failed("paramiko not installed")
+            return
+
+        ssh_cfg = get_ssh_config(self.config, self.config.get("inventory", {}))
+        host = ssh_cfg["ssh_host"]
+        user = ssh_cfg["ssh_user"]
+        key_path = ssh_cfg["ssh_key_path"]
+
+        if not host or not key_path:
+            self.set_failed("Missing host or key_file")
+            return
+
+        runtime = self.config.get("runtime", 30)
+        memory_gb = self.config.get("memory_gb", 16)
+        image = self.config.get("image", "nvcr.io/nvidia/pytorch:25.04-py3")
+        container_runtime = self.config.get("container_runtime")
+        expected_gpus = self.config.get("expected_gpus", ssh_cfg.get("gpu_count"))
+
+        script_path = Path(__file__).parent.parent / "workloads" / "scripts" / "gpu_stress_torch.py"
+        if not script_path.exists():
+            self.set_failed(f"GPU stress script not found: {script_path}")
+            return
+
+        try:
+            ssh = get_ssh_client(host, user, key_path, timeout=60)
+
+            # Auto-detect runtime if not explicitly configured
+            if not container_runtime:
+                container_runtime = _detect_ssh_container_runtime(ssh)
+                self.log.info(f"Auto-detected runtime: {container_runtime}")
+
+            script_b64 = base64.b64encode(script_path.read_bytes()).decode()
+            decode_and_run = f"echo {script_b64} | base64 -d | python3"
+            env_vars = f"GPU_STRESS_RUNTIME={runtime} GPU_MEMORY_GB={memory_gb}"
+
+            if container_runtime == "python":
+                cmd = f"bash -c '{env_vars} {decode_and_run}'"
+            else:
+                cmd = (
+                    f"docker run --rm --gpus all "
+                    f"-e GPU_STRESS_RUNTIME={runtime} -e GPU_MEMORY_GB={memory_gb} "
+                    f"{image} bash -c '{decode_and_run}'"
+                )
+
+            self.log.info(
+                f"Running GPU stress on {host}: runtime={runtime}s, memory={memory_gb}GB, mode={container_runtime}"
+            )
+
+            _, stdout, stderr = run_ssh_command(ssh, cmd)
+            ssh.close()
+
+            output = f"{stdout}\n{stderr}".strip()
+            self.log.debug(f"GPU stress output:\n{output[:2000]}")
+
+            if "FAILURE:" in output:
+                self.report_subtest("gpu_stress", False, output.strip())
+                self.set_failed(f"GPU stress failed on {host}: {output.strip()}")
+                return
+
+            if "SUCCESS:" not in output:
+                self.report_subtest("gpu_stress", False, "SUCCESS marker not found")
+                self.set_failed(
+                    f"GPU stress did not complete successfully on {host}",
+                    output=output[-500:],
+                )
+                return
+
+            # Parse SUCCESS line: "SUCCESS: hostname completed N loops with M GPU(s)"
+            match = re.search(r"SUCCESS:.*completed (\d+) loops with (\d+) GPU", output)
+            if match:
+                loops = int(match.group(1))
+                gpu_count = int(match.group(2))
+                self.report_subtest("loops", loops > 0, f"{loops} loops completed")
+                self.report_subtest("gpu_count", True, f"{gpu_count} GPU(s) stressed")
+
+                if expected_gpus and gpu_count < expected_gpus:
+                    self.report_subtest(
+                        "gpu_count_check",
+                        False,
+                        f"Expected {expected_gpus} GPUs, got {gpu_count}",
+                    )
+                    self.set_failed(f"GPU count mismatch: expected {expected_gpus}, got {gpu_count}")
+                    return
+            else:
+                self.report_subtest("parse", False, "Could not parse SUCCESS output")
+
+            failed = get_failed_subtests(self._subtest_results)
+            if failed:
+                self.set_failed(f"GPU stress subtests failed: {', '.join(failed)}")
+            else:
+                self.set_passed(f"GPU stress passed on {host}: {output.strip().splitlines()[-1]}")
+
+        except Exception as e:
+            self.set_failed(f"GPU stress failed: {e}")
+
+
+class SshNcclCheck(BaseValidation):
+    """Run single-node NCCL AllReduce test via SSH.
+
+    Validates GPU-to-GPU communication (NVLink/NVSwitch) by running
+    NCCL all_reduce_perf_mpi via MPI inside a Docker container on the
+    target host. Uses the NVIDIA HPC Benchmarks image. Requires at least
+    2 GPUs.
+
+    Config:
+        host, key_file, user: SSH connection details
+        image (str): Container image (default: nvcr.io/nvidia/hpc-benchmarks:25.04)
+        min_bus_bw_gbps (float): Minimum acceptable bus bandwidth in GB/s (default: 0 = no threshold)
+        expected_gpus (int): Expected GPU count (optional, used for -np argument)
+        message_sizes (str): NCCL test size range flags (default: "-b 1M -e 256M -f 2")
+    """
+
+    description: ClassVar[str] = "NCCL AllReduce test via SSH"
+    timeout: ClassVar[int] = 900
+    markers: ClassVar[list[str]] = ["ssh", "gpu", "workload"]
+
+    _DEFAULT_IMAGE = "nvcr.io/nvidia/hpc-benchmarks:25.04"
+
+    def run(self) -> None:
+        try:
+            import paramiko  # noqa: F401
+        except ImportError:
+            self.set_failed("paramiko not installed")
+            return
+
+        ssh_cfg = get_ssh_config(self.config, self.config.get("inventory", {}))
+        host = ssh_cfg["ssh_host"]
+        user = ssh_cfg["ssh_user"]
+        key_path = ssh_cfg["ssh_key_path"]
+
+        if not host or not key_path:
+            self.set_failed("Missing host or key_file")
+            return
+
+        image = self.config.get("image", self._DEFAULT_IMAGE)
+        min_bus_bw = float(self.config.get("min_bus_bw_gbps", 0))
+        message_sizes = self.config.get("message_sizes", "-b 1M -e 256M -f 2")
+
+        try:
+            ssh = get_ssh_client(host, user, key_path, timeout=60)
+
+            # Verify Docker + NVIDIA runtime are available (NCCL binaries come from the container)
+            has_docker = _detect_ssh_container_runtime(ssh) == "docker"
+            if not has_docker:
+                self.set_failed(
+                    f"Docker with NVIDIA runtime not available on {host}. "
+                    "NCCL tests require a container with NCCL test binaries."
+                )
+                ssh.close()
+                return
+
+            # Detect GPU count
+            exit_code, stdout, _ = run_ssh_command(ssh, "nvidia-smi --query-gpu=name --format=csv,noheader | wc -l")
+            if exit_code != 0 or not stdout.strip().isdigit():
+                self.set_failed(f"Cannot detect GPU count on {host}")
+                ssh.close()
+                return
+
+            gpu_count = int(stdout.strip())
+            expected_gpus = self.config.get("expected_gpus")
+            if expected_gpus:
+                gpu_count = int(expected_gpus)
+
+            if gpu_count < 2:
+                self.set_passed(f"Skipped: {host} has {gpu_count} GPU(s), need >= 2 for NCCL test")
+                ssh.close()
+                return
+
+            self.report_subtest("gpu_count", True, f"{gpu_count} GPUs detected")
+
+            nccl_cmd = (
+                f"docker run --rm --gpus all --ipc=host {image} "
+                f"mpirun --allow-run-as-root -np {gpu_count} "
+                f"--bind-to none --map-by slot "
+                f"all_reduce_perf_mpi {message_sizes} -g 1"
+            )
+
+            self.log.info(f"Running NCCL AllReduce on {host} with {gpu_count} GPUs")
+            exit_code, stdout, stderr = run_ssh_command(ssh, nccl_cmd)
+            ssh.close()
+
+            output = f"{stdout}\n{stderr}".strip()
+            self.log.debug(f"NCCL output:\n{output[:3000]}")
+
+            if exit_code != 0 and "Avg bus bandwidth" not in output:
+                self.report_subtest("nccl_run", False, f"Exit code {exit_code}")
+                self.set_failed(f"NCCL test failed on {host}", output=output[-500:])
+                return
+
+            self.report_subtest("nccl_run", True, "NCCL test completed")
+
+            # Parse average bus bandwidth
+            avg_bw_match = re.search(r"#\s*Avg bus bandwidth\s*:\s*([\d.]+)", output)
+            if avg_bw_match:
+                avg_bw = float(avg_bw_match.group(1))
+                self.report_subtest("avg_bus_bw", True, f"{avg_bw:.2f} GB/s")
+
+                if min_bus_bw > 0:
+                    bw_ok = avg_bw >= min_bus_bw
+                    self.report_subtest(
+                        "bw_threshold",
+                        bw_ok,
+                        f"{avg_bw:.2f} GB/s vs {min_bus_bw} GB/s minimum",
+                    )
+                    if not bw_ok:
+                        self.set_failed(f"Bus bandwidth {avg_bw:.2f} GB/s below threshold {min_bus_bw} GB/s")
+                        return
+            else:
+                self.report_subtest("avg_bus_bw", False, "Could not parse bandwidth")
+
+            # Check out-of-bounds (data corruption)
+            oob_match = re.search(r"#\s*Out of bounds values\s*:\s*(\d+)", output)
+            if oob_match:
+                oob = int(oob_match.group(1))
+                oob_ok = oob == 0
+                self.report_subtest("data_integrity", oob_ok, f"{oob} out of bounds values")
+                if not oob_ok:
+                    self.set_failed(f"Data corruption: {oob} out of bounds values")
+                    return
+
+            failed = get_failed_subtests(self._subtest_results)
+            if failed:
+                self.set_failed(f"NCCL subtests failed: {', '.join(failed)}")
+            else:
+                bw_msg = f", avg BW: {avg_bw:.2f} GB/s" if avg_bw_match else ""
+                self.set_passed(f"NCCL AllReduce passed on {host} ({gpu_count} GPUs{bw_msg})")
+
+        except Exception as e:
+            self.set_failed(f"NCCL test failed: {e}")
 
 
 class SshContainerRuntimeCheck(BaseValidation):

--- a/isvtest/src/isvtest/workloads/scripts/gpu_train_torch.py
+++ b/isvtest/src/isvtest/workloads/scripts/gpu_train_torch.py
@@ -1,0 +1,79 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#   'torch>=2.8.0',
+# ]
+#
+# [tool.uv]
+# extra-index-url = ["https://download.pytorch.org/whl/cu129"]
+# ///
+import os
+import socket
+
+import torch
+import torch.nn as nn
+
+h = socket.gethostname()
+n = torch.cuda.device_count()
+steps = int(os.getenv("TRAIN_STEPS", "50"))
+batch = int(os.getenv("TRAIN_BATCH_SIZE", "64"))
+hidden = int(os.getenv("TRAIN_HIDDEN_SIZE", "2048"))
+lr = float(os.getenv("TRAIN_LR", "0.01"))
+
+if n == 0:
+    print(f"FAILURE: No GPUs on {h}")
+    exit(1)
+
+print(f"{h}: {n} GPUs, steps={steps}, batch={batch}, hidden={hidden}")
+
+results = []
+for gpu in range(n):
+    dev = f"cuda:{gpu}"
+    model = nn.Sequential(
+        nn.Linear(hidden, hidden),
+        nn.ReLU(),
+        nn.Linear(hidden, hidden),
+        nn.ReLU(),
+        nn.Linear(hidden, 10),
+    ).to(dev)
+    optimizer = torch.optim.SGD(model.parameters(), lr=lr)
+    loss_fn = nn.CrossEntropyLoss()
+
+    first_loss = 0.0
+    last_loss = 0.0
+    for step in range(steps):
+        x = torch.randn(batch, hidden, device=dev)
+        target = torch.randint(0, 10, (batch,), device=dev)
+        optimizer.zero_grad()
+        loss = loss_fn(model(x), target)
+        loss.backward()
+        optimizer.step()
+        lv = loss.item()
+        if step == 0:
+            first_loss = lv
+        last_loss = lv
+
+    # Verify gradients were computed
+    has_grads = all(p.grad is not None and p.grad.abs().sum().item() > 0 for p in model.parameters() if p.requires_grad)
+    decreased = last_loss < first_loss
+    results.append(
+        {
+            "gpu": gpu,
+            "first_loss": first_loss,
+            "last_loss": last_loss,
+            "decreased": decreased,
+            "has_grads": has_grads,
+        }
+    )
+    status = "ok" if (decreased and has_grads) else "WARN"
+    print(
+        f"  GPU {gpu}: loss {first_loss:.4f} -> {last_loss:.4f} (decreased={decreased}, grads={has_grads}) [{status}]"
+    )
+
+failed = [r for r in results if not r["has_grads"]]
+if failed:
+    gpus = ", ".join(str(r["gpu"]) for r in failed)
+    print(f"FAILURE: No gradients on GPU(s) {gpus}")
+    exit(1)
+
+print(f"SUCCESS: {h} trained {steps} steps on {n} GPU(s)")

--- a/isvtest/src/isvtest/workloads/scripts/gpu_train_torch.py
+++ b/isvtest/src/isvtest/workloads/scripts/gpu_train_torch.py
@@ -7,73 +7,109 @@
 # [tool.uv]
 # extra-index-url = ["https://download.pytorch.org/whl/cu129"]
 # ///
+"""DDP training validation script.
+
+Launched via ``torchrun --nproc_per_node=<gpus>``.  Each process trains
+on one GPU using DistributedDataParallel, which synchronises gradients
+across all GPUs via NCCL AllReduce every step -- the same communication
+path real training workloads use.
+
+Validates:
+  - Forward / backward / optimizer work on every GPU
+  - NCCL gradient sync completes without error
+  - Weights stay identical across ranks (DDP invariant)
+"""
+
 import os
 import socket
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel as DDP
 
 h = socket.gethostname()
-n = torch.cuda.device_count()
 steps = int(os.getenv("TRAIN_STEPS", "50"))
 batch = int(os.getenv("TRAIN_BATCH_SIZE", "64"))
 hidden = int(os.getenv("TRAIN_HIDDEN_SIZE", "2048"))
 lr = float(os.getenv("TRAIN_LR", "0.01"))
 
-if n == 0:
-    print(f"FAILURE: No GPUs on {h}")
-    exit(1)
+rank = int(os.environ["LOCAL_RANK"])
+world = int(os.environ["WORLD_SIZE"])
 
-print(f"{h}: {n} GPUs, steps={steps}, batch={batch}, hidden={hidden}")
+torch.cuda.set_device(rank)
+dev = f"cuda:{rank}"
+dist.init_process_group(backend="nccl")
 
-results = []
-for gpu in range(n):
-    dev = f"cuda:{gpu}"
-    model = nn.Sequential(
-        nn.Linear(hidden, hidden),
-        nn.ReLU(),
-        nn.Linear(hidden, hidden),
-        nn.ReLU(),
-        nn.Linear(hidden, 10),
-    ).to(dev)
-    optimizer = torch.optim.SGD(model.parameters(), lr=lr)
-    loss_fn = nn.CrossEntropyLoss()
+if rank == 0:
+    print(f"{h}: {world} GPUs (DDP), steps={steps}, batch={batch}, hidden={hidden}")
 
-    first_loss = 0.0
-    last_loss = 0.0
-    for step in range(steps):
-        x = torch.randn(batch, hidden, device=dev)
-        target = torch.randint(0, 10, (batch,), device=dev)
-        optimizer.zero_grad()
-        loss = loss_fn(model(x), target)
-        loss.backward()
-        optimizer.step()
-        lv = loss.item()
-        if step == 0:
-            first_loss = lv
-        last_loss = lv
+model = nn.Sequential(
+    nn.Linear(hidden, hidden),
+    nn.ReLU(),
+    nn.Linear(hidden, hidden),
+    nn.ReLU(),
+    nn.Linear(hidden, 10),
+).to(dev)
+ddp_model = DDP(model, device_ids=[rank])
+optimizer = torch.optim.SGD(ddp_model.parameters(), lr=lr)
+loss_fn = nn.CrossEntropyLoss()
 
-    # Verify gradients were computed
-    has_grads = all(p.grad is not None and p.grad.abs().sum().item() > 0 for p in model.parameters() if p.requires_grad)
-    decreased = last_loss < first_loss
-    results.append(
-        {
-            "gpu": gpu,
-            "first_loss": first_loss,
-            "last_loss": last_loss,
-            "decreased": decreased,
-            "has_grads": has_grads,
-        }
-    )
-    status = "ok" if (decreased and has_grads) else "WARN"
-    print(
-        f"  GPU {gpu}: loss {first_loss:.4f} -> {last_loss:.4f} (decreased={decreased}, grads={has_grads}) [{status}]"
-    )
+first_loss = 0.0
+last_loss = 0.0
+for step in range(steps):
+    x = torch.randn(batch, hidden, device=dev)
+    target = torch.randint(0, 10, (batch,), device=dev)
+    optimizer.zero_grad()
+    loss = loss_fn(ddp_model(x), target)
+    loss.backward()
+    optimizer.step()
+    lv = loss.item()
+    if step == 0:
+        first_loss = lv
+    last_loss = lv
 
-failed = [r for r in results if not r["has_grads"]]
-if failed:
-    gpus = ", ".join(str(r["gpu"]) for r in failed)
-    print(f"FAILURE: No gradients on GPU(s) {gpus}")
-    exit(1)
+has_grads = all(p.grad is not None and p.grad.abs().sum().item() > 0 for p in ddp_model.parameters() if p.requires_grad)
+decreased = last_loss < first_loss
 
-print(f"SUCCESS: {h} trained {steps} steps on {n} GPU(s)")
+# Verify DDP kept weights in sync: compare rank 0 params with every other rank
+params_flat = torch.cat([p.detach().flatten() for p in model.parameters()])
+if rank == 0:
+    ref = params_flat.clone()
+else:
+    ref = torch.zeros_like(params_flat)
+dist.broadcast(ref, src=0)
+weights_match = torch.allclose(params_flat, ref, atol=1e-6)
+
+# Gather results to rank 0
+result = torch.tensor(
+    [float(has_grads), float(decreased), float(weights_match)],
+    device=dev,
+)
+gathered = [torch.zeros(3, device=dev) for _ in range(world)] if rank == 0 else None
+dist.gather(result, gather_list=gathered, dst=0)
+
+if rank == 0 and gathered is not None:
+    all_ok = True
+    for i, g in enumerate(gathered):
+        grads_ok = bool(g[0].item())
+        dec = bool(g[1].item())
+        sync = bool(g[2].item())
+        status = "ok" if (grads_ok and sync) else "WARN"
+        print(
+            f"  GPU {i}: loss {first_loss:.4f} -> {last_loss:.4f} "
+            f"(decreased={dec}, grads={grads_ok}, synced={sync}) [{status}]"
+        )
+        if not grads_ok:
+            all_ok = False
+        if not sync:
+            all_ok = False
+
+    if not all_ok:
+        print(f"FAILURE: Training validation failed on {h}")
+        dist.destroy_process_group()
+        exit(1)
+
+    print(f"SUCCESS: {h} trained {steps} steps on {world} GPU(s) with DDP")
+
+dist.destroy_process_group()


### PR DESCRIPTION
## Summary

Add SSH-based validation tests for bare metal GPU workloads and network interconnects.

**Workload validations** (run via Docker on the target host):
- `SshGpuStressCheck` — PyTorch matrix multiplications on all GPUs, auto-detects Docker/Python runtime
- `SshNcclCheck` — NCCL AllReduce via MPI using the NVIDIA HPC Benchmarks image, validates bandwidth and data integrity
- `SshTrainingCheck` — DDP training with `torchrun`, validates gradients and weight sync across all GPUs

**Network validations** (host-level, no container needed):
- `SshNvlinkCheck` — NVLink topology and link status via `nvidia-smi nvlink`
- `SshInfiniBandCheck` — IB port status via `ibstat`
- `SshEthernetCheck` — interface enumeration and optional ping connectivity

All checks gracefully skip when hardware isn't present (e.g., NVLink on consumer GPUs, IB on AWS).

**Reinstall** (#58): step and validations uncommented with `skip: true` — script exists but is too slow on AWS metal (~30-45 min). Set `skip: false` on platforms where reinstall is fast/supported.

**Bug fix:** `skip: true` on a step now also skips its associated validations with INFO-level logging (previously they ran against empty output and failed).

**Templates:** synced all provider-agnostic templates with AWS reference configs (BM workloads/network, KaaS NIM Helm workloads, image-registry note).

## Test plan

- [x] GPU stress, NCCL, training, and network checks pass on `g4dn.metal` (8x T4)
- [x] NVLink and InfiniBand gracefully skip on non-NVLink/non-IB hardware


Closes #58
Closes #60
Closes #63
Closes #65
Closes #66
