### PR TITLE
fix: use NGC_API_KEY env var in NIM inference job manifest

### DIFF
--- a/isvtest/src/isvtest/workloads/manifests/k8s/nim_llama_3b_inference_job.yaml
+++ b/isvtest/src/isvtest/workloads/manifests/k8s/nim_llama_3b_inference_job.yaml
@@ -60,7 +60,7 @@ spec:
               echo "[INFO] Server exited on its own"
               exit 0
           env:
-            - name: NGC_NIM_API_KEY
+            - name: NGC_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: ngc-api-secret


### PR DESCRIPTION
## Summary

Fix NIM inference job manifest to use `NGC_API_KEY` env var instead of `NGC_NIM_API_KEY`.