### PR TITLE
refactor: standardize NGC API key handling and fix validation warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,8 +335,7 @@ tests:
 | `ISV_SSA_ISSUER` | ISV Lab Service SSA issuer URL | isvreporter |
 | `ISV_CLIENT_ID` | ISV Lab Service client ID | isvreporter |
 | `ISV_CLIENT_SECRET` | ISV Lab Service client secret | isvreporter |
-| `NGC_API_KEY` | NGC API key | install.sh |
-| `NGC_NIM_API_KEY` | NGC NIM API key | isvtest NIM workloads |
+| `NGC_NIM_API_KEY` | NGC API key for NIM workloads and container registry | isvtest, isvctl |
 | `AWS_ACCESS_KEY_ID` | AWS access key | AWS scripts |
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key | AWS scripts |
 | `AWS_REGION` | AWS region | AWS scripts |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,7 +335,7 @@ tests:
 | `ISV_SSA_ISSUER` | ISV Lab Service SSA issuer URL | isvreporter |
 | `ISV_CLIENT_ID` | ISV Lab Service client ID | isvreporter |
 | `ISV_CLIENT_SECRET` | ISV Lab Service client secret | isvreporter |
-| `NGC_NIM_API_KEY` | NGC API key for NIM workloads and container registry | isvtest, isvctl |
+| `NGC_API_KEY` | NGC API key for NIM workloads and container registry | isvtest, isvctl |
 | `AWS_ACCESS_KEY_ID` | AWS access key | AWS scripts |
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key | AWS scripts |
 | `AWS_REGION` | AWS region | AWS scripts |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ See [Contributing](docs/contributing.md) for development setup and guidelines.
 | `ISV_SSA_ISSUER` | Required for ISV Lab Service uploads |
 | `ISV_CLIENT_ID` | Required for ISV Lab Service uploads |
 | `ISV_CLIENT_SECRET` | Required for ISV Lab Service uploads |
-| `NGC_NIM_API_KEY` | Required for NIM model benchmarks |
+| `NGC_API_KEY` | Required for NIM model benchmarks |
 
 ## License
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -106,7 +106,7 @@ See [Remote Deployment Guide](guides/remote-deployment.md) for details.
 | `ISV_SSA_ISSUER` | Required for result upload to ISV Lab Service |
 | `ISV_CLIENT_ID` | Required for result upload to ISV Lab Service |
 | `ISV_CLIENT_SECRET` | Required for result upload to ISV Lab Service |
-| `NGC_NIM_API_KEY` | Required for NIM model benchmarks |
+| `NGC_API_KEY` | Required for NIM model benchmarks |
 
 ## Next Steps
 

--- a/docs/guides/remote-deployment.md
+++ b/docs/guides/remote-deployment.md
@@ -26,7 +26,7 @@ Environment variables required by tests must be set on the local machine - they 
 | `ISV_SSA_ISSUER` | Required for result upload to ISV Lab Service |
 | `ISV_CLIENT_ID` | Required for result upload to ISV Lab Service |
 | `ISV_CLIENT_SECRET` | Required for result upload to ISV Lab Service |
-| `NGC_NIM_API_KEY` | Required for NIM model benchmarks |
+| `NGC_API_KEY` | Required for NIM model benchmarks |
 
 ## Usage
 

--- a/docs/guides/troubleshooting-started-tests.md
+++ b/docs/guides/troubleshooting-started-tests.md
@@ -43,12 +43,12 @@ Use one command so that create and update happen in the same process:
 
 ```bash
 # Required env (see ISV Lab Validation Guide)
-export NGC_API_KEY="..."
-export ISV_LAB_ID="35"   # Your assigned lab ID
-export ISV_SERVICE_ENDPOINT="..."   # From NVIDIA
+export ISV_LAB_ID="35"  # Your assigned lab ID
+export ISV_SERVICE_ENDPOINT="..."  # From NVIDIA
 export ISV_SSA_ISSUER="..."
 export ISV_CLIENT_ID="..."
 export ISV_CLIENT_SECRET="..."
+export NGC_NIM_API_KEY="..."  # From https://build.nvidia.com/settings/api-keys
 
 # Kubernetes
 isvctl test run -f configs/k8s.yaml --lab-id ${ISV_LAB_ID}

--- a/docs/guides/troubleshooting-started-tests.md
+++ b/docs/guides/troubleshooting-started-tests.md
@@ -48,7 +48,7 @@ export ISV_SERVICE_ENDPOINT="..."  # From NVIDIA
 export ISV_SSA_ISSUER="..."
 export ISV_CLIENT_ID="..."
 export ISV_CLIENT_SECRET="..."
-export NGC_NIM_API_KEY="..."  # From https://build.nvidia.com/settings/api-keys
+export NGC_API_KEY="..."  # optional, for NIM tests
 
 # Kubernetes
 isvctl test run -f configs/k8s.yaml --lab-id ${ISV_LAB_ID}

--- a/isvctl/configs/aws/bm.yaml
+++ b/isvctl/configs/aws/bm.yaml
@@ -140,7 +140,7 @@ commands:
         timeout: 3600
 
       # Deploy NIM container via SSH (shared script)
-      # Requires NGC_NIM_API_KEY env var
+      # Requires NGC_API_KEY env var
       - name: deploy_nim
         phase: test
         command: "python3 ../stubs/common/deploy_nim.py"

--- a/isvctl/configs/aws/eks.yaml
+++ b/isvctl/configs/aws/eks.yaml
@@ -101,7 +101,7 @@ tests:
           memory_gb: 1
           runtime: 30
       - K8sNimInferenceWorkload:
-          timeout: 900
+          timeout: 1500
       - K8sNimHelmWorkload-1b:
           model: "meta/llama-3.2-1b-instruct"
           model_tag: "latest"

--- a/isvctl/configs/aws/eks.yaml
+++ b/isvctl/configs/aws/eks.yaml
@@ -18,7 +18,7 @@
 #   - TF_AUTO_APPROVE: Set to "true" to skip Terraform approval prompts (default: false)
 #   - TF_VAR_*: Terraform variables (e.g., TF_VAR_region, TF_VAR_gpu_node_instance_types)
 #   - AWS_SKIP_TEARDOWN: Set to "true" to skip teardown and preserve resources (default: false)
-#   - NGC_NIM_API_KEY: NGC API key for NIM workloads
+#   - NGC_API_KEY: NGC API key for NIM workloads
 #   - AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY: AWS credentials (if not using IAM roles)
 
 version: "1.0"

--- a/isvctl/configs/k8s.yaml
+++ b/isvctl/configs/k8s.yaml
@@ -86,7 +86,7 @@ tests:
             memory_gb: 1
             runtime: 30
         - K8sNimInferenceWorkload:
-            timeout: 900
+            timeout: 1500
         - K8sNimHelmWorkload-1b:
             model: "meta/llama-3.2-1b-instruct"
             model_tag: "latest"

--- a/isvctl/configs/microk8s.yaml
+++ b/isvctl/configs/microk8s.yaml
@@ -96,7 +96,7 @@ tests:
             memory_gb: 1
             runtime: 30
         - K8sNimInferenceWorkload:
-            timeout: 900
+            timeout: 1500
         - K8sNimHelmWorkload-1b:
             model: "meta/llama-3.2-1b-instruct"
             model_tag: "latest"

--- a/isvctl/configs/stubs/aws/eks/docs/aws-eks.md
+++ b/isvctl/configs/stubs/aws/eks/docs/aws-eks.md
@@ -62,7 +62,7 @@ export AWS_REGION=us-west-2
 Required for NIM inference workloads:
 
 ```bash
-export NGC_NIM_API_KEY=nvapi-XXXXX
+export NGC_API_KEY=nvapi-XXXXX
 ```
 
 Get your API key from [NGC](https://ngc.nvidia.com/setup/api-key).
@@ -81,7 +81,7 @@ uv sync
 
 # Run full validation (setup -> test -> teardown)
 # This runs all three phases: setup provisions/queries cluster, test runs validations
-NGC_NIM_API_KEY=nvapi-XXXXX \
+NGC_API_KEY=nvapi-XXXXX \
   uv run isvctl test run -f isvctl/configs/aws/eks.yaml
 ```
 
@@ -322,7 +322,7 @@ Here's a complete example running all phases:
 set -e
 
 # Configuration
-export NGC_NIM_API_KEY=nvapi-XXXXX
+export NGC_API_KEY=nvapi-XXXXX
 export TF_VAR_region=us-west-2
 export TF_VAR_gpu_node_instance_types='["g5.xlarge"]'
 export TF_VAR_gpu_node_desired_size=1
@@ -383,7 +383,7 @@ MIG (Multi-Instance GPU) requires A100 or H100 GPUs. For g5/g4 instances:
 
 ```bash
 # Check NGC API key
-echo $NGC_NIM_API_KEY
+echo $NGC_API_KEY
 
 # Check NIM pod status
 kubectl get pods -l app.kubernetes.io/name=nim-llm

--- a/isvctl/configs/stubs/aws/eks/setup.sh
+++ b/isvctl/configs/stubs/aws/eks/setup.sh
@@ -203,10 +203,10 @@ if [ "$SKIP_PREFLIGHT" != "true" ]; then
     fi
 
     # Check NGC credentials
-    if [ -z "${NGC_NIM_API_KEY:-}" ]; then
-        echo "  Warning: NGC_NIM_API_KEY not set (required for NIM workloads)" >&2
+    if [ -z "${NGC_API_KEY:-}" ]; then
+        echo "  Warning: NGC_API_KEY not set (required for NIM workloads)" >&2
     else
-        echo "  NGC_NIM_API_KEY: set" >&2
+        echo "  NGC_API_KEY: set" >&2
     fi
 
     echo "" >&2

--- a/isvctl/configs/stubs/aws/eks/terraform/README.md
+++ b/isvctl/configs/stubs/aws/eks/terraform/README.md
@@ -58,7 +58,7 @@ kubectl get pods -n gpu-operator
 # 8. Run ISV Lab tests
 export AWS_REGION=$(terraform output -raw region)
 export EKS_CLUSTER_NAME=$(terraform output -raw cluster_name)
-export NGC_NIM_API_KEY=nvapi-XXXXX  # Your NGC API key
+export NGC_API_KEY=nvapi-XXXXX  # Your NGC API key
 
 cd ../../../../..  # Back to repo root
 uv run isvctl test run -f isvctl/configs/aws/eks.yaml

--- a/isvctl/configs/stubs/aws/eks/terraform/outputs.tf
+++ b/isvctl/configs/stubs/aws/eks/terraform/outputs.tf
@@ -99,7 +99,7 @@ output "run_tests" {
     # Set environment variables
     export AWS_REGION=${var.region}
     export EKS_CLUSTER_NAME=${module.eks.cluster_name}
-    export NGC_NIM_API_KEY=nvapi-XXXXX  # Replace with your NGC API key
+    export NGC_API_KEY=nvapi-XXXXX  # Replace with your NGC API key
 
     # Run tests
     uv run isvctl test run -f isvctl/configs/aws/eks.yaml

--- a/isvctl/configs/stubs/aws/vm/docs/aws-vm.md
+++ b/isvctl/configs/stubs/aws/vm/docs/aws-vm.md
@@ -60,7 +60,7 @@ to prevent resource leaks. NIM steps are shared and reusable across VMaaS and BM
 
 - AWS CLI v2, Python 3.12+ with boto3/paramiko, uv package manager
 - AWS credentials with EC2 permissions (RunInstances, TerminateInstances, CreateKeyPair, etc.)
-- `NGC_NIM_API_KEY` environment variable (optional, for NIM tests)
+- `NGC_API_KEY` environment variable (optional, for NIM tests)
 
 ```bash
 aws --version
@@ -77,7 +77,7 @@ cd ISV-NCP-Validation-Suite && uv sync
 export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
 export AWS_REGION=us-west-2
-export NGC_NIM_API_KEY=...  # optional, for NIM tests
+export NGC_API_KEY=...  # optional, for NIM tests
 
 # 3. Run all tests
 uv run isvctl test run -f isvctl/configs/aws/vm.yaml
@@ -266,7 +266,7 @@ Validates that an EC2 instance rebooted successfully and fully recovered.
 }
 ```
 
-When `NGC_NIM_API_KEY` is not set, returns `{"success": true, "skipped": true}`.
+When `NGC_API_KEY` is not set, returns `{"success": true, "skipped": true}`.
 
 ### teardown_nim.py
 

--- a/isvctl/configs/stubs/common/deploy_nim.py
+++ b/isvctl/configs/stubs/common/deploy_nim.py
@@ -70,7 +70,7 @@ def main() -> int:
     parser.add_argument("--port", type=int, default=8000, help="Host port to expose NIM on")
     parser.add_argument("--container-name", default="isv-nim", help="Docker container name")
     parser.add_argument(
-        "--ngc-api-key",
+        "--ngc-nim-api-key",
         default=os.environ.get("NGC_NIM_API_KEY", ""),
         help="NGC API key for pulling NIM images",
     )
@@ -100,7 +100,7 @@ def main() -> int:
         "ssh_user": args.user,
     }
 
-    if not args.ngc_api_key:
+    if not args.ngc_nim_api_key:
         print("NGC_NIM_API_KEY not set, skipping NIM deployment", file=sys.stderr)
         result["success"] = True
         result["skipped"] = True
@@ -116,7 +116,7 @@ def main() -> int:
         print("Logging in to NGC registry...", file=sys.stderr)
         exit_code, _, stderr_out = run_cmd(
             ssh,
-            f"echo '{args.ngc_api_key}' | docker login nvcr.io -u '$oauthtoken' --password-stdin 2>&1",
+            f"echo '{args.ngc_nim_api_key}' | docker login nvcr.io -u '$oauthtoken' --password-stdin 2>&1",
         )
         if exit_code != 0:
             result["error"] = f"NGC login failed: {stderr_out}"
@@ -133,7 +133,7 @@ def main() -> int:
             f"docker run -d --gpus all"
             f" --name {args.container_name}"
             f" -p {args.port}:8000"
-            f" -e NGC_API_KEY='{args.ngc_api_key}'"
+            f" -e NGC_NIM_API_KEY='{args.ngc_nim_api_key}'"
             f" {image}"
         )
         exit_code, stdout, stderr_out = run_cmd(ssh, docker_cmd, timeout=1200)

--- a/isvctl/configs/stubs/common/deploy_nim.py
+++ b/isvctl/configs/stubs/common/deploy_nim.py
@@ -70,8 +70,8 @@ def main() -> int:
     parser.add_argument("--port", type=int, default=8000, help="Host port to expose NIM on")
     parser.add_argument("--container-name", default="isv-nim", help="Docker container name")
     parser.add_argument(
-        "--ngc-nim-api-key",
-        default=os.environ.get("NGC_NIM_API_KEY", ""),
+        "--ngc-api-key",
+        default=os.environ.get("NGC_API_KEY", "") or os.environ.get("NGC_NIM_API_KEY", ""),
         help="NGC API key for pulling NIM images",
     )
     parser.add_argument(
@@ -100,11 +100,11 @@ def main() -> int:
         "ssh_user": args.user,
     }
 
-    if not args.ngc_nim_api_key:
-        print("NGC_NIM_API_KEY not set, skipping NIM deployment", file=sys.stderr)
+    if not args.ngc_api_key:
+        print("NGC_API_KEY not set, skipping NIM deployment", file=sys.stderr)
         result["success"] = True
         result["skipped"] = True
-        result["skip_reason"] = "NGC_NIM_API_KEY not set"
+        result["skip_reason"] = "NGC_API_KEY not set"
         print(json.dumps(result, indent=2))
         return 0
 
@@ -116,7 +116,7 @@ def main() -> int:
         print("Logging in to NGC registry...", file=sys.stderr)
         exit_code, _, stderr_out = run_cmd(
             ssh,
-            f"echo '{args.ngc_nim_api_key}' | docker login nvcr.io -u '$oauthtoken' --password-stdin 2>&1",
+            f"echo '{args.ngc_api_key}' | docker login nvcr.io -u '$oauthtoken' --password-stdin 2>&1",
         )
         if exit_code != 0:
             result["error"] = f"NGC login failed: {stderr_out}"
@@ -133,7 +133,7 @@ def main() -> int:
             f"docker run -d --gpus all"
             f" --name {args.container_name}"
             f" -p {args.port}:8000"
-            f" -e NGC_API_KEY='{args.ngc_nim_api_key}'"  # NIM container expects NGC_API_KEY
+            f" -e NGC_API_KEY='{args.ngc_api_key}'"  # NIM container expects NGC_API_KEY
             f" {image}"
         )
         exit_code, stdout, stderr_out = run_cmd(ssh, docker_cmd, timeout=1200)

--- a/isvctl/configs/stubs/common/deploy_nim.py
+++ b/isvctl/configs/stubs/common/deploy_nim.py
@@ -133,7 +133,7 @@ def main() -> int:
             f"docker run -d --gpus all"
             f" --name {args.container_name}"
             f" -p {args.port}:8000"
-            f" -e NGC_NIM_API_KEY='{args.ngc_nim_api_key}'"
+            f" -e NGC_API_KEY='{args.ngc_nim_api_key}'"  # NIM container expects NGC_API_KEY
             f" {image}"
         )
         exit_code, stdout, stderr_out = run_cmd(ssh, docker_cmd, timeout=1200)

--- a/isvctl/configs/templates/kaas.yaml
+++ b/isvctl/configs/templates/kaas.yaml
@@ -111,7 +111,7 @@ tests:
           memory_gb: 1
           runtime: 30
       - K8sNimInferenceWorkload:
-          timeout: 900
+          timeout: 1500
       - K8sNimHelmWorkload-1b:
           model: "meta/llama-3.2-1b-instruct"
           model_tag: "latest"

--- a/isvctl/configs/templates/stubs/common/deploy_nim.py
+++ b/isvctl/configs/templates/stubs/common/deploy_nim.py
@@ -11,7 +11,7 @@ This script must:
   4. Start the container with GPU access
   5. Wait for the health endpoint to report ready
 
-Requires the NGC_NIM_API_KEY environment variable to be set.
+Requires the NGC_API_KEY environment variable to be set (fallback: NGC_NIM_API_KEY).
 
 Required JSON output fields:
   success          (bool)  - whether the operation succeeded
@@ -23,7 +23,7 @@ Required JSON output fields:
   error            (str, optional) - error message provided when success is false
 
 Usage:
-    NGC_NIM_API_KEY=nvapi-... python deploy_nim.py \\
+    NGC_API_KEY=nvapi-... python deploy_nim.py \\
         --host 54.1.2.3 --key-file /tmp/key.pem
 
 Reference implementation (AWS):
@@ -43,7 +43,7 @@ def main() -> int:
     parser.add_argument("--key-file", required=True, help="SSH private key path")
     args = parser.parse_args()
 
-    ngc_nim_api_key = os.environ.get("NGC_NIM_API_KEY", "")
+    ngc_api_key = os.environ.get("NGC_API_KEY", "") or os.environ.get("NGC_NIM_API_KEY", "")
 
     result = {
         "success": False,
@@ -54,10 +54,10 @@ def main() -> int:
         "model_name": "",
     }
 
-    if not ngc_nim_api_key:
+    if not ngc_api_key:
         result["success"] = True
         result["skipped"] = True
-        result["skip_reason"] = "NGC_NIM_API_KEY not set"
+        result["skip_reason"] = "NGC_API_KEY not set"
         print(json.dumps(result, indent=2))
         return 0
 
@@ -78,7 +78,7 @@ def main() -> int:
         # ║  4. Start the container with GPU access                      ║
         # ║     ssh.run("docker run -d --gpus all "                      ║
         # ║             f"--name isv-nim -p 8000:8000 "                  ║
-        # ║             f"-e NGC_API_KEY={ngc_nim_api_key} {image}")     ║
+        # ║             f"-e NGC_API_KEY={ngc_api_key} {image}")     ║
         # ║                                                              ║
         # ║  5. Wait for the health endpoint to report ready             ║
         # ║     poll until: curl http://localhost:8000/v1/health/ready   ║

--- a/isvctl/configs/templates/stubs/common/deploy_nim.py
+++ b/isvctl/configs/templates/stubs/common/deploy_nim.py
@@ -78,7 +78,7 @@ def main() -> int:
         # ║  4. Start the container with GPU access                      ║
         # ║     ssh.run("docker run -d --gpus all "                      ║
         # ║             f"--name isv-nim -p 8000:8000 "                  ║
-        # ║             f"-e NGC_NIM_API_KEY={ngc_nim_api_key} {image}")     ║
+        # ║             f"-e NGC_API_KEY={ngc_nim_api_key} {image}")     ║
         # ║                                                              ║
         # ║  5. Wait for the health endpoint to report ready             ║
         # ║     poll until: curl http://localhost:8000/v1/health/ready   ║

--- a/isvctl/configs/templates/stubs/common/deploy_nim.py
+++ b/isvctl/configs/templates/stubs/common/deploy_nim.py
@@ -43,7 +43,7 @@ def main() -> int:
     parser.add_argument("--key-file", required=True, help="SSH private key path")
     args = parser.parse_args()
 
-    ngc_api_key = os.environ.get("NGC_NIM_API_KEY", "")
+    ngc_nim_api_key = os.environ.get("NGC_NIM_API_KEY", "")
 
     result = {
         "success": False,
@@ -54,7 +54,7 @@ def main() -> int:
         "model_name": "",
     }
 
-    if not ngc_api_key:
+    if not ngc_nim_api_key:
         result["success"] = True
         result["skipped"] = True
         result["skip_reason"] = "NGC_NIM_API_KEY not set"
@@ -78,7 +78,7 @@ def main() -> int:
         # ║  4. Start the container with GPU access                      ║
         # ║     ssh.run("docker run -d --gpus all "                      ║
         # ║             f"--name isv-nim -p 8000:8000 "                  ║
-        # ║             f"-e NGC_API_KEY={ngc_api_key} {image}")         ║
+        # ║             f"-e NGC_NIM_API_KEY={ngc_nim_api_key} {image}")     ║
         # ║                                                              ║
         # ║  5. Wait for the health endpoint to report ready             ║
         # ║     poll until: curl http://localhost:8000/v1/health/ready   ║

--- a/isvctl/src/isvctl/cli/deploy.py
+++ b/isvctl/src/isvctl/cli/deploy.py
@@ -437,8 +437,8 @@ def run(
         config_args = " ".join(f"-f {c}" for c in configs)
 
         # Handle NGC API key securely - use shlex.quote to prevent shell injection
-        ngc_nim_api_key = os.environ.get("NGC_NIM_API_KEY", "")
-        env_vars = f"NGC_NIM_API_KEY={shlex.quote(ngc_nim_api_key)}" if ngc_nim_api_key else ""
+        ngc_api_key = os.environ.get("NGC_API_KEY", "") or os.environ.get("NGC_NIM_API_KEY", "")
+        env_vars = f"NGC_API_KEY={shlex.quote(ngc_api_key)}" if ngc_api_key else ""
 
         # Note: Variables like $PATH and $TEST_RESULT expand on the remote shell
         remote_script = f"""

--- a/isvctl/src/isvctl/cli/deploy.py
+++ b/isvctl/src/isvctl/cli/deploy.py
@@ -437,8 +437,8 @@ def run(
         config_args = " ".join(f"-f {c}" for c in configs)
 
         # Handle NGC API key securely - use shlex.quote to prevent shell injection
-        ngc_api_key = os.environ.get("NGC_NIM_API_KEY", "")
-        env_vars = f"NGC_NIM_API_KEY={shlex.quote(ngc_api_key)}" if ngc_api_key else ""
+        ngc_nim_api_key = os.environ.get("NGC_NIM_API_KEY", "")
+        env_vars = f"NGC_NIM_API_KEY={shlex.quote(ngc_nim_api_key)}" if ngc_nim_api_key else ""
 
         # Note: Variables like $PATH and $TEST_RESULT expand on the remote shell
         remote_script = f"""

--- a/isvtest/src/isvtest/core/ngc.py
+++ b/isvtest/src/isvtest/core/ngc.py
@@ -23,6 +23,17 @@ NGC_IMAGE_SECRET_NAME = "ngc-image-secret"
 NGC_API_SECRET_NAME = "ngc-api-secret"
 
 
+def get_ngc_api_key() -> str:
+    """Read the NGC API key from environment variables.
+
+    Checks NGC_API_KEY first, then NGC_NIM_API_KEY as a legacy fallback.
+
+    Returns:
+        The API key string, or empty string if neither variable is set.
+    """
+    return os.environ.get("NGC_API_KEY", "") or os.environ.get("NGC_NIM_API_KEY", "")
+
+
 def get_kubectl_base() -> str:
     """Get the kubectl base command as a shell-safe string.
 
@@ -33,7 +44,7 @@ def get_kubectl_base() -> str:
     return " ".join(shlex.quote(part) for part in kubectl_parts)
 
 
-def ensure_ngc_secrets(namespace: str, ngc_nim_api_key: str | None = None) -> tuple[bool, str]:
+def ensure_ngc_secrets(namespace: str, ngc_api_key: str | None = None) -> tuple[bool, str]:
     """Ensure NGC secrets exist in the namespace, creating them if needed.
 
     Creates two secrets as per NVIDIA NIM docs:
@@ -42,16 +53,16 @@ def ensure_ngc_secrets(namespace: str, ngc_nim_api_key: str | None = None) -> tu
 
     Args:
         namespace: Kubernetes namespace.
-        ngc_nim_api_key: NGC API key. If None, reads from NGC_NIM_API_KEY environment variable.
+        ngc_api_key: NGC API key. If None, reads via get_ngc_api_key().
 
     Returns:
         Tuple of (success, error_message). If success is True, error_message is empty.
     """
-    if ngc_nim_api_key is None:
-        ngc_nim_api_key = os.environ.get("NGC_NIM_API_KEY")
+    if ngc_api_key is None:
+        ngc_api_key = get_ngc_api_key() or None
 
-    if not ngc_nim_api_key:
-        return False, "NGC_NIM_API_KEY not set"
+    if not ngc_api_key:
+        return False, "NGC_API_KEY not set"
 
     kubectl_parts = get_kubectl_command()
 
@@ -86,7 +97,7 @@ def ensure_ngc_secrets(namespace: str, ngc_nim_api_key: str | None = None) -> tu
                 NGC_IMAGE_SECRET_NAME,
                 "--docker-server=nvcr.io",
                 "--docker-username=$oauthtoken",
-                f"--docker-password={ngc_nim_api_key}",
+                f"--docker-password={ngc_api_key}",
                 "-n",
                 namespace,
             ]
@@ -121,7 +132,7 @@ def ensure_ngc_secrets(namespace: str, ngc_nim_api_key: str | None = None) -> tu
                     "-n",
                     namespace,
                 ],
-                input=ngc_nim_api_key,
+                input=ngc_api_key,
                 capture_output=True,
                 text=True,
                 timeout=30,
@@ -273,13 +284,13 @@ spec:
         run_kubectl(["delete", "job", job_name, "-n", namespace, "--wait=false"], timeout=10)
 
 
-def create_ngc_docker_config(ngc_nim_api_key: str) -> dict[str, Any]:
+def create_ngc_docker_config(ngc_api_key: str) -> dict[str, Any]:
     """Create a Docker config JSON for NGC registry authentication.
 
     This is useful when you need the full docker config (e.g., for --from-file).
 
     Args:
-        ngc_nim_api_key: NGC API key.
+        ngc_api_key: NGC API key.
 
     Returns:
         Docker config dictionary suitable for .dockerconfigjson.
@@ -290,8 +301,8 @@ def create_ngc_docker_config(ngc_nim_api_key: str) -> dict[str, Any]:
         "auths": {
             "nvcr.io": {
                 "username": "$oauthtoken",
-                "password": ngc_nim_api_key,
-                "auth": base64.b64encode(f"$oauthtoken:{ngc_nim_api_key}".encode()).decode(),
+                "password": ngc_api_key,
+                "auth": base64.b64encode(f"$oauthtoken:{ngc_api_key}".encode()).decode(),
             }
         }
     }

--- a/isvtest/src/isvtest/core/ngc.py
+++ b/isvtest/src/isvtest/core/ngc.py
@@ -33,7 +33,7 @@ def get_kubectl_base() -> str:
     return " ".join(shlex.quote(part) for part in kubectl_parts)
 
 
-def ensure_ngc_secrets(namespace: str, ngc_api_key: str | None = None) -> tuple[bool, str]:
+def ensure_ngc_secrets(namespace: str, ngc_nim_api_key: str | None = None) -> tuple[bool, str]:
     """Ensure NGC secrets exist in the namespace, creating them if needed.
 
     Creates two secrets as per NVIDIA NIM docs:
@@ -42,15 +42,15 @@ def ensure_ngc_secrets(namespace: str, ngc_api_key: str | None = None) -> tuple[
 
     Args:
         namespace: Kubernetes namespace.
-        ngc_api_key: NGC API key. If None, reads from NGC_NIM_API_KEY environment variable.
+        ngc_nim_api_key: NGC API key. If None, reads from NGC_NIM_API_KEY environment variable.
 
     Returns:
         Tuple of (success, error_message). If success is True, error_message is empty.
     """
-    if ngc_api_key is None:
-        ngc_api_key = os.environ.get("NGC_NIM_API_KEY")
+    if ngc_nim_api_key is None:
+        ngc_nim_api_key = os.environ.get("NGC_NIM_API_KEY")
 
-    if not ngc_api_key:
+    if not ngc_nim_api_key:
         return False, "NGC_NIM_API_KEY not set"
 
     kubectl_parts = get_kubectl_command()
@@ -86,7 +86,7 @@ def ensure_ngc_secrets(namespace: str, ngc_api_key: str | None = None) -> tuple[
                 NGC_IMAGE_SECRET_NAME,
                 "--docker-server=nvcr.io",
                 "--docker-username=$oauthtoken",
-                f"--docker-password={ngc_api_key}",
+                f"--docker-password={ngc_nim_api_key}",
                 "-n",
                 namespace,
             ]
@@ -121,7 +121,7 @@ def ensure_ngc_secrets(namespace: str, ngc_api_key: str | None = None) -> tuple[
                     "-n",
                     namespace,
                 ],
-                input=ngc_api_key,
+                input=ngc_nim_api_key,
                 capture_output=True,
                 text=True,
                 timeout=30,
@@ -273,13 +273,13 @@ spec:
         run_kubectl(["delete", "job", job_name, "-n", namespace, "--wait=false"], timeout=10)
 
 
-def create_ngc_docker_config(ngc_api_key: str) -> dict[str, Any]:
+def create_ngc_docker_config(ngc_nim_api_key: str) -> dict[str, Any]:
     """Create a Docker config JSON for NGC registry authentication.
 
     This is useful when you need the full docker config (e.g., for --from-file).
 
     Args:
-        ngc_api_key: NGC API key.
+        ngc_nim_api_key: NGC API key.
 
     Returns:
         Docker config dictionary suitable for .dockerconfigjson.
@@ -290,8 +290,8 @@ def create_ngc_docker_config(ngc_api_key: str) -> dict[str, Any]:
         "auths": {
             "nvcr.io": {
                 "username": "$oauthtoken",
-                "password": ngc_api_key,
-                "auth": base64.b64encode(f"$oauthtoken:{ngc_api_key}".encode()).decode(),
+                "password": ngc_nim_api_key,
+                "auth": base64.b64encode(f"$oauthtoken:{ngc_nim_api_key}".encode()).decode(),
             }
         }
     }

--- a/isvtest/src/isvtest/main.py
+++ b/isvtest/src/isvtest/main.py
@@ -154,6 +154,17 @@ def run_validations_via_pytest(
         # Get detailed results captured during test execution
         results = get_validation_results()
 
+        if not results and extra_pytest_args:
+            k_filters = [
+                extra_pytest_args[i + 1]
+                for i, a in enumerate(extra_pytest_args)
+                if a == "-k" and i + 1 < len(extra_pytest_args)
+            ]
+            if k_filters:
+                logger.warning(
+                    f"No tests matched -k '{k_filters[0]}' — check spelling or run without -k to see available tests"
+                )
+
         return exit_code, results
 
     finally:

--- a/isvtest/src/isvtest/main.py
+++ b/isvtest/src/isvtest/main.py
@@ -17,6 +17,7 @@ import typer
 from isvtest.config.loader import ConfigLoader
 from isvtest.core import runners as reframe_runner
 from isvtest.core.logger import setup_logger
+from isvtest.tests.test_validations import ADAPTER_HANDLED_CATEGORIES
 
 logger = setup_logger()
 
@@ -196,6 +197,9 @@ def _transform_validations_for_pytest(
     result = []
 
     for category, category_config in validations.items():
+        if category in ADAPTER_HANDLED_CATEGORIES:
+            continue
+
         # Determine format: group defaults or list
         if isinstance(category_config, dict) and "checks" in category_config:
             # Group defaults format

--- a/isvtest/src/isvtest/tests/test_validations.py
+++ b/isvtest/src/isvtest/tests/test_validations.py
@@ -153,10 +153,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
                         hint = f"Did you mean: {', '.join(similar)}?"
                     else:
                         hint = "Check spelling or run without --config to see all available tests."
-                    print(
-                        f"WARNING: Validation not found: '{validation_name}'. {hint}",
-                        file=sys.stderr,
-                    )
+                    sys.stderr.write(f"\n\033[33mWarning:\033[0m Validation not found: '{validation_name}'. {hint}\n")
 
             # 2. Add skipped tests for classes NOT in config (if show_skipped)
             if show_skipped:

--- a/isvtest/src/isvtest/validations/ssh.py
+++ b/isvtest/src/isvtest/validations/ssh.py
@@ -1753,7 +1753,7 @@ class SshContainerRuntimeCheck(BaseValidation):
 
     Config:
         host, key_file, user: SSH connection details
-        ngc_api_key: NGC API key for registry access (optional)
+        ngc_nim_api_key: NGC API key for registry access (optional)
     """
 
     description: ClassVar[str] = "Tests container runtime and NVIDIA Docker support"
@@ -1771,7 +1771,7 @@ class SshContainerRuntimeCheck(BaseValidation):
         host = ssh_cfg["ssh_host"]
         user = ssh_cfg["ssh_user"]
         key_path = ssh_cfg["ssh_key_path"]
-        ngc_api_key = self.config.get("ngc_api_key", os.environ.get("NGC_NIM_API_KEY", ""))
+        ngc_nim_api_key = self.config.get("ngc_nim_api_key", os.environ.get("NGC_NIM_API_KEY", ""))
 
         if not host or not key_path:
             self.set_failed("Missing host or key_file")
@@ -1803,10 +1803,10 @@ class SshContainerRuntimeCheck(BaseValidation):
             )
 
             # Check NGC login if key provided
-            if ngc_api_key:
+            if ngc_nim_api_key:
                 self.log.info("Testing NGC registry access...")
                 _, stdout, _ = run_ssh_command(
-                    ssh, f"echo '{ngc_api_key}' | docker login nvcr.io -u '$oauthtoken' --password-stdin 2>&1"
+                    ssh, f"echo '{ngc_nim_api_key}' | docker login nvcr.io -u '$oauthtoken' --password-stdin 2>&1"
                 )
                 login_ok = "Succeeded" in stdout
                 self.report_subtest("ngc_login", login_ok, "NGC login successful" if login_ok else "NGC login failed")

--- a/isvtest/src/isvtest/validations/ssh.py
+++ b/isvtest/src/isvtest/validations/ssh.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, ClassVar
 if TYPE_CHECKING:
     import paramiko
 
+from isvtest.core.ngc import get_ngc_api_key
 from isvtest.core.ssh import (
     get_failed_subtests,
     get_ssh_client,
@@ -1753,7 +1754,7 @@ class SshContainerRuntimeCheck(BaseValidation):
 
     Config:
         host, key_file, user: SSH connection details
-        ngc_nim_api_key: NGC API key for registry access (optional)
+        ngc_api_key: NGC API key for registry access (optional)
     """
 
     description: ClassVar[str] = "Tests container runtime and NVIDIA Docker support"
@@ -1771,7 +1772,7 @@ class SshContainerRuntimeCheck(BaseValidation):
         host = ssh_cfg["ssh_host"]
         user = ssh_cfg["ssh_user"]
         key_path = ssh_cfg["ssh_key_path"]
-        ngc_nim_api_key = self.config.get("ngc_nim_api_key", os.environ.get("NGC_NIM_API_KEY", ""))
+        ngc_api_key = self.config.get("ngc_api_key", get_ngc_api_key())
 
         if not host or not key_path:
             self.set_failed("Missing host or key_file")
@@ -1803,15 +1804,15 @@ class SshContainerRuntimeCheck(BaseValidation):
             )
 
             # Check NGC login if key provided
-            if ngc_nim_api_key:
+            if ngc_api_key:
                 self.log.info("Testing NGC registry access...")
                 _, stdout, _ = run_ssh_command(
-                    ssh, f"echo '{ngc_nim_api_key}' | docker login nvcr.io -u '$oauthtoken' --password-stdin 2>&1"
+                    ssh, f"echo '{ngc_api_key}' | docker login nvcr.io -u '$oauthtoken' --password-stdin 2>&1"
                 )
                 login_ok = "Succeeded" in stdout
                 self.report_subtest("ngc_login", login_ok, "NGC login successful" if login_ok else "NGC login failed")
             else:
-                self.report_subtest("ngc_login", True, "NGC_NIM_API_KEY not provided (skipped)")
+                self.report_subtest("ngc_login", True, "NGC_API_KEY not provided (skipped)")
 
             ssh.close()
             self.set_passed("Container runtime check passed")

--- a/isvtest/src/isvtest/workloads/k8s_nim_helm.py
+++ b/isvtest/src/isvtest/workloads/k8s_nim_helm.py
@@ -20,7 +20,7 @@ import pytest
 
 from isvtest.config.settings import get_k8s_namespace
 from isvtest.core.k8s import get_gpu_nodes, get_kubectl_command
-from isvtest.core.ngc import get_kubectl_base, validate_nim_inference
+from isvtest.core.ngc import get_kubectl_base, get_ngc_api_key, validate_nim_inference
 from isvtest.core.workload import BaseWorkloadCheck
 
 
@@ -246,15 +246,15 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
 
         Creates two secrets as per NVIDIA NIM Helm docs:
         1. ngc-secret: docker-registry secret for pulling NIM images from nvcr.io
-        2. ngc-api: generic secret with NGC_API_KEY key (value from NGC_NIM_API_KEY env var)
+        2. ngc-api: generic secret with NGC_API_KEY key (value from NGC_API_KEY env var)
 
         Reference: https://docs.nvidia.com/nim/large-language-models/latest/deploy-helm.html
         """
-        ngc_nim_api_key = os.environ.get("NGC_NIM_API_KEY")
+        ngc_api_key = get_ngc_api_key()
 
-        if not ngc_nim_api_key:
-            self.log.warning("Skipping: NGC_NIM_API_KEY not set - NGC credentials required")
-            pytest.skip("NGC_NIM_API_KEY not set - NGC credentials required")
+        if not ngc_api_key:
+            self.log.warning("Skipping: NGC_API_KEY not set - NGC credentials required")
+            pytest.skip("NGC_API_KEY not set - NGC credentials required")
 
         kubectl_parts = get_kubectl_command()
         kubectl_base = get_kubectl_base()
@@ -282,7 +282,7 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
                 "ngc-secret",
                 "--docker-server=nvcr.io",
                 "--docker-username=$oauthtoken",  # Literal string - NGC special username
-                f"--docker-password={ngc_nim_api_key}",
+                f"--docker-password={ngc_api_key}",
                 "-n",
                 namespace,
             ]
@@ -313,7 +313,7 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
                 "secret",
                 "generic",
                 "ngc-api",
-                f"--from-literal=NGC_API_KEY={ngc_nim_api_key}",  # Key name required by NIM Helm chart
+                f"--from-literal=NGC_API_KEY={ngc_api_key}",  # Key name required by NIM Helm chart
                 "-n",
                 namespace,
             ]
@@ -337,9 +337,9 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
         as a .tgz file, not from a public Helm repository.
         Reference: https://docs.nvidia.com/nim/large-language-models/latest/deploy-helm.html
         """
-        ngc_nim_api_key = os.environ.get("NGC_NIM_API_KEY", "")
-        if not ngc_nim_api_key:
-            self.set_failed("NGC_NIM_API_KEY is required to download NIM Helm chart")
+        ngc_api_key = get_ngc_api_key()
+        if not ngc_api_key:
+            self.set_failed("NGC_API_KEY is required to download NIM Helm chart")
             return False
 
         chart_version = self.config.get("helm_chart_version", self.HELM_CHART_VERSION)
@@ -359,7 +359,7 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
                     "--username",
                     "$oauthtoken",
                     "--password",
-                    ngc_nim_api_key,
+                    ngc_api_key,
                 ],
                 capture_output=True,
                 text=True,

--- a/isvtest/src/isvtest/workloads/k8s_nim_helm.py
+++ b/isvtest/src/isvtest/workloads/k8s_nim_helm.py
@@ -246,7 +246,7 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
 
         Creates two secrets as per NVIDIA NIM Helm docs:
         1. ngc-secret: docker-registry secret for pulling NIM images from nvcr.io
-        2. ngc-api: generic secret with NGC_NIM_API_KEY key (value from NGC_NIM_API_KEY env var)
+        2. ngc-api: generic secret with NGC_API_KEY key (value from NGC_NIM_API_KEY env var)
 
         Reference: https://docs.nvidia.com/nim/large-language-models/latest/deploy-helm.html
         """
@@ -313,7 +313,7 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
                 "secret",
                 "generic",
                 "ngc-api",
-                f"--from-literal=NGC_NIM_API_KEY={ngc_nim_api_key}",
+                f"--from-literal=NGC_API_KEY={ngc_nim_api_key}",  # Key name required by NIM Helm chart
                 "-n",
                 namespace,
             ]

--- a/isvtest/src/isvtest/workloads/k8s_nim_helm.py
+++ b/isvtest/src/isvtest/workloads/k8s_nim_helm.py
@@ -246,13 +246,13 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
 
         Creates two secrets as per NVIDIA NIM Helm docs:
         1. ngc-secret: docker-registry secret for pulling NIM images from nvcr.io
-        2. ngc-api: generic secret with NGC_API_KEY key (value from NGC_NIM_API_KEY env var)
+        2. ngc-api: generic secret with NGC_NIM_API_KEY key (value from NGC_NIM_API_KEY env var)
 
         Reference: https://docs.nvidia.com/nim/large-language-models/latest/deploy-helm.html
         """
-        ngc_api_key = os.environ.get("NGC_NIM_API_KEY")
+        ngc_nim_api_key = os.environ.get("NGC_NIM_API_KEY")
 
-        if not ngc_api_key:
+        if not ngc_nim_api_key:
             self.log.warning("Skipping: NGC_NIM_API_KEY not set - NGC credentials required")
             pytest.skip("NGC_NIM_API_KEY not set - NGC credentials required")
 
@@ -282,7 +282,7 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
                 "ngc-secret",
                 "--docker-server=nvcr.io",
                 "--docker-username=$oauthtoken",  # Literal string - NGC special username
-                f"--docker-password={ngc_api_key}",
+                f"--docker-password={ngc_nim_api_key}",
                 "-n",
                 namespace,
             ]
@@ -313,7 +313,7 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
                 "secret",
                 "generic",
                 "ngc-api",
-                f"--from-literal=NGC_API_KEY={ngc_api_key}",  # Key name required by Helm chart
+                f"--from-literal=NGC_NIM_API_KEY={ngc_nim_api_key}",
                 "-n",
                 namespace,
             ]
@@ -337,8 +337,8 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
         as a .tgz file, not from a public Helm repository.
         Reference: https://docs.nvidia.com/nim/large-language-models/latest/deploy-helm.html
         """
-        ngc_api_key = os.environ.get("NGC_NIM_API_KEY", "")
-        if not ngc_api_key:
+        ngc_nim_api_key = os.environ.get("NGC_NIM_API_KEY", "")
+        if not ngc_nim_api_key:
             self.set_failed("NGC_NIM_API_KEY is required to download NIM Helm chart")
             return False
 
@@ -359,7 +359,7 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
                     "--username",
                     "$oauthtoken",
                     "--password",
-                    ngc_api_key,
+                    ngc_nim_api_key,
                 ],
                 capture_output=True,
                 text=True,

--- a/isvtest/src/isvtest/workloads/manifests/k8s/nim_llama_3b_inference_job.yaml
+++ b/isvtest/src/isvtest/workloads/manifests/k8s/nim_llama_3b_inference_job.yaml
@@ -60,7 +60,7 @@ spec:
               echo "[INFO] Server exited on its own"
               exit 0
           env:
-            - name: NGC_API_KEY
+            - name: NGC_API_KEY # NIM container expects this env var name
               valueFrom:
                 secretKeyRef:
                   name: ngc-api-secret

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -361,11 +361,11 @@ class TestSshNimHealthCheck:
             config={
                 "step_output": {
                     "skipped": True,
-                    "skip_reason": "NGC_NIM_API_KEY not set",
+                    "skip_reason": "NGC_API_KEY not set",
                 },
             }
         )
-        with pytest.raises(pytest.skip.Exception, match="NGC_NIM_API_KEY"):
+        with pytest.raises(pytest.skip.Exception, match="NGC_API_KEY"):
             v.execute()
 
     @patch("isvtest.validations.nim.get_ssh_client")
@@ -597,7 +597,7 @@ class TestValidationResultCapture:
     def test_skipped_validation_captured(self) -> None:
         """Skipped validations must appear in _validation_results with skipped=True."""
         config = {
-            "step_output": {"skipped": True, "skip_reason": "NGC_NIM_API_KEY not set"},
+            "step_output": {"skipped": True, "skip_reason": "NGC_API_KEY not set"},
             "_category": "nim",
         }
         subtests = MagicMock()
@@ -611,7 +611,7 @@ class TestValidationResultCapture:
         assert r["skipped"] is True
         assert r["passed"] is True
         assert r["category"] == "nim"
-        assert "NGC_NIM_API_KEY" in r["message"]
+        assert "NGC_API_KEY" in r["message"]
 
     def test_passed_validation_captured(self) -> None:
         """Passed validations must appear with skipped=False."""


### PR DESCRIPTION
## Summary

- Standardize on `NGC_API_KEY` as the primary env var for NIM workloads, with
  `NGC_NIM_API_KEY` as a legacy fallback for backward compatibility
- Extract `get_ngc_api_key()` helper in `isvtest/core/ngc.py` to centralize
  the env var lookup with fallback logic
- Rename all Python variables to `ngc_api_key` consistently across isvtest and isvctl
- Fix reframe validation warnings (`CPUInfoCheck`, `GpuMemoryCheck`) leaking
  into test collection by filtering adapter-handled categories during
  validation transformation
- Improve "Validation not found" warnings: yellow formatting, proper newlines
- Add warning when `-k` filter matches zero tests