### PR TITLE
fix: update NCCL image reference in settings and Kubernetes manifest

### DIFF
--- a/isvctl/configs/aws/eks.yaml
+++ b/isvctl/configs/aws/eks.yaml
@@ -95,7 +95,8 @@ tests:
           error_states: ["Error", "CrashLoopBackOff"]
 
     k8s_workloads:
-      - K8sNcclWorkload: {}
+      - K8sNcclWorkload:
+          min_bus_bw_gbps: 100
       - K8sGpuStressWorkload:
           memory_gb: 1
           runtime: 30

--- a/isvctl/configs/k8s.yaml
+++ b/isvctl/configs/k8s.yaml
@@ -80,7 +80,8 @@ tests:
 
     k8s_workloads:
       checks:
-        - K8sNcclWorkload: {}
+        - K8sNcclWorkload:
+            min_bus_bw_gbps: 100
         - K8sGpuStressWorkload:
             memory_gb: 1
             runtime: 30

--- a/isvctl/configs/microk8s.yaml
+++ b/isvctl/configs/microk8s.yaml
@@ -90,7 +90,8 @@ tests:
 
     k8s_workloads:
       checks:
-        - K8sNcclWorkload: {}
+        - K8sNcclWorkload:
+            min_bus_bw_gbps: 100
         - K8sGpuStressWorkload:
             memory_gb: 1
             runtime: 30

--- a/isvctl/configs/templates/kaas.yaml
+++ b/isvctl/configs/templates/kaas.yaml
@@ -105,7 +105,8 @@ tests:
           error_states: ["Error", "CrashLoopBackOff"]
 
     k8s_workloads:
-      - K8sNcclWorkload: {}
+      - K8sNcclWorkload:
+          min_bus_bw_gbps: 100
       - K8sGpuStressWorkload:
           memory_gb: 1
           runtime: 30

--- a/isvtest/src/isvtest/config/settings.py
+++ b/isvtest/src/isvtest/config/settings.py
@@ -28,7 +28,7 @@ class Settings:
         GPU_CUDA_ARCH: CUDA compute capability for CuPy on ARM64 (e.g., "80" for A100, "90" for H100, default: auto-detect)
 
         NCCL Allreduce Test Configuration:
-        NCCL_IMAGE: Container image for NCCL test (default: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.27.5-1-0120901)
+        NCCL_IMAGE: Container image for NCCL test (default: nvcr.io/nvidia/hpc-benchmarks:25.04)
         NCCL_TIMEOUT: Total timeout for NCCL test job (default: 600 = 10 minutes)
         NCCL_GPU_COUNT: Number of GPUs to request per job (default: auto-detect all)
         NCCL_MIN_BUS_BW_GBPS: Minimum expected bus bandwidth in GB/s (default: 0 = no check)
@@ -149,7 +149,7 @@ def get_nccl_image() -> str:
     """
     return os.getenv(
         "NCCL_IMAGE",
-        "ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.27.5-1-0120901",
+        "nvcr.io/nvidia/hpc-benchmarks:25.04",
     )
 
 

--- a/isvtest/src/isvtest/workloads/k8s_nccl.py
+++ b/isvtest/src/isvtest/workloads/k8s_nccl.py
@@ -14,6 +14,12 @@ from isvtest.core.workload import BaseWorkloadCheck
 
 
 class K8sNcclWorkload(BaseWorkloadCheck):
+    """Run NCCL allreduce test on Kubernetes.
+
+    Config:
+        min_bus_bw_gbps (float): Minimum expected bus bandwidth in GB/s (default: env or 0 = no check)
+    """
+
     description = "Run NCCL allreduce test on Kubernetes."
     markers: ClassVar[list[str]] = ["workload", "kubernetes", "gpu", "slow"]
 
@@ -21,7 +27,9 @@ class K8sNcclWorkload(BaseWorkloadCheck):
         # Get configuration
         namespace = get_k8s_namespace()
         timeout = get_nccl_timeout()
-        min_bus_bw = get_nccl_min_bus_bw_gbps()
+
+        min_bus_bw_config = self.config.get("min_bus_bw_gbps")
+        min_bus_bw = float(min_bus_bw_config) if min_bus_bw_config is not None else get_nccl_min_bus_bw_gbps()
 
         # Verify GPU nodes available
         # Note: We still rely on k8s_utils here for convenience, but we should eventually move this to Runner

--- a/isvtest/src/isvtest/workloads/manifests/k8s/nccl_allreduce_job.yaml
+++ b/isvtest/src/isvtest/workloads/manifests/k8s/nccl_allreduce_job.yaml
@@ -12,7 +12,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: nccl-allreduce
-          image: ghcr.io/coreweave/nccl-tests:12.9.1-devel-ubuntu22.04-nccl2.27.5-1-0120901
+          image: nvcr.io/nvidia/hpc-benchmarks:25.04
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -20,17 +20,18 @@ spec:
             - |
               set -euo pipefail
               TS=$(date +%Y%m%dT%H%M%S)
+              # Note: '-np 8' is overridden at runtime by K8sNcclWorkload
               mpirun --allow-run-as-root -np 8 \
                      --bind-to none --map-by slot \
                      -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
-                     /opt/nccl-tests/build/all_reduce_perf -b 8 -e 2G -f 2 -g 1 \
+                     all_reduce_perf_mpi -b 8 -e 2G -f 2 -g 1 \
                      2>&1 | tee /results/nccl-allreduce_${TS}.log
           volumeMounts:
             - name: results
               mountPath: /results
           resources:
             limits:
-              nvidia.com/gpu: 8
+              nvidia.com/gpu: 8 # overridden at runtime by K8sNcclWorkload
           securityContext:
             #  runAsNonRoot: true
             allowPrivilegeEscalation: false

--- a/isvtest/tests/test_settings.py
+++ b/isvtest/tests/test_settings.py
@@ -142,7 +142,7 @@ class TestNcclSettings:
         """Test default NCCL image."""
         with patch.dict(os.environ, {}, clear=True):
             result = get_nccl_image()
-            assert "nccl" in result.lower()
+            assert "hpc-benchmarks" in result
 
     def test_get_nccl_timeout_default(self) -> None:
         """Test default NCCL timeout."""


### PR DESCRIPTION
Replaced the default NCCL image from `ghcr.io/coreweave/nccl-tests` to `nvcr.io/nvidia/hpc-benchmarks:25.04` in both the settings and the Kubernetes job manifest, and updated the manifest command from `/opt/nccl-tests/build/all_reduce_perf` to `all_reduce_perf_mpi` to match the HPC benchmarks binary.

Also added `min_bus_bw_gbps` config support to `K8sNcclWorkload` (matching the existing Slurm workload pattern) and set a 100 GB/s minimum bandwidth threshold across all K8s configs to catch degraded GPU interconnects.