### PR TITLE
chore: update CODEOWNERS to remove admin role for NCP ISV Lab

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # Rules are evaluated from top to bottom, with later rules taking precedence.
 
 # Default owners for everything in the repo
-* @NVIDIA/ncp-isv-lab-maintainer @NVIDIA/ncp-isv-lab-admin
+* @NVIDIA/ncp-isv-lab-maintainer


### PR DESCRIPTION
Removed the @NVIDIA/ncp-isv-lab-admin from the default owners in the CODEOWNERS file, streamlining ownership assignments for repository management.