### PR TITLE
chore: simplify versioning with pyproject.toml as source of truth

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,33 @@
+name: Create version tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to tag (e.g. 1.0.0, without leading v)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Normalize version
+        id: version
+        run: |
+          VERSION="${{ inputs.version }}"
+          VERSION="${VERSION#v}"
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Verify version matches pyproject.toml
+        run: python3 scripts/bump-version.py --check "${{ steps.version.outputs.value }}"
+
+      - name: Create and push tag
+        run: |
+          git tag "v${{ steps.version.outputs.value }}"
+          git push origin "v${{ steps.version.outputs.value }}"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -162,6 +162,49 @@ ISV-NCP-Validation-Suite/
 └── docs/             # Documentation
 ```
 
+## Releasing
+
+### Version Bumping
+
+All packages share a single version. The canonical version lives in each package's `pyproject.toml` and is read at runtime via `importlib.metadata`.
+
+To bump the version, use the bump script:
+
+```bash
+# Bump using keywords (increments from the latest git tag)
+python scripts/bump-version.py patch          # 0.4.2 -> 0.4.3 (alias: fix)
+python scripts/bump-version.py minor          # 0.4.2 -> 0.5.0 (alias: feat)
+python scripts/bump-version.py major          # 0.4.2 -> 1.0.0
+
+# Or set an explicit version
+python scripts/bump-version.py 1.2.3
+
+# Pre-release versions are also supported
+python scripts/bump-version.py 1.0.0-rc.1
+```
+
+The script will:
+
+1. Show the current version (from the latest git tag) and the proposed new version
+2. Warn about major changes, skipped versions, or other anomalies
+3. Ask for confirmation before writing
+4. Update all 4 `pyproject.toml` files (root + isvctl + isvtest + isvreporter)
+5. Run `uv lock` to sync the lockfile
+
+### Creating a Release Tag
+
+After bumping, open a PR, review, and merge. Then create the tag:
+
+1. Go to **Actions** > **Create version tag** in GitHub
+2. Enter the version (e.g. `1.0.0`, without leading `v`)
+3. The workflow verifies all `pyproject.toml` files match, then creates and pushes `v1.0.0`
+
+You can also verify locally before triggering the workflow:
+
+```bash
+python scripts/bump-version.py --check 1.0.0
+```
+
 ## Advanced
 
 ### Minimal Installation

--- a/isvctl/src/isvctl/main.py
+++ b/isvctl/src/isvctl/main.py
@@ -1,10 +1,10 @@
 """Main CLI entry point for isvctl."""
 
-from importlib.metadata import version
 from typing import Annotated
 
 import typer
 from isvreporter.main import app as report_app
+from isvreporter.version import get_version
 
 from isvctl.cli import clean, deploy, docs, test
 
@@ -18,7 +18,7 @@ app = typer.Typer(
 def _version_callback(value: bool) -> None:
     """Print version and exit."""
     if value:
-        typer.echo(f"isvctl {version('isvctl')}")
+        typer.echo(f"isvctl {get_version('isvctl')}")
         raise typer.Exit()
 
 

--- a/isvreporter/src/isvreporter/main.py
+++ b/isvreporter/src/isvreporter/main.py
@@ -16,12 +16,30 @@ from isvreporter.client import (
     update_test_run,
 )
 from isvreporter.platform import get_platform_from_config, is_valid_platform, normalize_platform
+from isvreporter.version import get_version
 
 app = typer.Typer(
     name="report",
     help="Report ISV Lab test results to the ISV Lab Service API",
     no_args_is_help=True,
 )
+
+
+def _version_callback(value: bool) -> None:
+    """Print version and exit."""
+    if value:
+        typer.echo(f"isvreporter {get_version('isvreporter')}")
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: Annotated[
+        bool,
+        typer.Option("--version", "-V", help="Show version and exit.", callback=_version_callback, is_eager=True),
+    ] = False,
+) -> None:
+    """Report ISV Lab test results to the ISV Lab Service API."""
 
 
 def _get_credentials() -> tuple[str, str, str, str]:

--- a/isvreporter/src/isvreporter/version.py
+++ b/isvreporter/src/isvreporter/version.py
@@ -1,71 +1,23 @@
-"""Version detection utilities.
+"""Version resolution for all workspace packages.
 
-Version resolution works as follows:
-
-1. CI/CD build: The CI pipeline generates `_version.py` files with the
-   release version (e.g., `__version__ = "1.2.3"` or `__version__ = "dev-abc1234"`).
-   These files are baked into the wheel and take priority at runtime.
-
-2. Git tag: If `_version.py` doesn't exist (e.g., running from a cloned repo),
-   we use `git describe --tags` to resolve the version from tags. This covers:
-   - Exact tagged release: `v1.2.3` -> `1.2.3`
-   - Commits after a tag: `v1.2.3-5-gabc1234` -> `1.2.3-5-gabc1234`
-
-3. Git SHA: If no tags are found, we fall back to the commit SHA for a
-   meaningful dev version (e.g., `dev-c42ee70`).
-
-4. Fallback: If git isn't available, we use `dev-local`.
-
-Note: `_version.py` files are in `.gitignore` and should never be committed.
+The canonical version lives in each package's pyproject.toml. At runtime,
+importlib.metadata reads it from installed package metadata (works in wheels,
+editable installs, and airgapped environments after ``uv sync``).
 """
 
-import importlib
-import subprocess
+from importlib.metadata import PackageNotFoundError, version
 
 
 def get_version(package_name: str) -> str:
-    """Get package version with fallback chain.
+    """Return the installed version of *package_name*, or ``"dev"`` if unavailable.
 
     Args:
-        package_name: Name of the package (e.g., 'isvctl', 'isvtest', 'isvreporter')
+        package_name: Distribution name (e.g. ``"isvreporter"``).
 
     Returns:
-        Version string (e.g., '1.2.3', '1.2.3-5-gabc1234', 'dev-c42ee70', or 'dev-local')
+        Version string such as ``"1.2.3"`` or ``"dev"``.
     """
-    # CI/CD baked version
     try:
-        version_module = importlib.import_module(f"{package_name}._version")
-        return version_module.__version__
-    except (ModuleNotFoundError, AttributeError):
-        # Fall back to git/local when the baked version module is missing
-        pass
-
-    # Git tag: try git describe for tagged versions
-    try:
-        result = subprocess.run(
-            ["git", "describe", "--tags", "--match", "v*"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode == 0:
-            version = result.stdout.strip().lstrip("v")
-            return version
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        pass
-
-    # Git SHA: fall back to commit hash when no tags exist
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--short", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode == 0:
-            return f"dev-{result.stdout.strip()}"
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        # Fall back to dev-local if git is unavailable or too slow
-        pass
-
-    return "dev-local"
+        return version(package_name)
+    except PackageNotFoundError:
+        return "dev"

--- a/isvreporter/tests/test_bump_version.py
+++ b/isvreporter/tests/test_bump_version.py
@@ -1,0 +1,252 @@
+"""Tests for bump-version.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Load bump-version.py as a module (filename has a hyphen so normal import won't work)
+_spec = importlib.util.spec_from_file_location(
+    "bump_version", Path(__file__).resolve().parent.parent.parent / "scripts" / "bump-version.py"
+)
+assert _spec and _spec.loader
+bump_version = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bump_version)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_version
+# ---------------------------------------------------------------------------
+class TestResolveVersion:
+    """Tests for bump keyword resolution."""
+
+    @pytest.mark.parametrize(
+        ("arg", "current", "expected"),
+        [
+            ("patch", "0.1.0", "0.1.1"),
+            ("fix", "0.1.0", "0.1.1"),
+            ("patch", "1.2.9", "1.2.10"),
+            ("minor", "0.1.5", "0.2.0"),
+            ("feat", "0.1.5", "0.2.0"),
+            ("minor", "1.9.3", "1.10.0"),
+            ("major", "0.1.0", "1.0.0"),
+            ("major", "2.3.4", "3.0.0"),
+        ],
+    )
+    def test_bump_keywords(self, arg: str, current: str, expected: str) -> None:
+        assert bump_version._resolve_version(arg, current) == expected
+
+    @pytest.mark.parametrize(
+        ("arg", "expected"),
+        [
+            ("1.2.3", "1.2.3"),
+            ("v1.2.3", "1.2.3"),
+            ("0.0.1", "0.0.1"),
+        ],
+    )
+    def test_explicit_version(self, arg: str, expected: str) -> None:
+        assert bump_version._resolve_version(arg, "0.0.0") == expected
+
+    def test_invalid_version_exits(self) -> None:
+        with pytest.raises(SystemExit):
+            bump_version._resolve_version("abc", "0.1.0")
+
+
+# ---------------------------------------------------------------------------
+# bump + check (using temp pyproject files)
+# ---------------------------------------------------------------------------
+class TestBumpAndCheck:
+    """Tests for bump() and check() against real files."""
+
+    PYPROJECT_TEMPLATE = textwrap.dedent("""\
+        [project]
+        name = "test-pkg"
+        version = "{version}"
+    """)
+
+    @pytest.fixture()
+    def fake_pyprojects(self, tmp_path: Path) -> list[Path]:
+        """Create 4 fake pyproject.toml files mirroring the real layout."""
+        paths = []
+        for name in ["root", "a", "b", "c"]:
+            p = tmp_path / name / "pyproject.toml"
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(self.PYPROJECT_TEMPLATE.format(version="0.1.0"))
+            paths.append(p)
+        return paths
+
+    def test_bump_updates_all_files(self, fake_pyprojects: list[Path], tmp_path: Path) -> None:
+        with (
+            patch.object(bump_version, "PYPROJECT_FILES", fake_pyprojects),
+            patch.object(bump_version, "REPO_ROOT", tmp_path),
+        ):
+            bump_version.bump("1.0.0")
+
+        for p in fake_pyprojects:
+            assert 'version = "1.0.0"' in p.read_text()
+
+    def test_bump_skips_already_matching(
+        self, fake_pyprojects: list[Path], tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch.object(bump_version, "PYPROJECT_FILES", fake_pyprojects),
+            patch.object(bump_version, "REPO_ROOT", tmp_path),
+        ):
+            bump_version.bump("0.1.0")
+
+        out = capsys.readouterr().out
+        assert "already 0.1.0" in out
+
+    def test_check_passes_when_matching(self, fake_pyprojects: list[Path], tmp_path: Path) -> None:
+        with (
+            patch.object(bump_version, "PYPROJECT_FILES", fake_pyprojects),
+            patch.object(bump_version, "REPO_ROOT", tmp_path),
+        ):
+            bump_version.check("0.1.0")
+
+    def test_check_fails_on_mismatch(self, fake_pyprojects: list[Path], tmp_path: Path) -> None:
+        with (
+            patch.object(bump_version, "PYPROJECT_FILES", fake_pyprojects),
+            patch.object(bump_version, "REPO_ROOT", tmp_path),
+        ):
+            with pytest.raises(SystemExit):
+                bump_version.check("9.9.9")
+
+    def test_check_rejects_invalid_semver(self) -> None:
+        with pytest.raises(SystemExit):
+            bump_version.check("not-a-version")
+
+
+# ---------------------------------------------------------------------------
+# _git_tag_version
+# ---------------------------------------------------------------------------
+class TestGitTagVersion:
+    """Tests for git tag lookup."""
+
+    def test_returns_version_on_success(self) -> None:
+        mock_result = MagicMock(returncode=0, stdout="v1.2.3\n")
+        with patch.object(bump_version.subprocess, "run", return_value=mock_result):
+            assert bump_version._git_tag_version() == "1.2.3"
+
+    def test_returns_none_when_no_tags(self) -> None:
+        mock_result = MagicMock(returncode=128, stdout="")
+        with patch.object(bump_version.subprocess, "run", return_value=mock_result):
+            assert bump_version._git_tag_version() is None
+
+    def test_returns_none_when_git_missing(self) -> None:
+        with patch.object(bump_version.subprocess, "run", side_effect=FileNotFoundError):
+            assert bump_version._git_tag_version() is None
+
+
+# ---------------------------------------------------------------------------
+# _base_version
+# ---------------------------------------------------------------------------
+class TestBaseVersion:
+    """Tests for base version resolution (git tag vs pyproject.toml)."""
+
+    def test_prefers_git_tag_over_pyproject(self) -> None:
+        with (
+            patch.object(bump_version, "_git_tag_version", return_value="0.4.2"),
+            patch.object(bump_version, "_pyproject_version", return_value="0.1.0"),
+        ):
+            version, source = bump_version._base_version()
+            assert version == "0.4.2"
+            assert source == "git tag"
+
+    def test_falls_back_to_pyproject_when_no_tags(self) -> None:
+        with (
+            patch.object(bump_version, "_git_tag_version", return_value=None),
+            patch.object(bump_version, "_pyproject_version", return_value="0.1.0"),
+        ):
+            version, source = bump_version._base_version()
+            assert version == "0.1.0"
+            assert source == "pyproject.toml"
+
+    def test_falls_back_to_pyproject_when_tag_not_semver(self) -> None:
+        with (
+            patch.object(bump_version, "_git_tag_version", return_value="not-semver"),
+            patch.object(bump_version, "_pyproject_version", return_value="0.1.0"),
+        ):
+            version, source = bump_version._base_version()
+            assert version == "0.1.0"
+            assert source == "pyproject.toml"
+
+
+# ---------------------------------------------------------------------------
+# _confirm warnings
+# ---------------------------------------------------------------------------
+class TestConfirmWarnings:
+    """Tests for skip/downgrade/major warnings in _confirm."""
+
+    def _collect_warnings(self, base: str, new: str) -> list[str]:
+        """Run the warning-detection logic from _confirm and return the warnings list."""
+        base_parts = bump_version._parse_core(base)
+        new_parts = bump_version._parse_core(new)
+        warnings: list[str] = []
+        if new_parts < base_parts:
+            warnings.append(f"DOWNGRADE from {base}")
+        if new_parts[0] != base_parts[0]:
+            warnings.append("MAJOR version change")
+        if new_parts > base_parts:
+            if new_parts[0] > base_parts[0] + 1:
+                warnings.append(f"skipping major versions ({base_parts[0]} -> {new_parts[0]})")
+            elif new_parts[0] == base_parts[0] and new_parts[1] > base_parts[1] + 1:
+                warnings.append(f"skipping minor versions ({base_parts[1]} -> {new_parts[1]})")
+            elif new_parts[:2] == base_parts[:2] and new_parts[2] > base_parts[2] + 1:
+                warnings.append(f"skipping patch versions ({base_parts[2]} -> {new_parts[2]})")
+            if new_parts[0] != base_parts[0] and (new_parts[1] != 0 or new_parts[2] != 0):
+                warnings.append(f"major bump should reset to {new_parts[0]}.0.0")
+            elif new_parts[1] != base_parts[1] and new_parts[2] != 0:
+                warnings.append(f"minor bump should reset to {new_parts[0]}.{new_parts[1]}.0")
+        return warnings
+
+    def test_no_warnings_for_normal_patch(self) -> None:
+        assert self._collect_warnings("0.4.2", "0.4.3") == []
+
+    def test_no_warnings_for_normal_minor(self) -> None:
+        assert self._collect_warnings("0.4.2", "0.5.0") == []
+
+    def test_no_warnings_for_normal_major(self) -> None:
+        w = self._collect_warnings("0.4.2", "1.0.0")
+        assert "MAJOR version change" in w
+        assert not any("skipping" in x for x in w)
+
+    def test_warns_on_skipped_patch(self) -> None:
+        w = self._collect_warnings("0.4.2", "0.4.4")
+        assert any("skipping patch" in x for x in w)
+
+    def test_warns_on_skipped_minor(self) -> None:
+        w = self._collect_warnings("0.4.2", "0.6.0")
+        assert any("skipping minor" in x for x in w)
+
+    def test_warns_on_skipped_major(self) -> None:
+        w = self._collect_warnings("1.0.0", "3.0.0")
+        assert any("skipping major" in x for x in w)
+
+    def test_warns_on_downgrade(self) -> None:
+        w = self._collect_warnings("1.0.0", "0.9.0")
+        assert any("DOWNGRADE" in x for x in w)
+
+    def test_warns_on_minor_bump_with_nonzero_patch(self) -> None:
+        w = self._collect_warnings("0.4.2", "0.5.2")
+        assert any("should reset to 0.5.0" in x for x in w)
+
+    def test_warns_on_major_bump_with_nonzero_minor(self) -> None:
+        w = self._collect_warnings("0.4.2", "1.1.0")
+        assert any("should reset to 1.0.0" in x for x in w)
+
+    def test_warns_on_major_bump_with_nonzero_patch(self) -> None:
+        w = self._collect_warnings("0.4.2", "1.0.1")
+        assert any("should reset to 1.0.0" in x for x in w)
+
+    def test_no_reset_warning_for_clean_minor(self) -> None:
+        w = self._collect_warnings("0.4.2", "0.5.0")
+        assert not any("should reset" in x for x in w)
+
+    def test_no_reset_warning_for_clean_major(self) -> None:
+        w = self._collect_warnings("0.4.2", "1.0.0")
+        assert not any("should reset" in x for x in w)

--- a/isvreporter/tests/test_version.py
+++ b/isvreporter/tests/test_version.py
@@ -1,190 +1,21 @@
 """Tests for version module."""
 
-import subprocess
-from unittest.mock import MagicMock, call, patch
+from importlib.metadata import PackageNotFoundError
+from unittest.mock import patch
+
+from isvreporter.version import get_version
 
 
 class TestGetVersion:
     """Tests for get_version function."""
 
-    def test_returns_baked_version_when_available(self) -> None:
-        """Test that baked _version module takes priority."""
-        mock_module = MagicMock()
-        mock_module.__version__ = "1.2.3"
+    def test_returns_metadata_version_when_installed(self) -> None:
+        """When package is installed, version comes from importlib.metadata."""
+        with patch("isvreporter.version.version", return_value="1.2.3") as mock:
+            assert get_version("isvreporter") == "1.2.3"
+            mock.assert_called_once_with("isvreporter")
 
-        with patch("isvreporter.version.importlib") as mock_importlib:
-            mock_importlib.import_module.return_value = mock_module
-            from isvreporter.version import get_version
-
-            result = get_version("isvreporter")
-            assert result == "1.2.3"
-
-    def test_returns_tagged_version_on_exact_tag(self) -> None:
-        """Test that exact git tag is returned with v prefix stripped."""
-        with patch("isvreporter.version.importlib") as mock_importlib:
-            with patch("isvreporter.version.subprocess") as mock_subprocess:
-                mock_importlib.import_module.side_effect = ModuleNotFoundError
-                mock_subprocess.run.return_value = MagicMock(returncode=0, stdout="v1.2.3\n")
-                mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
-
-                from isvreporter.version import get_version
-
-                result = get_version("isvreporter")
-                assert result == "1.2.3"
-                # Should only call git describe, not rev-parse
-                mock_subprocess.run.assert_called_once()
-
-    def test_returns_tagged_version_with_distance(self) -> None:
-        """Test version after a tag includes commit distance and SHA."""
-        with patch("isvreporter.version.importlib") as mock_importlib:
-            with patch("isvreporter.version.subprocess") as mock_subprocess:
-                mock_importlib.import_module.side_effect = ModuleNotFoundError
-                mock_subprocess.run.return_value = MagicMock(returncode=0, stdout="v1.2.3-5-gabc1234\n")
-                mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
-
-                from isvreporter.version import get_version
-
-                result = get_version("isvreporter")
-                assert result == "1.2.3-5-gabc1234"
-
-    def test_falls_back_to_git_sha_when_no_tags(self) -> None:
-        """Test fallback to git SHA when no tags exist."""
-        with patch("isvreporter.version.importlib") as mock_importlib:
-            with patch("isvreporter.version.subprocess") as mock_subprocess:
-                mock_importlib.import_module.side_effect = ModuleNotFoundError
-                # git describe fails (no tags), git rev-parse succeeds
-                mock_subprocess.run.side_effect = [
-                    MagicMock(returncode=128, stdout=""),
-                    MagicMock(returncode=0, stdout="abc1234\n"),
-                ]
-                mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
-
-                from isvreporter.version import get_version
-
-                result = get_version("isvreporter")
-                assert result == "dev-abc1234"
-                assert mock_subprocess.run.call_count == 2
-
-    def test_falls_back_to_git_sha_when_version_attr_missing(self) -> None:
-        """Test fallback to git when __version__ attribute is missing."""
-        with patch("isvreporter.version.importlib") as mock_importlib:
-            with patch("isvreporter.version.subprocess") as mock_subprocess:
-                mock_importlib.import_module.side_effect = AttributeError
-                # git describe fails, git rev-parse succeeds
-                mock_subprocess.run.side_effect = [
-                    MagicMock(returncode=128, stdout=""),
-                    MagicMock(returncode=0, stdout="def5678\n"),
-                ]
-                mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
-
-                from isvreporter.version import get_version
-
-                result = get_version("isvreporter")
-                assert result == "dev-def5678"
-
-    def test_returns_dev_local_when_all_git_fails(self) -> None:
-        """Test fallback to dev-local when all git commands fail."""
-        with patch("isvreporter.version.importlib") as mock_importlib:
-            with patch("isvreporter.version.subprocess") as mock_subprocess:
-                mock_importlib.import_module.side_effect = ModuleNotFoundError
-                # Both git describe and git rev-parse fail
-                mock_subprocess.run.side_effect = [
-                    MagicMock(returncode=128, stdout=""),
-                    MagicMock(returncode=1, stdout=""),
-                ]
-                mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
-
-                from isvreporter.version import get_version
-
-                result = get_version("isvreporter")
-                assert result == "dev-local"
-
-    def test_returns_dev_local_when_git_not_found(self) -> None:
-        """Test fallback to dev-local when git is not installed."""
-        with patch("isvreporter.version.importlib") as mock_importlib:
-            with patch("isvreporter.version.subprocess") as mock_subprocess:
-                mock_importlib.import_module.side_effect = ModuleNotFoundError
-                mock_subprocess.run.side_effect = FileNotFoundError
-                mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
-
-                from isvreporter.version import get_version
-
-                result = get_version("isvreporter")
-                assert result == "dev-local"
-
-    def test_returns_dev_local_when_git_times_out(self) -> None:
-        """Test fallback to dev-local when git command times out."""
-        with patch("isvreporter.version.importlib") as mock_importlib:
-            with patch("isvreporter.version.subprocess") as mock_subprocess:
-                mock_importlib.import_module.side_effect = ModuleNotFoundError
-                mock_subprocess.run.side_effect = subprocess.TimeoutExpired("git", 5)
-                mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
-
-                from isvreporter.version import get_version
-
-                result = get_version("isvreporter")
-                assert result == "dev-local"
-
-    def test_returns_dev_local_on_os_error(self) -> None:
-        """Test fallback to dev-local on OSError."""
-        with patch("isvreporter.version.importlib") as mock_importlib:
-            with patch("isvreporter.version.subprocess") as mock_subprocess:
-                mock_importlib.import_module.side_effect = ModuleNotFoundError
-                mock_subprocess.run.side_effect = OSError("Permission denied")
-                mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
-
-                from isvreporter.version import get_version
-
-                result = get_version("isvreporter")
-                assert result == "dev-local"
-
-    def test_git_tag_version_is_stripped(self) -> None:
-        """Test that git tag output whitespace is stripped."""
-        with patch("isvreporter.version.importlib") as mock_importlib:
-            with patch("isvreporter.version.subprocess") as mock_subprocess:
-                mock_importlib.import_module.side_effect = ModuleNotFoundError
-                mock_subprocess.run.return_value = MagicMock(returncode=0, stdout="  v2.0.0  \n")
-                mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
-
-                from isvreporter.version import get_version
-
-                result = get_version("isvreporter")
-                assert result == "2.0.0"
-
-    def test_git_sha_is_stripped(self) -> None:
-        """Test that git SHA whitespace is stripped."""
-        with patch("isvreporter.version.importlib") as mock_importlib:
-            with patch("isvreporter.version.subprocess") as mock_subprocess:
-                mock_importlib.import_module.side_effect = ModuleNotFoundError
-                # git describe fails, git rev-parse returns SHA with whitespace
-                mock_subprocess.run.side_effect = [
-                    MagicMock(returncode=128, stdout=""),
-                    MagicMock(returncode=0, stdout="  abc1234  \n"),
-                ]
-                mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
-
-                from isvreporter.version import get_version
-
-                result = get_version("isvreporter")
-                assert result == "dev-abc1234"
-
-    def test_git_describe_uses_v_tag_pattern(self) -> None:
-        """Test that git describe only matches v* tags."""
-        with patch("isvreporter.version.importlib") as mock_importlib:
-            with patch("isvreporter.version.subprocess") as mock_subprocess:
-                mock_importlib.import_module.side_effect = ModuleNotFoundError
-                mock_subprocess.run.return_value = MagicMock(returncode=0, stdout="v3.1.0\n")
-                mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
-
-                from isvreporter.version import get_version
-
-                get_version("isvreporter")
-
-                # Verify git describe is called with --match v*
-                describe_call = mock_subprocess.run.call_args_list[0]
-                assert describe_call == call(
-                    ["git", "describe", "--tags", "--match", "v*"],
-                    capture_output=True,
-                    text=True,
-                    timeout=5,
-                )
+    def test_returns_dev_when_package_not_found(self) -> None:
+        """When metadata lookup fails, return 'dev'."""
+        with patch("isvreporter.version.version", side_effect=PackageNotFoundError("nope")):
+            assert get_version("nonexistent") == "dev"

--- a/isvtest/src/isvtest/main.py
+++ b/isvtest/src/isvtest/main.py
@@ -13,6 +13,7 @@ from typing import Annotated, Any
 
 import pytest
 import typer
+from isvreporter.version import get_version
 
 from isvtest.config.loader import ConfigLoader
 from isvtest.core import runners as reframe_runner
@@ -478,14 +479,26 @@ def workload(
     raise typer.Exit(code=0 if results["success"] else 1)
 
 
+def _version_callback(value: bool) -> None:
+    """Print version and exit."""
+    if value:
+        typer.echo(f"isvtest {get_version('isvtest')}")
+        raise typer.Exit()
+
+
 @app.callback(invoke_without_command=True)
-def callback(ctx: typer.Context) -> None:
+def callback(
+    ctx: typer.Context,
+    version: Annotated[
+        bool,
+        typer.Option("--version", "-V", help="Show version and exit.", callback=_version_callback, is_eager=True),
+    ] = False,
+) -> None:
     """NVIDIA ISV Lab validation tests.
 
     For full cluster lifecycle management, use isvctl:
         isvctl test run -f isvctl/configs/k8s.yaml
     """
-    # If no command specified, run test with defaults
     if ctx.invoked_subcommand is None:
         ctx.invoke(test_cmd)
 

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Bump or verify the version in all workspace pyproject.toml files.
+
+Bump keywords increment from the latest git tag (the last actual release),
+falling back to pyproject.toml if no tags exist.
+
+Usage:
+    python scripts/bump-version.py patch          # v0.4.2 -> 0.4.3  (alias: fix)
+    python scripts/bump-version.py minor          # v0.4.2 -> 0.5.0  (alias: feat)
+    python scripts/bump-version.py major          # v0.4.2 -> 1.0.0
+    python scripts/bump-version.py 1.2.3          # explicit version
+    python scripts/bump-version.py --check 1.2.3  # verify they already match (for CI)
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+PYPROJECT_FILES = [
+    REPO_ROOT / "pyproject.toml",
+    REPO_ROOT / "isvctl" / "pyproject.toml",
+    REPO_ROOT / "isvtest" / "pyproject.toml",
+    REPO_ROOT / "isvreporter" / "pyproject.toml",
+]
+
+VERSION_RE = re.compile(r'^(version\s*=\s*")([^"]+)(")', re.MULTILINE)
+# Official semver.org regex (https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string)
+SEMVER_RE = re.compile(
+    r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+)
+
+BUMP_ALIASES = {"fix": "patch", "feat": "minor"}
+
+
+def _parse_core(version: str) -> list[int]:
+    """Extract [major, minor, patch] integers from a semver string."""
+    m = SEMVER_RE.match(version)
+    if not m:
+        return [int(x) for x in version.split(".")[:3]]
+    return [int(m.group("major")), int(m.group("minor")), int(m.group("patch"))]
+
+
+def _pyproject_version() -> str:
+    """Read the current version from the root pyproject.toml."""
+    text = PYPROJECT_FILES[0].read_text()
+    match = VERSION_RE.search(text)
+    if not match:
+        print("error: no version field found in root pyproject.toml", file=sys.stderr)
+        sys.exit(1)
+    return match.group(2)
+
+
+def _git_tag_version() -> str | None:
+    """Get the latest version from git tags."""
+    try:
+        result = subprocess.run(
+            ["git", "describe", "--tags", "--abbrev=0", "--match", "v*"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=REPO_ROOT,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip().lstrip("v")
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return None
+
+
+def _base_version() -> tuple[str, str]:
+    """Determine the base version to bump from and its source.
+
+    Prefers the latest git tag over pyproject.toml since the tag represents
+    the last actual release (pyproject.toml may be stale).
+    """
+    tag = _git_tag_version()
+    pyproject = _pyproject_version()
+
+    if tag and SEMVER_RE.match(tag):
+        return tag, "git tag"
+    return pyproject, "pyproject.toml"
+
+
+def _resolve_version(arg: str, base: str) -> str:
+    """Resolve a bump keyword or explicit version string.
+
+    For bump keywords (patch/fix, minor/feat, major), increments from *base*.
+    For explicit versions, validates and returns as-is.
+    """
+    kind = BUMP_ALIASES.get(arg, arg)
+    parts = [int(x) for x in base.split(".")]
+
+    if kind == "patch":
+        parts[2] += 1
+    elif kind == "minor":
+        parts[1] += 1
+        parts[2] = 0
+    elif kind == "major":
+        parts[0] += 1
+        parts[1] = 0
+        parts[2] = 0
+    else:
+        version = arg.lstrip("v")
+        if not SEMVER_RE.match(version):
+            print(
+                f"error: '{arg}' is not valid semver or bump keyword (patch/fix, minor/feat, major)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        return version
+
+    return ".".join(str(x) for x in parts)
+
+
+def _confirm(base: str, base_source: str, new: str) -> None:
+    """Show the planned change and ask for confirmation."""
+    base_parts = _parse_core(base)
+    new_parts = _parse_core(new)
+
+    yellow = "\033[33m" if sys.stderr.isatty() else ""
+    reset = "\033[0m" if sys.stderr.isatty() else ""
+
+    warnings: list[str] = []
+    if new_parts < base_parts:
+        warnings.append(f"DOWNGRADE from {base}")
+    if new_parts[0] != base_parts[0]:
+        warnings.append("MAJOR version change")
+
+    if new_parts > base_parts:
+        if new_parts[0] > base_parts[0] + 1:
+            warnings.append(
+                f"skipping major versions ({base_parts[0]} -> {new_parts[0]})"
+            )
+        elif new_parts[0] == base_parts[0] and new_parts[1] > base_parts[1] + 1:
+            warnings.append(
+                f"skipping minor versions ({base_parts[1]} -> {new_parts[1]})"
+            )
+        elif new_parts[:2] == base_parts[:2] and new_parts[2] > base_parts[2] + 1:
+            warnings.append(
+                f"skipping patch versions ({base_parts[2]} -> {new_parts[2]})"
+            )
+
+        # Non-zero trailing digits on major/minor bump (e.g. 0.4.2 -> 0.5.2 should be 0.5.0)
+        if new_parts[0] != base_parts[0] and (new_parts[1] != 0 or new_parts[2] != 0):
+            warnings.append(f"major bump should reset to {new_parts[0]}.0.0")
+        elif new_parts[1] != base_parts[1] and new_parts[2] != 0:
+            warnings.append(
+                f"minor bump should reset to {new_parts[0]}.{new_parts[1]}.0"
+            )
+
+    if new == base:
+        print(f"Already at {base}, nothing to do.")
+        sys.exit(0)
+
+    print(f"  current:  {base} ({base_source})")
+    print(f"  new:      {new}")
+
+    if warnings:
+        print(f"\n  {yellow}WARNING: {', '.join(warnings)}{reset}", file=sys.stderr)
+
+    answer = input("\nProceed? [y/N] ").strip().lower()
+    if answer != "y":
+        print("Aborted.")
+        sys.exit(1)
+
+
+def bump(new_version: str) -> None:
+    """Update version in all pyproject.toml files."""
+    for path in PYPROJECT_FILES:
+        text = path.read_text()
+        match = VERSION_RE.search(text)
+        if not match:
+            print(
+                f"warning: no version field found in {path.relative_to(REPO_ROOT)}",
+                file=sys.stderr,
+            )
+            continue
+
+        old_version = match.group(2)
+        if old_version == new_version:
+            print(f"  {path.relative_to(REPO_ROOT)}: already {new_version}")
+            continue
+
+        updated = VERSION_RE.sub(rf"\g<1>{new_version}\3", text, count=1)
+        path.write_text(updated)
+        print(f"  {path.relative_to(REPO_ROOT)}: {old_version} -> {new_version}")
+
+
+def check(expected: str) -> None:
+    """Verify all pyproject.toml files already have the expected version."""
+    if not SEMVER_RE.match(expected):
+        print(
+            f"error: '{expected}' is not valid semver (expected X.Y.Z)", file=sys.stderr
+        )
+        sys.exit(1)
+
+    ok = True
+    for path in PYPROJECT_FILES:
+        text = path.read_text()
+        match = VERSION_RE.search(text)
+        actual = match.group(2) if match else "<not found>"
+        rel = path.relative_to(REPO_ROOT)
+        if actual != expected:
+            print(f"  MISMATCH {rel}: {actual} (expected {expected})", file=sys.stderr)
+            ok = False
+        else:
+            print(f"  ok {rel}: {actual}")
+
+    if not ok:
+        print(
+            f"\nerror: run 'python scripts/bump-version.py {expected}' and merge a PR first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    print("\nAll versions match.")
+
+
+def main() -> None:
+    """Entry point."""
+    if len(sys.argv) == 3 and sys.argv[1] == "--check":
+        expected = sys.argv[2].lstrip("v")
+        print(f"Checking for {expected}:")
+        check(expected)
+        return
+
+    if len(sys.argv) != 2 or sys.argv[1].startswith("-"):
+        print(f"usage: {sys.argv[0]} [--check] <version>", file=sys.stderr)
+        print("  version: X.Y.Z | patch | minor | major | fix | feat", file=sys.stderr)
+        sys.exit(1)
+
+    arg = sys.argv[1]
+    base, base_source = _base_version()
+    new_version = _resolve_version(arg, base)
+    _confirm(base, base_source, new_version)
+
+    print(f"\nBumping to {new_version}:")
+    bump(new_version)
+
+    print("\nRunning uv lock...")
+    subprocess.run(["uv", "lock"], cwd=REPO_ROOT, check=True)
+
+    print("\nDone. Review with 'git diff', then commit and open a PR.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Replace runtime `git describe`/`git rev-parse` versioning with `importlib.metadata` reading from `pyproject.toml`. Works in airgapped and tarball installs without git.

- Simplify `version.py` to `importlib.metadata.version()` with `"dev"` fallback
- Add `scripts/bump-version.py` with keyword support (`patch`/`fix`, `minor`/`feat`, `major`), official semver.org regex validation, git tag awareness, and interactive confirmation with warnings
- Add `.github/workflows/tag.yml` for creating version tags after bump PRs merge
- Add `--version` / `-V` flag to `isvtest` and `isvreporter` CLIs, unify `isvctl` to use shared `get_version`
- Document release workflow in `docs/contributing.md`