### PR TITLE
fix(k8s): fix NCCL workload timeout config and privileges

### DIFF
--- a/isvctl/configs/k8s.yaml
+++ b/isvctl/configs/k8s.yaml
@@ -82,9 +82,11 @@ tests:
       checks:
         - K8sNcclWorkload:
             min_bus_bw_gbps: 100
+            timeout: 600
         - K8sGpuStressWorkload:
             memory_gb: 1
             runtime: 30
+            timeout: 420
         - K8sNimInferenceWorkload:
             timeout: 1500
         - K8sNimHelmWorkload-1b:

--- a/isvctl/configs/k8s.yaml
+++ b/isvctl/configs/k8s.yaml
@@ -86,7 +86,7 @@ tests:
         - K8sGpuStressWorkload:
             memory_gb: 1
             runtime: 30
-            timeout: 420
+            timeout: 300
         - K8sNimInferenceWorkload:
             timeout: 1500
         - K8sNimHelmWorkload-1b:

--- a/isvctl/configs/k8s.yaml
+++ b/isvctl/configs/k8s.yaml
@@ -103,6 +103,4 @@ tests:
             genai_perf_concurrency: 8
 
   exclude:
-    markers:
-      - slow
-      - workload
+    markers: []

--- a/isvtest/src/isvtest/core/workload.py
+++ b/isvtest/src/isvtest/core/workload.py
@@ -92,8 +92,11 @@ class BaseWorkloadCheck(BaseValidation):
             # Timeout
             self.log.error(f"Job {job_name} timed out after {timeout}s")
             # Try to get debug info
-            self.run_command(f"{kubectl_base} describe job {job_name} -n {namespace}")
-            self.run_command(f"{kubectl_base} get pods -n {namespace} -l job-name={job_name}")
+            res_desc = self.run_command(f"{kubectl_base} describe job {job_name} -n {namespace}")
+            self.log.error(f"Job Description:\n{res_desc.stdout}")
+
+            res_pods = self.run_command(f"{kubectl_base} get pods -n {namespace} -l job-name={job_name}")
+            self.log.error(f"Job Pods:\n{res_pods.stdout}")
 
             # Cleanup and return failure
             self.run_command(f"{kubectl_base} delete job {job_name} -n {namespace} --wait=false")

--- a/isvtest/src/isvtest/workloads/k8s_nccl.py
+++ b/isvtest/src/isvtest/workloads/k8s_nccl.py
@@ -26,7 +26,7 @@ class K8sNcclWorkload(BaseWorkloadCheck):
     def run(self) -> None:
         # Get configuration
         namespace = get_k8s_namespace()
-        timeout = get_nccl_timeout()
+        timeout = self.config.get("timeout") or get_nccl_timeout()
 
         min_bus_bw_config = self.config.get("min_bus_bw_gbps")
         min_bus_bw = float(min_bus_bw_config) if min_bus_bw_config is not None else get_nccl_min_bus_bw_gbps()

--- a/isvtest/src/isvtest/workloads/k8s_stress.py
+++ b/isvtest/src/isvtest/workloads/k8s_stress.py
@@ -215,5 +215,10 @@ spec:
       limits:
         nvidia.com/gpu: "{gpu_count}"
     imagePullPolicy: IfNotPresent
+  runtimeClassName: nvidia
+  tolerations:
+  - key: "nvidia.com/gpu"
+    operator: "Exists"
+    effect: "NoSchedule"
 """
         return pod_yaml

--- a/isvtest/src/isvtest/workloads/manifests/k8s/nccl_allreduce_job.yaml
+++ b/isvtest/src/isvtest/workloads/manifests/k8s/nccl_allreduce_job.yaml
@@ -37,6 +37,7 @@ spec:
             allowPrivilegeEscalation: false
       nodeSelector:
         nvidia.com/gpu.present: "true"
+      runtimeClassName: nvidia
       tolerations:
         - key: "nvidia.com/gpu"
           operator: "Exists"

--- a/isvtest/src/isvtest/workloads/manifests/k8s/nim_llama_3b_inference_job.yaml
+++ b/isvtest/src/isvtest/workloads/manifests/k8s/nim_llama_3b_inference_job.yaml
@@ -227,8 +227,13 @@ spec:
               mountPath: /shared
 
       # Node selection - schedule on GPU nodes
+      runtimeClassName: nvidia
       nodeSelector:
         nvidia.com/gpu.present: "true"
+      tolerations:
+        - key: "nvidia.com/gpu"
+          operator: "Exists"
+          effect: "NoSchedule"
 
       volumes:
         - name: nim-cache


### PR DESCRIPTION
* workload.py: On job timeout, log describe job and get pods output to aid debugging.
* Manifests (stress, NCCL, NIM): Add runtimeClassName: nvidia and GPU tolerations so pods schedule on GPU nodes.
* k8s.yaml: Set timeouts for NCCL (600s) and GPU stress (300s) workloads; stop excluding slow/workload markers.
* NCCL workload: Use config timeout when set, else default.