### PR TITLE
feat(nccl): add multi-node NCCL workload support for Kubernetes and enhance Slurm NCCL

### DIFF
--- a/docs/packages/isvtest.md
+++ b/docs/packages/isvtest.md
@@ -39,6 +39,7 @@ isvtest/src/isvtest/
 │   └── reframe_*.py     # ReFrame validations
 ├── workloads/           # Workload-based tests (longer running)
 │   ├── k8s_*.py         # K8s workloads (NCCL, stress, NIM)
+│   ├── slurm_*.py       # Slurm workloads (NCCL, stress, sbatch)
 │   └── reframe_*.py     # ReFrame tests
 └── main.py              # CLI entry point
 ```
@@ -85,12 +86,26 @@ isvtest/src/isvtest/
 
 | Workload | Description |
 | -------- | ----------- |
-| `K8sNcclWorkload` | NCCL allreduce validation |
+| `K8sNcclWorkload` | Single-node NCCL AllReduce validation |
+| `K8sNcclMultiNodeWorkload` | Multi-node NCCL AllReduce via MPIJob |
 | `K8sGpuStressWorkload` | GPU stress test |
 | `K8sNimHelmWorkload` | NIM Helm deployment + GenAI-Perf KPIs |
 | `K8sNimInferenceWorkload` | NIM inference validation |
+| `SlurmNcclMultiNodeWorkload` | Multi-node NCCL AllReduce via Slurm |
+| `SlurmGpuStressWorkload` | GPU stress test across Slurm partition |
+| `SlurmSbatchWorkload` | Run arbitrary sbatch script |
 
 Each workload class has detailed docstrings covering config options, environment variables, and troubleshooting.
+
+#### Workload Prerequisites
+
+Some workloads require additional cluster components beyond the base GPU Operator:
+
+| Workload | Requirement | Notes |
+| -------- | ----------- | ----- |
+| `K8sNcclMultiNodeWorkload` | [Kubeflow MPI Operator](https://github.com/kubeflow/mpi-operator) | Provides the `MPIJob` CRD (`kubeflow.org/v2beta1`) used to orchestrate multi-node runs |
+| `K8sNcclMultiNodeWorkload` | NVIDIA DRA driver (optional) | When the `ComputeDomain` CRD is present, MNNVL/IMEX channels are enabled automatically for full NVLink bandwidth across nodes. Controlled by `use_compute_domain: auto\|true\|false` |
+| `K8sNimHelmWorkload` | `NGC_API_KEY` env var | Required to pull NIM models from NGC |
 
 ## Configuration Format
 

--- a/isvctl/configs/k8s.yaml
+++ b/isvctl/configs/k8s.yaml
@@ -86,7 +86,8 @@ tests:
         - K8sNcclMultiNodeWorkload:
             nodes: 2
             min_bus_bw_gbps: 100
-            timeout: 600
+            timeout: 900
+            use_compute_domain: auto
         - K8sGpuStressWorkload:
             memory_gb: 1
             runtime: 30

--- a/isvctl/configs/k8s.yaml
+++ b/isvctl/configs/k8s.yaml
@@ -83,6 +83,10 @@ tests:
         - K8sNcclWorkload:
             min_bus_bw_gbps: 100
             timeout: 600
+        - K8sNcclMultiNodeWorkload:
+            nodes: 2
+            min_bus_bw_gbps: 100
+            timeout: 900
         - K8sGpuStressWorkload:
             memory_gb: 1
             runtime: 30

--- a/isvctl/configs/k8s.yaml
+++ b/isvctl/configs/k8s.yaml
@@ -86,7 +86,7 @@ tests:
         - K8sNcclMultiNodeWorkload:
             nodes: 2
             min_bus_bw_gbps: 100
-            timeout: 900
+            timeout: 600
         - K8sGpuStressWorkload:
             memory_gb: 1
             runtime: 30

--- a/isvctl/configs/k8s.yaml
+++ b/isvctl/configs/k8s.yaml
@@ -86,6 +86,7 @@ tests:
         - K8sNcclMultiNodeWorkload:
             nodes: "{{ steps.setup.kubernetes.gpu_node_count | default(2, true) }}"
             min_bus_bw_gbps: 100
+            quick_mode: false
             timeout: 600
             use_compute_domain: auto
         - K8sGpuStressWorkload:

--- a/isvctl/configs/k8s.yaml
+++ b/isvctl/configs/k8s.yaml
@@ -84,9 +84,9 @@ tests:
             min_bus_bw_gbps: 100
             timeout: 600
         - K8sNcclMultiNodeWorkload:
-            nodes: 2
+            nodes: "{{ steps.setup.kubernetes.gpu_node_count | default(2, true) }}"
             min_bus_bw_gbps: 100
-            timeout: 900
+            timeout: 600
             use_compute_domain: auto
         - K8sGpuStressWorkload:
             memory_gb: 1

--- a/isvctl/configs/slurm.yaml
+++ b/isvctl/configs/slurm.yaml
@@ -68,7 +68,7 @@ tests:
             partition: "{{ steps.setup.slurm.default_partition | default('gpu') }}"
             runtime: 30
             memory_gb: 16
-            timeout: 600
+            timeout: 900
             cuda_arch: "{{ steps.setup.slurm.cuda_arch | default('100') }}"
 
         # Multi-node NCCL test - validates GPU communication across nodes

--- a/isvctl/configs/slurm.yaml
+++ b/isvctl/configs/slurm.yaml
@@ -74,7 +74,7 @@ tests:
         # Multi-node NCCL test - validates GPU communication across nodes
         - SlurmNcclMultiNodeWorkload:
             partition: "{{ steps.setup.slurm.default_partition | default('gpu') }}"
-            nodes: 2
+            nodes: "{{ steps.setup.slurm.partitions.gpu.nodes | default([]) | length }}"
             # gpus_per_node: auto-detected from partition GRES if not specified
             min_bus_bw_gbps: 100 # Set to expected bandwidth to enforce threshold
             quick_mode: true

--- a/isvctl/configs/slurm.yaml
+++ b/isvctl/configs/slurm.yaml
@@ -77,7 +77,7 @@ tests:
             nodes: "{{ steps.setup.slurm.partitions.gpu.nodes | default([]) | length }}"
             # gpus_per_node: auto-detected from partition GRES if not specified
             min_bus_bw_gbps: 100 # Set to expected bandwidth to enforce threshold
-            quick_mode: true
+            quick_mode: false
             timeout: 900
 
         # Run GPU job from manifest file with variable substitution

--- a/isvtest/src/isvtest/workloads/k8s_nccl.py
+++ b/isvtest/src/isvtest/workloads/k8s_nccl.py
@@ -1,4 +1,3 @@
-import re
 import uuid
 from pathlib import Path
 from typing import ClassVar
@@ -11,6 +10,7 @@ from isvtest.config.settings import (
 )
 from isvtest.core.k8s import get_gpu_nodes, get_node_gpu_count
 from isvtest.core.workload import BaseWorkloadCheck
+from isvtest.workloads.nccl_common import parse_nccl_output
 
 
 class K8sNcclWorkload(BaseWorkloadCheck):
@@ -80,29 +80,19 @@ class K8sNcclWorkload(BaseWorkloadCheck):
             self.set_failed(f"NCCL test failed: {result.stderr}")
             return
 
-        logs = result.stdout
+        nccl = parse_nccl_output(result.stdout)
 
-        # Parse NCCL results
-        avg_bw_match = re.search(r"Avg bus bandwidth\s*:\s*([\d.]+)", logs)
-        oob_match = re.search(r"Out of bounds values\s*:\s*(\d+)", logs)
+        if not nccl.success:
+            self.set_failed(nccl.error, output=nccl.output)
+            return
 
-        output_msg = ""
-        if avg_bw_match:
-            avg_bus_bw = float(avg_bw_match.group(1))
-            output_msg += f"Average Bus Bandwidth: {avg_bus_bw:.2f} GB/s\n"
+        if min_bus_bw > 0 and nccl.avg_bus_bw_gbps < min_bus_bw:
+            self.set_failed(f"Bus bandwidth {nccl.avg_bus_bw_gbps:.2f} GB/s below minimum {min_bus_bw} GB/s")
+            return
 
-            if min_bus_bw > 0:
-                if avg_bus_bw < min_bus_bw:
-                    self.set_failed(f"Bus bandwidth {avg_bus_bw:.2f} GB/s below minimum {min_bus_bw} GB/s")
-                    return
-        else:
-            output_msg += "Warning: Could not parse average bus bandwidth from logs\n"
+        msg = "NCCL allreduce test passed\n"
+        msg += f"Average Bus Bandwidth: {nccl.avg_bus_bw_gbps:.2f} GB/s\n"
+        if nccl.out_of_bounds >= 0:
+            msg += f"Out of Bounds Values: {nccl.out_of_bounds} (Pass)\n"
 
-        if oob_match:
-            oob_values = int(oob_match.group(1))
-            if oob_values != 0:
-                self.set_failed(f"NCCL test found {oob_values} out of bounds values (data corruption)")
-                return
-            output_msg += f"Out of Bounds Values: {oob_values} (Pass)\n"
-
-        self.set_passed(f"NCCL allreduce test passed\n{output_msg}")
+        self.set_passed(msg)

--- a/isvtest/src/isvtest/workloads/k8s_nccl_multinode.py
+++ b/isvtest/src/isvtest/workloads/k8s_nccl_multinode.py
@@ -57,6 +57,8 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
         gpus_per_node (int): GPUs per node (default: auto-detect, fallback 8)
         min_bus_bw_gbps (float): Minimum expected bus bandwidth in GB/s (default: 0 = no check)
         timeout (int): Job timeout in seconds (default: 900 via env)
+        startup_timeout (int): Seconds to wait for launcher pod to appear (default: 300).
+            Covers image pulls on workers, SSH key setup, and StatefulSet creation.
         image (str): Container image (default: nvcr.io/nvidia/hpc-benchmarks:25.04)
     """
 
@@ -199,9 +201,11 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
         total_gpus: int,
     ) -> None:
         """Wait for MPIJob launcher completion, collect logs, and report."""
-        launcher_pod = self._wait_for_launcher_pod(job_name, namespace, timeout=120)
+        startup_timeout = int(self.config.get("startup_timeout", 300))
+        launcher_pod = self._wait_for_launcher_pod(job_name, namespace, timeout=startup_timeout)
         if not launcher_pod:
-            self.set_failed(f"Launcher pod for MPIJob {job_name} not found within 120s")
+            self._dump_debug_info(job_name, namespace)
+            self.set_failed(f"Launcher pod for MPIJob {job_name} not found within {startup_timeout}s")
             return
 
         self.log.info(f"Launcher pod: {launcher_pod}, waiting for completion (timeout: {timeout}s)...")

--- a/isvtest/src/isvtest/workloads/k8s_nccl_multinode.py
+++ b/isvtest/src/isvtest/workloads/k8s_nccl_multinode.py
@@ -6,6 +6,10 @@ fabric (inter-node).
 
 Requires the Kubeflow MPI Operator (kubeflow.org/v2beta1) to be installed
 in the cluster.
+
+When the NVIDIA DRA driver is available (ComputeDomain CRD registered),
+automatically creates a ComputeDomain to enable Multi-Node NVLink (MNNVL)
+via IMEX channels for full NVLink bandwidth across nodes.
 """
 
 import subprocess
@@ -35,6 +39,20 @@ from isvtest.workloads.nccl_common import parse_nccl_output
 _MPIJOB_LABEL_JOB_NAME = "training.kubeflow.org/job-name"
 _MPIJOB_LABEL_REPLICA_TYPE = "training.kubeflow.org/replica-type"
 
+_COMPUTE_DOMAIN_TEMPLATE = """\
+---
+apiVersion: resource.nvidia.com/v1beta1
+kind: ComputeDomain
+metadata:
+  name: {cd_name}
+spec:
+  numNodes: {num_nodes}
+  channel:
+    resourceClaimTemplate:
+      name: {cd_channel_name}
+---
+"""
+
 
 class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
     """Run NCCL AllReduce test across multiple Kubernetes nodes via MPIJob.
@@ -59,6 +77,8 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
         startup_timeout (int): Seconds to wait for launcher pod to appear (default: 300).
             Covers image pulls on workers, SSH key setup, and StatefulSet creation.
         image (str): Container image (default: nvcr.io/nvidia/hpc-benchmarks:25.04)
+        use_compute_domain (str): "auto" (default) detects DRA driver availability,
+            "true" to require ComputeDomain/MNNVL, "false" to skip.
     """
 
     description: ClassVar[str] = "Run NCCL AllReduce test across multiple K8s nodes (MPIJob)"
@@ -93,14 +113,19 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
             self.set_passed(f"Skipped: Multi-node NCCL test requires at least 2 GPU nodes, found {len(gpu_nodes)}")
             return
 
+        use_cd = self._resolve_compute_domain_mode()
+
         node_count, gpus_per_node = self._resolve_topology(gpu_nodes)
         total_gpus = node_count * gpus_per_node
         job_name = f"nccl-allreduce-mn-{uuid.uuid4().hex[:8]}"
+        cd_name = f"{job_name}-cd"
+        cd_channel_name = f"{job_name}-cd-channel"
 
         self.log.info(
             f"Starting multi-node NCCL test: {node_count} nodes x {gpus_per_node} GPUs = {total_gpus} total GPUs"
         )
         self.log.info(f"Image: {image}, Min BW: {min_bus_bw} GB/s, Timeout: {job_timeout}s")
+        self.log.info(f"ComputeDomain (MNNVL/IMEX): {'enabled' if use_cd else 'disabled'}")
 
         manifest_path = Path(__file__).parent / "manifests" / "k8s" / "nccl_allreduce_mpijob.yaml"
         if not manifest_path.exists():
@@ -109,6 +134,11 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
 
         yaml_content = manifest_path.read_text()
         yaml_content = self._patch_manifest(yaml_content, job_name, node_count, gpus_per_node, total_gpus, image)
+
+        if use_cd:
+            yaml_content = self._add_compute_domain(
+                yaml_content, job_name, cd_name, cd_channel_name, node_count, gpus_per_node
+            )
 
         self.log.info(f"Deploying MPIJob {job_name} in namespace {namespace}...")
         try:
@@ -131,6 +161,9 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
         finally:
             self.log.info(f"Cleaning up MPIJob {job_name}...")
             run_kubectl(["delete", "mpijob", job_name, "-n", namespace, "--ignore-not-found=true"])
+            if use_cd:
+                self.log.info(f"Cleaning up ComputeDomain {cd_name}...")
+                run_kubectl(["delete", "computedomain", cd_name, "-n", namespace, "--ignore-not-found=true"])
 
     def _check_mpi_operator(self) -> bool:
         """Check if the Kubeflow MPI Operator CRD is installed."""
@@ -189,6 +222,102 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
         if image != "nvcr.io/nvidia/hpc-benchmarks:25.04":
             yaml_content = yaml_content.replace("nvcr.io/nvidia/hpc-benchmarks:25.04", image)
         return yaml_content
+
+    def _resolve_compute_domain_mode(self) -> bool:
+        """Determine whether to use ComputeDomain for MNNVL/IMEX.
+
+        Checks the ``use_compute_domain`` config option:
+        - ``"auto"`` (default): enables ComputeDomain if the DRA driver CRD is present.
+        - ``"true"``: always enable (fails if CRD is missing).
+        - ``"false"``: never enable.
+
+        Returns:
+            True if ComputeDomain should be used.
+        """
+        mode = str(self.config.get("use_compute_domain", "auto")).lower()
+
+        if mode == "false":
+            return False
+
+        has_cd = self._has_compute_domain_support()
+
+        if mode == "true" and not has_cd:
+            self.log.warning(
+                "use_compute_domain=true but ComputeDomain CRD not found. "
+                "Install the NVIDIA DRA driver for GPUs to enable MNNVL."
+            )
+
+        if mode == "auto":
+            if has_cd:
+                self.log.info("ComputeDomain CRD detected -- enabling MNNVL/IMEX for NVLink fabric access")
+            return has_cd
+
+        return has_cd
+
+    def _has_compute_domain_support(self) -> bool:
+        """Check if the NVIDIA DRA driver ComputeDomain CRD is registered."""
+        result = run_kubectl(["api-resources", "--api-group=resource.nvidia.com", "-o", "name"], timeout=10)
+        if result.returncode != 0:
+            return False
+        return "computedomains.resource.nvidia.com" in result.stdout
+
+    def _add_compute_domain(
+        self,
+        yaml_content: str,
+        job_name: str,
+        cd_name: str,
+        cd_channel_name: str,
+        node_count: int,
+        gpus_per_node: int,
+    ) -> str:
+        """Prepend a ComputeDomain resource and add DRA claims to the MPIJob.
+
+        Modifies the manifest to:
+        1. Prepend a ComputeDomain resource for IMEX channel allocation
+        2. Add resourceClaims to the Worker pod spec
+        3. Add resource claims to the Worker container
+        4. Add podAffinity with nvidia.com/gpu.clique topology key
+        """
+        cd_yaml = _COMPUTE_DOMAIN_TEMPLATE.format(
+            cd_name=cd_name,
+            num_nodes=node_count,
+            cd_channel_name=cd_channel_name,
+        )
+
+        # Add resource claim reference to the worker container's resources
+        gpu_limit_line = f"nvidia.com/gpu: {gpus_per_node} # overridden at runtime by K8sNcclMultiNodeWorkload"
+        gpu_limit_with_claims = (
+            f"nvidia.com/gpu: {gpus_per_node}\n                claims:\n                  - name: cd-channel"
+        )
+        yaml_content = yaml_content.replace(gpu_limit_line, gpu_limit_with_claims)
+
+        # Add resourceClaims at the Worker pod spec level (after volumes)
+        yaml_content = yaml_content.replace(
+            "                sizeLimit: 8Gi",
+            "                sizeLimit: 8Gi\n"
+            "          resourceClaims:\n"
+            "            - name: cd-channel\n"
+            f"              resourceClaimTemplateName: {cd_channel_name}",
+        )
+
+        # Add podAffinity for GPU clique topology so workers land on same NVLink domain
+        yaml_content = yaml_content.replace(
+            '          nodeSelector:\n            nvidia.com/gpu.present: "true"',
+            "          nodeSelector:\n"
+            '            nvidia.com/gpu.present: "true"\n'
+            "          affinity:\n"
+            "            podAffinity:\n"
+            "              requiredDuringSchedulingIgnoredDuringExecution:\n"
+            "              - labelSelector:\n"
+            "                  matchExpressions:\n"
+            f"                  - key: {_MPIJOB_LABEL_JOB_NAME}\n"
+            "                    operator: In\n"
+            "                    values:\n"
+            f"                    - {job_name}\n"
+            "                topologyKey: nvidia.com/gpu.clique",
+        )
+
+        return cd_yaml + yaml_content
 
     def _wait_and_report(
         self,

--- a/isvtest/src/isvtest/workloads/k8s_nccl_multinode.py
+++ b/isvtest/src/isvtest/workloads/k8s_nccl_multinode.py
@@ -37,7 +37,6 @@ from isvtest.core.workload import BaseWorkloadCheck
 from isvtest.workloads.nccl_common import parse_nccl_output
 
 _MPIJOB_LABEL_JOB_NAME = "training.kubeflow.org/job-name"
-_MPIJOB_LABEL_REPLICA_TYPE = "training.kubeflow.org/replica-type"
 
 _COMPUTE_DOMAIN_TEMPLATE = """\
 ---
@@ -274,9 +273,11 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
 
         Modifies the manifest to:
         1. Prepend a ComputeDomain resource for IMEX channel allocation
-        2. Add resourceClaims to the Worker pod spec
-        3. Add resource claims to the Worker container
-        4. Add podAffinity with nvidia.com/gpu.clique topology key
+        2. Add resourceClaims to the Worker container resources
+        3. Add resourceClaims to the Worker pod spec
+
+        The DRA controller handles topology-aware scheduling via the
+        ComputeDomain, so explicit podAffinity is not needed.
         """
         cd_yaml = _COMPUTE_DOMAIN_TEMPLATE.format(
             cd_name=cd_name,
@@ -284,37 +285,19 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
             cd_channel_name=cd_channel_name,
         )
 
-        # Add resource claim reference to the worker container's resources
-        gpu_limit_line = f"nvidia.com/gpu: {gpus_per_node} # overridden at runtime by K8sNcclMultiNodeWorkload"
-        gpu_limit_with_claims = (
-            f"nvidia.com/gpu: {gpus_per_node}\n                claims:\n                  - name: cd-channel"
+        # Add resource claim to worker container's resources (alongside GPU limit)
+        yaml_content = yaml_content.replace(
+            f"nvidia.com/gpu: {gpus_per_node}",
+            f"nvidia.com/gpu: {gpus_per_node}\n                claims:\n                  - name: cd-channel",
         )
-        yaml_content = yaml_content.replace(gpu_limit_line, gpu_limit_with_claims)
 
-        # Add resourceClaims at the Worker pod spec level (after volumes)
+        # Add resourceClaims at Worker pod spec level (after volumes section)
         yaml_content = yaml_content.replace(
             "                sizeLimit: 8Gi",
             "                sizeLimit: 8Gi\n"
             "          resourceClaims:\n"
             "            - name: cd-channel\n"
             f"              resourceClaimTemplateName: {cd_channel_name}",
-        )
-
-        # Add podAffinity for GPU clique topology so workers land on same NVLink domain
-        yaml_content = yaml_content.replace(
-            '          nodeSelector:\n            nvidia.com/gpu.present: "true"',
-            "          nodeSelector:\n"
-            '            nvidia.com/gpu.present: "true"\n'
-            "          affinity:\n"
-            "            podAffinity:\n"
-            "              requiredDuringSchedulingIgnoredDuringExecution:\n"
-            "              - labelSelector:\n"
-            "                  matchExpressions:\n"
-            f"                  - key: {_MPIJOB_LABEL_JOB_NAME}\n"
-            "                    operator: In\n"
-            "                    values:\n"
-            f"                    - {job_name}\n"
-            "                topologyKey: nvidia.com/gpu.clique",
         )
 
         return cd_yaml + yaml_content
@@ -340,7 +323,7 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
 
         completed, phase = self._wait_for_mpijob_completion(launcher_pod, job_name, namespace, timeout)
 
-        # Collect logs before any cleanup -- pod may still exist with cleanPodPolicy: None
+        # Collect logs before cleanup -- pods still exist with cleanPodPolicy: Running
         logs = get_pod_logs(launcher_pod, namespace, container="launcher", timeout=60)
 
         if not completed:

--- a/isvtest/src/isvtest/workloads/k8s_nccl_multinode.py
+++ b/isvtest/src/isvtest/workloads/k8s_nccl_multinode.py
@@ -28,7 +28,6 @@ from isvtest.core.k8s import (
     get_node_gpu_count,
     get_pod_logs,
     run_kubectl,
-    wait_for_pod_completion,
 )
 from isvtest.core.workload import BaseWorkloadCheck
 from isvtest.workloads.nccl_common import parse_nccl_output
@@ -210,24 +209,34 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
 
         self.log.info(f"Launcher pod: {launcher_pod}, waiting for completion (timeout: {timeout}s)...")
 
-        completed, phase = wait_for_pod_completion(launcher_pod, namespace, timeout=timeout)
+        completed, phase = self._wait_for_mpijob_completion(launcher_pod, job_name, namespace, timeout)
+
+        # Collect logs before any cleanup -- pod may still exist with cleanPodPolicy: None
+        logs = get_pod_logs(launcher_pod, namespace, container="launcher", timeout=60)
 
         if not completed:
             self._dump_debug_info(job_name, namespace)
-            self.set_failed(f"MPIJob {job_name} timed out after {timeout}s (launcher phase: {phase})")
+            self.set_failed(
+                f"MPIJob {job_name} timed out after {timeout}s (launcher phase: {phase})",
+                output=logs,
+            )
             return
 
-        logs = get_pod_logs(launcher_pod, namespace, container="launcher", timeout=60)
-
         if phase != "Succeeded":
+            self._dump_debug_info(job_name, namespace)
             self.set_failed(f"MPIJob {job_name} failed (launcher phase: {phase})", output=logs)
             return
 
         self._check_and_report(logs, min_bus_bw, node_count, total_gpus, job_name)
 
     def _wait_for_launcher_pod(self, job_name: str, namespace: str, timeout: int = 120) -> str | None:
-        """Wait for the MPIJob launcher pod to appear and return its name."""
-        label_selector = f"{_MPIJOB_LABEL_JOB_NAME}={job_name},{_MPIJOB_LABEL_REPLICA_TYPE}=launcher"
+        """Wait for the MPIJob launcher pod to appear and return its name.
+
+        Searches by job-name label, then identifies the launcher pod by name
+        suffix (works across MPI Operator versions regardless of label casing).
+        """
+        label_selector = f"{_MPIJOB_LABEL_JOB_NAME}={job_name}"
+        launcher_prefix = f"{job_name}-launcher-"
         start = time.time()
         while time.time() - start < timeout:
             result = run_kubectl(
@@ -239,20 +248,179 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
                     "-l",
                     label_selector,
                     "-o",
-                    "jsonpath={.items[0].metadata.name}",
+                    "jsonpath={range .items[*]}{.metadata.name}{'\\n'}{end}",
                 ]
             )
             if result.returncode == 0 and result.stdout.strip():
-                return result.stdout.strip()
+                for pod_name in result.stdout.strip().split("\n"):
+                    if pod_name.startswith(launcher_prefix):
+                        return pod_name
             time.sleep(5)
         return None
 
+    def _wait_for_mpijob_completion(
+        self,
+        launcher_pod: str,
+        job_name: str,
+        namespace: str,
+        timeout: int,
+    ) -> tuple[bool, str]:
+        """Wait for MPIJob completion, checking launcher pod and MPIJob conditions.
+
+        Checks three signals each iteration:
+        1. Launcher pod phase (Succeeded/Failed)
+        2. MPIJob status conditions (catches BackoffLimitExceeded, etc.)
+        3. Worker pod health (catches StartError, ImagePullBackOff)
+
+        Returns:
+            (completed, phase) tuple matching wait_for_pod_completion semantics.
+        """
+        label_selector = f"{_MPIJOB_LABEL_JOB_NAME}={job_name}"
+        worker_prefix = f"{job_name}-worker-"
+        start = time.time()
+        last_phase = "Unknown"
+
+        while time.time() - start < timeout:
+            # 1. Check launcher pod phase and container state
+            result = run_kubectl(
+                [
+                    "get",
+                    "pod",
+                    launcher_pod,
+                    "-n",
+                    namespace,
+                    "-o",
+                    "jsonpath={.status.phase}{'\\t'}"
+                    "{.status.containerStatuses[0].state}{'\\t'}"
+                    "{.status.containerStatuses[0].restartCount}",
+                ]
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                parts = result.stdout.strip().split("\t")
+                last_phase = parts[0] if parts else "Unknown"
+                container_state = parts[1] if len(parts) > 1 else ""
+                restart_count = int(parts[2]) if len(parts) > 2 and parts[2].isdigit() else 0
+
+                if last_phase in ("Succeeded", "Failed"):
+                    return True, last_phase
+
+                if "CrashLoopBackOff" in container_state or restart_count >= 3:
+                    self.log.error(f"Launcher pod crash-looping (restarts: {restart_count})")
+                    return True, "Failed"
+            elif result.returncode != 0:
+                # Pod may have been deleted -- check MPIJob directly
+                pass
+
+            # 2. Check MPIJob status conditions directly
+            mpijob_failed = self._check_mpijob_conditions(job_name, namespace)
+            if mpijob_failed:
+                self.log.error(f"MPIJob failed: {mpijob_failed}")
+                return True, "Failed"
+
+            # 3. Check worker pods for unrecoverable errors
+            worker_error = self._check_worker_health(label_selector, worker_prefix, namespace)
+            if worker_error:
+                self.log.error(f"Worker failure detected: {worker_error}")
+                self._dump_debug_info(job_name, namespace)
+                return True, "Failed"
+
+            time.sleep(5)
+
+        return False, last_phase
+
+    def _check_mpijob_conditions(self, job_name: str, namespace: str) -> str | None:
+        """Check MPIJob status conditions for terminal failure.
+
+        Returns:
+            Error message if MPIJob has failed, None otherwise.
+        """
+        result = run_kubectl(
+            [
+                "get",
+                "mpijob",
+                job_name,
+                "-n",
+                namespace,
+                "-o",
+                "jsonpath={range .status.conditions[*]}"
+                "{.type}{'\\t'}{.status}{'\\t'}{.reason}{'\\t'}{.message}{'\\n'}{end}",
+            ]
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return None
+
+        for line in result.stdout.strip().split("\n"):
+            parts = line.split("\t")
+            if len(parts) < 3:
+                continue
+            cond_type, status, reason = parts[0], parts[1], parts[2]
+            message = parts[3] if len(parts) > 3 else ""
+            if cond_type == "Failed" and status == "True":
+                return f"{reason}: {message}"
+
+        return None
+
+    def _check_worker_health(self, label_selector: str, worker_prefix: str, namespace: str) -> str | None:
+        """Check if any worker pods are in an unrecoverable error state.
+
+        Returns:
+            Error description if workers have failed, None if healthy or pending.
+        """
+        result = run_kubectl(
+            [
+                "get",
+                "pods",
+                "-n",
+                namespace,
+                "-l",
+                label_selector,
+                "-o",
+                "jsonpath={range .items[*]}"
+                "{.metadata.name}{'\\t'}{.status.phase}{'\\t'}"
+                "{.status.containerStatuses[0].state}{'\\n'}{end}",
+            ]
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return None
+
+        failed_workers: list[str] = []
+        for line in result.stdout.strip().split("\n"):
+            parts = line.split("\t")
+            if len(parts) < 2:
+                continue
+            pod_name, phase = parts[0], parts[1]
+            if not pod_name.startswith(worker_prefix):
+                continue
+            state_info = parts[2] if len(parts) > 2 else ""
+
+            # StartError and ImagePullBackOff are unrecoverable without intervention
+            if phase == "Failed" or "StartError" in state_info or "ImagePullBackOff" in state_info:
+                failed_workers.append(f"{pod_name}: phase={phase} {state_info}")
+
+        if failed_workers:
+            return "Worker pods failed:\n  " + "\n  ".join(failed_workers)
+        return None
+
     def _dump_debug_info(self, job_name: str, namespace: str) -> None:
-        """Log debug info on timeout to help troubleshoot."""
+        """Log debug info on failure to help troubleshoot."""
         label_selector = f"{_MPIJOB_LABEL_JOB_NAME}={job_name}"
         result = run_kubectl(["get", "pods", "-n", namespace, "-l", label_selector, "-o", "wide"])
         if result.returncode == 0:
             self.log.error(f"MPIJob pods:\n{result.stdout}")
+
+        # Get worker pod events/describe for StartError diagnosis
+        result = run_kubectl(
+            [
+                "describe",
+                "pods",
+                "-n",
+                namespace,
+                "-l",
+                label_selector,
+            ]
+        )
+        if result.returncode == 0:
+            self.log.error(f"Pod details:\n{result.stdout}")
 
         result = run_kubectl(["describe", "mpijob", job_name, "-n", namespace])
         if result.returncode == 0:

--- a/isvtest/src/isvtest/workloads/k8s_nccl_multinode.py
+++ b/isvtest/src/isvtest/workloads/k8s_nccl_multinode.py
@@ -76,6 +76,9 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
         startup_timeout (int): Seconds to wait for launcher pod to appear (default: 300).
             Covers image pulls on workers, SSH key setup, and StatefulSet creation.
         image (str): Container image (default: nvcr.io/nvidia/hpc-benchmarks:25.04)
+        quick_mode (bool): Use reduced message sizes for faster execution (default: False)
+            - True: 1M-256M range, ~30 seconds (CI/dev validation)
+            - False: 8B-4G range, 2-5 minutes (full performance test)
         use_compute_domain (str): "auto" (default) detects DRA driver availability,
             "true" to require ComputeDomain/MNNVL, "false" to skip.
     """
@@ -95,6 +98,7 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
         min_bus_bw = float(min_bus_bw_config) if min_bus_bw_config is not None else get_nccl_min_bus_bw_gbps()
 
         image = self.config.get("image") or get_nccl_hpc_image()
+        quick_mode = self.config.get("quick_mode", False)
 
         if not self._check_mpi_operator():
             self.set_failed(
@@ -120,8 +124,10 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
         cd_name = f"{job_name}-cd"
         cd_channel_name = f"{job_name}-cd-channel"
 
+        mode_str = "quick" if quick_mode else "full"
         self.log.info(
-            f"Starting multi-node NCCL test: {node_count} nodes x {gpus_per_node} GPUs = {total_gpus} total GPUs"
+            f"Starting multi-node NCCL test ({mode_str} mode): "
+            f"{node_count} nodes x {gpus_per_node} GPUs = {total_gpus} total GPUs"
         )
         self.log.info(f"Image: {image}, Min BW: {min_bus_bw} GB/s, Timeout: {job_timeout}s")
         self.log.info(f"ComputeDomain (MNNVL/IMEX): {'enabled' if use_cd else 'disabled'}")
@@ -132,7 +138,9 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
             return
 
         yaml_content = manifest_path.read_text()
-        yaml_content = self._patch_manifest(yaml_content, job_name, node_count, gpus_per_node, total_gpus, image)
+        yaml_content = self._patch_manifest(
+            yaml_content, job_name, node_count, gpus_per_node, total_gpus, image, quick_mode
+        )
 
         if use_cd:
             yaml_content = self._add_compute_domain(
@@ -211,6 +219,7 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
         gpus_per_node: int,
         total_gpus: int,
         image: str,
+        quick_mode: bool = False,
     ) -> str:
         """Replace placeholder values in the MPIJob manifest."""
         yaml_content = yaml_content.replace("name: nccl-allreduce-multinode", f"name: {job_name}", 1)
@@ -220,6 +229,8 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
         yaml_content = yaml_content.replace("-np 8", f"-np {total_gpus}")
         if image != "nvcr.io/nvidia/hpc-benchmarks:25.04":
             yaml_content = yaml_content.replace("nvcr.io/nvidia/hpc-benchmarks:25.04", image)
+        if quick_mode:
+            yaml_content = yaml_content.replace("-b 8 -e 4G -f 2", "-b 1M -e 256M -f 2")
         return yaml_content
 
     def _resolve_compute_domain_mode(self) -> bool:

--- a/isvtest/src/isvtest/workloads/k8s_nccl_multinode.py
+++ b/isvtest/src/isvtest/workloads/k8s_nccl_multinode.py
@@ -1,0 +1,304 @@
+"""Kubernetes multi-node NCCL workload using MPI Operator.
+
+Runs NCCL AllReduce tests across multiple nodes via MPIJob to verify
+GPU-to-GPU communication over NVLink/NVSwitch (intra-node) and network
+fabric (inter-node).
+
+Requires the Kubeflow MPI Operator (kubeflow.org/v2beta1) to be installed
+in the cluster.
+"""
+
+import re
+import subprocess
+import time
+import uuid
+from pathlib import Path
+from typing import ClassVar
+
+from isvtest.config.settings import (
+    get_k8s_namespace,
+    get_nccl_hpc_image,
+    get_nccl_min_bus_bw_gbps,
+    get_nccl_multinode_gpus_per_node,
+    get_nccl_multinode_nodes,
+    get_nccl_multinode_timeout,
+)
+from isvtest.core.k8s import (
+    get_gpu_nodes,
+    get_kubectl_command,
+    get_node_gpu_count,
+    get_pod_logs,
+    run_kubectl,
+    wait_for_pod_completion,
+)
+from isvtest.core.workload import BaseWorkloadCheck
+
+_MPIJOB_LABEL_JOB_NAME = "training.kubeflow.org/job-name"
+_MPIJOB_LABEL_REPLICA_TYPE = "training.kubeflow.org/replica-type"
+
+
+class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
+    """Run NCCL AllReduce test across multiple Kubernetes nodes via MPIJob.
+
+    This workload validates GPU-to-GPU communication across multiple nodes
+    using the NVIDIA HPC Benchmarks container orchestrated by the Kubeflow
+    MPI Operator. It tests:
+    - NVLink/NVSwitch bandwidth within nodes
+    - Network fabric (InfiniBand/RoCE/RDMA) bandwidth between nodes
+    - Data integrity (out-of-bounds check)
+
+    Prerequisites:
+        - Kubeflow MPI Operator installed (MPIJob CRD available)
+        - At least 2 GPU nodes in the cluster
+        - For full NVLink bandwidth across nodes: DRA driver with IMEX channels
+
+    Config options:
+        nodes (int): Number of nodes (default: 2 via env or auto-detect)
+        gpus_per_node (int): GPUs per node (default: auto-detect, fallback 8)
+        min_bus_bw_gbps (float): Minimum expected bus bandwidth in GB/s (default: 0 = no check)
+        timeout (int): Job timeout in seconds (default: 900 via env)
+        image (str): Container image (default: nvcr.io/nvidia/hpc-benchmarks:25.04)
+    """
+
+    description: ClassVar[str] = "Run NCCL AllReduce test across multiple K8s nodes (MPIJob)"
+    timeout: ClassVar[int] = 1800
+    markers: ClassVar[list[str]] = ["workload", "kubernetes", "gpu", "slow"]
+
+    def run(self) -> None:
+        """Execute multi-node NCCL test via MPIJob."""
+        namespace = get_k8s_namespace()
+
+        timeout_config = self.config.get("timeout")
+        job_timeout = int(timeout_config) if timeout_config is not None else get_nccl_multinode_timeout()
+
+        min_bus_bw_config = self.config.get("min_bus_bw_gbps")
+        min_bus_bw = float(min_bus_bw_config) if min_bus_bw_config is not None else get_nccl_min_bus_bw_gbps()
+
+        image = self.config.get("image") or get_nccl_hpc_image()
+
+        if not self._check_mpi_operator():
+            self.set_failed(
+                "MPI Operator not found. Install the Kubeflow MPI Operator "
+                "(https://github.com/kubeflow/mpi-operator) to run multi-node NCCL tests on K8s."
+            )
+            return
+
+        gpu_nodes = get_gpu_nodes()
+        if not gpu_nodes:
+            self.set_passed("Skipped: No GPU nodes found in cluster")
+            return
+
+        if len(gpu_nodes) < 2:
+            self.set_passed(f"Skipped: Multi-node NCCL test requires at least 2 GPU nodes, found {len(gpu_nodes)}")
+            return
+
+        node_count, gpus_per_node = self._resolve_topology(gpu_nodes)
+        total_gpus = node_count * gpus_per_node
+        job_name = f"nccl-allreduce-mn-{uuid.uuid4().hex[:8]}"
+
+        self.log.info(
+            f"Starting multi-node NCCL test: {node_count} nodes x {gpus_per_node} GPUs = {total_gpus} total GPUs"
+        )
+        self.log.info(f"Image: {image}, Min BW: {min_bus_bw} GB/s, Timeout: {job_timeout}s")
+
+        manifest_path = Path(__file__).parent / "manifests" / "k8s" / "nccl_allreduce_mpijob.yaml"
+        if not manifest_path.exists():
+            self.set_failed(f"Manifest file not found: {manifest_path}")
+            return
+
+        yaml_content = manifest_path.read_text()
+        yaml_content = self._patch_manifest(yaml_content, job_name, node_count, gpus_per_node, total_gpus, image)
+
+        self.log.info(f"Deploying MPIJob {job_name} in namespace {namespace}...")
+        try:
+            result = subprocess.run(
+                get_kubectl_command() + ["apply", "-f", "-", "-n", namespace],
+                input=yaml_content,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                self.set_failed(f"Failed to create MPIJob: {result.stderr}")
+                return
+        except Exception as e:
+            self.set_failed(f"Exception creating MPIJob: {e}")
+            return
+
+        try:
+            self._wait_and_report(job_name, namespace, job_timeout, min_bus_bw, node_count, total_gpus)
+        finally:
+            self.log.info(f"Cleaning up MPIJob {job_name}...")
+            run_kubectl(["delete", "mpijob", job_name, "-n", namespace, "--ignore-not-found=true"])
+
+    def _check_mpi_operator(self) -> bool:
+        """Check if the Kubeflow MPI Operator CRD is installed."""
+        result = run_kubectl(["api-resources", "--api-group=kubeflow.org", "-o", "name"], timeout=10)
+        if result.returncode != 0:
+            return False
+        return "mpijobs.kubeflow.org" in result.stdout
+
+    def _resolve_topology(self, gpu_nodes: list[str]) -> tuple[int, int]:
+        """Determine node count and GPUs per node from config or auto-detection.
+
+        Returns:
+            (node_count, gpus_per_node) tuple.
+        """
+        nodes_config = self.config.get("nodes")
+        if nodes_config is not None:
+            node_count = int(nodes_config)
+        else:
+            node_count = get_nccl_multinode_nodes()
+
+        if len(gpu_nodes) < node_count:
+            self.log.warning(
+                f"Requested {node_count} nodes but only {len(gpu_nodes)} GPU nodes available, using {len(gpu_nodes)}"
+            )
+            node_count = len(gpu_nodes)
+
+        gpus_config = self.config.get("gpus_per_node")
+        if gpus_config is not None:
+            gpus_per_node = int(gpus_config)
+        else:
+            detected = get_node_gpu_count(gpu_nodes[0])
+            if detected > 0:
+                gpus_per_node = detected
+                self.log.info(f"Auto-detected {gpus_per_node} GPUs per node from {gpu_nodes[0]}")
+            else:
+                gpus_per_node = get_nccl_multinode_gpus_per_node()
+                self.log.warning(f"Could not detect GPUs per node, using default: {gpus_per_node}")
+
+        return node_count, gpus_per_node
+
+    def _patch_manifest(
+        self,
+        yaml_content: str,
+        job_name: str,
+        node_count: int,
+        gpus_per_node: int,
+        total_gpus: int,
+        image: str,
+    ) -> str:
+        """Replace placeholder values in the MPIJob manifest."""
+        yaml_content = yaml_content.replace("name: nccl-allreduce-multinode", f"name: {job_name}", 1)
+        yaml_content = yaml_content.replace("slotsPerWorker: 4", f"slotsPerWorker: {gpus_per_node}")
+        yaml_content = yaml_content.replace("replicas: 2", f"replicas: {node_count}")
+        yaml_content = yaml_content.replace("nvidia.com/gpu: 4", f"nvidia.com/gpu: {gpus_per_node}")
+        yaml_content = yaml_content.replace("-np 8", f"-np {total_gpus}")
+        if image != "nvcr.io/nvidia/hpc-benchmarks:25.04":
+            yaml_content = yaml_content.replace("nvcr.io/nvidia/hpc-benchmarks:25.04", image)
+        return yaml_content
+
+    def _wait_and_report(
+        self,
+        job_name: str,
+        namespace: str,
+        timeout: int,
+        min_bus_bw: float,
+        node_count: int,
+        total_gpus: int,
+    ) -> None:
+        """Wait for MPIJob launcher completion, collect logs, and report."""
+        launcher_pod = self._wait_for_launcher_pod(job_name, namespace, timeout=120)
+        if not launcher_pod:
+            self.set_failed(f"Launcher pod for MPIJob {job_name} not found within 120s")
+            return
+
+        self.log.info(f"Launcher pod: {launcher_pod}, waiting for completion (timeout: {timeout}s)...")
+
+        completed, phase = wait_for_pod_completion(launcher_pod, namespace, timeout=timeout)
+
+        if not completed:
+            self._dump_debug_info(job_name, namespace)
+            self.set_failed(f"MPIJob {job_name} timed out after {timeout}s (launcher phase: {phase})")
+            return
+
+        logs = get_pod_logs(launcher_pod, namespace, container="launcher", timeout=60)
+
+        if phase != "Succeeded":
+            self.set_failed(f"MPIJob {job_name} failed (launcher phase: {phase})", output=logs)
+            return
+
+        self._parse_and_report(logs, min_bus_bw, node_count, total_gpus, job_name)
+
+    def _wait_for_launcher_pod(self, job_name: str, namespace: str, timeout: int = 120) -> str | None:
+        """Wait for the MPIJob launcher pod to appear and return its name."""
+        label_selector = f"{_MPIJOB_LABEL_JOB_NAME}={job_name},{_MPIJOB_LABEL_REPLICA_TYPE}=launcher"
+        start = time.time()
+        while time.time() - start < timeout:
+            result = run_kubectl(
+                [
+                    "get",
+                    "pods",
+                    "-n",
+                    namespace,
+                    "-l",
+                    label_selector,
+                    "-o",
+                    "jsonpath={.items[0].metadata.name}",
+                ]
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return result.stdout.strip()
+            time.sleep(5)
+        return None
+
+    def _dump_debug_info(self, job_name: str, namespace: str) -> None:
+        """Log debug info on timeout to help troubleshoot."""
+        label_selector = f"{_MPIJOB_LABEL_JOB_NAME}={job_name}"
+        result = run_kubectl(["get", "pods", "-n", namespace, "-l", label_selector, "-o", "wide"])
+        if result.returncode == 0:
+            self.log.error(f"MPIJob pods:\n{result.stdout}")
+
+        result = run_kubectl(["describe", "mpijob", job_name, "-n", namespace])
+        if result.returncode == 0:
+            self.log.error(f"MPIJob description:\n{result.stdout}")
+
+    def _parse_and_report(
+        self,
+        logs: str,
+        min_bus_bw: float,
+        node_count: int,
+        total_gpus: int,
+        job_name: str,
+    ) -> None:
+        """Parse NCCL output and report results."""
+        avg_bw_match = re.search(r"Avg bus bandwidth\s*:\s*([\d.]+)", logs)
+        oob_match = re.search(r"Out of bounds values\s*:\s*(\d+)", logs)
+
+        avg_bus_bw = float(avg_bw_match.group(1)) if avg_bw_match else 0.0
+        oob_values = int(oob_match.group(1)) if oob_match else -1
+
+        if oob_match and oob_values > 0:
+            self.set_failed(
+                f"NCCL test found {oob_values} out of bounds values (data corruption)",
+                output=logs,
+            )
+            return
+
+        if avg_bus_bw == 0:
+            self.set_failed("Could not parse average bus bandwidth from NCCL output", output=logs[:2000])
+            return
+
+        if min_bus_bw > 0 and avg_bus_bw < min_bus_bw:
+            self.set_failed(
+                f"Bus bandwidth {avg_bus_bw:.2f} GB/s below minimum threshold {min_bus_bw} GB/s",
+                output=logs,
+            )
+            return
+
+        bw_matches = re.findall(r"^\s+\d+\s+\d+\s+\w+\s+\w+\s+[\d.]+\s+([\d.]+)", logs, re.MULTILINE)
+        max_bus_bw = max(float(bw) for bw in bw_matches) if bw_matches else 0.0
+
+        msg = (
+            f"NCCL multi-node test passed (MPIJob {job_name})\n"
+            f"  Nodes: {node_count}\n"
+            f"  Total GPUs: {total_gpus}\n"
+            f"  Average Bus Bandwidth: {avg_bus_bw:.2f} GB/s\n"
+            f"  Max Bus Bandwidth: {max_bus_bw:.2f} GB/s\n"
+            f"  Out of Bounds: {oob_values if oob_values >= 0 else 'N/A'}"
+        )
+        if min_bus_bw > 0:
+            msg += f"\n  Minimum Required: {min_bus_bw} GB/s"
+
+        self.set_passed(msg)

--- a/isvtest/src/isvtest/workloads/k8s_nccl_multinode.py
+++ b/isvtest/src/isvtest/workloads/k8s_nccl_multinode.py
@@ -8,7 +8,6 @@ Requires the Kubeflow MPI Operator (kubeflow.org/v2beta1) to be installed
 in the cluster.
 """
 
-import re
 import subprocess
 import time
 import uuid
@@ -32,6 +31,7 @@ from isvtest.core.k8s import (
     wait_for_pod_completion,
 )
 from isvtest.core.workload import BaseWorkloadCheck
+from isvtest.workloads.nccl_common import parse_nccl_output
 
 _MPIJOB_LABEL_JOB_NAME = "training.kubeflow.org/job-name"
 _MPIJOB_LABEL_REPLICA_TYPE = "training.kubeflow.org/replica-type"
@@ -219,7 +219,7 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
             self.set_failed(f"MPIJob {job_name} failed (launcher phase: {phase})", output=logs)
             return
 
-        self._parse_and_report(logs, min_bus_bw, node_count, total_gpus, job_name)
+        self._check_and_report(logs, min_bus_bw, node_count, total_gpus, job_name)
 
     def _wait_for_launcher_pod(self, job_name: str, namespace: str, timeout: int = 120) -> str | None:
         """Wait for the MPIJob launcher pod to appear and return its name."""
@@ -254,7 +254,7 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
         if result.returncode == 0:
             self.log.error(f"MPIJob description:\n{result.stdout}")
 
-    def _parse_and_report(
+    def _check_and_report(
         self,
         logs: str,
         min_bus_bw: float,
@@ -262,41 +262,28 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
         total_gpus: int,
         job_name: str,
     ) -> None:
-        """Parse NCCL output and report results."""
-        avg_bw_match = re.search(r"Avg bus bandwidth\s*:\s*([\d.]+)", logs)
-        oob_match = re.search(r"Out of bounds values\s*:\s*(\d+)", logs)
+        """Parse NCCL output, check thresholds, and report results."""
+        nccl = parse_nccl_output(logs)
 
-        avg_bus_bw = float(avg_bw_match.group(1)) if avg_bw_match else 0.0
-        oob_values = int(oob_match.group(1)) if oob_match else -1
+        if not nccl.success:
+            self.set_failed(nccl.error, output=nccl.output)
+            return
 
-        if oob_match and oob_values > 0:
+        if min_bus_bw > 0 and nccl.avg_bus_bw_gbps < min_bus_bw:
             self.set_failed(
-                f"NCCL test found {oob_values} out of bounds values (data corruption)",
+                f"Bus bandwidth {nccl.avg_bus_bw_gbps:.2f} GB/s below minimum threshold {min_bus_bw} GB/s",
                 output=logs,
             )
             return
 
-        if avg_bus_bw == 0:
-            self.set_failed("Could not parse average bus bandwidth from NCCL output", output=logs[:2000])
-            return
-
-        if min_bus_bw > 0 and avg_bus_bw < min_bus_bw:
-            self.set_failed(
-                f"Bus bandwidth {avg_bus_bw:.2f} GB/s below minimum threshold {min_bus_bw} GB/s",
-                output=logs,
-            )
-            return
-
-        bw_matches = re.findall(r"^\s+\d+\s+\d+\s+\w+\s+\w+\s+[\d.]+\s+([\d.]+)", logs, re.MULTILINE)
-        max_bus_bw = max(float(bw) for bw in bw_matches) if bw_matches else 0.0
-
+        oob_str = str(nccl.out_of_bounds) if nccl.out_of_bounds >= 0 else "N/A"
         msg = (
             f"NCCL multi-node test passed (MPIJob {job_name})\n"
             f"  Nodes: {node_count}\n"
             f"  Total GPUs: {total_gpus}\n"
-            f"  Average Bus Bandwidth: {avg_bus_bw:.2f} GB/s\n"
-            f"  Max Bus Bandwidth: {max_bus_bw:.2f} GB/s\n"
-            f"  Out of Bounds: {oob_values if oob_values >= 0 else 'N/A'}"
+            f"  Average Bus Bandwidth: {nccl.avg_bus_bw_gbps:.2f} GB/s\n"
+            f"  Max Bus Bandwidth: {nccl.max_bus_bw_gbps:.2f} GB/s\n"
+            f"  Out of Bounds: {oob_str}"
         )
         if min_bus_bw > 0:
             msg += f"\n  Minimum Required: {min_bus_bw} GB/s"

--- a/isvtest/src/isvtest/workloads/manifests/k8s/nccl_allreduce_mpijob.yaml
+++ b/isvtest/src/isvtest/workloads/manifests/k8s/nccl_allreduce_mpijob.yaml
@@ -1,0 +1,53 @@
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: nccl-allreduce-multinode
+spec:
+  slotsPerWorker: 4
+  runPolicy:
+    cleanPodPolicy: Running
+    ttlSecondsAfterFinished: 600
+  mpiReplicaSpecs:
+    Launcher:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: launcher
+              image: nvcr.io/nvidia/hpc-benchmarks:25.04
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+                  # Note: '-np 8' is overridden at runtime by K8sNcclMultiNodeWorkload
+                  mpirun --allow-run-as-root \
+                         -np 8 \
+                         --bind-to none --map-by slot \
+                         -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
+                         all_reduce_perf_mpi -b 8 -e 2G -f 2 -g 1
+    Worker:
+      replicas: 2
+      template:
+        spec:
+          containers:
+            - name: worker
+              image: nvcr.io/nvidia/hpc-benchmarks:25.04
+              resources:
+                limits:
+                  nvidia.com/gpu: 4 # overridden at runtime by K8sNcclMultiNodeWorkload
+              volumeMounts:
+                - name: shm
+                  mountPath: /dev/shm
+          nodeSelector:
+            nvidia.com/gpu.present: "true"
+          runtimeClassName: nvidia
+          tolerations:
+            - key: "nvidia.com/gpu"
+              operator: "Exists"
+              effect: "NoSchedule"
+          volumes:
+            - name: shm
+              emptyDir:
+                medium: Memory
+                sizeLimit: 8Gi

--- a/isvtest/src/isvtest/workloads/manifests/k8s/nccl_allreduce_mpijob.yaml
+++ b/isvtest/src/isvtest/workloads/manifests/k8s/nccl_allreduce_mpijob.yaml
@@ -6,8 +6,7 @@ spec:
   slotsPerWorker: 4
   launcherCreationPolicy: WaitForWorkersReady
   runPolicy:
-    cleanPodPolicy: None
-    ttlSecondsAfterFinished: 600
+    cleanPodPolicy: Running
   sshAuthMountPath: /root/.ssh
   mpiReplicaSpecs:
     Launcher:
@@ -21,18 +20,22 @@ spec:
                 - /bin/bash
                 - -c
                 - |
-                  set -euo pipefail
-                  # Copy SSH keys from read-only Secret mount and fix permissions
-                  cp -r /root/.ssh /tmp/mpi-ssh
-                  chmod 700 /tmp/mpi-ssh
-                  chmod 600 /tmp/mpi-ssh/id_rsa
+                  # MPI Operator mounts SSH keys read-only; copy to fix permissions
+                  cp /root/.ssh/id_rsa /tmp/id_rsa && chmod 600 /tmp/id_rsa
                   # Note: '-np 8' is overridden at runtime by K8sNcclMultiNodeWorkload
-                  mpirun --allow-run-as-root \
-                         -np 8 \
-                         --bind-to none --map-by slot \
-                         -mca plm_rsh_args "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentityFile=/tmp/mpi-ssh/id_rsa -o ConnectionAttempts=10" \
-                         -x PATH -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
-                         /usr/local/bin/all_reduce_perf_mpi -b 8 -e 2G -f 2 -g 1
+                  exec mpirun --allow-run-as-root \
+                    -np 8 \
+                    --bind-to none --map-by slot \
+                    -mca plm_rsh_args "-o StrictHostKeyChecking=no -o IdentityFile=/tmp/id_rsa" \
+                    -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
+                    /usr/local/bin/all_reduce_perf_mpi -b 8 -e 2G -f 2 -g 1
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: Exists
     Worker:
       replicas: 2
       template:
@@ -43,17 +46,7 @@ spec:
               command:
                 - /bin/bash
                 - -c
-                - |
-                  if ! command -v sshd &>/dev/null; then
-                    apt-get update -qq && apt-get install -y -qq openssh-server >/dev/null 2>&1
-                  fi
-                  mkdir -p /var/run/sshd
-                  ssh-keygen -A 2>/dev/null
-                  cat >> /etc/ssh/sshd_config <<CFG
-                  PermitRootLogin yes
-                  StrictModes no
-                  CFG
-                  exec /usr/sbin/sshd -De
+                - "command -v sshd >/dev/null || { apt-get update -qq && apt-get install -y -qq openssh-server >/dev/null 2>&1; }; mkdir -p /var/run/sshd && ssh-keygen -A 2>/dev/null && exec /usr/sbin/sshd -De -o PermitRootLogin=yes -o StrictModes=no"
               readinessProbe:
                 tcpSocket:
                   port: 22

--- a/isvtest/src/isvtest/workloads/manifests/k8s/nccl_allreduce_mpijob.yaml
+++ b/isvtest/src/isvtest/workloads/manifests/k8s/nccl_allreduce_mpijob.yaml
@@ -4,9 +4,11 @@ metadata:
   name: nccl-allreduce-multinode
 spec:
   slotsPerWorker: 4
+  launcherCreationPolicy: WaitForWorkersReady
   runPolicy:
-    cleanPodPolicy: Running
+    cleanPodPolicy: None
     ttlSecondsAfterFinished: 600
+  sshAuthMountPath: /root/.ssh
   mpiReplicaSpecs:
     Launcher:
       replicas: 1
@@ -20,12 +22,17 @@ spec:
                 - -c
                 - |
                   set -euo pipefail
+                  # Copy SSH keys from read-only Secret mount and fix permissions
+                  cp -r /root/.ssh /tmp/mpi-ssh
+                  chmod 700 /tmp/mpi-ssh
+                  chmod 600 /tmp/mpi-ssh/id_rsa
                   # Note: '-np 8' is overridden at runtime by K8sNcclMultiNodeWorkload
                   mpirun --allow-run-as-root \
                          -np 8 \
                          --bind-to none --map-by slot \
-                         -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
-                         all_reduce_perf_mpi -b 8 -e 2G -f 2 -g 1
+                         -mca plm_rsh_args "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentityFile=/tmp/mpi-ssh/id_rsa -o ConnectionAttempts=10" \
+                         -x PATH -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
+                         /usr/local/bin/all_reduce_perf_mpi -b 8 -e 2G -f 2 -g 1
     Worker:
       replicas: 2
       template:
@@ -33,6 +40,25 @@ spec:
           containers:
             - name: worker
               image: nvcr.io/nvidia/hpc-benchmarks:25.04
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  if ! command -v sshd &>/dev/null; then
+                    apt-get update -qq && apt-get install -y -qq openssh-server >/dev/null 2>&1
+                  fi
+                  mkdir -p /var/run/sshd
+                  ssh-keygen -A 2>/dev/null
+                  cat >> /etc/ssh/sshd_config <<CFG
+                  PermitRootLogin yes
+                  StrictModes no
+                  CFG
+                  exec /usr/sbin/sshd -De
+              readinessProbe:
+                tcpSocket:
+                  port: 22
+                initialDelaySeconds: 2
+                periodSeconds: 3
               resources:
                 limits:
                   nvidia.com/gpu: 4 # overridden at runtime by K8sNcclMultiNodeWorkload

--- a/isvtest/src/isvtest/workloads/manifests/k8s/nccl_allreduce_mpijob.yaml
+++ b/isvtest/src/isvtest/workloads/manifests/k8s/nccl_allreduce_mpijob.yaml
@@ -28,7 +28,7 @@ spec:
                     --bind-to none --map-by slot \
                     -mca plm_rsh_args "-o StrictHostKeyChecking=no -o IdentityFile=/tmp/id_rsa" \
                     -x NCCL_DEBUG=INFO -x LD_LIBRARY_PATH \
-                    /usr/local/bin/all_reduce_perf_mpi -b 8 -e 2G -f 2 -g 1
+                    /usr/local/bin/all_reduce_perf_mpi -b 8 -e 4G -f 2 -g 1
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:

--- a/isvtest/src/isvtest/workloads/nccl_common.py
+++ b/isvtest/src/isvtest/workloads/nccl_common.py
@@ -1,0 +1,65 @@
+"""Shared NCCL output parsing utilities.
+
+Used by k8s_nccl, k8s_nccl_multinode, and slurm_nccl_multinode workloads
+to parse NCCL AllReduce benchmark output consistently.
+"""
+
+import re
+from dataclasses import dataclass
+
+# Regex patterns for NCCL benchmark output.
+# The "#" prefix is optional -- present in some container output, absent in others.
+_RE_AVG_BUS_BW = re.compile(r"#?\s*Avg bus bandwidth\s*:\s*([\d.]+)")
+_RE_OUT_OF_BOUNDS = re.compile(r"#?\s*Out of bounds values\s*:\s*(\d+)")
+_RE_MAX_BUS_BW = re.compile(r"^\s+\d+\s+\d+\s+\w+\s+\w+\s+[\d.]+\s+([\d.]+)", re.MULTILINE)
+
+
+@dataclass
+class NcclResult:
+    """Parsed result of an NCCL benchmark run."""
+
+    success: bool
+    avg_bus_bw_gbps: float = 0.0
+    max_bus_bw_gbps: float = 0.0
+    out_of_bounds: int = -1
+    error: str = ""
+    output: str = ""
+
+
+def parse_nccl_output(output: str) -> NcclResult:
+    """Parse NCCL AllReduce benchmark output for bandwidth and data integrity.
+
+    Extracts:
+    - Average bus bandwidth (GB/s)
+    - Maximum bus bandwidth from the data table (GB/s)
+    - Out-of-bounds value count (data corruption indicator)
+
+    Args:
+        output: Raw stdout/stderr from an NCCL allreduce benchmark run.
+
+    Returns:
+        NcclResult with parsed metrics. ``success`` is False if bandwidth
+        could not be parsed or data corruption was detected.
+    """
+    result = NcclResult(success=True, output=output)
+
+    avg_match = _RE_AVG_BUS_BW.search(output)
+    if avg_match:
+        result.avg_bus_bw_gbps = float(avg_match.group(1))
+
+    bw_matches = _RE_MAX_BUS_BW.findall(output)
+    if bw_matches:
+        result.max_bus_bw_gbps = max(float(bw) for bw in bw_matches)
+
+    oob_match = _RE_OUT_OF_BOUNDS.search(output)
+    if oob_match:
+        result.out_of_bounds = int(oob_match.group(1))
+        if result.out_of_bounds > 0:
+            result.success = False
+            result.error = f"Data corruption detected: {result.out_of_bounds} out of bounds values"
+
+    if result.avg_bus_bw_gbps == 0 and result.max_bus_bw_gbps == 0:
+        result.success = False
+        result.error = result.error or "Could not parse bandwidth results from NCCL output"
+
+    return result

--- a/isvtest/src/isvtest/workloads/nccl_common.py
+++ b/isvtest/src/isvtest/workloads/nccl_common.py
@@ -11,7 +11,8 @@ from dataclasses import dataclass
 # The "#" prefix is optional -- present in some container output, absent in others.
 _RE_AVG_BUS_BW = re.compile(r"#?\s*Avg bus bandwidth\s*:\s*([\d.]+)")
 _RE_OUT_OF_BOUNDS = re.compile(r"#?\s*Out of bounds values\s*:\s*(\d+)")
-_RE_MAX_BUS_BW = re.compile(r"^\s+\d+\s+\d+\s+\w+\s+\w+\s+[\d.]+\s+([\d.]+)", re.MULTILINE)
+_NCCL_DATA_TYPES = {"float", "half", "double", "int8", "int32", "uint8", "uint32", "int64", "uint64", "bfloat16"}
+_BUSBW_COL = 7
 
 
 @dataclass
@@ -24,6 +25,24 @@ class NcclResult:
     out_of_bounds: int = -1
     error: str = ""
     output: str = ""
+
+
+def _parse_max_bus_bw(output: str) -> float:
+    """Extract max bus bandwidth from NCCL data table lines.
+
+    Data lines have the format (column indices):
+      0:size 1:count 2:type 3:redop 4:root 5:time 6:algbw 7:busbw 8:#wrong ...
+    Identified by having a known NCCL data type (e.g. "float") in column 2.
+    """
+    max_bw = 0.0
+    for line in output.splitlines():
+        fields = line.split()
+        if len(fields) >= _BUSBW_COL + 1 and fields[2] in _NCCL_DATA_TYPES:
+            try:
+                max_bw = max(max_bw, float(fields[_BUSBW_COL]))
+            except (ValueError, IndexError):
+                pass
+    return max_bw
 
 
 def parse_nccl_output(output: str) -> NcclResult:
@@ -47,9 +66,7 @@ def parse_nccl_output(output: str) -> NcclResult:
     if avg_match:
         result.avg_bus_bw_gbps = float(avg_match.group(1))
 
-    bw_matches = _RE_MAX_BUS_BW.findall(output)
-    if bw_matches:
-        result.max_bus_bw_gbps = max(float(bw) for bw in bw_matches)
+    result.max_bus_bw_gbps = _parse_max_bus_bw(output)
 
     oob_match = _RE_OUT_OF_BOUNDS.search(output)
     if oob_match:

--- a/isvtest/src/isvtest/workloads/slurm_nccl_multinode.py
+++ b/isvtest/src/isvtest/workloads/slurm_nccl_multinode.py
@@ -71,7 +71,7 @@ class SlurmNcclMultiNodeWorkload(BaseWorkloadCheck):
         image (str): Container image (default: nvcr.io/nvidia/hpc-benchmarks:25.04)
         container_runtime (str): "enroot" | "pyxis" | "singularity" | "docker"
             (default: auto-detect, enroot > singularity > docker)
-        quick_mode (bool): Use reduced message sizes for faster execution (default: True)
+        quick_mode (bool): Use reduced message sizes for faster execution (default: False)
             - True: 1M-256M range, ~30 seconds (CI/dev validation)
             - False: 8B-4G range, 2-5 minutes (full performance test)
         env (dict[str, str]): Extra environment variables exported in the sbatch
@@ -104,7 +104,7 @@ class SlurmNcclMultiNodeWorkload(BaseWorkloadCheck):
         container_runtime = self.config.get("container_runtime")
         if not container_runtime:
             container_runtime = detect_container_runtime(self)
-        quick_mode = self.config.get("quick_mode", True)
+        quick_mode = self.config.get("quick_mode", False)
         extra_env: dict[str, str] = self.config.get("env", {})
 
         # Validate partition is GPU-enabled
@@ -204,7 +204,7 @@ class SlurmNcclMultiNodeWorkload(BaseWorkloadCheck):
         gpus_per_node: int,
         image: str,
         container_runtime: str,
-        quick_mode: bool = True,
+        quick_mode: bool = False,
         extra_env: dict[str, str] | None = None,
     ) -> str:
         """Generate sbatch script for multi-node NCCL test."""

--- a/isvtest/src/isvtest/workloads/slurm_nccl_multinode.py
+++ b/isvtest/src/isvtest/workloads/slurm_nccl_multinode.py
@@ -304,7 +304,7 @@ class SlurmNcclMultiNodeWorkload(BaseWorkloadCheck):
         """Wait for job completion and collect results."""
         start_time = time.time()
         end_time = start_time + timeout
-        poll_interval = 10
+        poll_interval = 30
         use_sacct = True
         nodelist = ""
 

--- a/isvtest/src/isvtest/workloads/slurm_nccl_multinode.py
+++ b/isvtest/src/isvtest/workloads/slurm_nccl_multinode.py
@@ -9,7 +9,6 @@ and benefit from NVLink/NVSwitch to accelerate those jobs.
 """
 
 import os
-import re
 import tempfile
 import time
 from dataclasses import dataclass
@@ -34,13 +33,14 @@ from isvtest.core.slurm import (
     parse_sbatch_job_id,
 )
 from isvtest.core.workload import BaseWorkloadCheck
+from isvtest.workloads.nccl_common import parse_nccl_output
 
 MANIFESTS_DIR = Path(__file__).parent / "manifests" / "slurm"
 
 
 @dataclass
-class NcclResult:
-    """Result of NCCL multi-node test."""
+class SlurmNcclResult:
+    """Result of a Slurm NCCL multi-node job (job tracking + parsed metrics)."""
 
     success: bool
     job_id: str = ""
@@ -264,7 +264,7 @@ class SlurmNcclMultiNodeWorkload(BaseWorkloadCheck):
             },
         )
 
-    def _submit_and_wait(self, script: str, timeout: int) -> NcclResult:
+    def _submit_and_wait(self, script: str, timeout: int) -> SlurmNcclResult:
         """Submit sbatch script and wait for completion."""
         # Write script to temp file
         with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False, prefix="isvtest_nccl_") as f:
@@ -278,14 +278,14 @@ class SlurmNcclMultiNodeWorkload(BaseWorkloadCheck):
             submit_result = self.run_command(f"sbatch {script_path}", timeout=30)
 
             if submit_result.exit_code != 0:
-                return NcclResult(
+                return SlurmNcclResult(
                     success=False,
                     error=f"sbatch failed (exit {submit_result.exit_code}): {submit_result.stderr}",
                 )
 
             job_id = parse_sbatch_job_id(submit_result.stdout)
             if not job_id:
-                return NcclResult(
+                return SlurmNcclResult(
                     success=False,
                     error=f"Could not parse job ID from: {submit_result.stdout}",
                 )
@@ -300,7 +300,7 @@ class SlurmNcclMultiNodeWorkload(BaseWorkloadCheck):
             except OSError:
                 pass
 
-    def _wait_for_job(self, job_id: str, timeout: int) -> NcclResult:
+    def _wait_for_job(self, job_id: str, timeout: int) -> SlurmNcclResult:
         """Wait for job completion and collect results."""
         start_time = time.time()
         end_time = start_time + timeout
@@ -325,7 +325,7 @@ class SlurmNcclMultiNodeWorkload(BaseWorkloadCheck):
                 output = f"{stdout}\n{stderr}".strip()
 
                 if state != "COMPLETED" or exit_code != 0:
-                    return NcclResult(
+                    return SlurmNcclResult(
                         success=False,
                         job_id=job_id,
                         error=f"Job {state} with exit code {exit_code}",
@@ -341,58 +341,36 @@ class SlurmNcclMultiNodeWorkload(BaseWorkloadCheck):
         self.log.warning(f"Job {job_id} timed out after {timeout}s, cancelling...")
         self.run_command(f"scancel {job_id}", timeout=30)
 
-        return NcclResult(
+        return SlurmNcclResult(
             success=False,
             job_id=job_id,
             error=f"Job timed out after {timeout}s",
         )
 
-    def _parse_nccl_output(self, job_id: str, output: str) -> NcclResult:
+    def _parse_nccl_output(self, job_id: str, output: str) -> SlurmNcclResult:
         """Parse NCCL test output for bandwidth and errors."""
-        result = NcclResult(success=True, job_id=job_id, output=output)
+        parsed = parse_nccl_output(output)
 
-        # Extract average bus bandwidth
-        # Format: "# Avg bus bandwidth    : 123.45"
-        avg_bw_match = re.search(r"#\s*Avg bus bandwidth\s*:\s*([\d.]+)", output)
-        if avg_bw_match:
-            result.avg_bus_bw_gbps = float(avg_bw_match.group(1))
-            self.log.info(f"Average Bus Bandwidth: {result.avg_bus_bw_gbps:.2f} GB/s")
+        result = SlurmNcclResult(
+            success=parsed.success,
+            job_id=job_id,
+            avg_bus_bw_gbps=parsed.avg_bus_bw_gbps,
+            max_bus_bw_gbps=parsed.max_bus_bw_gbps,
+            out_of_bounds=parsed.out_of_bounds,
+            error=parsed.error,
+            output=output,
+        )
 
-        # Extract max bus bandwidth (from the data table, last non-empty algbw value)
-        # Look for lines like: "  4294967296    1073741824    float     sum    123.45    456.78"
-        bw_matches = re.findall(r"^\s+\d+\s+\d+\s+\w+\s+\w+\s+[\d.]+\s+([\d.]+)", output, re.MULTILINE)
-        if bw_matches:
-            result.max_bus_bw_gbps = max(float(bw) for bw in bw_matches)
-            self.log.info(f"Max Bus Bandwidth: {result.max_bus_bw_gbps:.2f} GB/s")
-
-        # Check for out of bounds errors (data corruption)
-        # Format: "# Out of bounds values : 0 OK"
-        oob_match = re.search(r"#\s*Out of bounds values\s*:\s*(\d+)", output)
-        if oob_match:
-            result.out_of_bounds = int(oob_match.group(1))
-            if result.out_of_bounds > 0:
-                result.success = False
-                result.error = f"Data corruption detected: {result.out_of_bounds} out of bounds values"
-                self.log.error(result.error)
-
-        # Extract node count from output
-        nodes_match = re.search(r"Nodes:\s*(\d+)", output)
-        if nodes_match:
-            result.nodes_used = int(nodes_match.group(1))
-
-        gpus_match = re.search(r"Total GPUs:\s*(\d+)", output)
-        if gpus_match:
-            result.total_gpus = int(gpus_match.group(1))
-
-        # Validate we got bandwidth results
-        if result.avg_bus_bw_gbps == 0 and result.max_bus_bw_gbps == 0:
-            result.success = False
-            result.error = "Could not parse bandwidth results from NCCL output"
-            self.log.warning(f"NCCL output parsing failed. Raw output:\n{output[:2000]}")
+        if parsed.avg_bus_bw_gbps > 0:
+            self.log.info(f"Average Bus Bandwidth: {parsed.avg_bus_bw_gbps:.2f} GB/s")
+        if parsed.max_bus_bw_gbps > 0:
+            self.log.info(f"Max Bus Bandwidth: {parsed.max_bus_bw_gbps:.2f} GB/s")
+        if not parsed.success:
+            self.log.warning(f"NCCL parse issue: {parsed.error}")
 
         return result
 
-    def _report_result(self, result: NcclResult, min_bus_bw: float, nodes: int, total_gpus: int) -> None:
+    def _report_result(self, result: SlurmNcclResult, min_bus_bw: float, nodes: int, total_gpus: int) -> None:
         """Report test results."""
         if not result.success:
             msg = "NCCL multi-node test failed"


### PR DESCRIPTION
## Summary

- Add `K8sNcclMultiNodeWorkload` for running NCCL AllReduce benchmarks across multiple Kubernetes nodes using MPIJob (Kubeflow MPI Operator)
- Auto-detect NVIDIA DRA driver and create a ComputeDomain for MNNVL/IMEX channel support when available
- Extract shared NCCL output parsing into `nccl_common.py`, reused by K8s single-node, K8s multi-node, and Slurm workloads
- Standardize `quick_mode` default to `false` across all NCCL workloads for full-range benchmarking

## Changes

- **New**: `k8s_nccl_multinode.py` — Multi-node NCCL workload with MPIJob lifecycle management, ComputeDomain integration, startup timeout, worker health monitoring, and bus bandwidth validation
- **New**: `nccl_common.py` — Shared NCCL output parsing (avg/max bus bandwidth, out-of-bounds detection)
- **New**: `manifests/k8s/nccl_allreduce_mpijob.yaml` — MPIJob manifest template for `all_reduce_perf_mpi`
- **Updated**: `k8s_nccl.py` — Refactored to use shared `parse_nccl_output`
- **Updated**: `slurm_nccl_multinode.py` — Refactored to use shared parsing, renamed `NcclResult` to `SlurmNcclResult`, increased poll interval to 30s
- **Updated**: `k8s.yaml` / `slurm.yaml` — Added `K8sNcclMultiNodeWorkload` config, changed `quick_mode` default from `true` to `false`, bumped Slurm stress timeout to 900s

## Prerequisites

- Kubeflow MPI Operator (`kubeflow.org/v2beta1` MPIJob CRD)
- Optional: NVIDIA DRA driver with ComputeDomain CRD for MNNVL across nodes (`use_compute_domain: auto` detects this)

## Test results

Validated on a 4-node GPU cluster via `isvctl deploy run`:
```
[PASS] SETUP   : setup: passed
[PASS] TEST    : test phase completed
  [k8s_workloads] K8sNcclMultiNodeWorkload: PASSED - NCCL multi-node test passed (MPIJob nccl-allreduce-mn-b454e1cb)
  Nodes: 4
  Total GPUs: 16
  Average Bus Bandwidth: 204.75 GB/s
  Max Bus Bandwidth: 886.31 GB/s
  Out of Bounds: 0
  Minimum Required: 100.0 GB/s
[PASS] TEARDOWN: teardown: passed
```