### PR TITLE
chore: reorganize dependency groups and update package requirements

### DIFF
--- a/isvctl/pyproject.toml
+++ b/isvctl/pyproject.toml
@@ -19,12 +19,8 @@ dependencies = [
 isvctl = "isvctl.main:app"
 
 [build-system]
-requires = ["uv_build"]
+requires = ["uv_build>=0.7,<0.11"]
 build-backend = "uv_build"
-
-[tool.uv]
-package = true
-default-groups = ["dev"]
 
 [tool.uv.sources]
 isvtest = { workspace = true }
@@ -47,10 +43,3 @@ ignore = ["E501", "RUF005"]
 pythonpath = ["src"]
 testpaths = ["tests"]
 addopts = "-v --junitxml=junit.xml"
-
-[dependency-groups]
-dev = [
-    "pre-commit>=4.0.0",
-    "pytest>=8.3.4,<9.0.0",
-    "pytest-cov>=6.0.0",
-]

--- a/isvreporter/pyproject.toml
+++ b/isvreporter/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 isvreporter = "isvreporter.main:app"
 
 [build-system]
-requires = ["uv_build"]
+requires = ["uv_build>=0.7,<0.11"]
 build-backend = "uv_build"
 
 [tool.ruff]
@@ -31,10 +31,6 @@ line-ending = "auto"
 select = ["F", "E", "W", "I", "A", "UP", "RUF"]
 ignore = ["E501"]
 
-[tool.uv]
-package = true
-default-groups = ["dev"]
-
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]
@@ -44,9 +40,3 @@ addopts = "-v --junitxml=junit.xml"
 [tool.pyright]
 venvPath = "."
 venv = ".venv"
-
-[dependency-groups]
-dev = [
-    "pytest>=8.3.4",
-    "pytest-cov>=6.0.0",
-]

--- a/isvtest/pyproject.toml
+++ b/isvtest/pyproject.toml
@@ -24,12 +24,8 @@ dependencies = [
 isvtest = "isvtest.main:main"
 
 [build-system]
-requires = ["uv_build"]
+requires = ["uv_build>=0.7,<0.11"]
 build-backend = "uv_build"
-
-[tool.uv]
-package = true
-default-groups = ["dev"]
 
 [tool.uv.sources]
 isvreporter = { workspace = true }
@@ -56,9 +52,3 @@ ignore = ["E501", "RUF005"]
 pythonpath = ["src"]
 testpaths = ["tests", "src/isvtest/tests"]
 addopts = "-v --junitxml=junit.xml"
-
-[dependency-groups]
-dev = [
-    "pre-commit>=4.0.0",
-    "pytest-cov>=6.0.0",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,17 @@ isvtest = { workspace = true }
 isvreporter = { workspace = true }
 
 [dependency-groups]
-dev = [
+test = [
+    "pytest>=8.3.4,<9.0.0",
+    "pytest-cov>=6.0.0",
     "coverage>=7.0.0",
+]
+lint = [
+    "pre-commit>=4.0.0",
+]
+dev = [
+    { include-group = "test" },
+    { include-group = "lint" },
 ]
 
 [tool.uv.workspace]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,6 @@ authors = [
 requires-python = ">=3.12"
 dependencies = ["isvctl", "isvtest", "isvreporter"]
 
-[project.scripts]
-isvctl = "isvctl.main:app"
-isvtest = "isvtest.main:main"
-isvreporter = "isvreporter.main:main"
-
 [tool.uv.sources]
 isvctl = { workspace = true }
 isvtest = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -559,6 +559,17 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+lint = [
+    { name = "pre-commit" },
+]
+test = [
+    { name = "coverage" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -569,7 +580,18 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "coverage", specifier = ">=7.0.0" }]
+dev = [
+    { name = "coverage", specifier = ">=7.0.0" },
+    { name = "pre-commit", specifier = ">=4.0.0" },
+    { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+]
+lint = [{ name = "pre-commit", specifier = ">=4.0.0" }]
+test = [
+    { name = "coverage", specifier = ">=7.0.0" },
+    { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+]
 
 [[package]]
 name = "isvctl"
@@ -584,13 +606,6 @@ dependencies = [
     { name = "typer" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "isvreporter", editable = "isvreporter" },
@@ -599,13 +614,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10.0,<3.0.0" },
     { name = "pyyaml", specifier = ">=6.0.2,<7.0.0" },
     { name = "typer", specifier = ">=0.21.1,<1.0.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pre-commit", specifier = ">=4.0.0" },
-    { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
-    { name = "pytest-cov", specifier = ">=6.0.0" },
 ]
 
 [[package]]
@@ -617,22 +625,10 @@ dependencies = [
     { name = "typer" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2,<7.0.0" },
     { name = "typer", specifier = ">=0.21.1,<1.0.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.3.4" },
-    { name = "pytest-cov", specifier = ">=6.0.0" },
 ]
 
 [[package]]
@@ -653,12 +649,6 @@ dependencies = [
     { name = "urllib3" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "pre-commit" },
-    { name = "pytest-cov" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "attrs", specifier = ">=25.4.0,<26.0.0" },
@@ -672,12 +662,6 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2,<7.0.0" },
     { name = "reframe-hpc", specifier = ">=4.8.4" },
     { name = "urllib3", specifier = ">=2.6.0,<3.0.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pre-commit", specifier = ">=4.0.0" },
-    { name = "pytest-cov", specifier = ">=6.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Added separate dependency groups for `test` and `lint` in `pyproject.toml`, consolidating testing tools and linters.
- Updated `dev` group to include `test` and `lint` groups for better management of development dependencies.
- Ensured all relevant packages are included in the `uv.lock` file with appropriate version specifications.
- Removed redundant dependency declarations from individual package `pyproject.toml` files.