### PR TITLE
feat: add test catalog upload functionality and enhance test discovery

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -214,6 +214,39 @@ tests:
 | `teardown` | After teardown phase |
 | `<phase>` | After the specified phase |
 
+### Test Variants
+
+A validation check can be run multiple times with different parameters by appending a **dash-separated suffix** to the class name. The dash (`-`) is the only accepted variant separator.
+
+```yaml
+validations:
+  k8s_workloads:
+    checks:
+      - K8sNimHelmWorkload-1b:
+          model: "meta/llama-3.2-1b-instruct"
+          gpu_count: 1
+          timeout: 900
+      - K8sNimHelmWorkload-3b:
+          model: "meta/llama-3.2-3b-instruct"
+          gpu_count: 4
+          timeout: 1800
+
+  slurm:
+    checks:
+      - SlurmPartition-cpu:
+          partition_name: "cpu"
+      - SlurmPartition-gpu:
+          partition_name: "gpu"
+```
+
+The part before the dash must match an existing validation class name (e.g., `K8sNimHelmWorkload`, `SlurmPartition`). The suffix after the dash is a label -- it can be any descriptive string. Each variant runs as a separate test case with its own parameters and appears independently in test results and coverage.
+
+**Rules:**
+
+- Validation class names **cannot** contain dashes, so the first dash always marks the start of a variant suffix.
+- The suffix is free-form: `K8sNimHelmWorkload-small`, `SlurmPartition-cpu`, `SlurmGpuAllocation-1gpu` are all valid.
+- Each variant is a distinct test entry in coverage tracking.
+
 ## Template Variables
 
 ### Referencing Step Outputs

--- a/isvctl/configs/aws/bm.yaml
+++ b/isvctl/configs/aws/bm.yaml
@@ -193,7 +193,7 @@ commands:
         timeout: 120
 
 tests:
-  platform: bm
+  platform: bare_metal
   cluster_name: "aws-bm-validation"
   description: "AWS Bare Metal (BMaaS) validation tests"
 

--- a/isvctl/configs/templates/bm.yaml
+++ b/isvctl/configs/templates/bm.yaml
@@ -210,7 +210,7 @@ commands:
         timeout: 120
 
 tests:
-  platform: bm
+  platform: bare_metal
   cluster_name: "bm-validation"
   description: "Bare metal (BMaaS) GPU validation tests (template)"
 

--- a/isvctl/src/isvctl/cli/docs.py
+++ b/isvctl/src/isvctl/cli/docs.py
@@ -313,7 +313,7 @@ def _resolve_class(instance_name: str, class_map: dict[str, type]) -> type | Non
     """Resolve an instance name (possibly with suffix) to a class.
 
     Uses the same suffix matching logic as the test runner:
-    exact match first, then longest class name prefix with - or _ separator.
+    exact match first, then longest class name prefix with ``-`` separator.
     """
     if instance_name in class_map:
         return class_map[instance_name]
@@ -321,7 +321,7 @@ def _resolve_class(instance_name: str, class_map: dict[str, type]) -> type | Non
     possible = [name for name in class_map if instance_name.startswith(name)]
     if possible:
         longest = max(possible, key=len)
-        if instance_name.startswith(f"{longest}-") or instance_name.startswith(f"{longest}_"):
+        if instance_name.startswith(f"{longest}-"):
             return class_map[longest]
 
     return None

--- a/isvctl/src/isvctl/cli/test.py
+++ b/isvctl/src/isvctl/cli/test.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Annotated, TextIO
 
 import typer
+from isvtest.catalog import build_catalog, get_catalog_version
 
 from isvctl.cli import setup_logging
 from isvctl.config.merger import merge_yaml_files
@@ -270,6 +271,11 @@ def run(
     orchestrator = Orchestrator(config, working_dir=effective_working_dir)
     log_file_path = effective_working_dir / "pytest-output.log"
 
+    # Build test catalog early so it runs inside the TeeWriter context
+    # (avoids logging errors from stale stream references after the log file closes)
+    catalog_entries: list[dict] | None = None
+    catalog_version: str | None = None
+
     if upload_results:
         # Capture output to log file while still displaying (like `tee`)
         with open(log_file_path, "w") as log_file:
@@ -283,6 +289,19 @@ def run(
                     verbose=verbose,
                     junitxml=str(junitxml),
                 )
+                try:
+                    catalog_entries = build_catalog()
+                    catalog_version = get_catalog_version()
+                    typer.echo(f"Built test catalog: {len(catalog_entries)} tests (version: {catalog_version})")
+                    output_dir = Path("_output")
+                    output_dir.mkdir(exist_ok=True)
+                    catalog_path = output_dir / "test_catalog.json"
+                    catalog_path.write_text(
+                        json.dumps({"isvTestVersion": catalog_version, "entries": catalog_entries}, indent=2)
+                    )
+                    typer.echo(f"  Saved test catalog to: {catalog_path}")
+                except Exception as e:
+                    logger.warning("Failed to build test catalog: %s", e)
             finally:
                 sys.stdout, sys.stderr = original_stdout, original_stderr
     else:
@@ -309,6 +328,8 @@ def run(
             junit_xml=junit_path if junit_path.exists() else None,
             log_file=log_file_path if log_file_path.exists() else None,
             isv_software_version=isv_software_version,
+            catalog_entries=catalog_entries,
+            catalog_version=catalog_version,
         ):
             typer.echo(typer.style("[OK]", fg=typer.colors.GREEN) + " Test results uploaded successfully")
         else:

--- a/isvctl/src/isvctl/cli/test.py
+++ b/isvctl/src/isvctl/cli/test.py
@@ -293,8 +293,8 @@ def run(
                     catalog_entries = build_catalog()
                     catalog_version = get_catalog_version()
                     typer.echo(f"Built test catalog: {len(catalog_entries)} tests (version: {catalog_version})")
-                    output_dir = Path("_output")
-                    output_dir.mkdir(exist_ok=True)
+                    output_dir = effective_working_dir / "_output"
+                    output_dir.mkdir(parents=True, exist_ok=True)
                     catalog_path = output_dir / "test_catalog.json"
                     catalog_path.write_text(
                         json.dumps({"isvTestVersion": catalog_version, "entries": catalog_entries}, indent=2)

--- a/isvctl/src/isvctl/cli/test.py
+++ b/isvctl/src/isvctl/cli/test.py
@@ -293,7 +293,7 @@ def run(
                     catalog_entries = build_catalog()
                     catalog_version = get_catalog_version()
                     typer.echo(f"Built test catalog: {len(catalog_entries)} tests (version: {catalog_version})")
-                    output_dir = effective_working_dir / "_output"
+                    output_dir = Path("_output")
                     output_dir.mkdir(parents=True, exist_ok=True)
                     catalog_path = output_dir / "test_catalog.json"
                     catalog_path.write_text(

--- a/isvctl/src/isvctl/config/schema.py
+++ b/isvctl/src/isvctl/config/schema.py
@@ -325,7 +325,8 @@ class ValidationConfig(BaseModel):
     cluster_name: str | None = Field(default=None, description="Cluster name for test run")
     description: str | None = Field(default=None, description="Test run description")
     platform: str | None = Field(
-        default=None, description="Platform: kubernetes, slurm, bare_metal, network, vm, iam, image_registry"
+        default=None,
+        description="Platform type: KUBERNETES, SLURM, BARE_METAL, CONTROL_PLANE, IAM, NETWORK, VM, IMAGE_REGISTRY",
     )
     settings: dict[str, Any] = Field(default_factory=dict, description="Test settings")
     validations: dict[str, list[dict[str, Any]] | dict[str, Any]] = Field(

--- a/isvctl/src/isvctl/reporting.py
+++ b/isvctl/src/isvctl/reporting.py
@@ -129,6 +129,8 @@ def update_test_run(
     junit_xml: Path | None = None,
     log_content: str | None = None,
     isv_software_version: str | None = None,
+    catalog_entries: list[dict] | None = None,
+    catalog_version: str | None = None,
 ) -> bool:
     """Update a test run in ISV Lab Service.
 
@@ -141,6 +143,8 @@ def update_test_run(
         junit_xml: Path to JUnit XML file (optional)
         log_content: Direct log content string (optional, alternative to log_file)
         isv_software_version: ISV software stack version (opaque string from ISV)
+        catalog_entries: Test catalog entries for coverage tracking (optional)
+        catalog_version: Test suite version for the catalog (optional)
 
     Returns:
         True if successful, False otherwise
@@ -187,6 +191,22 @@ def update_test_run(
 
     try:
         jwt_token = get_jwt_token(ssa_issuer, client_id, client_secret)
+
+        # Upload test catalog for coverage tracking (if provided)
+        if catalog_entries and catalog_version:
+            try:
+                from isvreporter.client import upload_test_catalog as client_upload_catalog
+
+                client_upload_catalog(
+                    endpoint=endpoint,
+                    jwt_token=jwt_token,
+                    isv_test_version=catalog_version,
+                    entries=catalog_entries,
+                )
+            except SystemExit:
+                logger.warning("Failed to upload test catalog to ISV Lab Service")
+            except Exception as e:
+                logger.warning("Failed to upload test catalog: %s", e)
 
         # Upload JUnit XML test results first (if provided)
         if junit_xml and junit_xml.exists():

--- a/isvreporter/src/isvreporter/client.py
+++ b/isvreporter/src/isvreporter/client.py
@@ -283,6 +283,18 @@ def upload_test_catalog(
     Returns:
         True if catalog was uploaded or already exists, False on error
     """
+    # Check if this version's catalog already exists
+    try:
+        check_url = f"{endpoint}/v1/test-catalog"
+        check_req = Request(check_url, headers={"Authorization": f"Bearer {jwt_token}"}, method="GET")
+        with urlopen(check_req, timeout=10) as resp:
+            versions = json.loads(resp.read().decode())
+            if isv_test_version in versions:
+                print(f"Test catalog already exists for version {isv_test_version} (skipped)")
+                return True
+    except Exception:
+        pass
+
     url = f"{endpoint}/v1/test-catalog"
 
     payload = {

--- a/isvreporter/src/isvreporter/client.py
+++ b/isvreporter/src/isvreporter/client.py
@@ -261,6 +261,68 @@ def report_test_results(
         sys.exit(1)
 
 
+def upload_test_catalog(
+    endpoint: str,
+    jwt_token: str,
+    isv_test_version: str,
+    entries: list[dict[str, Any]],
+) -> bool:
+    """Upload test catalog for a suite version (idempotent per version).
+
+    Sends the full list of available validation tests for a given isvtest
+    version. If the backend already has a catalog for this version, it
+    returns 409 Conflict which is treated as success (dedup).
+
+    Args:
+        endpoint: ISV Lab Service endpoint URL
+        jwt_token: JWT access token
+        isv_test_version: Test suite version string (e.g. "1.2.3")
+        entries: List of catalog entry dicts with keys:
+            name, description, markers, module
+
+    Returns:
+        True if catalog was uploaded or already exists, False on error
+    """
+    url = f"{endpoint}/v1/test-catalog"
+
+    payload = {
+        "isvTestVersion": isv_test_version,
+        "entries": [
+            {
+                "name": e["name"],
+                "description": e.get("description", ""),
+                "markers": e.get("markers", []),
+                "module": e.get("module", ""),
+            }
+            for e in entries
+        ],
+    }
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {jwt_token}",
+    }
+
+    try:
+        request = Request(url, data=json.dumps(payload).encode(), headers=headers, method="POST")
+        with urlopen(request, timeout=30) as response:
+            json.loads(response.read().decode())
+            print(f"Test catalog uploaded successfully (version: {isv_test_version}, {len(entries)} entries)")
+            return True
+    except HTTPError as e:
+        if e.code == 409:
+            print(f"Test catalog already exists for version {isv_test_version} (skipped)")
+            return True
+        print(f"ERROR: Failed to upload test catalog (HTTP {e.code})", file=sys.stderr)
+        print(f"Response: {e.read().decode()}", file=sys.stderr)
+        return False
+    except URLError as e:
+        print("ERROR: Failed to upload test catalog - unable to connect to service", file=sys.stderr)
+        print(f"       Endpoint: {endpoint}", file=sys.stderr)
+        print(f"       Reason: {e.reason}", file=sys.stderr)
+        return False
+
+
 def calculate_duration(start_time_str: str) -> int:
     """
     Calculate duration in seconds from start time to now.

--- a/isvreporter/src/isvreporter/client.py
+++ b/isvreporter/src/isvreporter/client.py
@@ -293,6 +293,7 @@ def upload_test_catalog(
                 "description": e.get("description", ""),
                 "markers": e.get("markers", []),
                 "module": e.get("module", ""),
+                "platforms": e.get("platforms", []),
             }
             for e in entries
         ],

--- a/isvreporter/src/isvreporter/main.py
+++ b/isvreporter/src/isvreporter/main.py
@@ -14,6 +14,7 @@ from isvreporter.client import (
     load_test_run_id,
     report_test_results,
     update_test_run,
+    upload_test_catalog,
 )
 from isvreporter.platform import get_platform_from_config, is_valid_platform, normalize_platform
 from isvreporter.version import get_version
@@ -205,6 +206,13 @@ def update(
             help="ISV test tool version (e.g., '1.12.3')",
         ),
     ] = None,
+    test_catalog: Annotated[
+        Path | None,
+        typer.Option(
+            "--test-catalog",
+            help="Path to test catalog JSON file to upload for coverage tracking",
+        ),
+    ] = None,
 ) -> None:
     """Update an existing test run with completion status.
 
@@ -262,6 +270,27 @@ def update(
             typer.echo(f"Warning: JUnit XML file not found: {junit_xml}", err=True)
         except Exception as e:
             typer.echo(f"Warning: Failed to upload JUnit XML: {e}", err=True)
+
+    # Upload test catalog if provided (for coverage tracking)
+    if test_catalog:
+        try:
+            import json
+
+            typer.echo(f"Reading test catalog: {test_catalog}")
+            catalog_data = json.loads(test_catalog.read_text())
+            catalog_version = catalog_data.get("isvTestVersion", isv_test_version or "unknown")
+            catalog_entries = catalog_data.get("entries", [])
+
+            upload_test_catalog(
+                endpoint=endpoint,
+                jwt_token=jwt_token,
+                isv_test_version=catalog_version,
+                entries=catalog_entries,
+            )
+        except FileNotFoundError:
+            typer.echo(f"Warning: Test catalog file not found: {test_catalog}", err=True)
+        except Exception as e:
+            typer.echo(f"Warning: Failed to upload test catalog: {e}", err=True)
 
     # Update test run with status and log
     update_test_run(

--- a/isvreporter/src/isvreporter/main.py
+++ b/isvreporter/src/isvreporter/main.py
@@ -1,5 +1,6 @@
 """CLI entry point for isvreporter - ISV Lab test results reporting tool."""
 
+import json
 import os
 from pathlib import Path
 from typing import Annotated
@@ -274,8 +275,6 @@ def update(
     # Upload test catalog if provided (for coverage tracking)
     if test_catalog:
         try:
-            import json
-
             typer.echo(f"Reading test catalog: {test_catalog}")
             catalog_data = json.loads(test_catalog.read_text())
             catalog_version = catalog_data.get("isvTestVersion", isv_test_version or "unknown")

--- a/isvreporter/src/isvreporter/platform.py
+++ b/isvreporter/src/isvreporter/platform.py
@@ -7,37 +7,63 @@ from pathlib import Path
 
 import yaml
 
-# Valid platform types
-KUBERNETES = "kubernetes"
-SLURM = "slurm"
-BARE_METAL = "bare_metal"
+# Canonical platform types (uppercase, matching backend enums)
+KUBERNETES = "KUBERNETES"
+SLURM = "SLURM"
+BARE_METAL = "BARE_METAL"
+CONTROL_PLANE = "CONTROL_PLANE"
+IAM = "IAM"
+NETWORK = "NETWORK"
+VM = "VM"
+IMAGE_REGISTRY = "IMAGE_REGISTRY"
 
-# Platform aliases (normalized to canonical names)
+ALL_PLATFORMS = {
+    KUBERNETES,
+    SLURM,
+    BARE_METAL,
+    CONTROL_PLANE,
+    IAM,
+    NETWORK,
+    VM,
+    IMAGE_REGISTRY,
+}
+
+# Platform aliases (normalized to canonical uppercase names)
 PLATFORM_ALIASES: dict[str, str] = {
     "k8s": KUBERNETES,
     "kubernetes": KUBERNETES,
     "slurm": SLURM,
     "bare_metal": BARE_METAL,
-    "baremetal": BARE_METAL,
-    "bare-metal": BARE_METAL,
+    "bm": BARE_METAL,
+    "control_plane": CONTROL_PLANE,
+    "iam": IAM,
+    "network": NETWORK,
+    "vm": VM,
+    "image_registry": IMAGE_REGISTRY,
 }
 
 DEFAULT_PLATFORM = KUBERNETES
 
 
 def normalize_platform(platform: str | None) -> str:
-    """Normalize a platform string to a canonical platform name.
+    """Normalize a platform string to a canonical uppercase name.
 
     Args:
-        platform: Platform string (e.g., 'k8s', 'kubernetes', 'baremetal')
+        platform: Platform string (e.g., 'k8s', 'kubernetes', 'KUBERNETES',
+            'iam', 'control_plane')
 
     Returns:
-        Normalized platform string ('kubernetes', 'slurm', or 'bare_metal')
+        Canonical uppercase platform string (e.g., 'KUBERNETES', 'IAM')
     """
     if not platform:
         return DEFAULT_PLATFORM
 
-    normalized = platform.lower().strip().replace("-", "_")
+    cleaned = platform.strip()
+
+    if cleaned.upper() in ALL_PLATFORMS:
+        return cleaned.upper()
+
+    normalized = cleaned.lower().replace("-", "_")
     return PLATFORM_ALIASES.get(normalized, DEFAULT_PLATFORM)
 
 
@@ -48,7 +74,7 @@ def get_platform_from_config(config_path: Path | str) -> str:
         config_path: Path to the YAML config file
 
     Returns:
-        Normalized platform string ('kubernetes', 'slurm', or 'bare_metal')
+        Canonical uppercase platform string
     """
     try:
         with open(config_path) as f:
@@ -70,5 +96,8 @@ def is_valid_platform(platform: str | None) -> bool:
     """
     if not platform:
         return False
-    normalized = platform.lower().strip().replace("-", "_")
+    cleaned = platform.strip()
+    if cleaned.upper() in ALL_PLATFORMS:
+        return True
+    normalized = cleaned.lower().replace("-", "_")
     return normalized in PLATFORM_ALIASES

--- a/isvreporter/tests/test_catalog_upload.py
+++ b/isvreporter/tests/test_catalog_upload.py
@@ -14,11 +14,18 @@ class TestUploadTestCatalog:
     @patch("isvreporter.client.urlopen")
     def test_successful_upload(self, mock_urlopen: MagicMock) -> None:
         """Test successful catalog upload returns True."""
-        mock_response = MagicMock()
-        mock_response.read.return_value = json.dumps({"status": "created"}).encode()
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-        mock_urlopen.return_value = mock_response
+        # GET returns empty list (version not found), POST returns success
+        get_response = MagicMock()
+        get_response.read.return_value = json.dumps([]).encode()
+        get_response.__enter__ = MagicMock(return_value=get_response)
+        get_response.__exit__ = MagicMock(return_value=False)
+
+        post_response = MagicMock()
+        post_response.read.return_value = json.dumps({"status": "created"}).encode()
+        post_response.__enter__ = MagicMock(return_value=post_response)
+        post_response.__exit__ = MagicMock(return_value=False)
+
+        mock_urlopen.side_effect = [get_response, post_response]
 
         entries = [
             {"name": "TestA", "description": "Test A", "markers": ["k8s"], "module": "mod.a"},
@@ -33,10 +40,10 @@ class TestUploadTestCatalog:
         )
 
         assert result is True
-        mock_urlopen.assert_called_once()
+        assert mock_urlopen.call_count == 2
 
-        call_args = mock_urlopen.call_args
-        request = call_args[0][0]
+        post_call = mock_urlopen.call_args_list[1]
+        request = post_call[0][0]
         assert request.full_url == "https://api.example.com/v1/test-catalog"
         assert request.method == "POST"
 
@@ -44,6 +51,25 @@ class TestUploadTestCatalog:
         assert payload["isvTestVersion"] == "1.2.3"
         assert len(payload["entries"]) == 2
         assert payload["entries"][0]["name"] == "TestA"
+
+    @patch("isvreporter.client.urlopen")
+    def test_skips_upload_when_version_exists(self, mock_urlopen: MagicMock) -> None:
+        """Test that upload is skipped when version already exists."""
+        get_response = MagicMock()
+        get_response.read.return_value = json.dumps(["1.2.3"]).encode()
+        get_response.__enter__ = MagicMock(return_value=get_response)
+        get_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = get_response
+
+        result = upload_test_catalog(
+            endpoint="https://api.example.com",
+            jwt_token="test-token",
+            isv_test_version="1.2.3",
+            entries=[{"name": "TestA"}],
+        )
+
+        assert result is True
+        mock_urlopen.assert_called_once()
 
     @patch("isvreporter.client.urlopen")
     def test_conflict_returns_true(self, mock_urlopen: MagicMock) -> None:

--- a/isvreporter/tests/test_catalog_upload.py
+++ b/isvreporter/tests/test_catalog_upload.py
@@ -3,6 +3,7 @@
 import json
 from http import HTTPStatus
 from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError, URLError
 
 from isvreporter.client import upload_test_catalog
 
@@ -47,8 +48,6 @@ class TestUploadTestCatalog:
     @patch("isvreporter.client.urlopen")
     def test_conflict_returns_true(self, mock_urlopen: MagicMock) -> None:
         """Test that 409 Conflict (catalog already exists) returns True."""
-        from urllib.error import HTTPError
-
         mock_urlopen.side_effect = HTTPError(
             url="https://api.example.com/v1/test-catalog",
             code=HTTPStatus.CONFLICT,
@@ -69,8 +68,6 @@ class TestUploadTestCatalog:
     @patch("isvreporter.client.urlopen")
     def test_server_error_returns_false(self, mock_urlopen: MagicMock) -> None:
         """Test that 500 error returns False."""
-        from urllib.error import HTTPError
-
         mock_urlopen.side_effect = HTTPError(
             url="https://api.example.com/v1/test-catalog",
             code=HTTPStatus.INTERNAL_SERVER_ERROR,
@@ -91,8 +88,6 @@ class TestUploadTestCatalog:
     @patch("isvreporter.client.urlopen")
     def test_connection_error_returns_false(self, mock_urlopen: MagicMock) -> None:
         """Test that connection error returns False."""
-        from urllib.error import URLError
-
         mock_urlopen.side_effect = URLError("Connection refused")
 
         result = upload_test_catalog(

--- a/isvreporter/tests/test_catalog_upload.py
+++ b/isvreporter/tests/test_catalog_upload.py
@@ -1,0 +1,133 @@
+"""Tests for the test catalog upload functionality in the API client."""
+
+import json
+from http import HTTPStatus
+from unittest.mock import MagicMock, patch
+
+from isvreporter.client import upload_test_catalog
+
+
+class TestUploadTestCatalog:
+    """Tests for upload_test_catalog function."""
+
+    @patch("isvreporter.client.urlopen")
+    def test_successful_upload(self, mock_urlopen: MagicMock) -> None:
+        """Test successful catalog upload returns True."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"status": "created"}).encode()
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        entries = [
+            {"name": "TestA", "description": "Test A", "markers": ["k8s"], "module": "mod.a"},
+            {"name": "TestB", "description": "Test B", "markers": [], "module": "mod.b"},
+        ]
+
+        result = upload_test_catalog(
+            endpoint="https://api.example.com",
+            jwt_token="test-token",
+            isv_test_version="1.2.3",
+            entries=entries,
+        )
+
+        assert result is True
+        mock_urlopen.assert_called_once()
+
+        call_args = mock_urlopen.call_args
+        request = call_args[0][0]
+        assert request.full_url == "https://api.example.com/v1/test-catalog"
+        assert request.method == "POST"
+
+        payload = json.loads(request.data.decode())
+        assert payload["isvTestVersion"] == "1.2.3"
+        assert len(payload["entries"]) == 2
+        assert payload["entries"][0]["name"] == "TestA"
+
+    @patch("isvreporter.client.urlopen")
+    def test_conflict_returns_true(self, mock_urlopen: MagicMock) -> None:
+        """Test that 409 Conflict (catalog already exists) returns True."""
+        from urllib.error import HTTPError
+
+        mock_urlopen.side_effect = HTTPError(
+            url="https://api.example.com/v1/test-catalog",
+            code=HTTPStatus.CONFLICT,
+            msg="Conflict",
+            hdrs=MagicMock(),
+            fp=MagicMock(read=MagicMock(return_value=b"already exists")),
+        )
+
+        result = upload_test_catalog(
+            endpoint="https://api.example.com",
+            jwt_token="test-token",
+            isv_test_version="1.2.3",
+            entries=[{"name": "TestA"}],
+        )
+
+        assert result is True
+
+    @patch("isvreporter.client.urlopen")
+    def test_server_error_returns_false(self, mock_urlopen: MagicMock) -> None:
+        """Test that 500 error returns False."""
+        from urllib.error import HTTPError
+
+        mock_urlopen.side_effect = HTTPError(
+            url="https://api.example.com/v1/test-catalog",
+            code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            msg="Server Error",
+            hdrs=MagicMock(),
+            fp=MagicMock(read=MagicMock(return_value=b"internal error")),
+        )
+
+        result = upload_test_catalog(
+            endpoint="https://api.example.com",
+            jwt_token="test-token",
+            isv_test_version="1.2.3",
+            entries=[{"name": "TestA"}],
+        )
+
+        assert result is False
+
+    @patch("isvreporter.client.urlopen")
+    def test_connection_error_returns_false(self, mock_urlopen: MagicMock) -> None:
+        """Test that connection error returns False."""
+        from urllib.error import URLError
+
+        mock_urlopen.side_effect = URLError("Connection refused")
+
+        result = upload_test_catalog(
+            endpoint="https://api.example.com",
+            jwt_token="test-token",
+            isv_test_version="1.2.3",
+            entries=[{"name": "TestA"}],
+        )
+
+        assert result is False
+
+    @patch("isvreporter.client.urlopen")
+    def test_empty_optional_fields_use_defaults(self, mock_urlopen: MagicMock) -> None:
+        """Test that missing optional fields get empty defaults."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"status": "created"}).encode()
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        entries = [{"name": "TestA"}]
+
+        upload_test_catalog(
+            endpoint="https://api.example.com",
+            jwt_token="test-token",
+            isv_test_version="1.0.0",
+            entries=entries,
+        )
+
+        call_args = mock_urlopen.call_args
+        request = call_args[0][0]
+        payload = json.loads(request.data.decode())
+        entry = payload["entries"][0]
+
+        assert entry["name"] == "TestA"
+        assert entry["description"] == ""
+        assert entry["markers"] == []
+        assert entry["module"] == ""

--- a/isvreporter/tests/test_platform.py
+++ b/isvreporter/tests/test_platform.py
@@ -34,10 +34,9 @@ class TestNormalizePlatform:
     def test_normalize_bare_metal_aliases(self) -> None:
         """Test that bare metal aliases normalize correctly."""
         assert normalize_platform("bare_metal") == BARE_METAL
-        assert normalize_platform("baremetal") == BARE_METAL
         assert normalize_platform("bare-metal") == BARE_METAL
         assert normalize_platform("BARE_METAL") == BARE_METAL
-        assert normalize_platform("BAREMETAL") == BARE_METAL
+        assert normalize_platform("bm") == BARE_METAL
 
     def test_normalize_empty_and_none(self) -> None:
         """Test that empty/None returns default platform."""
@@ -65,8 +64,8 @@ class TestIsValidPlatform:
         assert is_valid_platform("k8s") is True
         assert is_valid_platform("slurm") is True
         assert is_valid_platform("bare_metal") is True
-        assert is_valid_platform("baremetal") is True
         assert is_valid_platform("bare-metal") is True
+        assert is_valid_platform("bm") is True
 
     def test_valid_platforms_case_insensitive(self) -> None:
         """Test that platform validation is case insensitive."""

--- a/isvtest/src/isvtest/catalog.py
+++ b/isvtest/src/isvtest/catalog.py
@@ -1,0 +1,56 @@
+"""Test catalog generation for coverage tracking.
+
+Builds a structured catalog of all available validation tests by calling
+discover_all_tests() and serializing each BaseValidation subclass's metadata.
+The catalog is version-keyed by the installed isvtest package version.
+"""
+
+import logging
+from typing import Any
+
+from isvreporter.version import get_version
+
+from isvtest.core.discovery import discover_all_tests
+
+logger = logging.getLogger(__name__)
+
+
+def build_catalog() -> list[dict[str, Any]]:
+    """Discover all validation tests and return structured catalog entries.
+
+    Returns:
+        List of catalog entry dicts, each containing:
+            - name: Validation class name (e.g. "K8sNodeCountCheck")
+            - description: Human-readable description from class metadata
+            - markers: List of marker strings (e.g. ["kubernetes", "gpu"])
+            - module: Fully qualified module path (e.g. "isvtest.validations.k8s_nodes")
+    """
+    catalog: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    for cls in discover_all_tests():
+        name = cls.__name__
+        if name in seen:
+            continue
+        seen.add(name)
+
+        catalog.append(
+            {
+                "name": name,
+                "description": getattr(cls, "description", "") or "",
+                "markers": list(getattr(cls, "markers", [])),
+                "module": cls.__module__,
+            }
+        )
+
+    logger.info("Built test catalog with %d entries", len(catalog))
+    return catalog
+
+
+def get_catalog_version() -> str:
+    """Return the installed isvtest package version.
+
+    Returns:
+        Version string (e.g. "1.2.3") or "dev" if not installed as a package.
+    """
+    return get_version("isvtest")

--- a/isvtest/src/isvtest/catalog.py
+++ b/isvtest/src/isvtest/catalog.py
@@ -3,43 +3,167 @@
 Builds a structured catalog of all available validation tests by calling
 discover_all_tests() and serializing each BaseValidation subclass's metadata.
 The catalog is version-keyed by the installed isvtest package version.
+
+Platform tagging is derived from config files in isvctl/configs/ -- each config
+declares a platform and lists which validation checks to run for that platform.
 """
 
 import logging
+from pathlib import Path
 from typing import Any
 
+import yaml
 from isvreporter.version import get_version
 
 from isvtest.core.discovery import discover_all_tests
 
 logger = logging.getLogger(__name__)
 
+# Configs that define the canonical test list per platform.
+# Relative to the isvctl/configs/ directory.
+PLATFORM_CONFIGS: dict[str, list[str]] = {
+    "KUBERNETES": ["k8s.yaml"],
+    "SLURM": ["slurm.yaml"],
+    "BARE_METAL": ["templates/bm.yaml"],
+    "CONTROL_PLANE": ["templates/control-plane.yaml"],
+    "IAM": ["templates/iam.yaml"],
+    "NETWORK": ["templates/network.yaml"],
+    "VM": ["templates/vm.yaml"],
+    "IMAGE_REGISTRY": ["templates/image-registry.yaml"],
+}
+
+
+def _find_configs_dir() -> Path | None:
+    """Locate the isvctl/configs/ directory."""
+    # Walk up from this file to find the workspace root
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        candidate = parent / "isvctl" / "configs"
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def _extract_checks_from_config(config_path: Path) -> list[str]:
+    """Extract all validation check names from a config file.
+
+    Handles both list format and group-defaults format (with 'checks' key).
+    Keeps variant names (e.g. 'K8sNimHelmWorkload-3b') as-is.
+    """
+    try:
+        data = yaml.safe_load(config_path.read_text())
+    except Exception:
+        return []
+
+    validations = (data or {}).get("tests", {}).get("validations", {})
+    checks: list[str] = []
+
+    for _cat, cat_config in validations.items():
+        items: list[dict] = []
+        if isinstance(cat_config, dict) and "checks" in cat_config:
+            items = cat_config["checks"]
+        elif isinstance(cat_config, list):
+            items = cat_config
+
+        for check in items:
+            if isinstance(check, dict):
+                for name in check:
+                    checks.append(name)
+
+    return checks
+
+
+def _build_platform_map() -> dict[str, set[str]]:
+    """Build a mapping from test name to set of platform strings.
+
+    Scans the canonical config files to determine which tests belong to
+    which platforms.
+    """
+    configs_dir = _find_configs_dir()
+    if not configs_dir:
+        logger.warning("Could not locate isvctl/configs/ directory")
+        return {}
+
+    test_to_platforms: dict[str, set[str]] = {}
+
+    for platform, config_files in PLATFORM_CONFIGS.items():
+        for config_file in config_files:
+            config_path = configs_dir / config_file
+            if not config_path.exists():
+                logger.debug("Config not found: %s", config_path)
+                continue
+
+            checks = _extract_checks_from_config(config_path)
+            for check_name in checks:
+                if check_name not in test_to_platforms:
+                    test_to_platforms[check_name] = set()
+                test_to_platforms[check_name].add(platform)
+
+    return test_to_platforms
+
 
 def build_catalog() -> list[dict[str, Any]]:
     """Discover all validation tests and return structured catalog entries.
 
+    Each entry includes a 'platforms' field derived from the config files,
+    indicating which platforms the test belongs to. Variant entries from
+    configs (e.g. K8sNimHelmWorkload-1b) are included as separate entries
+    inheriting metadata from their base class.
+
     Returns:
         List of catalog entry dicts, each containing:
-            - name: Validation class name (e.g. "K8sNodeCountCheck")
+            - name: Validation class name or variant name
             - description: Human-readable description from class metadata
             - markers: List of marker strings (e.g. ["kubernetes", "gpu"])
-            - module: Fully qualified module path (e.g. "isvtest.validations.k8s_nodes")
+            - module: Fully qualified module path
+            - platforms: List of platform strings (e.g. ["KUBERNETES"])
     """
+    platform_map = _build_platform_map()
+
+    # Build class metadata lookup
+    class_meta: dict[str, dict[str, Any]] = {}
+    for cls in discover_all_tests():
+        class_meta[cls.__name__] = {
+            "description": getattr(cls, "description", "") or "",
+            "markers": list(getattr(cls, "markers", [])),
+            "module": cls.__module__,
+        }
+
     catalog: list[dict[str, Any]] = []
     seen: set[str] = set()
 
-    for cls in discover_all_tests():
-        name = cls.__name__
-        if name in seen:
-            continue
+    # Add all discovered classes
+    for name, meta in class_meta.items():
         seen.add(name)
-
         catalog.append(
             {
                 "name": name,
-                "description": getattr(cls, "description", "") or "",
-                "markers": list(getattr(cls, "markers", [])),
-                "module": cls.__module__,
+                "description": meta["description"],
+                "markers": meta["markers"],
+                "module": meta["module"],
+                "platforms": sorted(platform_map.get(name, [])),
+            }
+        )
+
+    # Add variant entries from configs that aren't base classes
+    for name, platforms in platform_map.items():
+        if name in seen:
+            continue
+        seen.add(name)
+        # Inherit metadata from base class
+        base = name.split("-")[0] if "-" in name else name
+        meta = class_meta.get(base, {})
+        variant_suffix = name[len(base) :] if base != name else ""
+        desc = meta.get("description", "")
+        if variant_suffix:
+            desc = f"{desc} ({variant_suffix.lstrip('-')})" if desc else variant_suffix.lstrip("-")
+        catalog.append(
+            {
+                "name": name,
+                "description": desc,
+                "markers": meta.get("markers", []),
+                "module": meta.get("module", ""),
+                "platforms": sorted(platforms),
             }
         )
 

--- a/isvtest/src/isvtest/testing/subtests.py
+++ b/isvtest/src/isvtest/testing/subtests.py
@@ -13,6 +13,7 @@ Features:
 
 from __future__ import annotations
 
+import re
 import sys
 import time
 import xml.etree.ElementTree as ET
@@ -408,18 +409,39 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     if not junit_xml_path:
         return  # No JUnit output configured
 
-    # Get collected subtest reports from module-level collector
-    if not _collected_subtest_reports:
-        return  # No subtests to add
-
     junit_path = Path(junit_xml_path)
     if not junit_path.exists():
         return  # JUnit file not created yet (shouldn't happen)
 
-    _inject_subtests_into_junit(junit_path, _collected_subtest_reports)
+    _normalize_junit_testcase_names(junit_path)
 
-    # Clear the collector for next run (important for test isolation)
-    _collected_subtest_reports = []
+    if _collected_subtest_reports:
+        _inject_subtests_into_junit(junit_path, _collected_subtest_reports)
+        _collected_subtest_reports = []
+
+
+_PARAMETRIZED_NAME_RE = re.compile(r"^\w+\[(.+)]$")
+
+
+def _normalize_junit_testcase_names(junit_path: Path) -> None:
+    """Strip pytest parametrize wrappers from testcase names in JUnit XML.
+
+    Transforms names like ``test_validation[K8sNodeCountCheck]`` to
+    ``K8sNodeCountCheck`` so they match the test catalog used by the backend.
+    """
+    try:
+        tree = ET.parse(junit_path)
+        changed = False
+        for testcase in tree.iter("testcase"):
+            name = testcase.get("name", "")
+            m = _PARAMETRIZED_NAME_RE.match(name)
+            if m:
+                testcase.set("name", m.group(1))
+                changed = True
+        if changed:
+            tree.write(junit_path, encoding="utf-8", xml_declaration=True)
+    except Exception:
+        pass  # don't break the test run for post-processing failures
 
 
 def _inject_subtests_into_junit(junit_path: Path, reports: list[SubTestReport]) -> None:
@@ -475,10 +497,9 @@ def _inject_subtests_into_junit(junit_path: Path, reports: list[SubTestReport]) 
         insertions: list[tuple[int, list[ET.Element]]] = []
 
         for parent_nodeid, parent_reports in subtests_by_parent.items():
-            # Find parent testcase by matching name pattern
-            # pytest JUnit uses format like "test_validation[CheckName]"
-            # nodeid is like "isvtest/src/.../test_validation[CheckName]"
-            parent_name = parent_nodeid.split("::")[-1] if "::" in parent_nodeid else parent_nodeid
+            raw_parent = parent_nodeid.split("::")[-1] if "::" in parent_nodeid else parent_nodeid
+            m = _PARAMETRIZED_NAME_RE.match(raw_parent)
+            parent_name = m.group(1) if m else raw_parent
             parent_idx = testcase_indices.get(parent_name)
 
             if parent_idx is None:

--- a/isvtest/src/isvtest/tests/test_validations.py
+++ b/isvtest/src/isvtest/tests/test_validations.py
@@ -111,11 +111,8 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
                     possible_matches = [name for name in test_classes_map.keys() if validation_name.startswith(name)]
                     if possible_matches:
                         longest_match = max(possible_matches, key=len)
-                        # Verify it is a valid variant (starts with name + separator)
-                        # We accept - or _ as separator
-                        if validation_name.startswith(f"{longest_match}-") or validation_name.startswith(
-                            f"{longest_match}_"
-                        ):
+                        # Dash is the only accepted variant separator
+                        if validation_name.startswith(f"{longest_match}-"):
                             target_class = test_classes_map[longest_match]
 
                 if target_class:

--- a/isvtest/tests/test_catalog.py
+++ b/isvtest/tests/test_catalog.py
@@ -1,0 +1,83 @@
+"""Tests for the catalog module."""
+
+from unittest.mock import patch
+
+from isvtest.catalog import build_catalog, get_catalog_version
+
+
+class TestBuildCatalog:
+    """Tests for build_catalog function."""
+
+    def test_returns_list_of_dicts(self) -> None:
+        """Test that build_catalog returns a list of dicts."""
+        catalog = build_catalog()
+        assert isinstance(catalog, list)
+        assert len(catalog) > 0
+        for entry in catalog:
+            assert isinstance(entry, dict)
+
+    def test_entries_have_required_keys(self) -> None:
+        """Test that each entry has the required keys."""
+        catalog = build_catalog()
+        for entry in catalog:
+            assert "name" in entry
+            assert "description" in entry
+            assert "markers" in entry
+            assert "module" in entry
+
+    def test_entries_have_correct_types(self) -> None:
+        """Test that entry values have the correct types."""
+        catalog = build_catalog()
+        for entry in catalog:
+            assert isinstance(entry["name"], str)
+            assert isinstance(entry["description"], str)
+            assert isinstance(entry["markers"], list)
+            assert isinstance(entry["module"], str)
+
+    def test_no_duplicate_names(self) -> None:
+        """Test that there are no duplicate test names in the catalog."""
+        catalog = build_catalog()
+        names = [e["name"] for e in catalog]
+        assert len(names) == len(set(names))
+
+    def test_known_tests_present(self) -> None:
+        """Test that some known validation tests appear in the catalog."""
+        catalog = build_catalog()
+        names = {e["name"] for e in catalog}
+        assert "StepSuccessCheck" in names
+        assert "FieldExistsCheck" in names
+
+    def test_markers_are_lists_of_strings(self) -> None:
+        """Test that markers are lists of strings."""
+        catalog = build_catalog()
+        for entry in catalog:
+            for marker in entry["markers"]:
+                assert isinstance(marker, str)
+
+    def test_modules_are_valid_python_paths(self) -> None:
+        """Test that module paths look like valid Python module paths."""
+        catalog = build_catalog()
+        for entry in catalog:
+            assert "." in entry["module"]
+            assert entry["module"].startswith("isvtest.")
+
+
+class TestGetCatalogVersion:
+    """Tests for get_catalog_version function."""
+
+    def test_returns_string(self) -> None:
+        """Test that get_catalog_version returns a string."""
+        version = get_catalog_version()
+        assert isinstance(version, str)
+        assert len(version) > 0
+
+    def test_returns_dev_when_not_installed(self) -> None:
+        """Test that 'dev' is returned when package is not installed."""
+        from importlib.metadata import PackageNotFoundError
+
+        with patch(
+            "isvreporter.version.version",
+            side_effect=PackageNotFoundError("isvtest"),
+        ):
+            version = get_catalog_version()
+            assert version == "dev"


### PR DESCRIPTION
- Introduced the ability to upload a test catalog for coverage tracking in the ISV Lab Service, including new parameters in the `update_test_run` function.
- Implemented functions to build and retrieve the test catalog, ensuring structured entries for validation tests.
- Enhanced the `run` command to build the test catalog early and save it for upload.
- Added tests for the new catalog upload functionality and the catalog generation process.

Signed-off-by: Alexandre Begnoche <abegnoche@nvidia.com>