### PR TITLE
feat: add catalog subcommand for managing test catalog

### DIFF
--- a/isvctl/src/isvctl/cli/catalog.py
+++ b/isvctl/src/isvctl/cli/catalog.py
@@ -1,0 +1,95 @@
+"""Catalog subcommand for isvctl.
+
+Manage the test catalog: build, save, and upload to ISV Lab Service.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from isvtest.catalog import build_catalog, get_catalog_version
+
+from isvctl.cli import setup_logging
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer(
+    name="catalog",
+    help="Manage the test catalog for coverage tracking",
+    no_args_is_help=True,
+)
+
+
+@app.command("push")
+def push(
+    verbose: Annotated[
+        bool,
+        typer.Option("--verbose", "-v", help="Enable verbose logging"),
+    ] = False,
+    no_upload: Annotated[
+        bool,
+        typer.Option("--no-upload", help="Build and save locally without uploading"),
+    ] = False,
+) -> None:
+    """Build the test catalog and upload it to ISV Lab Service.
+
+    Discovers all validation tests, saves the catalog to
+    _output/test_catalog.json, and uploads it to the backend.
+    If the catalog for this version already exists, the upload
+    is skipped.
+
+    Examples:
+        isvctl catalog push
+        isvctl catalog push --no-upload
+    """
+    setup_logging(verbose)
+
+    typer.echo("Building test catalog...")
+    catalog_entries = build_catalog()
+    catalog_version = get_catalog_version()
+    typer.echo(f"  {len(catalog_entries)} tests (version: {catalog_version})")
+
+    output_dir = Path("_output")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    catalog_path = output_dir / "test_catalog.json"
+    catalog_path.write_text(json.dumps({"isvTestVersion": catalog_version, "entries": catalog_entries}, indent=2))
+    typer.echo(f"  Saved to: {catalog_path}")
+
+    if no_upload:
+        typer.echo("Skipping upload (--no-upload)")
+        return
+
+    from isvctl.reporting import check_upload_credentials, get_environment_config
+
+    can_upload, client_id, client_secret = check_upload_credentials()
+    if not can_upload or not client_id or not client_secret:
+        typer.echo(
+            typer.style("Error:", fg=typer.colors.RED) + " ISV_CLIENT_ID and/or ISV_CLIENT_SECRET not set",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    endpoint, ssa_issuer = get_environment_config()
+    if not endpoint or not ssa_issuer:
+        typer.echo(
+            typer.style("Error:", fg=typer.colors.RED) + " ISV_SERVICE_ENDPOINT and/or ISV_SSA_ISSUER not set",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    from isvreporter.auth import get_jwt_token
+    from isvreporter.client import upload_test_catalog
+
+    jwt_token = get_jwt_token(ssa_issuer, client_id, client_secret)
+    if upload_test_catalog(
+        endpoint=endpoint,
+        jwt_token=jwt_token,
+        isv_test_version=catalog_version,
+        entries=catalog_entries,
+    ):
+        typer.echo(typer.style("[OK]", fg=typer.colors.GREEN) + " Catalog push complete")
+    else:
+        typer.echo(typer.style("[FAIL]", fg=typer.colors.RED) + " Catalog upload failed")
+        raise typer.Exit(1)

--- a/isvctl/src/isvctl/cli/catalog.py
+++ b/isvctl/src/isvctl/cli/catalog.py
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
 """Catalog subcommand for isvctl.
 
 Manage the test catalog: build, save, and upload to ISV Lab Service.

--- a/isvctl/src/isvctl/main.py
+++ b/isvctl/src/isvctl/main.py
@@ -16,7 +16,7 @@ import typer
 from isvreporter.main import app as report_app
 from isvreporter.version import get_version
 
-from isvctl.cli import clean, deploy, docs, test
+from isvctl.cli import catalog, clean, deploy, docs, test
 
 app = typer.Typer(
     name="isvctl",
@@ -43,6 +43,7 @@ def main(
 
 
 # Register subcommands
+app.add_typer(catalog.app, name="catalog")
 app.add_typer(clean.app, name="clean")
 app.add_typer(deploy.app, name="deploy")
 app.add_typer(docs.app, name="docs")

--- a/isvreporter/tests/test_catalog_upload.py
+++ b/isvreporter/tests/test_catalog_upload.py
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
 """Tests for the test catalog upload functionality in the API client."""
 
 import json

--- a/isvtest/src/isvtest/catalog.py
+++ b/isvtest/src/isvtest/catalog.py
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
 """Test catalog generation for coverage tracking.
 
 Builds a structured catalog of all available validation tests by calling

--- a/isvtest/tests/test_catalog.py
+++ b/isvtest/tests/test_catalog.py
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
 """Tests for the catalog module."""
 
 from unittest.mock import patch

--- a/uv.lock
+++ b/uv.lock
@@ -661,7 +661,7 @@ requires-dist = [
     { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
     { name = "pyyaml", specifier = ">=6.0.2,<7.0.0" },
     { name = "reframe-hpc", specifier = ">=4.8.4" },
-    { name = "urllib3", specifier = ">=2.6.0,<3.0.0" },
+    { name = "urllib3", specifier = ">=2.6.3,<3.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Introduced a new `catalog` subcommand in `isvctl` to manage the test catalog, including functionality to build, save, and upload the catalog to ISV Lab Service.
- Updated `main.py` to register the new `catalog` command.
- Implemented the `push` command within the `catalog` subcommand to handle catalog creation and uploading, with options for verbose logging and local saving without upload.