### PR TITLE
feat: Platform IP management validation (#132, #131)

### DIFF
--- a/isvctl/configs/providers/aws/network.yaml
+++ b/isvctl/configs/providers/aws/network.yaml
@@ -13,13 +13,15 @@
 # Imports validations from the provider-agnostic network canonical config.
 # This file only provides AWS-specific commands (boto3 stubs) and settings.
 #
-# Comprehensive network testing with 6 test suites:
+# Comprehensive network testing with 8 test suites:
 #   1. VPC CRUD - Create, Read, Update, Delete VPC lifecycle
 #   2. Subnet Configuration - Multi-AZ subnet distribution
 #   3. VPC Isolation - Security boundaries between VPCs
 #   4. Security Blocking - SG/NACL blocking rules (negative tests)
 #   5. Connectivity - Instance network assignment
 #   6. Traffic Validation - Real ping tests via SSM
+#   7. VPC IP Config - DHCP options, subnet CIDRs, auto-assign IP (DDI)
+#   8. DHCP IP Management - DHCP lease, IP match, DNS options via SSH (DDI)
 #
 # Usage:
 #   uv run isvctl test run -f isvctl/configs/providers/aws/network.yaml
@@ -131,6 +133,34 @@ commands:
           - "10.93.0.0/16"
         timeout: 900
         output_schema: traffic_flow
+
+      # Test 7: VPC IP Configuration (DDI) (~10s)
+      - name: vpc_ip_config
+        phase: test
+        command: "python3 ../../stubs/aws/network/vpc_ip_config_test.py"
+        args:
+          - "--vpc-id"
+          - "{{steps.create_network.network_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 120
+        output_schema: vpc_ip_config
+
+      # Test 8: DHCP IP Management (DDI) (~3 min)
+      - name: dhcp_ip_test
+        phase: test
+        command: "python3 ../../stubs/aws/network/dhcp_ip_test.py"
+        args:
+          - "--vpc-id"
+          - "{{steps.create_network.network_id}}"
+          - "--subnet-id"
+          - "{{steps.create_network.subnets[0].subnet_id}}"
+          - "--sg-id"
+          - "{{steps.create_network.security_group_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 300
+        output_schema: dhcp_ip
 
       # Teardown: Clean up shared VPC from create_network
       - name: teardown

--- a/isvctl/configs/stubs/aws/common/ec2.py
+++ b/isvctl/configs/stubs/aws/common/ec2.py
@@ -153,6 +153,10 @@ def create_key_pair(
         raise RuntimeError(f"Failed to create key pair '{key_name}': {e}") from e
 
     key_dir.mkdir(parents=True, exist_ok=True)
+    # Remove stale key file if it exists (PEM files are 0400/read-only)
+    if key_path.exists():
+        key_path.chmod(0o600)
+        key_path.unlink()
     key_path.write_text(response["KeyMaterial"])
     key_path.chmod(0o400)
     print(f"Created key pair: {key_name}", file=sys.stderr)

--- a/isvctl/configs/stubs/aws/network/create_vpc.py
+++ b/isvctl/configs/stubs/aws/network/create_vpc.py
@@ -21,12 +21,20 @@ Output JSON:
     "network_id": "vpc-xxx",
     "cidr": "10.0.0.0/16",
     "subnets": [
-        {"subnet_id": "subnet-xxx", "cidr": "10.0.1.0/24", "az": "us-west-2a"},
-        {"subnet_id": "subnet-yyy", "cidr": "10.0.2.0/24", "az": "us-west-2b"}
+        {"subnet_id": "subnet-xxx", "cidr": "10.0.1.0/24", "az": "us-west-2a",
+         "auto_assign_public_ip": true, "available_ips": 251},
+        {"subnet_id": "subnet-yyy", "cidr": "10.0.2.0/24", "az": "us-west-2b",
+         "auto_assign_public_ip": true, "available_ips": 251}
     ],
     "internet_gateway_id": "igw-xxx",
     "route_table_id": "rtb-xxx",
-    "security_group_id": "sg-xxx"
+    "security_group_id": "sg-xxx",
+    "dhcp_options": {
+        "dhcp_options_id": "dopt-xxx",
+        "domain_name": "ec2.internal",
+        "domain_name_servers": ["AmazonProvidedDNS"],
+        "ntp_servers": []
+    }
 }
 """
 
@@ -55,6 +63,7 @@ def create_vpc(ec2: Any, name: str, cidr: str) -> dict[str, Any]:
         "internet_gateway_id": None,
         "route_table_id": None,
         "security_group_id": None,
+        "dhcp_options": None,
     }
 
     tag_suffix = str(uuid.uuid4())[:8]
@@ -116,11 +125,17 @@ def create_vpc(ec2: Any, name: str, cidr: str) -> dict[str, Any]:
             # Enable auto-assign public IP
             ec2.modify_subnet_attribute(SubnetId=subnet_id, MapPublicIpOnLaunch={"Value": True})
 
+            # Describe subnet to get available IP count
+            desc = ec2.describe_subnets(SubnetIds=[subnet_id])
+            available_ips = desc["Subnets"][0].get("AvailableIpAddressCount", 0)
+
             result["subnets"].append(
                 {
                     "subnet_id": subnet_id,
                     "cidr": subnet_cidr,
                     "az": az,
+                    "auto_assign_public_ip": True,
+                    "available_ips": available_ips,
                 }
             )
 
@@ -175,6 +190,35 @@ def create_vpc(ec2: Any, name: str, cidr: str) -> dict[str, Any]:
                 },
             ],
         )
+
+        # Collect DHCP options for VPC
+        vpc_desc = ec2.describe_vpcs(VpcIds=[vpc_id])
+        dhcp_options_id = vpc_desc["Vpcs"][0].get("DhcpOptionsId")
+        if dhcp_options_id and dhcp_options_id != "default":
+            dhcp_resp = ec2.describe_dhcp_options(DhcpOptionsIds=[dhcp_options_id])
+            dhcp_cfg = dhcp_resp["DhcpOptions"][0].get("DhcpConfigurations", [])
+            dhcp_info: dict[str, Any] = {
+                "dhcp_options_id": dhcp_options_id,
+                "domain_name": None,
+                "domain_name_servers": [],
+                "ntp_servers": [],
+            }
+            for cfg in dhcp_cfg:
+                vals = [v["Value"] for v in cfg.get("Values", [])]
+                if cfg["Key"] == "domain-name":
+                    dhcp_info["domain_name"] = vals[0] if vals else None
+                elif cfg["Key"] == "domain-name-servers":
+                    dhcp_info["domain_name_servers"] = vals
+                elif cfg["Key"] == "ntp-servers":
+                    dhcp_info["ntp_servers"] = vals
+            result["dhcp_options"] = dhcp_info
+        else:
+            result["dhcp_options"] = {
+                "dhcp_options_id": dhcp_options_id or "default",
+                "domain_name": "ec2.internal",
+                "domain_name_servers": ["AmazonProvidedDNS"],
+                "ntp_servers": [],
+            }
 
         result["success"] = True
 

--- a/isvctl/configs/stubs/aws/network/dhcp_ip_test.py
+++ b/isvctl/configs/stubs/aws/network/dhcp_ip_test.py
@@ -35,8 +35,10 @@ Output JSON:
 import argparse
 import json
 import os
+import socket
 import sys
 import time
+import uuid
 from typing import Any
 
 sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
@@ -123,8 +125,6 @@ def launch_instance(
 
 def wait_for_ssh(public_ip: str, timeout: int = 120) -> bool:
     """Wait for SSH port to become reachable (simple TCP check)."""
-    import socket
-
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
@@ -149,7 +149,7 @@ def main() -> int:
 
     ec2 = boto3.client("ec2", region_name=args.region)
 
-    key_name = f"{KEY_NAME_PREFIX}-{__import__('uuid').uuid4().hex[:8]}"
+    key_name = f"{KEY_NAME_PREFIX}-{uuid.uuid4().hex[:8]}"
 
     result: dict[str, Any] = {
         "success": False,

--- a/isvctl/configs/stubs/aws/network/dhcp_ip_test.py
+++ b/isvctl/configs/stubs/aws/network/dhcp_ip_test.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""DHCP/IP management test — AWS reference implementation.
+
+Creates an EC2 key pair, launches a t3.micro instance in the specified subnet,
+and outputs SSH connection details for the DhcpIpManagementCheck validation.
+
+Usage:
+    python dhcp_ip_test.py --vpc-id vpc-xxx --subnet-id subnet-xxx \\
+        --sg-id sg-xxx --region us-west-2
+
+Output JSON:
+{
+    "success": true,
+    "platform": "network",
+    "test_name": "dhcp_ip",
+    "public_ip": "3.1.2.3",
+    "private_ip": "10.0.1.5",
+    "key_file": "/tmp/isv-dhcp-test-key.pem",
+    "key_name": "isv-dhcp-test-key",
+    "ssh_user": "ubuntu",
+    "instance_id": "i-abc123"
+}
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Any
+
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+
+import boto3
+from botocore.exceptions import ClientError
+from common.ec2 import create_key_pair
+from common.errors import classify_aws_error, handle_aws_errors
+
+# Ubuntu 22.04 LTS AMI (us-west-2) — update per region as needed
+DEFAULT_AMI = "ami-0735c191cf914754d"
+INSTANCE_TYPE = "t3.micro"
+KEY_NAME_PREFIX = "isv-dhcp-test-key"
+
+
+def find_ubuntu_ami(ec2: Any) -> str:
+    """Find the latest Ubuntu 22.04 LTS AMI for the region."""
+    try:
+        response = ec2.describe_images(
+            Filters=[
+                {"Name": "name", "Values": ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]},
+                {"Name": "state", "Values": ["available"]},
+                {"Name": "architecture", "Values": ["x86_64"]},
+            ],
+            Owners=["099720109477"],  # Canonical
+        )
+        images = sorted(response["Images"], key=lambda x: x["CreationDate"], reverse=True)
+        if images:
+            return images[0]["ImageId"]
+    except ClientError:
+        pass
+    return DEFAULT_AMI
+
+
+def launch_instance(
+    ec2: Any,
+    subnet_id: str,
+    sg_id: str,
+    key_name: str,
+    ami_id: str,
+) -> dict[str, Any]:
+    """Launch an EC2 instance and wait for it to be running."""
+    response = ec2.run_instances(
+        ImageId=ami_id,
+        InstanceType=INSTANCE_TYPE,
+        KeyName=key_name,
+        MinCount=1,
+        MaxCount=1,
+        NetworkInterfaces=[
+            {
+                "DeviceIndex": 0,
+                "SubnetId": subnet_id,
+                "Groups": [sg_id],
+                "AssociatePublicIpAddress": True,
+            },
+        ],
+        TagSpecifications=[
+            {
+                "ResourceType": "instance",
+                "Tags": [
+                    {"Key": "Name", "Value": "isv-dhcp-test"},
+                    {"Key": "CreatedBy", "Value": "isvtest"},
+                ],
+            },
+        ],
+    )
+
+    instance_id = response["Instances"][0]["InstanceId"]
+
+    # Wait for running state
+    waiter = ec2.get_waiter("instance_running")
+    waiter.wait(InstanceIds=[instance_id])
+
+    # Describe to get IPs
+    desc = ec2.describe_instances(InstanceIds=[instance_id])
+    instance = desc["Reservations"][0]["Instances"][0]
+
+    return {
+        "instance_id": instance_id,
+        "public_ip": instance.get("PublicIpAddress"),
+        "private_ip": instance.get("PrivateIpAddress"),
+    }
+
+
+def wait_for_ssh(public_ip: str, timeout: int = 120) -> bool:
+    """Wait for SSH port to become reachable (simple TCP check)."""
+    import socket
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((public_ip, 22), timeout=5):
+                return True
+        except OSError:
+            time.sleep(5)
+    return False
+
+
+@handle_aws_errors
+def main() -> int:
+    """Create key pair, launch instance, output SSH details for DHCP validation."""
+    parser = argparse.ArgumentParser(description="DHCP/IP management test (AWS)")
+    parser.add_argument("--vpc-id", required=True, help="VPC ID")
+    parser.add_argument("--subnet-id", required=True, help="Subnet to launch instance in")
+    parser.add_argument("--sg-id", required=True, help="Security group ID")
+    parser.add_argument("--ssh-user", default="ubuntu", help="SSH username")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--ami-id", default=None, help="AMI ID (auto-detects Ubuntu if not set)")
+    args = parser.parse_args()
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+
+    key_name = f"{KEY_NAME_PREFIX}-{__import__('uuid').uuid4().hex[:8]}"
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "network",
+        "test_name": "dhcp_ip",
+        "public_ip": None,
+        "private_ip": None,
+        "key_file": None,
+        "key_name": key_name,
+        "ssh_user": args.ssh_user,
+        "instance_id": None,
+    }
+
+    try:
+        # Create key pair with unique name
+        key_file = create_key_pair(ec2, key_name)
+        result["key_file"] = key_file
+
+        # Find AMI
+        ami_id = args.ami_id or find_ubuntu_ami(ec2)
+
+        # Launch instance
+        instance_info = launch_instance(ec2, args.subnet_id, args.sg_id, key_name, ami_id)
+        result["instance_id"] = instance_info["instance_id"]
+        result["public_ip"] = instance_info["public_ip"]
+        result["private_ip"] = instance_info["private_ip"]
+
+        if not result["public_ip"]:
+            result["error"] = "Instance launched but no public IP assigned"
+            print(json.dumps(result, indent=2))
+            return 1
+
+        # Wait for SSH to become available
+        if not wait_for_ssh(result["public_ip"]):
+            result["error"] = f"SSH not reachable on {result['public_ip']} after 120s"
+            print(json.dumps(result, indent=2))
+            return 1
+
+        result["success"] = True
+
+    except ClientError as e:
+        result["error_type"], result["error"] = classify_aws_error(e)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/aws/network/docs/aws-network.md
+++ b/isvctl/configs/stubs/aws/network/docs/aws-network.md
@@ -338,7 +338,7 @@ tests:
 | `AWS_ACCESS_KEY_ID` | AWS access key | From AWS config |
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key | From AWS config |
 | `AWS_SESSION_TOKEN` | STS session token | None |
-| `AWS_NETWORK_SKIP_TEARDOWN` | Disable/ VPC teardown | `false` |
+| `AWS_NETWORK_SKIP_TEARDOWN` | Skip VPC teardown | `false` |
 
 ## Example Output
 

--- a/isvctl/configs/stubs/aws/network/docs/aws-network.md
+++ b/isvctl/configs/stubs/aws/network/docs/aws-network.md
@@ -338,7 +338,7 @@ tests:
 | `AWS_ACCESS_KEY_ID` | AWS access key | From AWS config |
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key | From AWS config |
 | `AWS_SESSION_TOKEN` | STS session token | None |
-| `AWS_NETWORK_TEARDOWN_ENABLED` | Enable VPC teardown | `false` |
+| `AWS_NETWORK_SKIP_TEARDOWN` | Disable/ VPC teardown | `false` |
 
 ## Example Output
 

--- a/isvctl/configs/stubs/aws/network/teardown.py
+++ b/isvctl/configs/stubs/aws/network/teardown.py
@@ -34,6 +34,7 @@ import json
 import os
 import sys
 import time
+from pathlib import Path
 from typing import Any
 
 sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
@@ -67,10 +68,30 @@ def delete_with_retry(func, resource_type: str, max_retries: int = 5, **kwargs) 
     return False
 
 
+def cleanup_key_pairs(ec2: Any, key_names: list[str]) -> list[str]:
+    """Delete key pairs by exact name (AWS + local PEM files)."""
+    deleted = []
+    for key_name in key_names:
+        try:
+            ec2.describe_key_pairs(KeyNames=[key_name])
+            ec2.delete_key_pair(KeyName=key_name)
+            deleted.append(key_name)
+        except ClientError as e:
+            if e.response["Error"]["Code"] != "InvalidKeyPair.NotFound":
+                raise
+        # Clean up local PEM file (0400 permissions require chmod first)
+        pem_path = Path(f"/tmp/{key_name}.pem")
+        if pem_path.exists():
+            pem_path.chmod(0o600)
+            pem_path.unlink()
+    return deleted
+
+
 def teardown_vpc(ec2: Any, vpc_id: str) -> dict[str, Any]:
     """Delete VPC and all associated resources."""
     deleted = {
         "instances": [],
+        "key_pairs": [],
         "security_groups": [],
         "subnets": [],
         "route_tables": [],
@@ -78,7 +99,7 @@ def teardown_vpc(ec2: Any, vpc_id: str) -> dict[str, Any]:
         "vpc": None,
     }
 
-    # Terminate all instances in VPC
+    # Terminate all instances in VPC and collect their key names
     instances = ec2.describe_instances(
         Filters=[
             {"Name": "vpc-id", "Values": [vpc_id]},
@@ -86,15 +107,22 @@ def teardown_vpc(ec2: Any, vpc_id: str) -> dict[str, Any]:
         ]
     )
     instance_ids = []
+    instance_key_names: set[str] = set()
     for reservation in instances["Reservations"]:
         for instance in reservation["Instances"]:
             instance_ids.append(instance["InstanceId"])
+            if instance.get("KeyName"):
+                instance_key_names.add(instance["KeyName"])
 
     if instance_ids:
         ec2.terminate_instances(InstanceIds=instance_ids)
         waiter = ec2.get_waiter("instance_terminated")
         waiter.wait(InstanceIds=instance_ids)
         deleted["instances"] = instance_ids
+
+    # Clean up key pairs that were used by terminated instances
+    if instance_key_names:
+        deleted["key_pairs"] = cleanup_key_pairs(ec2, list(instance_key_names))
 
     # Delete security groups (except default)
     sgs = ec2.describe_security_groups(Filters=[{"Name": "vpc-id", "Values": [vpc_id]}])
@@ -179,11 +207,11 @@ def main() -> int:
         "deleted": {},
     }
 
-    # Check both flag and environment variable
-    skip_destroy = args.skip_destroy or os.environ.get("AWS_NETWORK_TEARDOWN_ENABLED", "").lower() != "true"
+    # Skip only if explicitly requested via flag or env var
+    skip_destroy = args.skip_destroy or os.environ.get("AWS_NETWORK_SKIP_TEARDOWN", "").lower() == "true"
     if skip_destroy:
         result["success"] = True
-        result["message"] = "Destroy skipped (set AWS_NETWORK_TEARDOWN_ENABLED=true to enable)"
+        result["message"] = "Destroy skipped (--skip-destroy flag or AWS_NETWORK_SKIP_TEARDOWN=true)"
         print(json.dumps(result, indent=2))
         return 0
 

--- a/isvctl/configs/stubs/aws/network/vpc_ip_config_test.py
+++ b/isvctl/configs/stubs/aws/network/vpc_ip_config_test.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""VPC IP configuration test — AWS reference implementation.
+
+Inspects VPC DHCP options, subnet CIDRs, and auto-assign IP settings.
+Outputs structured JSON for the VpcIpConfigCheck validation.
+
+Usage:
+    python vpc_ip_config_test.py --vpc-id vpc-xxx --region us-west-2
+
+Output JSON:
+{
+    "success": true,
+    "platform": "network",
+    "test_name": "vpc_ip_config",
+    "network_id": "vpc-xxx",
+    "cidr": "10.0.0.0/16",
+    "subnets": [
+        {
+            "subnet_id": "subnet-xxx",
+            "cidr": "10.0.1.0/24",
+            "az": "us-west-2a",
+            "auto_assign_public_ip": true,
+            "available_ips": 251
+        }
+    ],
+    "dhcp_options": {
+        "dhcp_options_id": "dopt-xxx",
+        "domain_name": "ec2.internal",
+        "domain_name_servers": ["AmazonProvidedDNS"],
+        "ntp_servers": []
+    }
+}
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+
+import boto3
+from botocore.exceptions import ClientError
+from common.errors import classify_aws_error, handle_aws_errors
+
+
+def describe_dhcp_options(ec2: Any, dhcp_options_id: str) -> dict[str, Any]:
+    """Describe DHCP options set and extract configuration values."""
+    response = ec2.describe_dhcp_options(DhcpOptionsIds=[dhcp_options_id])
+    dhcp = response["DhcpOptions"][0]
+
+    result: dict[str, Any] = {
+        "dhcp_options_id": dhcp_options_id,
+        "domain_name": None,
+        "domain_name_servers": [],
+        "ntp_servers": [],
+    }
+
+    for config in dhcp.get("DhcpConfigurations", []):
+        key = config["Key"]
+        values = [v["Value"] for v in config.get("Values", [])]
+
+        if key == "domain-name":
+            result["domain_name"] = values[0] if values else None
+        elif key == "domain-name-servers":
+            result["domain_name_servers"] = values
+        elif key == "ntp-servers":
+            result["ntp_servers"] = values
+
+    return result
+
+
+def describe_subnets(ec2: Any, vpc_id: str) -> list[dict[str, Any]]:
+    """Describe all subnets in a VPC with IP config details."""
+    response = ec2.describe_subnets(
+        Filters=[{"Name": "vpc-id", "Values": [vpc_id]}],
+    )
+
+    subnets = []
+    for subnet in response["Subnets"]:
+        subnets.append(
+            {
+                "subnet_id": subnet["SubnetId"],
+                "cidr": subnet["CidrBlock"],
+                "az": subnet["AvailabilityZone"],
+                "auto_assign_public_ip": subnet.get("MapPublicIpOnLaunch", False),
+                "available_ips": subnet.get("AvailableIpAddressCount", 0),
+            }
+        )
+
+    return subnets
+
+
+@handle_aws_errors
+def main() -> int:
+    """Inspect VPC IP configuration and output JSON."""
+    parser = argparse.ArgumentParser(description="VPC IP configuration test (AWS)")
+    parser.add_argument("--vpc-id", required=True, help="VPC ID to inspect")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    args = parser.parse_args()
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "network",
+        "test_name": "vpc_ip_config",
+        "network_id": args.vpc_id,
+        "cidr": None,
+        "subnets": [],
+        "dhcp_options": None,
+    }
+
+    try:
+        # Describe VPC to get CIDR and DHCP options ID
+        vpc_response = ec2.describe_vpcs(VpcIds=[args.vpc_id])
+        vpc = vpc_response["Vpcs"][0]
+        result["cidr"] = vpc["CidrBlock"]
+        dhcp_options_id = vpc.get("DhcpOptionsId")
+
+        # Describe DHCP options
+        if dhcp_options_id and dhcp_options_id != "default":
+            result["dhcp_options"] = describe_dhcp_options(ec2, dhcp_options_id)
+        else:
+            # AWS default DHCP options
+            result["dhcp_options"] = {
+                "dhcp_options_id": dhcp_options_id or "default",
+                "domain_name": "ec2.internal",
+                "domain_name_servers": ["AmazonProvidedDNS"],
+                "ntp_servers": [],
+            }
+
+        # Describe subnets
+        result["subnets"] = describe_subnets(ec2, args.vpc_id)
+
+        result["success"] = True
+
+    except ClientError as e:
+        result["error_type"], result["error"] = classify_aws_error(e)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/network/create_vpc.py
+++ b/isvctl/configs/stubs/network/create_vpc.py
@@ -22,12 +22,18 @@ Required JSON output fields:
     "success": true,                       # boolean - did the operation succeed?
     "platform": "network",                 # string  - always "network"
     "network_id": "vpc-abc123",            # string  - VPC / network identifier
+    "cidr": "10.0.0.0/16",                # string  - the CIDR block assigned
     "subnets": [                           # list    - created subnets
-      {"subnet_id": "subnet-abc123"},
-      {"subnet_id": "subnet-def456"}
+      {"subnet_id": "subnet-abc123", "cidr": "10.0.1.0/24", "az": "us-west-2a",
+       "auto_assign_public_ip": true, "available_ips": 251}
     ],
     "security_group_id": "sg-abc123",      # string  - default security group ID
-    "cidr_block": "10.0.0.0/16"            # string  - the CIDR block assigned
+    "dhcp_options": {                      # object  - DHCP options configuration
+      "dhcp_options_id": "dopt-abc",       # string  - DHCP options set ID
+      "domain_name": "ec2.internal",       # string  - domain name
+      "domain_name_servers": ["..."],      # list    - DNS servers
+      "ntp_servers": []                    # list    - NTP servers (may be empty)
+    }
   }
 
 On failure, set "success": false and include an "error" field:
@@ -59,9 +65,10 @@ def main() -> int:
         "success": False,
         "platform": "network",
         "network_id": "",
+        "cidr": args.cidr,
         "subnets": [],
         "security_group_id": "",
-        "cidr_block": args.cidr,
+        "dhcp_options": None,
     }
 
     # ╔══════════════════════════════════════════════════════════════════╗

--- a/isvctl/configs/stubs/network/dhcp_ip_test.py
+++ b/isvctl/configs/stubs/network/dhcp_ip_test.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""DHCP/IP management test - TEMPLATE (replace with your platform implementation).
+
+This script is called during the "test" phase. It must:
+  1. Create an SSH key pair dynamically (idempotent — reuse if exists)
+  2. Launch an instance in the specified subnet
+  3. Wait for SSH to become reachable
+  4. Print a JSON object to stdout with SSH connection details
+
+The DhcpIpManagementCheck validation will SSH in and verify:
+  - DHCP lease is active
+  - Instance IP matches platform-reported IP
+  - DHCP-provided DNS options are configured
+
+Required JSON output fields:
+  {
+    "success": true,                           # boolean - did the instance launch?
+    "platform": "network",                     # string  - always "network"
+    "test_name": "dhcp_ip",                    # string  - always "dhcp_ip"
+    "public_ip": "3.1.2.3",                   # string  - SSH target address
+    "private_ip": "10.0.1.5",                 # string  - expected private IP
+    "key_file": "/tmp/isv-dhcp-test-key.pem", # string  - SSH private key path
+    "key_name": "isv-dhcp-test-key",          # string  - key pair name
+    "ssh_user": "ubuntu",                      # string  - SSH username
+    "instance_id": "i-abc123"                  # string  - instance identifier
+  }
+
+On failure, set "success": false and include an "error" field.
+
+Usage:
+    python dhcp_ip_test.py --vpc-id vpc-abc123 --subnet-id subnet-abc \\
+        --sg-id sg-abc123 --region us-west-2
+
+Reference implementation: ../aws/network/dhcp_ip_test.py
+"""
+
+import argparse
+import json
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="DHCP/IP management test (template)")
+    parser.add_argument("--vpc-id", required=True, help="VPC / network ID")
+    parser.add_argument("--subnet-id", required=True, help="Subnet to launch instance in")
+    parser.add_argument("--sg-id", required=True, help="Security group ID")
+    parser.add_argument("--ssh-user", default="ubuntu", help="SSH username")
+    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    args = parser.parse_args()
+
+    result: dict = {
+        "success": False,
+        "platform": "network",
+        "test_name": "dhcp_ip",
+        "public_ip": None,
+        "private_ip": None,
+        "key_file": None,
+        "key_name": None,
+        "ssh_user": args.ssh_user,
+        "instance_id": None,
+    }
+
+    # ╔══════════════════════════════════════════════════════════════════╗
+    # ║  TODO: Replace this block with your platform's implementation    ║
+    # ║                                                                  ║
+    # ║  Example (pseudocode):                                           ║
+    # ║    client = MyCloudClient(region=args.region)                    ║
+    # ║                                                                  ║
+    # ║    # Create key pair dynamically (idempotent)                    ║
+    # ║    key_name = "isv-dhcp-test-key"                                ║
+    # ║    key_file = client.create_key_pair(key_name)                   ║
+    # ║    result["key_file"] = key_file                                 ║
+    # ║    result["key_name"] = key_name                                 ║
+    # ║                                                                  ║
+    # ║    # Launch an instance in the specified subnet                  ║
+    # ║    inst = client.launch_instance(                                ║
+    # ║        subnet_id=args.subnet_id,                                 ║
+    # ║        security_group=args.sg_id,                                ║
+    # ║        key_name=key_name,                                        ║
+    # ║    )                                                             ║
+    # ║    result["instance_id"] = inst.id                               ║
+    # ║    result["public_ip"] = inst.public_ip                          ║
+    # ║    result["private_ip"] = inst.private_ip                        ║
+    # ║    result["success"] = True                                      ║
+    # ║                                                                  ║
+    # ║  Note: The DhcpIpManagementCheck validation handles SSH and      ║
+    # ║  DHCP verification. This script just needs to provide instance   ║
+    # ║  connection details.                                             ║
+    # ║                                                                  ║
+    # ║  Cleanup: Instance should be terminated in teardown phase or     ║
+    # ║  by a separate cleanup script.                                   ║
+    # ╚══════════════════════════════════════════════════════════════════╝
+
+    result["error"] = "Not implemented - replace with your platform's instance launch logic"
+    print(json.dumps(result, indent=2))
+
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/network/teardown.py
+++ b/isvctl/configs/stubs/network/teardown.py
@@ -12,11 +12,13 @@
 """Teardown VPC / virtual network - TEMPLATE (replace with your platform implementation).
 
 This script is called during the "teardown" phase. It must:
-  1. Delete all subnets in the VPC
-  2. Delete all security groups (except platform default, if any)
-  3. Detach and delete internet gateways
-  4. Delete the VPC itself
-  5. Print a JSON object to stdout
+  1. Terminate all instances in the VPC (wait for termination)
+  2. Delete key pairs created by test scripts (e.g., isv-dhcp-test-key)
+  3. Delete all subnets in the VPC
+  4. Delete all security groups (except platform default, if any)
+  5. Detach and delete internet gateways
+  6. Delete the VPC itself
+  7. Print a JSON object to stdout
 
 The script should be IDEMPOTENT - if a resource is already deleted, skip
 it and continue with the rest.

--- a/isvctl/configs/stubs/network/vpc_ip_config_test.py
+++ b/isvctl/configs/stubs/network/vpc_ip_config_test.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""VPC IP configuration test - TEMPLATE (replace with your platform implementation).
+
+This script is called during the "test" phase. It inspects the SHARED VPC
+created by create_vpc.py (VPC ID passed via Jinja2 template variables):
+  1. Describe VPC DHCP options configuration
+  2. Describe subnet CIDR allocations and auto-assign settings
+  3. Report available IP capacity per subnet
+  4. Print a JSON object to stdout
+
+Required JSON output fields:
+  {
+    "success": true,                           # boolean - did the inspection succeed?
+    "platform": "network",                     # string  - always "network"
+    "test_name": "vpc_ip_config",              # string  - always "vpc_ip_config"
+    "network_id": "vpc-abc123",                # string  - VPC identifier
+    "cidr": "10.0.0.0/16",                    # string  - VPC CIDR block
+    "subnets": [                               # list    - subnet details
+      {
+        "subnet_id": "subnet-abc",             # string  - subnet identifier
+        "cidr": "10.0.1.0/24",                # string  - subnet CIDR
+        "az": "us-west-2a",                   # string  - availability zone
+        "auto_assign_public_ip": true,         # boolean - auto-assign public IP?
+        "available_ips": 251                   # int     - available IP addresses
+      }
+    ],
+    "dhcp_options": {                          # object  - DHCP options set
+      "dhcp_options_id": "dopt-abc",           # string  - DHCP options set ID
+      "domain_name": "ec2.internal",           # string  - domain name
+      "domain_name_servers": ["AmazonProvidedDNS"],  # list - DNS servers
+      "ntp_servers": []                        # list    - NTP servers (may be empty)
+    }
+  }
+
+On failure, set "success": false and include an "error" field.
+
+Usage:
+    python vpc_ip_config_test.py --vpc-id vpc-abc123 --region us-west-2
+
+Reference implementation: ../aws/network/vpc_ip_config_test.py
+"""
+
+import argparse
+import json
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="VPC IP configuration test (template)")
+    parser.add_argument("--vpc-id", required=True, help="VPC / network ID to inspect")
+    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    args = parser.parse_args()
+
+    result: dict = {
+        "success": False,
+        "platform": "network",
+        "test_name": "vpc_ip_config",
+        "network_id": args.vpc_id,
+        "cidr": None,
+        "subnets": [],
+        "dhcp_options": None,
+    }
+
+    # ╔══════════════════════════════════════════════════════════════════╗
+    # ║  TODO: Replace this block with your platform's implementation    ║
+    # ║                                                                  ║
+    # ║  Example (pseudocode):                                           ║
+    # ║    client = MyCloudClient(region=args.region)                    ║
+    # ║                                                                  ║
+    # ║    # Describe VPC                                                ║
+    # ║    vpc = client.describe_vpc(args.vpc_id)                        ║
+    # ║    result["cidr"] = vpc.cidr_block                               ║
+    # ║                                                                  ║
+    # ║    # Describe DHCP options                                       ║
+    # ║    dhcp = client.describe_dhcp_options(vpc.dhcp_options_id)       ║
+    # ║    result["dhcp_options"] = {                                     ║
+    # ║        "dhcp_options_id": dhcp.id,                               ║
+    # ║        "domain_name": dhcp.domain_name,                          ║
+    # ║        "domain_name_servers": dhcp.dns_servers,                  ║
+    # ║        "ntp_servers": dhcp.ntp_servers or [],                    ║
+    # ║    }                                                             ║
+    # ║                                                                  ║
+    # ║    # Describe subnets                                            ║
+    # ║    for subnet in client.describe_subnets(vpc_id=args.vpc_id):    ║
+    # ║        result["subnets"].append({                                ║
+    # ║            "subnet_id": subnet.id,                               ║
+    # ║            "cidr": subnet.cidr_block,                            ║
+    # ║            "az": subnet.availability_zone,                       ║
+    # ║            "auto_assign_public_ip": subnet.map_public_ip,        ║
+    # ║            "available_ips": subnet.available_ip_count,           ║
+    # ║        })                                                        ║
+    # ║    result["success"] = True                                      ║
+    # ╚══════════════════════════════════════════════════════════════════╝
+
+    result["error"] = "Not implemented - replace with your platform's VPC inspection logic"
+    print(json.dumps(result, indent=2))
+
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/tests/network.yaml
+++ b/isvctl/configs/tests/network.yaml
@@ -29,6 +29,8 @@
 #   4. Security Blocking - Firewall / ACL blocking rules (negative tests)
 #   5. Connectivity - Instance network assignment
 #   6. Traffic Validation - Real ping tests between instances
+#   7. VPC IP Config - DHCP options, subnet CIDRs, auto-assign IP (DDI)
+#   8. DHCP IP Management - DHCP lease, IP match, DNS options via SSH (DDI)
 #
 # Quick start (new provider):
 #   1. Create your provider folder: mkdir -p isvctl/configs/providers/my-isv/
@@ -159,6 +161,42 @@ commands:
         timeout: 900
         output_schema: traffic_flow
 
+      # ─── Test 7: VPC IP Configuration (DDI) ──────────────────────────
+      # Uses the shared VPC from create_network step.
+      # YOUR SCRIPT must output JSON with: cidr, subnets (with
+      # auto_assign_public_ip, available_ips), dhcp_options (with
+      # domain_name_servers, domain_name).
+      - name: vpc_ip_config
+        phase: test
+        command: "python3 ../stubs/network/vpc_ip_config_test.py"
+        args:
+          - "--vpc-id"
+          - "{{steps.create_network.network_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 120
+        output_schema: vpc_ip_config
+
+      # ─── Test 8: DHCP IP Management (DDI) ────────────────────────────
+      # Uses the shared VPC from create_network step.
+      # Launches an instance and outputs SSH details for DhcpIpManagementCheck.
+      # YOUR SCRIPT must output JSON with: public_ip, private_ip,
+      # key_file, ssh_user.
+      - name: dhcp_ip_test
+        phase: test
+        command: "python3 ../stubs/network/dhcp_ip_test.py"
+        args:
+          - "--vpc-id"
+          - "{{steps.create_network.network_id}}"
+          - "--subnet-id"
+          - "{{steps.create_network.subnets[0].subnet_id}}"
+          - "--sg-id"
+          - "{{steps.create_network.security_group_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 300
+        output_schema: dhcp_ip
+
       # ─── Teardown: Clean up shared VPC ─────────────────────────────
       # YOUR SCRIPT must output JSON with at minimum:
       #   {
@@ -212,6 +250,10 @@ tests:
           step: connectivity_test
         TrafficFlowCheck:
           step: traffic_validation
+        VpcIpConfigCheck:
+          step: vpc_ip_config
+        DhcpIpManagementCheck:
+          step: dhcp_ip_test
 
     teardown_checks:
       step: teardown

--- a/isvctl/src/isvctl/config/output_schemas.py
+++ b/isvctl/src/isvctl/config/output_schemas.py
@@ -101,6 +101,11 @@ STEP_SCHEMA_MAPPING: dict[str, str | None] = {
     "connectivity_test": "connectivity_result",
     "launch_instances": "instance_launch",
     "launch_test_instances": "instance_launch",
+    # DDI (DNS/DHCP/IP Management) test operations
+    "vpc_ip_config": "vpc_ip_config",
+    "vpc_ip_config_test": "vpc_ip_config",
+    "dhcp_ip_test": "dhcp_ip",
+    "dhcp_ip": "dhcp_ip",
     # ISO/Image import operations (provider-agnostic)
     "upload_image": "iso_import",
     "import_image": "iso_import",
@@ -596,6 +601,64 @@ OUTPUT_SCHEMAS: dict[str, dict[str, Any]] = {
                 },
                 "description": "Launched instances",
             },
+        },
+        "additionalProperties": True,
+    },
+    # =========================================================================
+    # DDI (DNS/DHCP/IP Management) Schemas
+    # =========================================================================
+    "vpc_ip_config": {
+        "type": "object",
+        "required": ["success", "platform"],
+        "properties": {
+            **COMMON_PROPERTIES,
+            "network_id": {"type": "string", "description": "VPC/Network identifier"},
+            "cidr": {"type": "string", "description": "VPC CIDR block"},
+            "subnets": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "subnet_id": {"type": "string"},
+                        "cidr": {"type": "string"},
+                        "az": {"type": "string"},
+                        "auto_assign_public_ip": {"type": "boolean"},
+                        "available_ips": {"type": "integer"},
+                    },
+                },
+                "description": "Subnet configurations with IP details",
+            },
+            "dhcp_options": {
+                "type": "object",
+                "properties": {
+                    "dhcp_options_id": {"type": "string"},
+                    "domain_name": {"type": "string"},
+                    "domain_name_servers": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "ntp_servers": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                },
+                "description": "DHCP options configuration",
+            },
+        },
+        "additionalProperties": True,
+    },
+    "dhcp_ip": {
+        "type": "object",
+        "required": ["success", "platform"],
+        "properties": {
+            **COMMON_PROPERTIES,
+            "test_name": {"type": "string", "description": "Always 'dhcp_ip'"},
+            "public_ip": {"type": ["string", "null"], "description": "SSH target address"},
+            "private_ip": {"type": ["string", "null"], "description": "Expected private IP"},
+            "key_file": {"type": ["string", "null"], "description": "SSH private key path"},
+            "key_name": {"type": ["string", "null"], "description": "Key pair name"},
+            "ssh_user": {"type": "string", "description": "SSH username"},
+            "instance_id": {"type": ["string", "null"], "description": "Instance identifier"},
         },
         "additionalProperties": True,
     },

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -47,12 +47,14 @@ from isvtest.validations.instance import (
     InstanceStateCheck,
 )
 from isvtest.validations.network import (
+    DhcpIpManagementCheck,
     NetworkConnectivityCheck,
     NetworkProvisionedCheck,
     SecurityBlockingCheck,
     SubnetConfigCheck,
     TrafficFlowCheck,
     VpcCrudCheck,
+    VpcIpConfigCheck,
     VpcIsolationCheck,
 )
 from isvtest.validations.nim import (
@@ -67,6 +69,7 @@ __all__ = [
     "AccessKeyDisabledCheck",
     "AccessKeyRejectedCheck",
     "ClusterHealthCheck",
+    "DhcpIpManagementCheck",
     "FieldExistsCheck",
     "FieldValueCheck",
     "GpuOperatorInstalledCheck",
@@ -89,5 +92,6 @@ __all__ = [
     "TenantListedCheck",
     "TrafficFlowCheck",
     "VpcCrudCheck",
+    "VpcIpConfigCheck",
     "VpcIsolationCheck",
 ]

--- a/isvtest/src/isvtest/validations/network.py
+++ b/isvtest/src/isvtest/validations/network.py
@@ -10,11 +10,25 @@
 
 """Network validations for step outputs.
 
-Validations for VPCs, subnets, security groups, connectivity, and traffic flow.
+Validations for VPCs, subnets, security groups, connectivity, traffic flow,
+and DDI (DNS/DHCP/IP management).
 """
 
-from typing import ClassVar
+from __future__ import annotations
 
+import ipaddress
+import re
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    import paramiko
+
+from isvtest.core.ssh import (
+    get_failed_subtests,
+    get_ssh_client,
+    get_ssh_config,
+    run_ssh_command,
+)
 from isvtest.core.validation import BaseValidation
 
 
@@ -314,3 +328,327 @@ class TrafficFlowCheck(BaseValidation):
         else:
             latency = tests.get("traffic_allowed", {}).get("latency_ms", "N/A")
             self.set_passed(f"All {len(passed)} traffic tests passed (latency: {latency}ms)")
+
+
+class DhcpIpManagementCheck(BaseValidation):
+    """Validate DHCP/IP management on an instance via SSH.
+
+    SSHes into an instance and verifies that:
+    1. A DHCP lease is active (dhclient or systemd-networkd)
+    2. The instance IP matches what the platform reports
+    3. DHCP-provided options (DNS, domain) are correctly configured
+
+    Config:
+        step_output: Must include public_ip or host, key_file, ssh_user
+        inventory: Optional inventory for SSH config resolution
+
+    Step output:
+        public_ip: SSH target address
+        private_ip: Expected private IP (for comparison)
+        key_file: Path to SSH private key
+        ssh_user: SSH username
+    """
+
+    description: ClassVar[str] = "Check DHCP/IP management via SSH"
+    timeout: ClassVar[int] = 60
+    markers: ClassVar[list[str]] = ["network", "ssh"]
+
+    def run(self) -> None:
+        try:
+            import paramiko  # noqa: F401
+        except ImportError:
+            self.set_failed("paramiko not installed")
+            return
+
+        ssh_cfg = get_ssh_config(self.config, self.config.get("inventory", {}))
+        host = ssh_cfg["ssh_host"]
+        user = ssh_cfg["ssh_user"]
+        key_path = ssh_cfg["ssh_key_path"]
+
+        if not host:
+            self.set_failed("No SSH host configured")
+            return
+        if not key_path:
+            self.set_failed("No SSH key configured")
+            return
+
+        try:
+            ssh = get_ssh_client(host, user, key_path)
+        except Exception as e:
+            self.set_failed(f"SSH connection failed: {e}")
+            return
+
+        try:
+            self._check_dhcp_lease(ssh)
+            self._check_ip_matches_platform(ssh)
+            self._check_dhcp_options(ssh)
+
+            failed = get_failed_subtests(self._subtest_results)
+            if failed:
+                self.set_failed(f"DHCP subtests failed: {', '.join(failed)}")
+            else:
+                self.set_passed(f"DHCP/IP management verified on {host}")
+        finally:
+            ssh.close()
+
+    def _check_dhcp_lease(self, ssh: paramiko.SSHClient) -> None:
+        """Check that a DHCP client is active and a valid lease exists."""
+        cmd = (
+            "echo '---DHCP_PROC---' && "
+            "(pgrep -a 'dhclient|dhcpcd|systemd-network' 2>/dev/null || echo 'NO_DHCP_PROCESS') && "
+            "echo '---DHCP_LEASE---' && "
+            "(cat /var/lib/dhcp/dhclient*.leases "
+            "/run/systemd/netif/leases/* "
+            "/var/lib/NetworkManager/internal-*.lease "
+            "/var/lib/NetworkManager/dhclient-*.lease "
+            "2>/dev/null || echo 'NO_LEASE_FILES')"
+        )
+        _exit_code, stdout, _ = run_ssh_command(ssh, cmd)
+
+        proc_section = ""
+        lease_section = ""
+        if "---DHCP_PROC---" in stdout and "---DHCP_LEASE---" in stdout:
+            parts = stdout.split("---DHCP_LEASE---")
+            proc_section = parts[0].split("---DHCP_PROC---")[-1].strip()
+            lease_section = parts[1].strip()
+
+        has_process = "NO_DHCP_PROCESS" not in proc_section and proc_section != ""
+        has_lease = "NO_LEASE_FILES" not in lease_section and lease_section != ""
+
+        if has_process or has_lease:
+            details = []
+            if has_process:
+                details.append("DHCP process running")
+            if has_lease:
+                details.append("lease file found")
+            self.report_subtest("dhcp_lease_active", True, "; ".join(details))
+        else:
+            self.report_subtest("dhcp_lease_active", False, "No DHCP process or lease files found")
+
+    def _check_ip_matches_platform(self, ssh: paramiko.SSHClient) -> None:
+        """Compare instance IP against platform-reported private_ip."""
+        expected_ip = self.config.get("step_output", {}).get("private_ip")
+        if not expected_ip:
+            self.report_subtest(
+                "ip_matches_platform",
+                True,
+                "Skipped: no private_ip in step_output",
+                skipped=True,
+            )
+            return
+
+        cmd = "ip -4 addr show scope global | awk '/inet / {split($2, a, \"/\"); print a[1]}'"
+        _exit_code, stdout, _ = run_ssh_command(ssh, cmd)
+        actual_ips = [ip.strip() for ip in stdout.strip().splitlines() if ip.strip()]
+
+        if expected_ip in actual_ips:
+            self.report_subtest(
+                "ip_matches_platform",
+                True,
+                f"Platform IP {expected_ip} found on instance",
+            )
+        else:
+            self.report_subtest(
+                "ip_matches_platform",
+                False,
+                f"Expected {expected_ip}, found {actual_ips}",
+            )
+
+    def _check_dhcp_options(self, ssh: paramiko.SSHClient) -> None:
+        """Verify DHCP-provided DNS and domain options are configured."""
+        cmd = (
+            "echo '---RESOLV---' && "
+            "(cat /etc/resolv.conf 2>/dev/null || echo 'NO_RESOLV_CONF') && "
+            "echo '---DHCP_OPTS---' && "
+            "(grep -rh 'domain-name-servers\\|domain-name\\|ntp-servers' /var/lib/dhcp/ 2>/dev/null; "
+            "grep -rh 'DNS=\\|DOMAINNAME=\\|NTP=' /run/systemd/netif/leases/ 2>/dev/null; "
+            "echo 'DONE')"
+        )
+        _exit_code, stdout, _ = run_ssh_command(ssh, cmd)
+
+        resolv_section = ""
+        if "---RESOLV---" in stdout and "---DHCP_OPTS---" in stdout:
+            parts = stdout.split("---DHCP_OPTS---")
+            resolv_section = parts[0].split("---RESOLV---")[-1].strip()
+
+        nameservers = re.findall(r"nameserver\s+([\d.]+)", resolv_section)
+
+        if nameservers:
+            self.report_subtest(
+                "dhcp_options_correct",
+                True,
+                f"DNS servers: {', '.join(nameservers)}",
+            )
+        else:
+            self.report_subtest(
+                "dhcp_options_correct",
+                False,
+                "No nameserver entries found in /etc/resolv.conf",
+            )
+
+
+class VpcIpConfigCheck(BaseValidation):
+    """Validate VPC-level IP configuration is sensible.
+
+    Checks that:
+    1. DHCP options set is configured with DNS servers
+    2. Subnet CIDRs are valid, non-overlapping, and within VPC range
+    3. At least one subnet has auto-assign public IP enabled
+
+    Config:
+        step_output: VPC creation output with dhcp_options, subnets, cidr
+        min_ips_per_subnet: Minimum IPs per subnet (default: 16)
+
+    Step output:
+        cidr: VPC CIDR block (e.g. "10.0.0.0/16")
+        subnets: list of subnet dicts with cidr, auto_assign_public_ip, available_ips
+        dhcp_options: dict with domain_name_servers, domain_name, etc.
+    """
+
+    description: ClassVar[str] = "Check VPC IP configuration"
+    markers: ClassVar[list[str]] = ["network"]
+
+    def run(self) -> None:
+        step_output = self.config.get("step_output", {})
+
+        if not step_output:
+            self.set_failed("No step_output provided")
+            return
+
+        self._check_dhcp_options_configured(step_output)
+        self._check_subnet_cidr_valid(step_output)
+        self._check_auto_assign_ip(step_output)
+
+        failed = get_failed_subtests(self._subtest_results)
+        if failed:
+            self.set_failed(f"VPC IP config subtests failed: {', '.join(failed)}")
+        else:
+            self.set_passed("VPC IP configuration is valid")
+
+    def _check_dhcp_options_configured(self, step_output: dict) -> None:
+        """Verify DHCP options set is configured with DNS."""
+        dhcp_options = step_output.get("dhcp_options")
+        if not dhcp_options:
+            self.report_subtest(
+                "dhcp_options_configured",
+                False,
+                "No 'dhcp_options' in step output",
+            )
+            return
+
+        dns_servers = dhcp_options.get("domain_name_servers", [])
+        if not dns_servers:
+            self.report_subtest(
+                "dhcp_options_configured",
+                False,
+                "No domain_name_servers in DHCP options",
+            )
+            return
+
+        domain = dhcp_options.get("domain_name", "N/A")
+        self.report_subtest(
+            "dhcp_options_configured",
+            True,
+            f"DNS: {dns_servers}, domain: {domain}",
+        )
+
+    def _check_subnet_cidr_valid(self, step_output: dict) -> None:
+        """Validate subnet CIDRs are within VPC range and non-overlapping."""
+        vpc_cidr_str = step_output.get("cidr")
+        subnets = step_output.get("subnets", [])
+
+        if not vpc_cidr_str:
+            self.report_subtest(
+                "subnet_cidr_valid",
+                False,
+                "No 'cidr' in step output",
+            )
+            return
+
+        if not subnets:
+            self.report_subtest(
+                "subnet_cidr_valid",
+                False,
+                "No 'subnets' in step output",
+            )
+            return
+
+        try:
+            vpc_net = ipaddress.ip_network(vpc_cidr_str, strict=False)
+        except ValueError as e:
+            self.report_subtest(
+                "subnet_cidr_valid",
+                False,
+                f"Invalid VPC CIDR: {e}",
+            )
+            return
+
+        min_ips = self.config.get("min_ips_per_subnet", 16)
+        subnet_nets: list[ipaddress.IPv4Network] = []
+        errors: list[str] = []
+
+        for sub in subnets:
+            cidr_str = sub.get("cidr", "")
+            try:
+                subnet_net = ipaddress.ip_network(cidr_str, strict=False)
+            except ValueError:
+                errors.append(f"Invalid subnet CIDR: {cidr_str}")
+                continue
+
+            # Check within VPC range
+            if not subnet_net.subnet_of(vpc_net):
+                errors.append(f"{cidr_str} not within VPC {vpc_cidr_str}")
+
+            # Check overlap with previously seen subnets
+            for existing in subnet_nets:
+                if subnet_net.overlaps(existing):
+                    errors.append(f"{cidr_str} overlaps {existing}")
+
+            # Check IP capacity
+            available = sub.get("available_ips", subnet_net.num_addresses - 5)
+            if available < min_ips:
+                errors.append(f"{cidr_str} has only {available} IPs (min: {min_ips})")
+
+            subnet_nets.append(subnet_net)
+
+        if errors:
+            self.report_subtest(
+                "subnet_cidr_valid",
+                False,
+                "; ".join(errors),
+            )
+        else:
+            self.report_subtest(
+                "subnet_cidr_valid",
+                True,
+                f"{len(subnet_nets)} subnets valid within {vpc_cidr_str}",
+            )
+
+    def _check_auto_assign_ip(self, step_output: dict) -> None:
+        """Check that at least one subnet has auto-assign public IP enabled."""
+        subnets = step_output.get("subnets", [])
+
+        if not subnets:
+            self.report_subtest(
+                "auto_assign_ip_enabled",
+                False,
+                "No subnets in step output",
+            )
+            return
+
+        auto_assign_subnets = [
+            s.get("subnet_id", s.get("cidr", "unknown")) for s in subnets if s.get("auto_assign_public_ip")
+        ]
+
+        if auto_assign_subnets:
+            self.report_subtest(
+                "auto_assign_ip_enabled",
+                True,
+                f"{len(auto_assign_subnets)} subnet(s) with auto-assign IP",
+            )
+        else:
+            self.report_subtest(
+                "auto_assign_ip_enabled",
+                False,
+                "No subnets have auto_assign_public_ip enabled",
+            )

--- a/isvtest/src/isvtest/validations/network.py
+++ b/isvtest/src/isvtest/validations/network.py
@@ -584,7 +584,7 @@ class VpcIpConfigCheck(BaseValidation):
             return
 
         min_ips = self.config.get("min_ips_per_subnet", 16)
-        subnet_nets: list[ipaddress.IPv4Network] = []
+        subnet_nets: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
         errors: list[str] = []
 
         for sub in subnets:
@@ -595,14 +595,26 @@ class VpcIpConfigCheck(BaseValidation):
                 errors.append(f"Invalid subnet CIDR: {cidr_str}")
                 continue
 
-            # Check within VPC range
-            if not subnet_net.subnet_of(vpc_net):
-                errors.append(f"{cidr_str} not within VPC {vpc_cidr_str}")
+            # Check within VPC range (subnet_of requires matching IPv4/IPv6)
+            if isinstance(subnet_net, ipaddress.IPv4Network) and isinstance(vpc_net, ipaddress.IPv4Network):
+                if not subnet_net.subnet_of(vpc_net):
+                    errors.append(f"{cidr_str} not within VPC {vpc_cidr_str}")
+            elif isinstance(subnet_net, ipaddress.IPv6Network) and isinstance(vpc_net, ipaddress.IPv6Network):
+                if not subnet_net.subnet_of(vpc_net):
+                    errors.append(f"{cidr_str} not within VPC {vpc_cidr_str}")
+            else:
+                errors.append(
+                    f"{cidr_str} address family does not match VPC {vpc_cidr_str}",
+                )
 
-            # Check overlap with previously seen subnets
+            # Check overlap with previously seen subnets (same address family only)
             for existing in subnet_nets:
-                if subnet_net.overlaps(existing):
-                    errors.append(f"{cidr_str} overlaps {existing}")
+                if isinstance(subnet_net, ipaddress.IPv4Network) and isinstance(existing, ipaddress.IPv4Network):
+                    if subnet_net.overlaps(existing):
+                        errors.append(f"{cidr_str} overlaps {existing}")
+                elif isinstance(subnet_net, ipaddress.IPv6Network) and isinstance(existing, ipaddress.IPv6Network):
+                    if subnet_net.overlaps(existing):
+                        errors.append(f"{cidr_str} overlaps {existing}")
 
             # Check IP capacity
             available = sub.get("available_ips", subnet_net.num_addresses - 5)

--- a/isvtest/tests/test_network.py
+++ b/isvtest/tests/test_network.py
@@ -1,0 +1,414 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Tests for network DDI validations (DHCP/IP management)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from isvtest.validations.network import DhcpIpManagementCheck, VpcIpConfigCheck
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_ssh_run(
+    responses: dict[str, tuple[int, str, str]],
+) -> Any:
+    """Create a mock run_ssh_command that returns canned responses by substring match."""
+
+    def _run(ssh: MagicMock, command: str) -> tuple[int, str, str]:
+        for pattern, response in responses.items():
+            if pattern in command:
+                return response
+        return (1, "", "unknown command")
+
+    return _run
+
+
+def _dhcp_config(extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build a minimal DHCP validation config with SSH details."""
+    cfg: dict[str, Any] = {
+        "step_output": {
+            "public_ip": "3.1.2.3",
+            "private_ip": "10.0.1.5",
+            "key_file": "/tmp/test.pem",
+            "ssh_user": "ubuntu",
+        },
+    }
+    if extra:
+        cfg.update(extra)
+    return cfg
+
+
+def _vpc_config(extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build a minimal VPC IP config validation config."""
+    cfg: dict[str, Any] = {
+        "step_output": {
+            "network_id": "vpc-abc123",
+            "cidr": "10.0.0.0/16",
+            "subnets": [
+                {
+                    "subnet_id": "subnet-aaa",
+                    "cidr": "10.0.1.0/24",
+                    "az": "us-west-2a",
+                    "auto_assign_public_ip": True,
+                    "available_ips": 251,
+                },
+                {
+                    "subnet_id": "subnet-bbb",
+                    "cidr": "10.0.2.0/24",
+                    "az": "us-west-2b",
+                    "auto_assign_public_ip": False,
+                    "available_ips": 251,
+                },
+            ],
+            "dhcp_options": {
+                "dhcp_options_id": "dopt-xxx",
+                "domain_name": "ec2.internal",
+                "domain_name_servers": ["AmazonProvidedDNS"],
+                "ntp_servers": [],
+            },
+        },
+    }
+    if extra:
+        cfg["step_output"].update(extra)
+    return cfg
+
+
+# Mock SSH command outputs
+DHCP_PROC_AND_LEASE = (
+    "---DHCP_PROC---\n"
+    "1234 dhclient -4 -v -pf /run/dhclient.eth0.pid eth0\n"
+    "---DHCP_LEASE---\n"
+    "lease {\n"
+    '  interface "eth0";\n'
+    "  fixed-address 10.0.1.5;\n"
+    "  option domain-name-servers 10.0.0.2;\n"
+    '  option domain-name "ec2.internal";\n'
+    "}"
+)
+
+DHCP_LEASE_ONLY = (
+    "---DHCP_PROC---\n"
+    "NO_DHCP_PROCESS\n"
+    "---DHCP_LEASE---\n"
+    "[DHCP]\n"
+    "ADDRESS=10.0.1.5/24\n"
+    "DNS=10.0.0.2\n"
+    "DOMAINNAME=ec2.internal\n"
+)
+
+DHCP_NONE = "---DHCP_PROC---\nNO_DHCP_PROCESS\n---DHCP_LEASE---\nNO_LEASE_FILES"
+
+IP_ADDR_MATCH = "10.0.1.5\n"
+
+IP_ADDR_MISMATCH = "10.0.2.99\n"
+
+RESOLV_WITH_DNS = (
+    "---RESOLV---\n"
+    "nameserver 10.0.0.2\n"
+    "search ec2.internal\n"
+    "---DHCP_OPTS---\n"
+    "option domain-name-servers 10.0.0.2;\n"
+    "DONE"
+)
+
+RESOLV_NO_DNS = "---RESOLV---\nNO_RESOLV_CONF\n---DHCP_OPTS---\nDONE"
+
+
+# ---------------------------------------------------------------------------
+# TestDhcpIpManagementCheck
+# ---------------------------------------------------------------------------
+
+
+class TestDhcpIpManagementCheck:
+    """Tests for DhcpIpManagementCheck validation."""
+
+    @patch("isvtest.validations.network.get_ssh_client")
+    @patch("isvtest.validations.network.run_ssh_command")
+    def test_all_pass(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """All 3 subtests pass with valid DHCP configuration."""
+        mock_ssh.return_value = MagicMock()
+        mock_run.side_effect = _mock_ssh_run(
+            {
+                "pgrep": (0, DHCP_PROC_AND_LEASE, ""),
+                "ip -4 addr": (0, IP_ADDR_MATCH, ""),
+                "resolv.conf": (0, RESOLV_WITH_DNS, ""),
+            }
+        )
+
+        v = DhcpIpManagementCheck(config=_dhcp_config())
+        result = v.execute()
+        assert result["passed"] is True
+        assert "DHCP/IP management verified" in result["output"]
+
+    @patch("isvtest.validations.network.get_ssh_client")
+    @patch("isvtest.validations.network.run_ssh_command")
+    def test_dhcp_lease_not_found(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Fail when no DHCP process or lease files found."""
+        mock_ssh.return_value = MagicMock()
+        mock_run.side_effect = _mock_ssh_run(
+            {
+                "pgrep": (0, DHCP_NONE, ""),
+                "ip -4 addr": (0, IP_ADDR_MATCH, ""),
+                "resolv.conf": (0, RESOLV_WITH_DNS, ""),
+            }
+        )
+
+        v = DhcpIpManagementCheck(config=_dhcp_config())
+        result = v.execute()
+        assert result["passed"] is False
+        assert "dhcp_lease_active" in result["error"]
+
+    @patch("isvtest.validations.network.get_ssh_client")
+    @patch("isvtest.validations.network.run_ssh_command")
+    def test_dhcp_lease_only_no_process(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Pass when DHCP lease exists but no process (systemd-networkd)."""
+        mock_ssh.return_value = MagicMock()
+        mock_run.side_effect = _mock_ssh_run(
+            {
+                "pgrep": (0, DHCP_LEASE_ONLY, ""),
+                "ip -4 addr": (0, IP_ADDR_MATCH, ""),
+                "resolv.conf": (0, RESOLV_WITH_DNS, ""),
+            }
+        )
+
+        v = DhcpIpManagementCheck(config=_dhcp_config())
+        result = v.execute()
+        assert result["passed"] is True
+
+    @patch("isvtest.validations.network.get_ssh_client")
+    @patch("isvtest.validations.network.run_ssh_command")
+    def test_ip_mismatch(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Fail when actual IP doesn't match platform-reported IP."""
+        mock_ssh.return_value = MagicMock()
+        mock_run.side_effect = _mock_ssh_run(
+            {
+                "pgrep": (0, DHCP_PROC_AND_LEASE, ""),
+                "ip -4 addr": (0, IP_ADDR_MISMATCH, ""),
+                "resolv.conf": (0, RESOLV_WITH_DNS, ""),
+            }
+        )
+
+        v = DhcpIpManagementCheck(config=_dhcp_config())
+        result = v.execute()
+        assert result["passed"] is False
+        assert "ip_matches_platform" in result["error"]
+
+    @patch("isvtest.validations.network.get_ssh_client")
+    @patch("isvtest.validations.network.run_ssh_command")
+    def test_ip_check_skipped_no_private_ip(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """ip_matches_platform is skipped when no private_ip in step_output."""
+        mock_ssh.return_value = MagicMock()
+        mock_run.side_effect = _mock_ssh_run(
+            {
+                "pgrep": (0, DHCP_PROC_AND_LEASE, ""),
+                "ip -4 addr": (0, IP_ADDR_MATCH, ""),
+                "resolv.conf": (0, RESOLV_WITH_DNS, ""),
+            }
+        )
+
+        cfg = _dhcp_config()
+        del cfg["step_output"]["private_ip"]
+        v = DhcpIpManagementCheck(config=cfg)
+        result = v.execute()
+        assert result["passed"] is True
+
+    def test_missing_ssh_host(self) -> None:
+        """Fail when no SSH host is configured."""
+        v = DhcpIpManagementCheck(config={"step_output": {}})
+        result = v.execute()
+        assert result["passed"] is False
+        assert "No SSH host" in result["error"]
+
+    def test_missing_ssh_key(self) -> None:
+        """Fail when SSH key path is missing."""
+        cfg = _dhcp_config()
+        del cfg["step_output"]["key_file"]
+        v = DhcpIpManagementCheck(config=cfg)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "No SSH key" in result["error"]
+
+    @patch("isvtest.validations.network.get_ssh_client")
+    def test_ssh_connection_failure(self, mock_ssh: MagicMock) -> None:
+        """Fail when SSH connection raises exception."""
+        mock_ssh.side_effect = Exception("Connection refused")
+
+        v = DhcpIpManagementCheck(config=_dhcp_config())
+        result = v.execute()
+        assert result["passed"] is False
+        assert "SSH connection failed" in result["error"]
+
+    @patch("isvtest.validations.network.get_ssh_client")
+    @patch("isvtest.validations.network.run_ssh_command")
+    def test_dns_not_configured(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Fail when resolv.conf has no nameserver entries."""
+        mock_ssh.return_value = MagicMock()
+        mock_run.side_effect = _mock_ssh_run(
+            {
+                "pgrep": (0, DHCP_PROC_AND_LEASE, ""),
+                "ip -4 addr": (0, IP_ADDR_MATCH, ""),
+                "resolv.conf": (0, RESOLV_NO_DNS, ""),
+            }
+        )
+
+        v = DhcpIpManagementCheck(config=_dhcp_config())
+        result = v.execute()
+        assert result["passed"] is False
+        assert "dhcp_options_correct" in result["error"]
+
+    @patch("isvtest.validations.network.get_ssh_client")
+    @patch("isvtest.validations.network.run_ssh_command")
+    def test_systemd_networkd_lease(self, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Pass with systemd-networkd style lease format."""
+        mock_ssh.return_value = MagicMock()
+        mock_run.side_effect = _mock_ssh_run(
+            {
+                "pgrep": (0, DHCP_LEASE_ONLY, ""),
+                "ip -4 addr": (0, IP_ADDR_MATCH, ""),
+                "resolv.conf": (0, RESOLV_WITH_DNS, ""),
+            }
+        )
+
+        v = DhcpIpManagementCheck(config=_dhcp_config())
+        result = v.execute()
+        assert result["passed"] is True
+        # Verify subtests include lease info
+        subtests = result.get("subtests", [])
+        lease_subtest = next((s for s in subtests if s["name"] == "dhcp_lease_active"), None)
+        assert lease_subtest is not None
+        assert lease_subtest["passed"] is True
+        assert "lease file found" in lease_subtest["message"]
+
+
+# ---------------------------------------------------------------------------
+# TestVpcIpConfigCheck
+# ---------------------------------------------------------------------------
+
+
+class TestVpcIpConfigCheck:
+    """Tests for VpcIpConfigCheck validation."""
+
+    def test_all_pass(self) -> None:
+        """All subtests pass with valid VPC config."""
+        v = VpcIpConfigCheck(config=_vpc_config())
+        result = v.execute()
+        assert result["passed"] is True
+        assert "VPC IP configuration is valid" in result["output"]
+
+    def test_missing_dhcp_options(self) -> None:
+        """Fail when no dhcp_options in step_output."""
+        cfg = _vpc_config()
+        del cfg["step_output"]["dhcp_options"]
+        v = VpcIpConfigCheck(config=cfg)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "dhcp_options_configured" in result["error"]
+
+    def test_no_dns_servers(self) -> None:
+        """Fail when dhcp_options has empty DNS servers."""
+        cfg = _vpc_config({"dhcp_options": {"domain_name_servers": []}})
+        v = VpcIpConfigCheck(config=cfg)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "dhcp_options_configured" in result["error"]
+
+    def test_overlapping_subnet_cidrs(self) -> None:
+        """Fail when subnets have overlapping CIDRs."""
+        cfg = _vpc_config(
+            {
+                "subnets": [
+                    {
+                        "subnet_id": "subnet-a",
+                        "cidr": "10.0.1.0/24",
+                        "auto_assign_public_ip": True,
+                        "available_ips": 251,
+                    },
+                    {
+                        "subnet_id": "subnet-b",
+                        "cidr": "10.0.1.0/25",
+                        "auto_assign_public_ip": True,
+                        "available_ips": 123,
+                    },
+                ],
+            }
+        )
+        v = VpcIpConfigCheck(config=cfg)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "subnet_cidr_valid" in result["error"]
+
+    def test_subnet_outside_vpc_cidr(self) -> None:
+        """Fail when subnet is not within VPC CIDR range."""
+        cfg = _vpc_config(
+            {
+                "subnets": [
+                    {
+                        "subnet_id": "subnet-a",
+                        "cidr": "192.168.1.0/24",
+                        "auto_assign_public_ip": True,
+                        "available_ips": 251,
+                    },
+                ],
+            }
+        )
+        v = VpcIpConfigCheck(config=cfg)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "subnet_cidr_valid" in result["error"]
+
+    def test_insufficient_ips(self) -> None:
+        """Fail when subnet has fewer IPs than minimum."""
+        cfg = _vpc_config(
+            {
+                "subnets": [
+                    {
+                        "subnet_id": "subnet-a",
+                        "cidr": "10.0.1.0/29",
+                        "auto_assign_public_ip": True,
+                        "available_ips": 3,
+                    },
+                ],
+            }
+        )
+        v = VpcIpConfigCheck(config=cfg)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "subnet_cidr_valid" in result["error"]
+
+    def test_no_auto_assign(self) -> None:
+        """Fail when no subnet has auto-assign public IP enabled."""
+        cfg = _vpc_config(
+            {
+                "subnets": [
+                    {
+                        "subnet_id": "subnet-a",
+                        "cidr": "10.0.1.0/24",
+                        "auto_assign_public_ip": False,
+                        "available_ips": 251,
+                    },
+                    {
+                        "subnet_id": "subnet-b",
+                        "cidr": "10.0.2.0/24",
+                        "auto_assign_public_ip": False,
+                        "available_ips": 251,
+                    },
+                ],
+            }
+        )
+        v = VpcIpConfigCheck(config=cfg)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "auto_assign_ip_enabled" in result["error"]


### PR DESCRIPTION
Closes #131
Closes #132

## Summary

- Add `DhcpIpManagementCheck` validation — SSH into an EC2 instance and verifies DHCP lease is active, instance IP matches platform-reported IP, and DNS options are configured (3 subtests)
- Add `VpcIpConfigCheck` validation — checks VPC DHCP options, subnet CIDR validity/overlap, and auto-assign public IP settings from step output (3 subtests)
- Add AWS reference stubs (`dhcp_ip_test.py`, `vpc_ip_config_test.py`) and provider-agnostic templates
- Update `create_vpc.py` to output `dhcp_options`, `auto_assign_public_ip`, and `available_ips`
- Register `vpc_ip_config` and `dhcp_ip` output schemas
- Harden teardown: destroy by default (opt-out via `AWS_NETWORK_SKIP_TEARDOWN`), clean up instances/key pairs/PEM files, randomized key names for parallel safety
- Fix `create_key_pair()` to handle stale read-only PEM files

## Test plan

- [x] New unit tests covering both validation classes (success, failure, edge cases)
- [x] Full AWS integration test: all 8 network tests + 6 subtests pass
- [x] Teardown verified clean: 0 leaked VPCs, instances, key pairs, or PEM files
- [x] All unit tests pass (`make test`), linting clean (`make lint`)
