### PR TITLE
feat: add VM serial console access validation

### DIFF
--- a/isvctl/configs/providers/aws/vm.yaml
+++ b/isvctl/configs/providers/aws/vm.yaml
@@ -113,6 +113,17 @@ commands:
           - "{{steps.launch_instance.public_ip}}"
         timeout: 600
 
+      # AWS-specific: Serial console output (boto3)
+      - name: serial_console
+        phase: test
+        command: "python3 ../../stubs/aws/vm/serial_console.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 60
+
       # Shared: Deploy NIM container via SSH (paramiko)
       # Uses post-reboot IP/key since reboot may reassign the public IP
       - name: deploy_nim

--- a/isvctl/configs/stubs/aws/vm/serial_console.py
+++ b/isvctl/configs/stubs/aws/vm/serial_console.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Retrieve serial console output from an AWS EC2 instance (read-only).
+
+Checks that serial console access is enabled for the account/region,
+then retrieves the console output for the given instance.
+
+Usage:
+    python serial_console.py --instance-id i-xxx --region us-west-2
+
+Output JSON:
+{
+    "success": true,
+    "platform": "vm",
+    "instance_id": "i-xxx",
+    "console_available": true,
+    "serial_access_enabled": true,
+    "output_length": 4096,
+    "output_snippet": "... last 500 chars of console output ..."
+}
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+def check_serial_access(ec2: Any) -> dict[str, Any]:
+    """Check if EC2 serial console access is enabled for the account."""
+    result: dict[str, Any] = {"enabled": False}
+    try:
+        response = ec2.get_serial_console_access_status()
+        result["enabled"] = response.get("SerialConsoleAccessEnabled", False)
+    except ClientError as e:
+        result["error"] = str(e)
+    return result
+
+
+def get_console_output(ec2: Any, instance_id: str, retries: int = 3) -> dict[str, Any]:
+    """Retrieve the serial console output for an instance.
+
+    Nitro-based instances may return empty output; retries with the
+    ``Latest=True`` flag to fetch the most recent available output.
+    """
+    result: dict[str, Any] = {"available": False}
+    try:
+        for attempt in range(retries):
+            response = ec2.get_console_output(InstanceId=instance_id, Latest=True)
+            output = response.get("Output", "")
+
+            if output:
+                result["available"] = True
+                result["output_length"] = len(output)
+                result["output_snippet"] = output[-500:] if len(output) > 500 else output
+                result["timestamp"] = str(response.get("Timestamp", ""))
+                return result
+
+            if attempt < retries - 1:
+                time.sleep(10)
+
+        result["output_length"] = 0
+        result["message"] = "Console output empty (common on Nitro instances)"
+    except ClientError as e:
+        result["error"] = str(e)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Get EC2 serial console output")
+    parser.add_argument("--instance-id", required=True, help="EC2 instance ID")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    args = parser.parse_args()
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "vm",
+        "instance_id": args.instance_id,
+        "console_available": False,
+        "serial_access_enabled": False,
+    }
+
+    try:
+        # Check account-level serial console access
+        access = check_serial_access(ec2)
+        result["serial_access_enabled"] = access.get("enabled", False)
+        if access.get("error"):
+            result["serial_access_error"] = access["error"]
+
+        # Get console output (works even if serial console SSH is disabled)
+        console = get_console_output(ec2, args.instance_id)
+        result["console_available"] = console.get("available", False)
+        result["output_length"] = console.get("output_length", 0)
+
+        if console.get("output_snippet"):
+            result["output_snippet"] = console["output_snippet"]
+        if console.get("timestamp"):
+            result["timestamp"] = console["timestamp"]
+        if console.get("error"):
+            result["error"] = console["error"]
+
+        # Success if console output is available OR serial access is enabled.
+        # Nitro instances often return empty console output but the serial
+        # console feature is still accessible via EC2 Instance Connect.
+        result["success"] = result["console_available"] or result["serial_access_enabled"]
+
+    except Exception as e:
+        result["error"] = str(e)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/vm/serial_console.py
+++ b/isvctl/configs/stubs/vm/serial_console.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Serial console access test - TEMPLATE (replace with your platform implementation).
+
+This script retrieves serial console output from a running instance.
+Read-only access is sufficient; interactive access is preferred but not required.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "vm",
+    "instance_id": "<id>",
+    "console_available": true,
+    "serial_access_enabled": true,
+    "output_length": 4096,
+    "output_snippet": "... last 500 chars ..."
+  }
+
+Usage:
+    python serial_console.py --instance-id <id> --region us-west-2
+
+Reference implementation: ../aws/vm/serial_console.py
+"""
+
+import argparse
+import json
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Serial console access test (template)")
+    parser.add_argument("--instance-id", required=True, help="Instance ID")
+    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    args = parser.parse_args()
+
+    result: dict = {
+        "success": False,
+        "platform": "vm",
+        "instance_id": args.instance_id,
+        "console_available": False,
+        "serial_access_enabled": False,
+    }
+
+    # TODO: Replace with your platform's serial console implementation
+    result["error"] = "Not implemented - replace with your platform's serial console logic"
+    print(json.dumps(result, indent=2))
+
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/tests/vm.yaml
+++ b/isvctl/configs/tests/vm.yaml
@@ -199,6 +199,7 @@ commands:
         command: "python3 ../stubs/vm/serial_console.py"
         args:
           - "--instance-id"
+          # instance_id is stable across reboots; no need to use post-reboot step output
           - "{{steps.launch_instance.instance_id}}"
           - "--region"
           - "{{region}}"

--- a/isvctl/configs/tests/vm.yaml
+++ b/isvctl/configs/tests/vm.yaml
@@ -184,7 +184,27 @@ commands:
           - "{{steps.launch_instance.public_ip}}"
         timeout: 600
 
-      # ─── Step 7: Deploy NIM Container ─────────────────────────────
+      # ─── Step 7: Serial Console Access ──────────────────────────────
+      # YOUR SCRIPT must output JSON with at minimum:
+      #   {
+      #     "success": true,
+      #     "platform": "vm",
+      #     "instance_id": "<id>",
+      #     "console_available": true,
+      #     "serial_access_enabled": true,
+      #     "output_length": 4096
+      #   }
+      - name: serial_console
+        phase: test
+        command: "python3 ../stubs/vm/serial_console.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 60
+
+      # ─── Step 8: Deploy NIM Container ─────────────────────────────
       # Uses post-reboot IP/key since reboot may reassign the public IP.
       # See stubs/common/deploy_nim.py for the JSON contract.
       - name: deploy_nim
@@ -197,7 +217,7 @@ commands:
           - "{{steps.reboot_instance.key_file}}"
         timeout: 1800
 
-      # ─── Step 8: Teardown NIM ─────────────────────────────────────
+      # ─── Step 9: Teardown NIM ─────────────────────────────────────
       # Uses post-reboot IP/key to match what deploy_nim used.
       - name: teardown_nim
         phase: teardown
@@ -209,7 +229,7 @@ commands:
           - "{{steps.reboot_instance.key_file}}"
         timeout: 120
 
-      # ─── Step 9: Teardown Instance ────────────────────────────────
+      # ─── Step 10: Teardown Instance ───────────────────────────────
       # YOUR SCRIPT must output JSON with at minimum:
       #   {
       #     "success": true,
@@ -342,6 +362,11 @@ tests:
         SshPciBusCheck:
           expected_gpus: 1
         SshHostSoftwareCheck: {}
+
+    serial_console:
+      step: serial_console
+      checks:
+        SerialConsoleCheck: {}
 
     nim_health:
       step: deploy_nim

--- a/isvtest/src/isvtest/validations/instance.py
+++ b/isvtest/src/isvtest/validations/instance.py
@@ -331,6 +331,10 @@ class SerialConsoleCheck(BaseValidation):
             details.append(f"{output_length} chars of output")
         else:
             details.append("no output (Nitro instance)")
+            self.log.warning(
+                f"Serial access enabled but no console output for {instance_id} "
+                f"— expected on Nitro instances, but verify if this is not a Nitro instance"
+            )
 
         self.set_passed(f"Serial console available for {instance_id} ({', '.join(details)})")
 

--- a/isvtest/src/isvtest/validations/instance.py
+++ b/isvtest/src/isvtest/validations/instance.py
@@ -286,6 +286,55 @@ class InstanceTagCheck(BaseValidation):
         self.set_passed(f"Instance {instance_id} has {tag_count} tag(s): {list(tags.keys())}")
 
 
+class SerialConsoleCheck(BaseValidation):
+    """Validate serial console access for an instance (read-only).
+
+    Passes if serial console access is enabled at the account level OR
+    console output was successfully retrieved. Nitro-based instances
+    often return empty console output but still support serial console
+    access via EC2 Instance Connect.
+
+    Config:
+        step_output: The serial_console step output
+
+    Step output:
+        instance_id: Instance identifier
+        console_available: Whether console output was retrieved
+        serial_access_enabled: Whether serial console access is enabled at account level
+        output_length: Length of console output in characters
+    """
+
+    description: ClassVar[str] = "Check serial console access"
+    markers: ClassVar[list[str]] = ["vm"]
+
+    def run(self) -> None:
+        step_output = self.config.get("step_output", {})
+
+        instance_id = step_output.get("instance_id")
+        if not instance_id:
+            self.set_failed("No 'instance_id' in step output")
+            return
+
+        console_available = step_output.get("console_available", False)
+        serial_access = step_output.get("serial_access_enabled", False)
+        output_length = step_output.get("output_length", 0)
+
+        if not console_available and not serial_access:
+            error = step_output.get("error", "no console output and serial access not enabled")
+            self.set_failed(f"Serial console not accessible for {instance_id}: {error}")
+            return
+
+        details = []
+        if serial_access:
+            details.append("serial access enabled")
+        if console_available:
+            details.append(f"{output_length} chars of output")
+        else:
+            details.append("no output (Nitro instance)")
+
+        self.set_passed(f"Serial console available for {instance_id} ({', '.join(details)})")
+
+
 class InstanceListCheck(BaseValidation):
     """Validate instance list from a VPC.
 


### PR DESCRIPTION
Closes #114

## Summary

- Add `SerialConsoleCheck` validation for read-only serial console access on VMs
- AWS stub calls `get_serial_console_access_status()` (account-level feature check) and `get_console_output(Latest=True)` with retries for Nitro instances
- Passes if serial access is enabled at account level OR console output is retrieved (Nitro instances may return empty output but still support serial console via EC2 Instance Connect)
- Provider-agnostic template stub for other platforms
- Wired into `vm.yaml` as step 7 between reboot and NIM deploy

## Test plan

- [x] `make test` — all unit tests pass
- [x] `make lint` — clean
- [x] Full AWS integration: `uv run isvctl test run -f isvctl/configs/providers/aws/vm.yaml -- -v -s`
  - SerialConsoleCheck: PASSED — Serial console available for i-09aae3d0b4dd15ace (65535 chars of output)
  - All existing VM validations still pass
  - Clean teardown


Made with [Cursor](https://cursor.com)