### PR TITLE
feat: add CRUD custom OS image validation

### DIFF
--- a/isvctl/configs/providers/aws/image-registry.yaml
+++ b/isvctl/configs/providers/aws/image-registry.yaml
@@ -19,9 +19,10 @@
 #
 # Steps:
 #   1. upload_image - boto3: Downloads VMDK, uploads to S3, imports as AMI (setup)
-#   2. launch_instance - boto3: Creates GPU instance from imported image (test)
-#   3. crud_install_config - boto3: EC2 Launch Template lifecycle (test)
-#   4. teardown - boto3: Cleans up all resources (teardown)
+#   2. crud_image - boto3: Get, list, copy, delete AMI lifecycle (test)
+#   3. launch_instance - boto3: Creates GPU instance from imported image (test)
+#   4. crud_install_config - boto3: EC2 Launch Template lifecycle (test)
+#   5. teardown - boto3: Cleans up all resources (teardown)
 #
 # Usage:
 #   uv run isvctl test run -f isvctl/configs/providers/aws/image-registry.yaml
@@ -62,7 +63,18 @@ commands:
           - "{{region}}"
         timeout: 3600
 
-      # Step 2: Launch GPU instance from imported image
+      # Step 2: CRUD image operations (get, list, copy, delete)
+      - name: crud_image
+        phase: test
+        command: "python3 ../../stubs/aws/image-registry/crud_image.py"
+        args:
+          - "--image-id"
+          - "{{steps.upload_image.image_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 600
+
+      # Step 3: Launch GPU instance from imported image
       - name: launch_instance
         phase: test
         command: "python3 ../../stubs/aws/image-registry/launch_instance.py"
@@ -75,7 +87,7 @@ commands:
           - "{{region}}"
         timeout: 600
 
-      # Step 3: CRUD OS install config (EC2 Launch Template lifecycle)
+      # Step 4: CRUD OS install config (EC2 Launch Template lifecycle)
       - name: crud_install_config
         phase: test
         command: "python3 ../../stubs/aws/image-registry/crud_install_config.py"
@@ -84,7 +96,7 @@ commands:
           - "{{region}}"
         timeout: 120
 
-      # Step 4: Cleanup all resources
+      # Step 5: Cleanup all resources
       - name: teardown
         phase: teardown
         command: "python3 ../../stubs/aws/image-registry/teardown.py"

--- a/isvctl/configs/stubs/aws/image-registry/crud_image.py
+++ b/isvctl/configs/stubs/aws/image-registry/crud_image.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""CRUD custom OS images using EC2 AMIs.
+
+Self-contained test: given an existing image_id (from the upload_image step),
+performs get, list, create (copy), and delete operations.
+
+Usage:
+    python crud_image.py --image-id ami-xxx --region us-west-2
+
+Output JSON:
+{
+    "success": true,
+    "platform": "image_registry",
+    "image_id": "ami-xxx",
+    "operations": {
+        "get":    {"passed": true, "image_name": "...", "state": "available"},
+        "list":   {"passed": true, "image_count": 2},
+        "create": {"passed": true, "image_id": "ami-copy-xxx"},
+        "delete": {"passed": true}
+    }
+}
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Any
+
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+
+import boto3
+from botocore.exceptions import ClientError
+from common.errors import handle_aws_errors
+
+
+def test_get(ec2: Any, image_id: str) -> dict[str, Any]:
+    """Describe a single image by ID."""
+    result: dict[str, Any] = {"passed": False}
+    try:
+        response = ec2.describe_images(ImageIds=[image_id])
+        images = response.get("Images", [])
+        if not images:
+            result["error"] = f"Image {image_id} not found"
+            return result
+
+        image = images[0]
+        result["image_name"] = image.get("Name", "")
+        result["state"] = image.get("State", "")
+        result["architecture"] = image.get("Architecture", "")
+        result["image_type"] = image.get("ImageType", "")
+        result["passed"] = True
+        result["message"] = f"Described image {image_id}: state={image.get('State')}"
+    except ClientError as e:
+        result["error"] = str(e)
+    return result
+
+
+def test_list(ec2: Any, image_id: str) -> dict[str, Any]:
+    """List images owned by self and verify the target image appears."""
+    result: dict[str, Any] = {"passed": False}
+    try:
+        response = ec2.describe_images(Owners=["self"])
+        images = response.get("Images", [])
+        image_ids = [img["ImageId"] for img in images]
+
+        result["image_count"] = len(images)
+
+        if image_id not in image_ids:
+            result["error"] = f"Image {image_id} not found in owned images list ({len(images)} images)"
+            return result
+
+        result["passed"] = True
+        result["message"] = f"Found {image_id} in {len(images)} owned image(s)"
+    except ClientError as e:
+        result["error"] = str(e)
+    return result
+
+
+def test_create(ec2: Any, image_id: str, region: str) -> dict[str, Any]:
+    """Create a new image by copying an existing one."""
+    result: dict[str, Any] = {"passed": False}
+    copy_name = f"isvtest-copy-{image_id}"
+    try:
+        response = ec2.copy_image(
+            Name=copy_name,
+            SourceImageId=image_id,
+            SourceRegion=region,
+            Description="ISV validation test - image copy",
+        )
+        copy_id = response["ImageId"]
+        result["image_id"] = copy_id
+        result["image_name"] = copy_name
+
+        # Wait for copy to become available
+        print(f"Waiting for copied image {copy_id} to become available...", file=sys.stderr)
+        max_wait = 300
+        start = time.time()
+        while time.time() - start < max_wait:
+            desc = ec2.describe_images(ImageIds=[copy_id])
+            state = desc["Images"][0]["State"] if desc["Images"] else "unknown"
+            if state == "available":
+                result["passed"] = True
+                result["message"] = f"Copied image {copy_id} is available"
+                return result
+            if state == "failed":
+                result["error"] = f"Copied image {copy_id} entered failed state"
+                return result
+            time.sleep(10)
+
+        result["error"] = f"Copied image {copy_id} did not become available within {max_wait}s"
+    except ClientError as e:
+        result["error"] = str(e)
+    return result
+
+
+def test_delete(ec2: Any, image_id: str) -> dict[str, Any]:
+    """Delete (deregister) an image and its backing snapshots."""
+    result: dict[str, Any] = {"passed": False}
+    try:
+        # Get snapshot IDs before deregistering
+        desc = ec2.describe_images(ImageIds=[image_id])
+        snapshot_ids = []
+        if desc["Images"]:
+            for bdm in desc["Images"][0].get("BlockDeviceMappings", []):
+                snap_id = bdm.get("Ebs", {}).get("SnapshotId")
+                if snap_id:
+                    snapshot_ids.append(snap_id)
+
+        ec2.deregister_image(ImageId=image_id)
+
+        # Delete backing snapshots
+        for snap_id in snapshot_ids:
+            try:
+                ec2.delete_snapshot(SnapshotId=snap_id)
+            except ClientError:
+                pass  # Best-effort snapshot cleanup
+
+        result["passed"] = True
+        result["message"] = f"Deregistered {image_id}, deleted {len(snapshot_ids)} snapshot(s)"
+    except ClientError as e:
+        result["error"] = str(e)
+    return result
+
+
+@handle_aws_errors
+def main() -> int:
+    parser = argparse.ArgumentParser(description="CRUD custom OS images (AMI)")
+    parser.add_argument("--image-id", required=True, help="Source image ID from upload_image step")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    args = parser.parse_args()
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "image_registry",
+        "image_id": args.image_id,
+        "operations": {
+            "get": {"passed": False},
+            "list": {"passed": False},
+            "create": {"passed": False},
+            "delete": {"passed": False},
+        },
+    }
+
+    copy_id = ""
+
+    try:
+        # GET
+        get_result = test_get(ec2, args.image_id)
+        result["operations"]["get"] = get_result
+        if not get_result["passed"]:
+            raise RuntimeError(f"Get failed: {get_result.get('error')}")
+
+        # LIST
+        list_result = test_list(ec2, args.image_id)
+        result["operations"]["list"] = list_result
+        if not list_result["passed"]:
+            raise RuntimeError(f"List failed: {list_result.get('error')}")
+
+        # CREATE (copy)
+        create_result = test_create(ec2, args.image_id, args.region)
+        result["operations"]["create"] = create_result
+        if not create_result["passed"]:
+            raise RuntimeError(f"Create failed: {create_result.get('error')}")
+        copy_id = create_result["image_id"]
+
+        # DELETE (the copy, not the original)
+        delete_result = test_delete(ec2, copy_id)
+        result["operations"]["delete"] = delete_result
+        if not delete_result["passed"]:
+            raise RuntimeError(f"Delete failed: {delete_result.get('error')}")
+
+        result["success"] = True
+
+    except RuntimeError as e:
+        result["error"] = str(e)
+        # Cleanup on partial failure
+        if copy_id:
+            try:
+                ec2.deregister_image(ImageId=copy_id)
+            except ClientError:
+                pass
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/image-registry/crud_image.py
+++ b/isvctl/configs/stubs/image-registry/crud_image.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""CRUD custom OS images - TEMPLATE (replace with your platform implementation).
+
+This script validates get, list, create, and delete operations on OS images.
+Given an existing image_id (from the upload_image step), it should:
+
+  1. GET    - Retrieve image details by ID
+  2. LIST   - List images and verify the target appears
+  3. CREATE - Create a new image (e.g., copy/clone the source)
+  4. DELETE - Delete the created copy
+
+Required JSON output:
+{
+    "success": true,
+    "platform": "image_registry",
+    "image_id": "<source-image-id>",
+    "operations": {
+        "get":    {"passed": true, "image_name": "...", "state": "available"},
+        "list":   {"passed": true, "image_count": 2},
+        "create": {"passed": true, "image_id": "<copy-image-id>"},
+        "delete": {"passed": true}
+    }
+}
+
+Usage:
+    python crud_image.py --image-id <id> --region us-west-2
+
+Reference implementation: ../aws/image-registry/crud_image.py
+"""
+
+import argparse
+import json
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="CRUD custom OS images (template)")
+    parser.add_argument("--image-id", required=True, help="Source image ID from upload_image step")
+    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    args = parser.parse_args()
+
+    result: dict = {
+        "success": False,
+        "platform": "image_registry",
+        "image_id": args.image_id,
+        "operations": {
+            "get": {"passed": False},
+            "list": {"passed": False},
+            "create": {"passed": False},
+            "delete": {"passed": False},
+        },
+    }
+
+    # TODO: Replace with your platform's image CRUD implementation
+    result["error"] = "Not implemented - replace with your platform's image CRUD logic"
+    print(json.dumps(result, indent=2))
+
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/tests/image-registry.yaml
+++ b/isvctl/configs/tests/image-registry.yaml
@@ -25,11 +25,12 @@
 #
 # Steps:
 #   1. upload_image           (setup)    - Upload OS image to registry
-#   2. launch_instance        (test)     - Launch VM from imported image
-#   3. create_install_config  (test)     - CRUD an OS install configuration
-#   4. install_image_bm       (test)     - Install OS image on bare-metal
-#   5. install_config_bm      (test)     - Install OS config on bare-metal
-#   6. teardown               (teardown) - Clean up all resources
+#   2. crud_image             (test)     - CRUD operations on the uploaded image
+#   3. launch_instance        (test)     - Launch VM from imported image
+#   4. create_install_config  (test)     - CRUD an OS install configuration
+#   5. install_image_bm       (test)     - Install OS image on bare-metal
+#   6. install_config_bm      (test)     - Install OS config on bare-metal
+#   7. teardown               (teardown) - Clean up all resources
 #
 # Note: In the AWS reference implementation, the BM install/verify steps
 #   (install_image_bm, install_config_bm) are in ../aws/bm.yaml instead of
@@ -72,7 +73,30 @@ commands:
           - "{{region}}"
         timeout: 3600
 
-      # ─── Step 2: Launch Instance from Image ────────────────────────
+      # ─── Step 2: CRUD Image ───────────────────────────────────────
+      # YOUR SCRIPT must get, list, create (copy), and delete an image.
+      #   {
+      #     "success": true,
+      #     "platform": "image_registry",
+      #     "image_id": "<source-image-id>",
+      #     "operations": {
+      #       "get":    {"passed": true, "image_name": "...", "state": "available"},
+      #       "list":   {"passed": true, "image_count": 2},
+      #       "create": {"passed": true, "image_id": "<copy-image-id>"},
+      #       "delete": {"passed": true}
+      #     }
+      #   }
+      - name: crud_image
+        phase: test
+        command: "python3 ../stubs/image-registry/crud_image.py"
+        args:
+          - "--image-id"
+          - "{{steps.upload_image.image_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 600
+
+      # ─── Step 3: Launch Instance from Image ────────────────────────
       # YOUR SCRIPT must output JSON with at minimum:
       #   {
       #     "success": true,
@@ -97,7 +121,7 @@ commands:
           - "{{region}}"
         timeout: 600
 
-      # ─── Step 3: CRUD OS Install Configuration ────────────────────
+      # ─── Step 4: CRUD OS Install Configuration ────────────────────
       # YOUR SCRIPT must create, read, update, and delete an OS
       # install configuration (e.g., iPXE config, Carbide profile).
       #   {
@@ -120,7 +144,7 @@ commands:
           - "{{region}}"
         timeout: 300
 
-      # ─── Step 4: Install OS Image on Bare-Metal ──────────────────
+      # ─── Step 5: Install OS Image on Bare-Metal ──────────────────
       # YOUR SCRIPT must provision a BM node from the uploaded OS image.
       #   {
       #     "success": true,
@@ -139,7 +163,7 @@ commands:
           - "{{region}}"
         timeout: 1800
 
-      # ─── Step 5: Install OS Config on Bare-Metal ─────────────────
+      # ─── Step 6: Install OS Config on Bare-Metal ─────────────────
       # YOUR SCRIPT must provision a BM node using an install config.
       #   {
       #     "success": true,
@@ -158,7 +182,7 @@ commands:
           - "{{region}}"
         timeout: 1800
 
-      # ─── Step 6: Teardown ──────────────────────────────────────────
+      # ─── Step 7: Teardown ──────────────────────────────────────────
       # YOUR SCRIPT must clean up all resources: instances, images,
       # configs, storage, keys, security groups.
       - name: teardown
@@ -206,6 +230,16 @@ tests:
         StepSuccessCheck: {}
         FieldExistsCheck:
           fields: ["image_id", "storage_bucket", "disk_ids"]
+
+    # --- Image CRUD ---
+    image_crud:
+      step: crud_image
+      checks:
+        StepSuccessCheck: {}
+        FieldExistsCheck:
+          fields: ["image_id", "operations"]
+        CrudOperationsCheck:
+          operations: ["get", "list", "create", "delete"]
 
     # --- VM Launch from Image ---
     vm_from_image:

--- a/isvtest/src/isvtest/validations/generic.py
+++ b/isvtest/src/isvtest/validations/generic.py
@@ -221,3 +221,45 @@ class StepSuccessCheck(BaseValidation):
             self.set_failed(f"Step failed: {error}" if error else "Step failed")
         else:
             self.set_failed("No 'success' or 'status' in step output")
+
+
+class CrudOperationsCheck(BaseValidation):
+    """Validate that all CRUD operations in a step output passed.
+
+    Checks the ``operations`` dict in step output and verifies each
+    expected operation has ``passed: true``.
+
+    Config:
+        step_output: The step output containing an ``operations`` dict
+        operations: List of operation names to check (e.g. ["get", "list", "create", "delete"])
+    """
+
+    description: ClassVar[str] = "Check all CRUD operations passed"
+    markers: ClassVar[list[str]] = []
+
+    def run(self) -> None:
+        step_output = self.config.get("step_output", {})
+        expected_ops = self.config.get("operations", [])
+
+        ops = step_output.get("operations")
+        if not isinstance(ops, dict):
+            self.set_failed("No 'operations' dict in step output")
+            return
+
+        if not expected_ops:
+            expected_ops = list(ops.keys())
+
+        failed = []
+        passed = []
+        for op_name in expected_ops:
+            op = ops.get(op_name, {})
+            if op.get("passed"):
+                passed.append(op_name)
+            else:
+                error = op.get("error", "not passed")
+                failed.append(f"{op_name}: {error}")
+
+        if failed:
+            self.set_failed(f"CRUD operations failed: {'; '.join(failed)}")
+        else:
+            self.set_passed(f"All CRUD operations passed: {', '.join(passed)}")


### PR DESCRIPTION
## Summary

Closes #104

- Add `crud_image` step to image registry test suite — validates get, list, create (copy), and delete operations on OS images
- AWS stub uses `describe_images`, `copy_image`, and `deregister_image` with wait-for-available and snapshot cleanup
- Add reusable `CrudOperationsCheck` validation in `generic.py` — checks all operations in an `operations` dict passed (works for both image CRUD and install config CRUD)
- Provider-agnostic template stub for other platforms
- Wired into canonical `image-registry.yaml` as step 2 (between upload and launch) and AWS provider config

## Test plan

- [x] `make test` — all unit tests pass
- [x] `make lint` — clean
- [x] Full AWS integration: `uv run isvctl test run -f isvctl/configs/providers/aws/image-registry.yaml -- -v -s`
  - image_crud CrudOperationsCheck: PASSED — All CRUD operations passed: get, list, create, delete
  - All existing image registry validations still pass (upload, VM launch, SSH, install config CRUD)
  - BM steps correctly auto-skipped (not in AWS provider config)
  - Clean teardown


🤖 Generated with [Claude Code](https://claude.com/claude-code)