### PR TITLE
feat: add BMaaS topology, serial console, and cloud-init validation

### DIFF
--- a/isvctl/configs/providers/aws/bare_metal.yaml
+++ b/isvctl/configs/providers/aws/bare_metal.yaml
@@ -17,18 +17,20 @@
 # Steps:
 #   1. launch_instance - boto3: Provisions bare-metal EC2, outputs IP/key (setup)
 #   2. list_instances - boto3: Lists instances in VPC, verifies target exists (test)
-#   3. verify_image - boto3: Verifies OS image installed on BM instance (test)
-#   4. verify_config - boto3: Verifies install config can provision BM (test)
-#   5. stop_instance - boto3: Powers off BM node, verifies stopped state (test)
-#   6. start_instance - boto3: Powers on BM node, verifies recovery (test)
-#   7. describe_instance - boto3: Describes post-start state, passes SSH info (test)
+#   3. topology_placement - boto3: Validates placement group support (test)
+#   4. serial_console - boto3: Retrieves serial console output (test)
+#   5. verify_image - boto3: Verifies OS image installed on BM instance (test)
+#   6. verify_config - boto3: Verifies install config can provision BM (test)
+#   7. stop_instance - boto3: Powers off BM node, verifies stopped state (test)
+#   8. start_instance - boto3: Powers on BM node, verifies recovery (test)
+#   9. describe_instance - boto3: Describes post-start state, passes SSH info (test)
 #                          (runs after start so IP is current)
-#   8. reboot_instance - boto3: Reboots instance, validates recovery (test)
-#   9. reinstall_instance - boto3: Reinstalls OS from stock AMI (test) [skip: true]
-#  10. deploy_nim - paramiko: Deploys NIM container via SSH (test)
-#  11. teardown_nim - paramiko: Stops NIM container via SSH (teardown)
-#  12. teardown - boto3: Terminates bare-metal EC2 (teardown)
-#  13. verify_teardown - boto3: Confirms instance terminated (teardown)
+#  10. reboot_instance - boto3: Reboots instance, validates recovery (test)
+#  11. reinstall_instance - boto3: Reinstalls OS from stock AMI (test) [skip: true]
+#  12. deploy_nim - paramiko: Deploys NIM container via SSH (test)
+#  13. teardown_nim - paramiko: Stops NIM container via SSH (teardown)
+#  14. teardown - boto3: Terminates bare-metal EC2 (teardown)
+#  15. verify_teardown - boto3: Confirms instance terminated (teardown)
 #
 # Dev workflow (reuse existing instance):
 #   # Run 1: launch + test, keep instance alive
@@ -82,6 +84,28 @@ commands:
           - "{{region}}"
         timeout: 120
 
+      # Topology-based placement validation (boto3)
+      - name: topology_placement
+        phase: test
+        command: "python3 ../../stubs/aws/bare_metal/topology_placement.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 120
+
+      # Serial console output (boto3)
+      - name: serial_console
+        phase: test
+        command: "python3 ../../stubs/aws/bare_metal/serial_console.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 60
+
       # Verify OS image installed on BM instance
       - name: verify_image
         phase: test
@@ -130,7 +154,7 @@ commands:
           - "{{steps.launch_instance.key_file}}"
           - "--public-ip"
           - "{{steps.launch_instance.public_ip}}"
-        timeout: 1800
+        timeout: 2700
 
       # Describe post-start instance state - SSH/GPU validation anchor
       # Runs after start_instance so the IP is current (stop/start may reassign it)

--- a/isvctl/configs/stubs/aws/bare_metal/serial_console.py
+++ b/isvctl/configs/stubs/aws/bare_metal/serial_console.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Retrieve serial console output from an AWS bare-metal EC2 instance (read-only).
+
+Checks that serial console access is enabled for the account/region,
+then retrieves the console output for the given instance.
+
+Usage:
+    python serial_console.py --instance-id i-xxx --region us-west-2
+
+Output JSON:
+{
+    "success": true,
+    "platform": "bm",
+    "instance_id": "i-xxx",
+    "console_available": true,
+    "serial_access_enabled": true,
+    "output_length": 4096,
+    "output_snippet": "... last 500 chars of console output ..."
+}
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Any
+
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+
+import boto3
+from botocore.exceptions import ClientError
+from common.errors import handle_aws_errors
+
+
+def check_serial_access(ec2: Any) -> dict[str, Any]:
+    """Check if EC2 serial console access is enabled for the account."""
+    result: dict[str, Any] = {"enabled": False}
+    try:
+        response = ec2.get_serial_console_access_status()
+        result["enabled"] = response.get("SerialConsoleAccessEnabled", False)
+    except ClientError as e:
+        result["error"] = str(e)
+    return result
+
+
+def get_console_output(ec2: Any, instance_id: str, retries: int = 3) -> dict[str, Any]:
+    """Retrieve the serial console output for an instance.
+
+    Bare-metal instances typically return console output from POST/BIOS
+    and OS boot. Retries handle cases where output is not yet available.
+    """
+    result: dict[str, Any] = {"available": False}
+    try:
+        for attempt in range(retries):
+            response = ec2.get_console_output(InstanceId=instance_id, Latest=True)
+            output = response.get("Output", "")
+
+            if output:
+                result["available"] = True
+                result["output_length"] = len(output)
+                result["output_snippet"] = output[-500:] if len(output) > 500 else output
+                result["timestamp"] = str(response.get("Timestamp", ""))
+                return result
+
+            if attempt < retries - 1:
+                time.sleep(10)
+
+        result["output_length"] = 0
+        result["message"] = "Console output empty after retries"
+    except ClientError as e:
+        result["error"] = str(e)
+    return result
+
+
+@handle_aws_errors
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Get EC2 bare-metal serial console output")
+    parser.add_argument("--instance-id", required=True, help="EC2 instance ID")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    args = parser.parse_args()
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "bm",
+        "instance_id": args.instance_id,
+        "console_available": False,
+        "serial_access_enabled": False,
+    }
+
+    try:
+        access = check_serial_access(ec2)
+        result["serial_access_enabled"] = access.get("enabled", False)
+        if access.get("error"):
+            result["serial_access_error"] = access["error"]
+
+        console = get_console_output(ec2, args.instance_id)
+        result["console_available"] = console.get("available", False)
+        result["output_length"] = console.get("output_length", 0)
+
+        if console.get("output_snippet"):
+            result["output_snippet"] = console["output_snippet"]
+        if console.get("timestamp"):
+            result["timestamp"] = console["timestamp"]
+        if console.get("error"):
+            result["error"] = console["error"]
+
+        result["success"] = result["console_available"] or result["serial_access_enabled"]
+
+    except Exception as e:
+        result["error"] = str(e)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/aws/bare_metal/serial_console.py
+++ b/isvctl/configs/stubs/aws/bare_metal/serial_console.py
@@ -34,9 +34,10 @@ import json
 import os
 import sys
 import time
+from pathlib import Path
 from typing import Any
 
-sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import boto3
 from botocore.exceptions import ClientError

--- a/isvctl/configs/stubs/aws/bare_metal/serial_console.py
+++ b/isvctl/configs/stubs/aws/bare_metal/serial_console.py
@@ -11,77 +11,20 @@
 
 """Retrieve serial console output from an AWS bare-metal EC2 instance (read-only).
 
-Checks that serial console access is enabled for the account/region,
-then retrieves the console output for the given instance.
-
 Usage:
     python serial_console.py --instance-id i-xxx --region us-west-2
-
-Output JSON:
-{
-    "success": true,
-    "platform": "bm",
-    "instance_id": "i-xxx",
-    "console_available": true,
-    "serial_access_enabled": true,
-    "output_length": 4096,
-    "output_snippet": "... last 500 chars of console output ..."
-}
 """
 
 import argparse
-import json
 import os
 import sys
-import time
 from pathlib import Path
-from typing import Any
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import boto3
-from botocore.exceptions import ClientError
 from common.errors import handle_aws_errors
-
-
-def check_serial_access(ec2: Any) -> dict[str, Any]:
-    """Check if EC2 serial console access is enabled for the account."""
-    result: dict[str, Any] = {"enabled": False}
-    try:
-        response = ec2.get_serial_console_access_status()
-        result["enabled"] = response.get("SerialConsoleAccessEnabled", False)
-    except ClientError as e:
-        result["error"] = str(e)
-    return result
-
-
-def get_console_output(ec2: Any, instance_id: str, retries: int = 3) -> dict[str, Any]:
-    """Retrieve the serial console output for an instance.
-
-    Bare-metal instances typically return console output from POST/BIOS
-    and OS boot. Retries handle cases where output is not yet available.
-    """
-    result: dict[str, Any] = {"available": False}
-    try:
-        for attempt in range(retries):
-            response = ec2.get_console_output(InstanceId=instance_id, Latest=True)
-            output = response.get("Output", "")
-
-            if output:
-                result["available"] = True
-                result["output_length"] = len(output)
-                result["output_snippet"] = output[-500:] if len(output) > 500 else output
-                result["timestamp"] = str(response.get("Timestamp", ""))
-                return result
-
-            if attempt < retries - 1:
-                time.sleep(10)
-
-        result["output_length"] = 0
-        result["message"] = "Console output empty after retries"
-    except ClientError as e:
-        result["error"] = str(e)
-    return result
+from common.serial_console import run_serial_console_check
 
 
 @handle_aws_errors
@@ -92,39 +35,8 @@ def main() -> int:
     args = parser.parse_args()
 
     ec2 = boto3.client("ec2", region_name=args.region)
-
-    result: dict[str, Any] = {
-        "success": False,
-        "platform": "bm",
-        "instance_id": args.instance_id,
-        "console_available": False,
-        "serial_access_enabled": False,
-    }
-
-    try:
-        access = check_serial_access(ec2)
-        result["serial_access_enabled"] = access.get("enabled", False)
-        if access.get("error"):
-            result["serial_access_error"] = access["error"]
-
-        console = get_console_output(ec2, args.instance_id)
-        result["console_available"] = console.get("available", False)
-        result["output_length"] = console.get("output_length", 0)
-
-        if console.get("output_snippet"):
-            result["output_snippet"] = console["output_snippet"]
-        if console.get("timestamp"):
-            result["timestamp"] = console["timestamp"]
-        if console.get("error"):
-            result["error"] = console["error"]
-
-        result["success"] = result["console_available"] or result["serial_access_enabled"]
-
-    except Exception as e:
-        result["error"] = str(e)
-
-    print(json.dumps(result, indent=2))
-    return 0 if result["success"] else 1
+    _, exit_code = run_serial_console_check(ec2, args.instance_id, platform="bm")
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/isvctl/configs/stubs/aws/bare_metal/start_instance.py
+++ b/isvctl/configs/stubs/aws/bare_metal/start_instance.py
@@ -155,7 +155,7 @@ def main() -> int:
         waiter = ec2.get_waiter("instance_status_ok")
         waiter.wait(
             InstanceIds=[args.instance_id],
-            WaiterConfig={"Delay": 30, "MaxAttempts": 60},  # up to 30 min
+            WaiterConfig={"Delay": 30, "MaxAttempts": 90},  # up to 45 min
         )
         print("  Instance status checks passed", file=sys.stderr)
 

--- a/isvctl/configs/stubs/aws/bare_metal/topology_placement.py
+++ b/isvctl/configs/stubs/aws/bare_metal/topology_placement.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Validate topology-based placement for a bare-metal EC2 instance.
+
+Verifies that the instance supports placement group membership by:
+1. Creating a cluster placement group
+2. Verifying the instance's current placement (AZ, tenancy)
+3. Describing the placement group to confirm it exists and is available
+4. Cleaning up the placement group
+
+Note: AWS bare-metal instances cannot be moved into a placement group
+after launch. This test validates that the platform supports placement
+groups and that the instance has placement metadata. For a full
+topology-aware launch test, the placement group should be specified
+at launch time.
+
+Usage:
+    python topology_placement.py --instance-id i-xxx --region us-west-2
+
+Output JSON:
+{
+    "success": true,
+    "platform": "bm",
+    "instance_id": "i-xxx",
+    "placement_supported": true,
+    "availability_zone": "us-west-2a",
+    "placement_group": "isvtest-pg-xxx",
+    "placement_strategy": "cluster",
+    "operations": {
+        "create_group":    {"passed": true},
+        "verify_instance": {"passed": true},
+        "describe_group":  {"passed": true},
+        "delete_group":    {"passed": true}
+    }
+}
+"""
+
+import argparse
+import json
+import os
+import sys
+import uuid
+from typing import Any
+
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+
+import boto3
+from botocore.exceptions import ClientError
+from common.errors import handle_aws_errors
+
+
+def test_create_group(ec2: Any, group_name: str) -> dict[str, Any]:
+    """Create a cluster placement group."""
+    result: dict[str, Any] = {"passed": False}
+    try:
+        ec2.create_placement_group(
+            GroupName=group_name,
+            Strategy="cluster",
+            TagSpecifications=[
+                {
+                    "ResourceType": "placement-group",
+                    "Tags": [
+                        {"Key": "Name", "Value": group_name},
+                        {"Key": "CreatedBy", "Value": "isvtest"},
+                    ],
+                }
+            ],
+        )
+        result["passed"] = True
+        result["message"] = f"Created placement group {group_name}"
+    except ClientError as e:
+        result["error"] = str(e)
+    return result
+
+
+def test_verify_instance(ec2: Any, instance_id: str) -> dict[str, Any]:
+    """Verify instance placement metadata (AZ, tenancy, group if any)."""
+    result: dict[str, Any] = {"passed": False}
+    try:
+        response = ec2.describe_instances(InstanceIds=[instance_id])
+        reservations = response.get("Reservations", [])
+        if not reservations or not reservations[0].get("Instances"):
+            result["error"] = f"Instance {instance_id} not found"
+            return result
+
+        instance = reservations[0]["Instances"][0]
+        placement = instance.get("Placement", {})
+
+        result["availability_zone"] = placement.get("AvailabilityZone", "")
+        result["tenancy"] = placement.get("Tenancy", "")
+        result["group_name"] = placement.get("GroupName", "")
+        result["instance_type"] = instance.get("InstanceType", "")
+        result["passed"] = bool(result["availability_zone"])
+        result["message"] = f"Instance {instance_id} in AZ {result['availability_zone']}, tenancy={result['tenancy']}"
+    except ClientError as e:
+        result["error"] = str(e)
+    return result
+
+
+def test_describe_group(ec2: Any, group_name: str) -> dict[str, Any]:
+    """Describe the placement group and verify it's available."""
+    result: dict[str, Any] = {"passed": False}
+    try:
+        response = ec2.describe_placement_groups(GroupNames=[group_name])
+        groups = response.get("PlacementGroups", [])
+        if not groups:
+            result["error"] = f"Placement group {group_name} not found"
+            return result
+
+        group = groups[0]
+        result["state"] = group.get("State", "")
+        result["strategy"] = group.get("Strategy", "")
+        result["group_id"] = group.get("GroupId", "")
+        result["passed"] = result["state"] == "available"
+        result["message"] = f"Group {group_name}: state={result['state']}, strategy={result['strategy']}"
+    except ClientError as e:
+        result["error"] = str(e)
+    return result
+
+
+def test_delete_group(ec2: Any, group_name: str) -> dict[str, Any]:
+    """Delete the placement group."""
+    result: dict[str, Any] = {"passed": False}
+    try:
+        ec2.delete_placement_group(GroupName=group_name)
+        result["passed"] = True
+        result["message"] = f"Deleted placement group {group_name}"
+    except ClientError as e:
+        result["error"] = str(e)
+    return result
+
+
+@handle_aws_errors
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate topology-based placement (BM)")
+    parser.add_argument("--instance-id", required=True, help="EC2 instance ID")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    args = parser.parse_args()
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+    group_name = f"isvtest-pg-{uuid.uuid4().hex[:8]}"
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "bm",
+        "instance_id": args.instance_id,
+        "placement_supported": False,
+        "availability_zone": "",
+        "placement_group": group_name,
+        "placement_strategy": "cluster",
+        "operations": {
+            "create_group": {"passed": False},
+            "verify_instance": {"passed": False},
+            "describe_group": {"passed": False},
+            "delete_group": {"passed": False},
+        },
+    }
+
+    try:
+        # CREATE placement group
+        create_result = test_create_group(ec2, group_name)
+        result["operations"]["create_group"] = create_result
+        if not create_result["passed"]:
+            raise RuntimeError(f"Create group failed: {create_result.get('error')}")
+
+        # VERIFY instance placement metadata
+        verify_result = test_verify_instance(ec2, args.instance_id)
+        result["operations"]["verify_instance"] = verify_result
+        result["availability_zone"] = verify_result.get("availability_zone", "")
+        if not verify_result["passed"]:
+            raise RuntimeError(f"Verify instance failed: {verify_result.get('error')}")
+
+        # DESCRIBE placement group
+        describe_result = test_describe_group(ec2, group_name)
+        result["operations"]["describe_group"] = describe_result
+        if not describe_result["passed"]:
+            raise RuntimeError(f"Describe group failed: {describe_result.get('error')}")
+
+        # DELETE placement group
+        delete_result = test_delete_group(ec2, group_name)
+        result["operations"]["delete_group"] = delete_result
+        if not delete_result["passed"]:
+            raise RuntimeError(f"Delete group failed: {delete_result.get('error')}")
+
+        result["placement_supported"] = True
+        result["success"] = True
+
+    except RuntimeError as e:
+        result["error"] = str(e)
+        # Cleanup on partial failure
+        try:
+            ec2.delete_placement_group(GroupName=group_name)
+        except ClientError:
+            pass
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/aws/bare_metal/topology_placement.py
+++ b/isvctl/configs/stubs/aws/bare_metal/topology_placement.py
@@ -49,9 +49,10 @@ import json
 import os
 import sys
 import uuid
+from pathlib import Path
 from typing import Any
 
-sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import boto3
 from botocore.exceptions import ClientError

--- a/isvctl/configs/stubs/aws/common/serial_console.py
+++ b/isvctl/configs/stubs/aws/common/serial_console.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Shared serial console utilities for EC2 instances (VM and bare-metal).
+
+Provides the core boto3 calls for checking serial console access and
+retrieving console output. Used by both vm/serial_console.py and
+bare_metal/serial_console.py.
+"""
+
+import json
+import time
+from typing import Any
+
+from botocore.exceptions import ClientError
+
+
+def check_serial_access(ec2: Any) -> dict[str, Any]:
+    """Check if EC2 serial console access is enabled for the account."""
+    result: dict[str, Any] = {"enabled": False}
+    try:
+        response = ec2.get_serial_console_access_status()
+        result["enabled"] = response.get("SerialConsoleAccessEnabled", False)
+    except ClientError as e:
+        result["error"] = str(e)
+    return result
+
+
+def get_console_output(ec2: Any, instance_id: str, retries: int = 3) -> dict[str, Any]:
+    """Retrieve the serial console output for an instance.
+
+    Retries with ``Latest=True`` to handle cases where output is not
+    yet available (common on Nitro and bare-metal instances).
+    """
+    result: dict[str, Any] = {"available": False}
+    try:
+        for attempt in range(retries):
+            response = ec2.get_console_output(InstanceId=instance_id, Latest=True)
+            output = response.get("Output", "")
+
+            if output:
+                result["available"] = True
+                result["output_length"] = len(output)
+                result["output_snippet"] = output[-500:] if len(output) > 500 else output
+                result["timestamp"] = str(response.get("Timestamp", ""))
+                return result
+
+            if attempt < retries - 1:
+                time.sleep(10)
+
+        result["output_length"] = 0
+        result["message"] = "Console output empty after retries"
+    except ClientError as e:
+        result["error"] = str(e)
+    return result
+
+
+def run_serial_console_check(ec2: Any, instance_id: str, platform: str) -> tuple[dict[str, Any], int]:
+    """Run the full serial console check and return (result_dict, exit_code).
+
+    Args:
+        ec2: boto3 EC2 client
+        instance_id: EC2 instance ID
+        platform: Platform identifier ("vm" or "bm")
+    """
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": platform,
+        "instance_id": instance_id,
+        "console_available": False,
+        "serial_access_enabled": False,
+    }
+
+    try:
+        access = check_serial_access(ec2)
+        result["serial_access_enabled"] = access.get("enabled", False)
+        if access.get("error"):
+            result["serial_access_error"] = access["error"]
+
+        console = get_console_output(ec2, instance_id)
+        result["console_available"] = console.get("available", False)
+        result["output_length"] = console.get("output_length", 0)
+
+        if console.get("output_snippet"):
+            result["output_snippet"] = console["output_snippet"]
+        if console.get("timestamp"):
+            result["timestamp"] = console["timestamp"]
+        if console.get("error"):
+            result["error"] = console["error"]
+
+        result["success"] = result["console_available"] or result["serial_access_enabled"]
+
+    except Exception as e:
+        result["error"] = str(e)
+
+    print(json.dumps(result, indent=2))
+    return result, 0 if result["success"] else 1

--- a/isvctl/configs/stubs/aws/image-registry/crud_image.py
+++ b/isvctl/configs/stubs/aws/image-registry/crud_image.py
@@ -36,9 +36,10 @@ import json
 import os
 import sys
 import time
+from pathlib import Path
 from typing import Any
 
-sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import boto3
 from botocore.exceptions import ClientError

--- a/isvctl/configs/stubs/aws/vm/serial_console.py
+++ b/isvctl/configs/stubs/aws/vm/serial_console.py
@@ -9,122 +9,34 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
-"""Retrieve serial console output from an AWS EC2 instance (read-only).
-
-Checks that serial console access is enabled for the account/region,
-then retrieves the console output for the given instance.
+"""Retrieve serial console output from an AWS EC2 VM instance (read-only).
 
 Usage:
     python serial_console.py --instance-id i-xxx --region us-west-2
-
-Output JSON:
-{
-    "success": true,
-    "platform": "vm",
-    "instance_id": "i-xxx",
-    "console_available": true,
-    "serial_access_enabled": true,
-    "output_length": 4096,
-    "output_snippet": "... last 500 chars of console output ..."
-}
 """
 
 import argparse
-import json
 import os
 import sys
-import time
-from typing import Any
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import boto3
-from botocore.exceptions import ClientError
+from common.errors import handle_aws_errors
+from common.serial_console import run_serial_console_check
 
 
-def check_serial_access(ec2: Any) -> dict[str, Any]:
-    """Check if EC2 serial console access is enabled for the account."""
-    result: dict[str, Any] = {"enabled": False}
-    try:
-        response = ec2.get_serial_console_access_status()
-        result["enabled"] = response.get("SerialConsoleAccessEnabled", False)
-    except ClientError as e:
-        result["error"] = str(e)
-    return result
-
-
-def get_console_output(ec2: Any, instance_id: str, retries: int = 3) -> dict[str, Any]:
-    """Retrieve the serial console output for an instance.
-
-    Nitro-based instances may return empty output; retries with the
-    ``Latest=True`` flag to fetch the most recent available output.
-    """
-    result: dict[str, Any] = {"available": False}
-    try:
-        for attempt in range(retries):
-            response = ec2.get_console_output(InstanceId=instance_id, Latest=True)
-            output = response.get("Output", "")
-
-            if output:
-                result["available"] = True
-                result["output_length"] = len(output)
-                result["output_snippet"] = output[-500:] if len(output) > 500 else output
-                result["timestamp"] = str(response.get("Timestamp", ""))
-                return result
-
-            if attempt < retries - 1:
-                time.sleep(10)
-
-        result["output_length"] = 0
-        result["message"] = "Console output empty (common on Nitro instances)"
-    except ClientError as e:
-        result["error"] = str(e)
-    return result
-
-
+@handle_aws_errors
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Get EC2 serial console output")
+    parser = argparse.ArgumentParser(description="Get EC2 VM serial console output")
     parser.add_argument("--instance-id", required=True, help="EC2 instance ID")
     parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
     args = parser.parse_args()
 
     ec2 = boto3.client("ec2", region_name=args.region)
-
-    result: dict[str, Any] = {
-        "success": False,
-        "platform": "vm",
-        "instance_id": args.instance_id,
-        "console_available": False,
-        "serial_access_enabled": False,
-    }
-
-    try:
-        # Check account-level serial console access
-        access = check_serial_access(ec2)
-        result["serial_access_enabled"] = access.get("enabled", False)
-        if access.get("error"):
-            result["serial_access_error"] = access["error"]
-
-        # Get console output (works even if serial console SSH is disabled)
-        console = get_console_output(ec2, args.instance_id)
-        result["console_available"] = console.get("available", False)
-        result["output_length"] = console.get("output_length", 0)
-
-        if console.get("output_snippet"):
-            result["output_snippet"] = console["output_snippet"]
-        if console.get("timestamp"):
-            result["timestamp"] = console["timestamp"]
-        if console.get("error"):
-            result["error"] = console["error"]
-
-        # Success if console output is available OR serial access is enabled.
-        # Nitro instances often return empty console output but the serial
-        # console feature is still accessible via EC2 Instance Connect.
-        result["success"] = result["console_available"] or result["serial_access_enabled"]
-
-    except Exception as e:
-        result["error"] = str(e)
-
-    print(json.dumps(result, indent=2))
-    return 0 if result["success"] else 1
+    _, exit_code = run_serial_console_check(ec2, args.instance_id, platform="vm")
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/isvctl/configs/stubs/bare_metal/serial_console.py
+++ b/isvctl/configs/stubs/bare_metal/serial_console.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Serial console access test for bare-metal - TEMPLATE.
+
+This script retrieves serial console output from a running bare-metal instance.
+Read-only access is sufficient; interactive access is preferred but not required.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "bm",
+    "instance_id": "<id>",
+    "console_available": true,
+    "serial_access_enabled": true,
+    "output_length": 4096,
+    "output_snippet": "... last 500 chars ..."
+  }
+
+Usage:
+    python serial_console.py --instance-id <id> --region us-west-2
+
+Reference implementation: ../aws/bare_metal/serial_console.py
+"""
+
+import argparse
+import json
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Serial console access test (template)")
+    parser.add_argument("--instance-id", required=True, help="Instance ID")
+    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    args = parser.parse_args()
+
+    result: dict = {
+        "success": False,
+        "platform": "bm",
+        "instance_id": args.instance_id,
+        "console_available": False,
+        "serial_access_enabled": False,
+    }
+
+    # TODO: Replace with your platform's serial console implementation
+    result["error"] = "Not implemented - replace with your platform's serial console logic"
+    print(json.dumps(result, indent=2))
+
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/bare_metal/topology_placement.py
+++ b/isvctl/configs/stubs/bare_metal/topology_placement.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Topology-based placement test for bare-metal - TEMPLATE.
+
+This script validates that the platform supports topology-aware placement
+for bare-metal instances (e.g., placement groups, rack-awareness, spine-leaf
+topology constraints).
+
+Required JSON output:
+{
+    "success": true,
+    "platform": "bm",
+    "instance_id": "<id>",
+    "placement_supported": true,
+    "availability_zone": "us-west-2a",
+    "placement_group": "<group-name>",
+    "placement_strategy": "cluster",
+    "operations": {
+        "create_group":    {"passed": true},
+        "verify_instance": {"passed": true},
+        "describe_group":  {"passed": true},
+        "delete_group":    {"passed": true}
+    }
+}
+
+Usage:
+    python topology_placement.py --instance-id <id> --region us-west-2
+
+Reference implementation: ../aws/bare_metal/topology_placement.py
+"""
+
+import argparse
+import json
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Topology-based placement test (template)")
+    parser.add_argument("--instance-id", required=True, help="Instance ID")
+    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    args = parser.parse_args()
+
+    result: dict = {
+        "success": False,
+        "platform": "bm",
+        "instance_id": args.instance_id,
+        "placement_supported": False,
+        "availability_zone": "",
+        "placement_group": "",
+        "placement_strategy": "",
+        "operations": {
+            "create_group": {"passed": False},
+            "verify_instance": {"passed": False},
+            "describe_group": {"passed": False},
+            "delete_group": {"passed": False},
+        },
+    }
+
+    # TODO: Replace with your platform's topology placement implementation
+    result["error"] = "Not implemented - replace with your platform's topology placement logic"
+    print(json.dumps(result, indent=2))
+
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/tests/bare_metal.yaml
+++ b/isvctl/configs/tests/bare_metal.yaml
@@ -25,16 +25,18 @@
 # Steps:
 #   1. launch_instance      (setup)    - Provision bare-metal GPU instance
 #   2. list_instances       (test)     - List instances, verify target exists
-#   3. stop_instance        (test)     - Power off node, verify stopped state
-#   4. start_instance       (test)     - Power on node, verify recovery
-#   5. describe_instance    (test)     - Describe post-start state + SSH info
+#   3. topology_placement   (test)     - Validate topology-based placement support
+#   4. serial_console       (test)     - Retrieve serial console output (read-only)
+#   5. stop_instance        (test)     - Power off node, verify stopped state
+#   6. start_instance       (test)     - Power on node, verify recovery
+#   7. describe_instance    (test)     - Describe post-start state + SSH info
 #                                        (runs after start so IP is current)
-#   6. reboot_instance      (test)     - Reboot instance, validate recovery
-#   7. reinstall_instance   (test)     - Reinstall OS from stock image [skip: true by default]
-#   8. deploy_nim           (test)     - Deploy NIM container via SSH
-#   9. teardown_nim         (teardown) - Stop NIM container
-#  10. teardown             (teardown) - Terminate instance
-#  11. verify_teardown      (teardown) - Confirm resources deleted
+#   8. reboot_instance      (test)     - Reboot instance, validate recovery
+#   9. reinstall_instance   (test)     - Reinstall OS from stock image [skip: true by default]
+#  10. deploy_nim           (test)     - Deploy NIM container via SSH
+#  11. teardown_nim         (teardown) - Stop NIM container
+#  12. teardown             (teardown) - Terminate instance
+#  13. verify_teardown      (teardown) - Confirm resources deleted
 #
 # Dev workflow (reuse existing instance):
 #   # Run 1: launch + test, keep instance alive
@@ -99,7 +101,54 @@ commands:
           - "{{region}}"
         timeout: 120
 
-      # ─── Step 3: Stop Instance ────────────────────────────────────
+      # ─── Step 3: Topology Placement ──────────────────────────────
+      # YOUR SCRIPT must validate topology-based placement support.
+      #   {
+      #     "success": true,
+      #     "platform": "bm",
+      #     "instance_id": "...",
+      #     "placement_supported": true,
+      #     "availability_zone": "us-west-2a",
+      #     "placement_group": "...",
+      #     "placement_strategy": "cluster",
+      #     "operations": {
+      #       "create_group":    {"passed": true},
+      #       "verify_instance": {"passed": true},
+      #       "describe_group":  {"passed": true},
+      #       "delete_group":    {"passed": true}
+      #     }
+      #   }
+      - name: topology_placement
+        phase: test
+        command: "python3 ../stubs/bare_metal/topology_placement.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 120
+
+      # ─── Step 4: Serial Console Access ──────────────────────────────
+      # YOUR SCRIPT must output JSON with at minimum:
+      #   {
+      #     "success": true,
+      #     "platform": "bm",
+      #     "instance_id": "...",
+      #     "console_available": true,
+      #     "serial_access_enabled": true,
+      #     "output_length": 4096
+      #   }
+      - name: serial_console
+        phase: test
+        command: "python3 ../stubs/bare_metal/serial_console.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 60
+
+      # ─── Step 5: Stop Instance ────────────────────────────────────
       # YOUR SCRIPT must output JSON with at minimum:
       #   {
       #     "success": true,
@@ -118,7 +167,7 @@ commands:
           - "{{region}}"
         timeout: 1800
 
-      # ─── Step 4: Start Instance ───────────────────────────────────
+      # ─── Step 6: Start Instance ───────────────────────────────────
       # YOUR SCRIPT must output JSON with at minimum:
       #   {
       #     "success": true,
@@ -142,9 +191,9 @@ commands:
           - "{{steps.launch_instance.key_file}}"
           - "--public-ip"
           - "{{steps.launch_instance.public_ip}}"
-        timeout: 1800
+        timeout: 2700
 
-      # ─── Step 5: Describe Instance ────────────────────────────────
+      # ─── Step 7: Describe Instance ────────────────────────────────
       # Runs AFTER start_instance so the IP is current (stop/start may reassign it).
       # YOUR SCRIPT must output JSON with at minimum:
       #   {
@@ -167,7 +216,7 @@ commands:
           - "{{steps.launch_instance.key_file}}"
         timeout: 120
 
-      # ─── Step 6: Reboot Instance ──────────────────────────────────
+      # ─── Step 8: Reboot Instance ──────────────────────────────────
       # BM-specific: longer waits for hardware POST/BIOS/OS boot.
       # YOUR SCRIPT must output JSON with at minimum:
       #   {
@@ -194,7 +243,7 @@ commands:
           - "{{steps.launch_instance.public_ip}}"
         timeout: 1800
 
-      # ─── Step 7: Reinstall Instance ─────────────────────────────────
+      # ─── Step 9: Reinstall Instance ─────────────────────────────────
       # Reinstall the node from its configured stock OS.
       # Skipped by default: can be very slow depending on platform.
       # Set skip: false and implement stubs/bare_metal/reinstall_instance.py to enable.
@@ -214,7 +263,7 @@ commands:
           - "{{steps.launch_instance.public_ip}}"
         timeout: 3600
 
-      # ─── Step 8: Deploy NIM Container ─────────────────────────────
+      # ─── Step 10: Deploy NIM Container ────────────────────────────
       # Uses post-reboot IP/key since reboot may reassign the public IP
       - name: deploy_nim
         phase: test
@@ -226,7 +275,7 @@ commands:
           - "{{steps.reboot_instance.key_file}}"
         timeout: 1800
 
-      # ─── Step 9: Teardown NIM ─────────────────────────────────────
+      # ─── Step 11: Teardown NIM ────────────────────────────────────
       # Uses post-reboot IP/key to match what deploy_nim used
       - name: teardown_nim
         phase: teardown
@@ -238,7 +287,7 @@ commands:
           - "{{steps.reboot_instance.key_file}}"
         timeout: 120
 
-      # ─── Step 10: Teardown Instance ───────────────────────────────
+      # ─── Step 12: Teardown Instance ───────────────────────────────
       - name: teardown
         phase: teardown
         command: "python3 ../stubs/bare_metal/teardown.py"
@@ -252,7 +301,7 @@ commands:
           - "{{teardown_flag}}"
         timeout: 1800
 
-      # ─── Step 11: Verify Teardown ─────────────────────────────────
+      # ─── Step 13: Verify Teardown ─────────────────────────────────
       # Post-teardown sanitization: verify instance terminated and
       # resources deleted.
       - name: verify_teardown
@@ -293,6 +342,22 @@ tests:
       checks:
         InstanceListCheck:
           min_count: 1
+
+    topology_placement:
+      step: topology_placement
+      checks:
+        StepSuccessCheck: {}
+        TopologyPlacementCheck: {}
+
+    serial_console:
+      step: serial_console
+      checks:
+        SerialConsoleCheck: {}
+
+    cloud_init:
+      step: launch_instance
+      checks:
+        SshCloudInitCheck: {}
 
     instance_info:
       step: describe_instance

--- a/isvtest/src/isvtest/validations/generic.py
+++ b/isvtest/src/isvtest/validations/generic.py
@@ -14,7 +14,7 @@ These validations work with any step output and provide basic field checking,
 schema validation, and common success/failure patterns.
 """
 
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from isvtest.core.validation import BaseValidation
 
@@ -223,6 +223,32 @@ class StepSuccessCheck(BaseValidation):
             self.set_failed("No 'success' or 'status' in step output")
 
 
+def check_operations_passed(ops: dict[str, Any], expected: list[str] | None = None) -> tuple[list[str], list[str]]:
+    """Check which operations in an operations dict passed or failed.
+
+    Args:
+        ops: Dict of operation name -> {"passed": bool, ...}
+        expected: List of operation names to check (defaults to all keys)
+
+    Returns:
+        Tuple of (passed_names, failed_descriptions)
+    """
+    if expected is None:
+        expected = list(ops.keys())
+
+    failed = []
+    passed = []
+    for op_name in expected:
+        op = ops.get(op_name, {})
+        if op.get("passed"):
+            passed.append(op_name)
+        else:
+            error = op.get("error", "not passed")
+            failed.append(f"{op_name}: {error}")
+
+    return passed, failed
+
+
 class CrudOperationsCheck(BaseValidation):
     """Validate that all CRUD operations in a step output passed.
 
@@ -246,18 +272,7 @@ class CrudOperationsCheck(BaseValidation):
             self.set_failed("No 'operations' dict in step output")
             return
 
-        if not expected_ops:
-            expected_ops = list(ops.keys())
-
-        failed = []
-        passed = []
-        for op_name in expected_ops:
-            op = ops.get(op_name, {})
-            if op.get("passed"):
-                passed.append(op_name)
-            else:
-                error = op.get("error", "not passed")
-                failed.append(f"{op_name}: {error}")
+        passed, failed = check_operations_passed(ops, expected_ops or None)
 
         if failed:
             self.set_failed(f"CRUD operations failed: {'; '.join(failed)}")

--- a/isvtest/src/isvtest/validations/instance.py
+++ b/isvtest/src/isvtest/validations/instance.py
@@ -305,7 +305,7 @@ class SerialConsoleCheck(BaseValidation):
     """
 
     description: ClassVar[str] = "Check serial console access"
-    markers: ClassVar[list[str]] = ["vm"]
+    markers: ClassVar[list[str]] = ["vm", "bm"]
 
     def run(self) -> None:
         step_output = self.config.get("step_output", {})
@@ -344,6 +344,7 @@ class TopologyPlacementCheck(BaseValidation):
 
     Checks that the platform supports placement groups (or equivalent
     topology-aware scheduling) and that all placement operations passed.
+    Delegates operations checking to ``CrudOperationsCheck``.
 
     Config:
         step_output: The topology_placement step output
@@ -360,6 +361,8 @@ class TopologyPlacementCheck(BaseValidation):
     markers: ClassVar[list[str]] = ["bm"]
 
     def run(self) -> None:
+        from isvtest.validations.generic import check_operations_passed
+
         step_output = self.config.get("step_output", {})
 
         instance_id = step_output.get("instance_id")
@@ -377,9 +380,9 @@ class TopologyPlacementCheck(BaseValidation):
             return
 
         ops = step_output.get("operations", {})
-        failed_ops = [name for name, op in ops.items() if not op.get("passed")]
-        if failed_ops:
-            self.set_failed(f"Placement operations failed: {', '.join(failed_ops)}")
+        _, failed = check_operations_passed(ops)
+        if failed:
+            self.set_failed(f"Placement operations failed: {', '.join(failed)}")
             return
 
         details = [f"AZ={az}", f"strategy={strategy}"]

--- a/isvtest/src/isvtest/validations/instance.py
+++ b/isvtest/src/isvtest/validations/instance.py
@@ -16,6 +16,7 @@ Validations for EC2 instances, virtual machines, and compute resources.
 from typing import ClassVar
 
 from isvtest.core.validation import BaseValidation
+from isvtest.validations.generic import check_operations_passed
 
 
 class InstanceStateCheck(BaseValidation):
@@ -361,8 +362,6 @@ class TopologyPlacementCheck(BaseValidation):
     markers: ClassVar[list[str]] = ["bm"]
 
     def run(self) -> None:
-        from isvtest.validations.generic import check_operations_passed
-
         step_output = self.config.get("step_output", {})
 
         instance_id = step_output.get("instance_id")

--- a/isvtest/src/isvtest/validations/instance.py
+++ b/isvtest/src/isvtest/validations/instance.py
@@ -339,6 +339,53 @@ class SerialConsoleCheck(BaseValidation):
         self.set_passed(f"Serial console available for {instance_id} ({', '.join(details)})")
 
 
+class TopologyPlacementCheck(BaseValidation):
+    """Validate topology-based placement support for an instance.
+
+    Checks that the platform supports placement groups (or equivalent
+    topology-aware scheduling) and that all placement operations passed.
+
+    Config:
+        step_output: The topology_placement step output
+
+    Step output:
+        placement_supported: Whether placement groups are supported
+        availability_zone: Instance availability zone
+        placement_group: Name of the test placement group
+        placement_strategy: Placement strategy (e.g., cluster)
+        operations: Dict of operation results
+    """
+
+    description: ClassVar[str] = "Check topology-based placement support"
+    markers: ClassVar[list[str]] = ["bm"]
+
+    def run(self) -> None:
+        step_output = self.config.get("step_output", {})
+
+        instance_id = step_output.get("instance_id")
+        if not instance_id:
+            self.set_failed("No 'instance_id' in step output")
+            return
+
+        placement_supported = step_output.get("placement_supported", False)
+        az = step_output.get("availability_zone", "")
+        strategy = step_output.get("placement_strategy", "")
+
+        if not placement_supported:
+            error = step_output.get("error", "placement not supported")
+            self.set_failed(f"Topology placement not supported for {instance_id}: {error}")
+            return
+
+        ops = step_output.get("operations", {})
+        failed_ops = [name for name, op in ops.items() if not op.get("passed")]
+        if failed_ops:
+            self.set_failed(f"Placement operations failed: {', '.join(failed_ops)}")
+            return
+
+        details = [f"AZ={az}", f"strategy={strategy}"]
+        self.set_passed(f"Topology placement supported for {instance_id} ({', '.join(details)})")
+
+
 class InstanceListCheck(BaseValidation):
     """Validate instance list from a VPC.
 


### PR DESCRIPTION
## Summary

Closes #105, #107, #109, #120

- **Topology-based placement (#105)**: AWS stub creates/describes/deletes a cluster placement group and verifies instance placement metadata. New `TopologyPlacementCheck` validation.
- **Cloud-init / metadata (#107)**: Wires existing `SshCloudInitCheck` into bare_metal config — validates cloud-init status and 169.254.169.254 metadata service reachability via SSH. No new stub needed.
- **Serial console (#109, #120)**: AWS stub retrieves console output via `get_console_output` and checks account-level serial access. Reuses existing `SerialConsoleCheck` validation.
- **Timeout fix**: Bump BM `start_instance` waiter from 30 → 45 min (MaxAttempts 60 → 90) to handle slow g4dn.metal cold starts.

## Test plan

- [x] `make test` — all unit tests pass
- [x] `make lint` — clean
- [x] Full AWS integration: `AWS_BM_INSTANCE_ID=i-xxx AWS_BM_KEY_FILE=... uv run isvctl test run -f isvctl/configs/providers/aws/bare_metal.yaml -- -v -s`
  - TopologyPlacementCheck: PASSED — AZ=us-west-2a, strategy=cluster
  - SerialConsoleCheck: PASSED — 65535 chars of output
  - SshCloudInitCheck: PASSED — cloud-init and metadata service OK
  - All existing BM validations pass (stop/start, reboot, GPU stress, NCCL, training, etc.)
  - Clean teardown


🤖 Generated with [Claude Code](https://claude.com/claude-code)