### PR TITLE
docs: fix broken links, add test suites README, and link-check hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,12 @@ repos:
     rev: v0.20.0
     hooks:
       - id: yamlfmt
+
+  - repo: local
+    hooks:
+      - id: check-md-links
+        name: Check markdown relative links
+        entry: python3 scripts/check_md_links.py
+        language: system
+        pass_filenames: false
+        types: [markdown]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cp -r isvctl/configs/tests/ isvctl/configs/my-isv/
 uv run isvctl test run -f isvctl/configs/my-isv/vm.yaml
 ```
 
-Templates are available for: [IAM](isvctl/configs/tests/iam.yaml) | [Network](isvctl/configs/tests/network.yaml) | [VM](isvctl/configs/tests/vm.yaml) | [Bare Metal](isvctl/configs/tests/bm.yaml) | [Kubernetes](isvctl/configs/tests/k8s.yaml) | [Control Plane](isvctl/configs/tests/control-plane.yaml) | [Image Registry](isvctl/configs/tests/image-registry.yaml)
+Templates are available for: [IAM](isvctl/configs/tests/iam.yaml) | [Network](isvctl/configs/tests/network.yaml) | [VM](isvctl/configs/tests/vm.yaml) | [Bare Metal](isvctl/configs/tests/bare_metal.yaml) | [Kubernetes](isvctl/configs/tests/k8s.yaml) | [Control Plane](isvctl/configs/tests/control-plane.yaml) | [Image Registry](isvctl/configs/tests/image-registry.yaml)
 
 See the [Templates README](isvctl/configs/tests/README.md) for the full guide, and the [AWS Reference Implementation](docs/references/aws.md) as a working example.
 

--- a/docs/guides/external-validation-guide.md
+++ b/docs/guides/external-validation-guide.md
@@ -245,15 +245,15 @@ python ./scripts/provision.py --name test 2>/dev/null | jq .
 
 ## Templates
 
-For common validation scenarios, **pre-built templates** are available in [`isvctl/configs/tests/`](../../isvctl/configs/tests/README.md). These provide a copy-and-customize starting point with skeleton scripts and documented JSON contracts.
+For common validation scenarios, **pre-built test suites** are available in [`isvctl/configs/tests/`](../../isvctl/configs/tests/README.md). These provide a copy-and-customize starting point with skeleton scripts and documented JSON contracts.
 
 | Template | What it tests | Stubs |
 |----------|---------------|-------|
 | [`iam.yaml`](../../isvctl/configs/tests/iam.yaml) | User create → verify credentials → delete | 3 scripts |
 | [`network.yaml`](../../isvctl/configs/tests/network.yaml) | VPC CRUD, subnets, isolation, security, connectivity, traffic | 8 scripts |
 | [`vm.yaml`](../../isvctl/configs/tests/vm.yaml) | Launch GPU VM → list → reboot → NIM deploy → teardown | 4 scripts + 2 shared |
-| [`bm.yaml`](../../isvctl/configs/tests/bm.yaml) | Launch bare-metal → describe → reboot → NIM → teardown → verify | 5 scripts + 2 shared |
-| [`kaas.yaml`](../../isvctl/configs/tests/kaas.yaml) | Provision K8s GPU cluster → validate nodes/GPU/workloads → teardown | 2 scripts |
+| [`bare_metal.yaml`](../../isvctl/configs/tests/bare_metal.yaml) | Launch bare-metal → describe → reboot → NIM → teardown → verify | 5 scripts + 2 shared |
+| [`k8s.yaml`](../../isvctl/configs/tests/k8s.yaml) | Provision K8s GPU cluster → validate nodes/GPU/workloads → teardown | 2 scripts |
 | [`control-plane.yaml`](../../isvctl/configs/tests/control-plane.yaml) | API health, access key lifecycle, tenant lifecycle | 10 scripts |
 | [`image-registry.yaml`](../../isvctl/configs/tests/image-registry.yaml) | Image upload → VM launch → install config CRUD → BMaaS install → teardown | 6 scripts |
 
@@ -271,7 +271,7 @@ Each template has a matching **AWS reference implementation** you can study as a
 ## Related Documentation
 
 - [Configuration Guide](configuration.md) - Full config reference (steps, schemas, validations, templates)
-- [Validation Templates](../../isvctl/configs/tests/README.md) - Provider-agnostic templates with full guide
+- [Validation Test Suites](../../isvctl/configs/tests/README.md) - Provider-agnostic test suites with step-by-step details
 - [AWS Reference Implementation](../references/aws.md) - Working AWS examples for all templates
 - [isvctl Package](../packages/isvctl.md) - CLI documentation
 - [Local Development](local-development.md) - Development setup

--- a/docs/packages/isvctl.md
+++ b/docs/packages/isvctl.md
@@ -42,7 +42,7 @@ isvctl test run -f isvctl/configs/tests/k8s.yaml -- -v -s -k "NodeCount"
 ```text
 isvctl/
 ├── configs/           # Unified configuration files
-│   ├── tests/        # Test configs (k8s.yaml, slurm.yaml, bm.yaml)
+│   ├── tests/        # Test configs (k8s.yaml, slurm.yaml, bare_metal.yaml)
 │   └── providers/    # Provider configs (microk8s.yaml, aws/)
 ├── stubs/            # Inventory and lifecycle scripts
 │   ├── k8s/

--- a/docs/references/aws.md
+++ b/docs/references/aws.md
@@ -21,7 +21,7 @@ Each template has a corresponding AWS config and scripts that show exactly how t
 | **IAM** | [`providers/aws/iam.yaml`](../../isvctl/configs/providers/aws/iam.yaml) | [`stubs/aws/iam/`](../../isvctl/configs/stubs/aws/iam/) | [Guide](../../isvctl/configs/stubs/aws/iam/docs/aws-iam.md) | [`tests/iam.yaml`](../../isvctl/configs/tests/iam.yaml) |
 | **Network** | [`providers/aws/network.yaml`](../../isvctl/configs/providers/aws/network.yaml) | [`stubs/aws/network/`](../../isvctl/configs/stubs/aws/network/) | [Guide](../../isvctl/configs/stubs/aws/network/docs/aws-network.md) | [`tests/network.yaml`](../../isvctl/configs/tests/network.yaml) |
 | **VM** | [`providers/aws/vm.yaml`](../../isvctl/configs/providers/aws/vm.yaml) | [`stubs/aws/vm/`](../../isvctl/configs/stubs/aws/vm/) | [Guide](../../isvctl/configs/stubs/aws/vm/docs/aws-vm.md) | [`tests/vm.yaml`](../../isvctl/configs/tests/vm.yaml) |
-| **Bare Metal** | [`providers/aws/bm.yaml`](../../isvctl/configs/providers/aws/bm.yaml) | [`stubs/aws/bm/`](../../isvctl/configs/stubs/aws/bm/) | [Guide](../../isvctl/configs/stubs/aws/bm/docs/aws-bm.md) | [`tests/bm.yaml`](../../isvctl/configs/tests/bm.yaml) |
+| **Bare Metal** | [`providers/aws/bare_metal.yaml`](../../isvctl/configs/providers/aws/bare_metal.yaml) | [`stubs/aws/bare_metal/`](../../isvctl/configs/stubs/aws/bare_metal/) | [Guide](../../isvctl/configs/stubs/aws/bare_metal/docs/aws-bm.md) | [`tests/bare_metal.yaml`](../../isvctl/configs/tests/bare_metal.yaml) |
 | **EKS** | [`providers/aws/eks.yaml`](../../isvctl/configs/providers/aws/eks.yaml) | [`stubs/aws/eks/`](../../isvctl/configs/stubs/aws/eks/) | [Guide](../../isvctl/configs/stubs/aws/eks/docs/aws-eks.md) | [`tests/k8s.yaml`](../../isvctl/configs/tests/k8s.yaml) |
 | **Control Plane** | [`providers/aws/control-plane.yaml`](../../isvctl/configs/providers/aws/control-plane.yaml) | [`stubs/aws/control-plane/`](../../isvctl/configs/stubs/aws/control-plane/) | [Guide](../../isvctl/configs/stubs/aws/control-plane/docs/aws-control-plane.md) | [`tests/control-plane.yaml`](../../isvctl/configs/tests/control-plane.yaml) |
 | **Image Registry** | [`providers/aws/image-registry.yaml`](../../isvctl/configs/providers/aws/image-registry.yaml) | [`stubs/aws/image-registry/`](../../isvctl/configs/stubs/aws/image-registry/) | [Guide](../../isvctl/configs/stubs/aws/image-registry/docs/aws-image-registry.md) | [`tests/image-registry.yaml`](../../isvctl/configs/tests/image-registry.yaml) |
@@ -36,7 +36,7 @@ Shared AWS utilities (error handling, EC2/VPC helpers) are in [`stubs/aws/common
 uv run isvctl test run -f isvctl/configs/providers/aws/iam.yaml
 uv run isvctl test run -f isvctl/configs/providers/aws/network.yaml
 uv run isvctl test run -f isvctl/configs/providers/aws/vm.yaml
-uv run isvctl test run -f isvctl/configs/providers/aws/bm.yaml
+uv run isvctl test run -f isvctl/configs/providers/aws/bare_metal.yaml
 uv run isvctl test run -f isvctl/configs/providers/aws/eks.yaml
 uv run isvctl test run -f isvctl/configs/providers/aws/control-plane.yaml
 uv run isvctl test run -f isvctl/configs/providers/aws/image-registry.yaml
@@ -46,7 +46,7 @@ uv run isvctl test run -f isvctl/configs/providers/aws/image-registry.yaml
 
 When implementing a template for your platform:
 
-1. Open the template stub (e.g., `templates/stubs/vm/launch_instance.py`)
+1. Open the template stub (e.g., `stubs/vm/launch_instance.py`)
 2. Open the AWS equivalent side-by-side (e.g., `stubs/aws/vm/launch_instance.py`)
 3. Replace the TODO block with your platform's API calls, keeping the same JSON output fields
 4. Read the AWS domain guide (linked above) for context on what each test validates and why

--- a/isvctl/configs/stubs/aws/bare_metal/docs/aws-bm.md
+++ b/isvctl/configs/stubs/aws/bare_metal/docs/aws-bm.md
@@ -38,16 +38,16 @@ Same as VM validation. See [AWS VM Guide](../../vm/docs/aws-vm.md) for the full 
 
 ```bash
 # Run all tests (provisions g4dn.metal by default)
-uv run isvctl test run -f isvctl/configs/providers/aws/bm.yaml
+uv run isvctl test run -f isvctl/configs/providers/aws/bare_metal.yaml
 
 # Verbose output
-uv run isvctl test run -f isvctl/configs/providers/aws/bm.yaml -- -v -s
+uv run isvctl test run -f isvctl/configs/providers/aws/bare_metal.yaml -- -v -s
 
 # Run only SSH tests
-uv run isvctl test run -f isvctl/configs/providers/aws/bm.yaml -- -k "Ssh"
+uv run isvctl test run -f isvctl/configs/providers/aws/bare_metal.yaml -- -k "Ssh"
 
 # Run only reboot validations
-uv run isvctl test run -f isvctl/configs/providers/aws/bm.yaml -- -k "reboot"
+uv run isvctl test run -f isvctl/configs/providers/aws/bare_metal.yaml -- -k "reboot"
 ```
 
 ## Dev Workflow (Instance Reuse)
@@ -58,15 +58,15 @@ between runs.
 
 ```bash
 # Run 1: launch + test, keep instance alive
-AWS_BM_SKIP_TEARDOWN=true uv run isvctl test run -f isvctl/configs/providers/aws/bm.yaml -- -v -s
+AWS_BM_SKIP_TEARDOWN=true uv run isvctl test run -f isvctl/configs/providers/aws/bare_metal.yaml -- -v -s
 
 # Run 2+: reuse existing instance (get instance ID from run 1 output)
 AWS_BM_INSTANCE_ID=i-xxx AWS_BM_KEY_FILE=/tmp/isv-bm-test-key.pem \
-  AWS_BM_SKIP_TEARDOWN=true uv run isvctl test run -f isvctl/configs/providers/aws/bm.yaml -- -v -s
+  AWS_BM_SKIP_TEARDOWN=true uv run isvctl test run -f isvctl/configs/providers/aws/bare_metal.yaml -- -v -s
 
 # Final: teardown (unset skip flag)
 AWS_BM_INSTANCE_ID=i-xxx AWS_BM_KEY_FILE=/tmp/isv-bm-test-key.pem \
-  uv run isvctl test run -f isvctl/configs/providers/aws/bm.yaml -- -v -s
+  uv run isvctl test run -f isvctl/configs/providers/aws/bare_metal.yaml -- -v -s
 ```
 
 ## Settings
@@ -135,5 +135,5 @@ aws ec2 delete-key-pair --key-name isv-bm-test-key
 - [AWS Image Registry Validation Guide](../../image-registry/docs/aws-image-registry.md) - Image import tests
 - [AWS EKS Validation Guide](../../eks/docs/aws-eks.md) - Kubernetes cluster tests
 - [AWS Network Validation Guide](../../network/docs/aws-network.md) - VPC and network tests
-- [Configuration Guide](../../../../../docs/guides/configuration.md) - Config file options
-- [isvctl Documentation](../../../../../docs/packages/isvctl.md) - CLI reference
+- [Configuration Guide](../../../../../../docs/guides/configuration.md) - Config file options
+- [isvctl Documentation](../../../../../../docs/packages/isvctl.md) - CLI reference

--- a/isvctl/configs/stubs/aws/control-plane/docs/aws-control-plane.md
+++ b/isvctl/configs/stubs/aws/control-plane/docs/aws-control-plane.md
@@ -328,5 +328,5 @@ Access key operations may take 5-20 seconds to propagate. The scripts include re
 
 ## Related Documentation
 
-- [Configuration Guide](../../../../../docs/guides/configuration.md) - Step-based configuration reference
-- [Output Schemas](../../../../../isvctl/src/isvctl/config/output_schemas.py) - JSON schema definitions
+- [Configuration Guide](../../../../../../docs/guides/configuration.md) - Step-based configuration reference
+- [Output Schemas](../../../../../../isvctl/src/isvctl/config/output_schemas.py) - JSON schema definitions

--- a/isvctl/configs/stubs/aws/eks/terraform/README.md
+++ b/isvctl/configs/stubs/aws/eks/terraform/README.md
@@ -228,6 +228,6 @@ Approximate monthly costs (us-west-2, as of 2024):
 
 ## Related Documentation
 
-- [AWS Infrastructure Guide](../docs/aws-infrastructure.md)
-- [ISV NCP Validation Suite Getting Started](../../../../docs/getting-started.md)
+- [AWS EKS Validation Guide](../docs/aws-eks.md)
+- [ISV NCP Validation Suite Getting Started](../../../../../../docs/getting-started.md)
 - [NVIDIA GPU Operator Documentation](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/)

--- a/isvctl/configs/stubs/aws/image-registry/docs/aws-image-registry.md
+++ b/isvctl/configs/stubs/aws/image-registry/docs/aws-image-registry.md
@@ -494,5 +494,5 @@ qemu-img convert -f qcow2 -O raw image.qcow2 image.raw
 
 - [AWS VM Validation Guide](../../vm/docs/aws-vm.md) - EC2 GPU instance tests
 - [AWS Network Validation Guide](../../network/docs/aws-network.md) - VPC and network tests
-- [Configuration Guide](../../../../../docs/guides/configuration.md) - Config file options
-- [isvctl Documentation](../../../../../docs/packages/isvctl.md) - CLI reference
+- [Configuration Guide](../../../../../../docs/guides/configuration.md) - Config file options
+- [isvctl Documentation](../../../../../../docs/packages/isvctl.md) - CLI reference

--- a/isvctl/configs/stubs/aws/network/docs/aws-network.md
+++ b/isvctl/configs/stubs/aws/network/docs/aws-network.md
@@ -436,7 +436,7 @@ aws ec2 delete-vpc --vpc-id $VPC_ID
 ```
 
 For automated cleanup, use the suite's teardown phase which handles the full
-dependency sequence via [`teardown_vpc.py`](../teardown_vpc.py):
+dependency sequence via [`teardown.py`](../teardown.py):
 
 ```bash
 uv run isvctl test run -f isvctl/configs/providers/aws/network.yaml --phase teardown
@@ -444,6 +444,6 @@ uv run isvctl test run -f isvctl/configs/providers/aws/network.yaml --phase tear
 
 ## Related Documentation
 
-- [Configuration Guide](../../../../../docs/guides/configuration.md)
-- [isvctl Documentation](../../../../../docs/packages/isvctl.md)
+- [Configuration Guide](../../../../../../docs/guides/configuration.md)
+- [isvctl Documentation](../../../../../../docs/packages/isvctl.md)
 - [AWS EKS Validation Guide](../../eks/docs/aws-eks.md)

--- a/isvctl/configs/stubs/aws/vm/docs/aws-vm.md
+++ b/isvctl/configs/stubs/aws/vm/docs/aws-vm.md
@@ -363,5 +363,5 @@ aws ec2 delete-key-pair --key-name isv-test-key
 
 - [AWS EKS Validation Guide](../../eks/docs/aws-eks.md) - Kubernetes cluster tests
 - [AWS Network Validation Guide](../../network/docs/aws-network.md) - VPC and network tests
-- [Configuration Guide](../../../../../docs/guides/configuration.md) - Config file options
-- [isvctl Documentation](../../../../../docs/packages/isvctl.md) - CLI reference
+- [Configuration Guide](../../../../../../docs/guides/configuration.md) - Config file options
+- [isvctl Documentation](../../../../../../docs/packages/isvctl.md) - CLI reference

--- a/isvctl/configs/tests/README.md
+++ b/isvctl/configs/tests/README.md
@@ -1,0 +1,160 @@
+# Validation Test Suites
+
+Provider-agnostic test suites for ISV Lab validation. Each YAML defines **what to test**; provider configs import them and supply **how** (platform-specific scripts).
+
+For background on the step-based architecture, writing scripts, and running validations, see the [External Validation Guide](../../../docs/guides/external-validation-guide.md).
+
+## Quick Start
+
+```bash
+# 1. Copy the test suites and stubs
+cp -r isvctl/configs/tests/ isvctl/configs/my-isv/
+cp -r isvctl/configs/stubs/ isvctl/configs/my-isv/stubs/
+
+# 2. Implement the stub scripts for your platform
+#    Each stub has a TODO block showing what to implement
+
+# 3. Run
+uv run isvctl test run -f isvctl/configs/my-isv/vm.yaml
+```
+
+Or use the **import directive** (recommended for providers):
+
+```yaml
+# isvctl/configs/providers/my-isv/vm.yaml
+import: ../../tests/vm.yaml
+
+commands:
+  vm:
+    steps:
+      - name: launch_instance
+        command: "python3 ../../stubs/my-isv/vm/launch_instance.py"
+      # ... override only the commands, validations stay the same
+```
+
+## Available Test Suites
+
+| Test Suite | Domain | Stubs | AWS Reference |
+|------------|--------|-------|---------------|
+| [`iam.yaml`](iam.yaml) | User lifecycle (create → verify → delete) | [`stubs/iam/`](../stubs/iam/) (3 scripts) | [`providers/aws/iam.yaml`](../providers/aws/iam.yaml) |
+| [`network.yaml`](network.yaml) | VPC CRUD, subnets, isolation, security, connectivity, traffic, DDI, SDN | [`stubs/network/`](../stubs/network/) (15 scripts) | [`providers/aws/network.yaml`](../providers/aws/network.yaml) |
+| [`vm.yaml`](vm.yaml) | GPU VM lifecycle: launch → tags → stop/start → reboot → NIM → teardown | [`stubs/vm/`](../stubs/vm/) (8 scripts) | [`providers/aws/vm.yaml`](../providers/aws/vm.yaml) |
+| [`bare_metal.yaml`](bare_metal.yaml) | BMaaS lifecycle: launch → topology → serial → stop/start → reboot → NIM → teardown | [`stubs/bare_metal/`](../stubs/bare_metal/) (9 scripts) | [`providers/aws/bare_metal.yaml`](../providers/aws/bare_metal.yaml) |
+| [`k8s.yaml`](k8s.yaml) | Kubernetes GPU cluster: nodes, GPU operator, scheduling, workloads | [`stubs/k8s/`](../stubs/k8s/) (2 scripts) | [`providers/aws/eks.yaml`](../providers/aws/eks.yaml) |
+| [`slurm.yaml`](slurm.yaml) | Slurm HPC cluster: partitions, jobs, GPU allocation | [`stubs/slurm/`](../stubs/slurm/) (2 scripts) | — |
+| [`control-plane.yaml`](control-plane.yaml) | API health, access key lifecycle, tenant lifecycle | [`stubs/control-plane/`](../stubs/control-plane/) (10 scripts) | [`providers/aws/control-plane.yaml`](../providers/aws/control-plane.yaml) |
+| [`image-registry.yaml`](image-registry.yaml) | Image upload, CRUD, VM launch, install config, BMaaS provisioning | [`stubs/image-registry/`](../stubs/image-registry/) (7 scripts) | [`providers/aws/image-registry.yaml`](../providers/aws/image-registry.yaml) |
+
+## Test Suite Details
+
+### IAM (`iam.yaml`)
+
+| Step | Phase | Script | Key JSON Fields |
+|------|-------|--------|-----------------|
+| `create_user` | setup | `stubs/iam/create_user.py` | `username`, `user_id`, `access_key_id`, `secret_access_key` |
+| `test_credentials` | test | `stubs/iam/test_credentials.py` | `account_id`, `tests.identity.passed`, `tests.access.passed` |
+| `teardown` | teardown | `stubs/iam/delete_user.py` | `resources_deleted`, `message` |
+
+### Network (`network.yaml`)
+
+| Step | Phase | Script | What It Tests |
+|------|-------|--------|---------------|
+| `create_network` | setup | `stubs/network/create_vpc.py` | Shared VPC creation |
+| `vpc_crud` | test | `stubs/network/vpc_crud_test.py` | Create/Read/Update/Delete lifecycle |
+| `subnet_config` | test | `stubs/network/subnet_test.py` | Multi-AZ subnet distribution |
+| `vpc_isolation` | test | `stubs/network/isolation_test.py` | Security boundaries between VPCs |
+| `security_blocking` | test | `stubs/network/security_test.py` | Firewall/ACL blocking rules |
+| `connectivity_test` | test | `stubs/network/test_connectivity.py` | Instance network assignment |
+| `traffic_validation` | test | `stubs/network/traffic_test.py` | Ping allowed/blocked, internet |
+| `vpc_ip_config` | test | `stubs/network/vpc_ip_config_test.py` | DHCP options, subnet CIDRs, auto-assign IP |
+| `dhcp_ip_test` | test | `stubs/network/dhcp_ip_test.py` | DHCP lease, IP match, DNS options via SSH |
+| `byoip_test` | test | `stubs/network/byoip_test.py` | Bring-Your-Own-IP with custom CIDRs |
+| `stable_ip_test` | test | `stubs/network/stable_ip_test.py` | IP persistence across stop/start |
+| `floating_ip_test` | test | `stubs/network/floating_ip_test.py` | Atomic IP switch between instances |
+| `dns_test` | test | `stubs/network/dns_test.py` | Custom internal domain resolution |
+| `peering_test` | test | `stubs/network/peering_test.py` | Cross-VPC connectivity |
+| `teardown` | teardown | `stubs/network/teardown.py` | VPC cleanup |
+
+### VM (`vm.yaml`)
+
+| Step | Phase | Script | Key JSON Fields |
+|------|-------|--------|-----------------|
+| `launch_instance` | setup | `stubs/vm/launch_instance.py` | `instance_id`, `public_ip`, `key_file`, `vpc_id` |
+| `list_instances` | test | `stubs/vm/list_instances.py` | `instances`, `total_count` |
+| `verify_tags` | test | `stubs/vm/describe_tags.py` | `instance_id`, `tags`, `tag_count` |
+| `stop_instance` | test | `stubs/vm/stop_instance.py` | `instance_id`, `state`, `stop_initiated` |
+| `start_instance` | test | `stubs/vm/start_instance.py` | `instance_id`, `state`, `public_ip`, `ssh_ready` |
+| `reboot_instance` | test | `stubs/vm/reboot_instance.py` | `uptime_seconds`, `ssh_connectivity` |
+| `serial_console` | test | `stubs/vm/serial_console.py` | `console_available`, `serial_access_enabled` |
+| `deploy_nim` | test | `stubs/common/deploy_nim.py` | `container_id`, `health_endpoint` |
+| `teardown_nim` | teardown | `stubs/common/teardown_nim.py` | `message` |
+| `teardown` | teardown | `stubs/vm/teardown.py` | `resources_deleted`, `message` |
+
+### Bare Metal (`bare_metal.yaml`)
+
+| Step | Phase | Script | Key JSON Fields |
+|------|-------|--------|-----------------|
+| `launch_instance` | setup | `stubs/bare_metal/launch_instance.py` | `instance_id`, `public_ip`, `key_file`, `vpc_id` |
+| `list_instances` | test | `stubs/vm/list_instances.py` | Reuses VM script |
+| `topology_placement` | test | `stubs/bare_metal/topology_placement.py` | `placement_supported`, `operations` |
+| `serial_console` | test | `stubs/bare_metal/serial_console.py` | `console_available`, `serial_access_enabled` |
+| `stop_instance` | test | `stubs/bare_metal/stop_instance.py` | `instance_id`, `state`, `stop_initiated` |
+| `start_instance` | test | `stubs/bare_metal/start_instance.py` | `instance_id`, `state`, `public_ip`, `ssh_ready` |
+| `describe_instance` | test | `stubs/bare_metal/describe_instance.py` | `instance_state`, `public_ip`, `key_file` |
+| `reboot_instance` | test | `stubs/bare_metal/reboot_instance.py` | `uptime_seconds`, `ssh_connectivity` |
+| `reinstall_instance` | test | `stubs/bare_metal/reinstall_instance.py` | `instance_state` (skipped by default) |
+| `deploy_nim` | test | `stubs/common/deploy_nim.py` | Shared NIM deployment |
+| `teardown_nim` | teardown | `stubs/common/teardown_nim.py` | Shared NIM cleanup |
+| `teardown` | teardown | `stubs/bare_metal/teardown.py` | `resources_deleted`, `message` |
+| `verify_teardown` | teardown | `stubs/bare_metal/verify_terminated.py` | `checks.instance_terminated`, `checks.sg_deleted` |
+
+### Kubernetes (`k8s.yaml`)
+
+| Step | Phase | Script |
+|------|-------|--------|
+| `setup` | setup | `stubs/k8s/setup.sh` |
+| `teardown` | teardown | `stubs/k8s/teardown.sh` |
+
+Validations use `kubectl` directly: node counts, GPU operator, pod health, NCCL/NIM workloads.
+
+### Slurm (`slurm.yaml`)
+
+| Step | Phase | Script |
+|------|-------|--------|
+| `setup` | setup | `stubs/slurm/setup.sh` |
+| `teardown` | teardown | `stubs/slurm/teardown.sh` |
+
+Validations use `sinfo`/`srun` directly: partitions, GPU allocation, job scheduling.
+
+### Control Plane (`control-plane.yaml`)
+
+| Step | Phase | Script | Key JSON Fields |
+|------|-------|--------|-----------------|
+| `check_api` | setup | `stubs/control-plane/check_api.py` | `account_id`, `tests` |
+| `create_access_key` | setup | `stubs/control-plane/create_access_key.py` | `username`, `access_key_id` |
+| `create_tenant` | setup | `stubs/control-plane/create_tenant.py` | `tenant_name`, `tenant_id` |
+| `test_access_key` | test | `stubs/control-plane/test_access_key.py` | `authenticated`, `account_id` |
+| `disable_access_key` | test | `stubs/control-plane/disable_access_key.py` | `status` |
+| `verify_key_rejected` | test | `stubs/control-plane/verify_key_rejected.py` | `rejected`, `error_type` |
+| `list_tenants` | test | `stubs/control-plane/list_tenants.py` | `tenants`, `found` |
+| `get_tenant` | test | `stubs/control-plane/get_tenant.py` | `tenant_name`, `description` |
+| `delete_access_key` | teardown | `stubs/control-plane/delete_access_key.py` | `resources_deleted` |
+| `delete_tenant` | teardown | `stubs/control-plane/delete_tenant.py` | `resources_deleted` |
+
+### Image Registry (`image-registry.yaml`)
+
+| Step | Phase | Script | Key JSON Fields |
+|------|-------|--------|-----------------|
+| `upload_image` | setup | `stubs/image-registry/upload_image.py` | `image_id`, `storage_bucket`, `disk_ids` |
+| `crud_image` | test | `stubs/image-registry/crud_image.py` | `image_id`, `operations` |
+| `launch_instance` | test | `stubs/image-registry/launch_instance.py` | `instance_id`, `public_ip`, `key_path` |
+| `crud_install_config` | test | `stubs/image-registry/crud_install_config.py` | `config_id`, `config_name`, `operations` |
+| `install_image_bm` | test | `stubs/image-registry/install_image_bm.py` | `instance_id`, `image_id`, `instance_state` |
+| `install_config_bm` | test | `stubs/image-registry/install_config_bm.py` | `instance_id`, `config_id`, `instance_state` |
+| `teardown` | teardown | `stubs/image-registry/teardown.py` | `resources_deleted`, `message` |
+
+## Related Documentation
+
+- [External Validation Guide](../../../docs/guides/external-validation-guide.md) — Writing scripts, config format, running validations
+- [Configuration Guide](../../../docs/guides/configuration.md) — Full config reference (steps, schemas, templates)
+- [AWS Reference Implementation](../../../docs/references/aws.md) — Working AWS examples for all test suites

--- a/isvctl/configs/tests/image-registry.yaml
+++ b/isvctl/configs/tests/image-registry.yaml
@@ -33,7 +33,7 @@
 #   7. teardown               (teardown) - Clean up all resources
 #
 # Note: In the AWS reference implementation, the BM install/verify steps
-#   (install_image_bm, install_config_bm) are in ../aws/bm.yaml instead of
+#   (install_image_bm, install_config_bm) are in ../aws/bare_metal.yaml instead of
 #   here, as verify_image and verify_config steps within the BM lifecycle.
 #
 # Quick start (new provider):

--- a/isvtest/src/isvtest/catalog.py
+++ b/isvtest/src/isvtest/catalog.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 PLATFORM_CONFIGS: dict[str, list[str]] = {
     "KUBERNETES": ["tests/k8s.yaml"],
     "SLURM": ["tests/slurm.yaml"],
-    "BARE_METAL": ["tests/bm.yaml"],
+    "BARE_METAL": ["tests/bare_metal.yaml"],
     "CONTROL_PLANE": ["tests/control-plane.yaml"],
     "IAM": ["tests/iam.yaml"],
     "NETWORK": ["tests/network.yaml"],

--- a/scripts/check_md_links.py
+++ b/scripts/check_md_links.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Validate that relative links in markdown files point to existing targets.
+
+Checks all [text](path) links in tracked .md files, resolving relative paths
+from each file's directory.  External URLs (http/https/mailto) and anchor-only
+links (#section) are skipped.
+
+Exit codes:
+    0  All links valid
+    1  One or more broken links found
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+SKIP_PREFIXES = ("http://", "https://", "mailto:", "#")
+SKIP_DIRS = {".git", ".venv", ".terraform", "node_modules", "__pycache__"}
+
+
+def repo_root() -> Path:
+    """Return the repository root via git."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def find_markdown_files(root: Path) -> list[Path]:
+    """Find all tracked .md files, excluding generated directories."""
+    files: list[Path] = []
+    for path in sorted(root.rglob("*.md")):
+        rel = path.relative_to(root)
+        if any(part in SKIP_DIRS for part in rel.parts):
+            continue
+        if (
+            any(part.startswith(".") for part in rel.parts)
+            and rel.parts[0] != ".github"
+        ):
+            continue
+        files.append(path)
+    return files
+
+
+def check_links(root: Path, md_files: list[Path]) -> list[tuple[Path, int, str]]:
+    """Return list of (file, line_number, url) for broken relative links."""
+    broken: list[tuple[Path, int, str]] = []
+    for md in md_files:
+        for lineno, line in enumerate(
+            md.read_text(errors="replace").splitlines(), start=1
+        ):
+            for url in LINK_RE.findall(line):
+                if any(url.startswith(p) for p in SKIP_PREFIXES):
+                    continue
+                path_part = url.split("#")[0]
+                if not path_part:
+                    continue
+                target = (md.parent / path_part).resolve()
+                if not target.exists():
+                    broken.append((md.relative_to(root), lineno, url))
+    return broken
+
+
+def main() -> int:
+    root = repo_root()
+    md_files = find_markdown_files(root)
+    broken = check_links(root, md_files)
+
+    if broken:
+        print(f"Found {len(broken)} broken markdown link(s):\n")
+        for path, lineno, url in broken:
+            print(f"  {path}:{lineno}")
+            print(f"    -> {url}\n")
+        return 1
+
+    print(f"All relative links OK ({len(md_files)} files checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **Fix 21 broken relative links** across 11 markdown files caused by the `templates/` → `tests/`+`providers/`+`stubs/` restructure in #137 (`bm`→`bare_metal`, `kaas`→`k8s`, wrong `../` depth in AWS stub docs, stale script names)
- **Create `isvctl/configs/tests/README.md`** — the file was deleted in #137 but all doc links were updated to point at the new path. Restored as a lean index of test suites with per-template step tables (general content defers to the External Validation Guide to avoid duplication)
- **Fix `catalog.py`** — `PLATFORM_CONFIGS` still referenced `tests/bm.yaml` instead of `tests/bare_metal.yaml`
- **Add `scripts/check_md_links.py`** — stdlib-only checker that validates all `[text](path)` links in tracked `.md` files resolve to existing targets
- **Add `check-md-links` pre-commit hook** — runs the checker on any `.md` change; enforced in CI via existing `make pre-commit`

## Files changed (15)

| Category | Files |
|----------|-------|
| New | `isvctl/configs/tests/README.md`, `scripts/check_md_links.py` |
| Link fixes | `README.md`, `docs/guides/external-validation-guide.md`, `docs/references/aws.md`, `docs/packages/isvctl.md`, 6 AWS stub docs |
| Code fix | `isvtest/src/isvtest/catalog.py` (`bm.yaml` → `bare_metal.yaml`) |
| Config | `.pre-commit-config.yaml`, `isvctl/configs/tests/image-registry.yaml` |

## Test plan

- [x] `make test` — 203 passed, 0 warnings
- [x] `pre-commit run -a` — all hooks pass including new `check-md-links`
- [x] Link checker validates 175/175 relative links across 31 markdown files
- [x] Verified checker catches intentionally broken links (exit code 1 with file:line output)