### PR TITLE
ci: disable Trivy in Makefile and add SPDX header pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,10 @@ repos:
         language: system
         pass_filenames: false
         types: [markdown]
+
+      - id: check-spdx-headers
+        name: Check SPDX license headers
+        entry: python3 scripts/add_spdx_headers.py --check
+        language: system
+        pass_filenames: false
+        types_or: [python, shell, yaml]

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,13 @@
 PACKAGES := isvctl isvreporter isvtest
 BUMP_SCRIPT := scripts/bump-version.py
 
-# Align with .github/workflows/ci.yaml security-trivy-scan (filesystem scan). Requires Docker.
-TRIVY_IMAGE ?= aquasec/trivy:latest
+# DISABLED (2026-03-24): Trivy supply chain compromise — see GHSA-69fq-xp46-6x23.
+# Do NOT pull aquasec/trivy images from Docker Hub until Aqua Security regains control.
+# When re-enabling, pin by digest and verify against a trusted source (GitHub release, not Docker Hub).
+# TRIVY_IMAGE ?= aquasec/trivy@sha256:bcc376de8d77cfe086a917230e818dc9f8528e3c852f7b1aff648949b6258d1c  # 0.69.3 (last known-good release)
 TRUFFLEHOG_IMAGE ?= trufflesecurity/trufflehog:latest
 SECURITY_SKIP_DIRS := .git,dist,htmlcov,.pytest_cache,.ruff_cache,.venv,node_modules,vendor,.terraform
-# SARIF path written by CI dsx trivy-scan / aquasecurity/trivy-action (default filename).
-TRIVY_SARIF ?= vulnerability-scan-results.sarif
+# TRIVY_SARIF ?= vulnerability-scan-results.sarif
 
 help: ## Show this help message
 	@echo "Available targets:"
@@ -43,31 +44,20 @@ format: ## Format code with ruff on all packages
 		(cd $$pkg && uvx ruff format src/) || exit 1; \
 	done
 
-security-trivy: ## Trivy fs scan (HIGH/CRITICAL; Docker). Writes $(TRIVY_SARIF), prints per-finding summary; fails on un-ignored findings
-	@command -v docker >/dev/null 2>&1 || { echo "docker not found; install Docker to run local security scans"; exit 1; }
-	docker run --rm -v "$(CURDIR):/repo" -w /repo $(TRIVY_IMAGE) fs \
-		--severity HIGH,CRITICAL \
-		--ignore-unfixed \
-		--skip-dirs "$(SECURITY_SKIP_DIRS)" \
-		--ignorefile /repo/.trivyignore.yaml \
-		--scanners vuln,secret,misconfig,license \
-		--exit-code 1 \
-		--format sarif \
-		--output "/repo/$(TRIVY_SARIF)" \
-		/repo
-	@echo ""
-	@echo "=== Per-finding summary (same as: make security-trivy-detail) ==="
-	@$(MAKE) security-trivy-detail
-
-security-trivy-detail: ## List each finding from $(TRIVY_SARIF) (jq). Run after security-trivy or CI; GITHUB_STEP_SUMMARY appends in Actions
-	@./scripts/trivy-sarif-summary.sh "$(TRIVY_SARIF)"
+# DISABLED (2026-03-24): Trivy supply chain compromise — see GHSA-69fq-xp46-6x23.
+# security-trivy: ## Trivy fs scan (HIGH/CRITICAL; Docker). Writes $(TRIVY_SARIF), prints per-finding summary; fails on un-ignored findings
+# security-trivy-detail: ## List each finding from $(TRIVY_SARIF) (jq)
+security-trivy security-trivy-detail:
+	@echo "ERROR: Trivy targets are disabled due to active supply chain compromise (GHSA-69fq-xp46-6x23)." >&2
+	@echo "See: https://github.com/advisories/GHSA-69fq-xp46-6x23" >&2
+	@exit 1
 
 security-trufflehog: ## Run TruffleHog secret scan (Docker; verified/unknown, --only-verified). Exits non-zero if verified secrets are found
 	@command -v docker >/dev/null 2>&1 || { echo "docker not found; install Docker to run local security scans"; exit 1; }
 	docker run --rm -v "$(CURDIR):/work" -w /work $(TRUFFLEHOG_IMAGE) filesystem /work \
 		--results=verified,unknown --only-verified --fail
 
-ci-security: security-trivy security-trufflehog ## Run local equivalents of CI Trivy + TruffleHog (not CodeQL; use GitHub Actions or install CodeQL CLI)
+ci-security: security-trufflehog ## Run local equivalents of CI security scans (Trivy disabled — GHSA-69fq-xp46-6x23)
 
 test: ## Run tests for all packages
 	@for pkg in $(PACKAGES); do \

--- a/scripts/add_spdx_headers.py
+++ b/scripts/add_spdx_headers.py
@@ -5,6 +5,7 @@ Handles Python, Shell, YAML, and Terraform files.
 Preserves shebangs and skips files that already have SPDX headers.
 """
 
+import argparse
 import os
 import sys
 from pathlib import Path
@@ -111,14 +112,48 @@ def add_header(filepath: Path) -> bool:
     return True
 
 
+def check_headers(files: list[Path]) -> int:
+    """Check files for missing SPDX headers without modifying them. Returns count of missing."""
+    missing = 0
+    for fpath in files:
+        rel = fpath.relative_to(REPO_ROOT)
+        try:
+            content = fpath.read_text(encoding="utf-8")
+            if not has_spdx_header(content):
+                missing += 1
+                print(f"  ! {rel} — missing SPDX header")
+        except Exception as e:
+            missing += 1
+            print(f"  ! {rel} ERROR: {e}", file=sys.stderr)
+    return missing
+
+
 def main() -> int:
-    """Add SPDX headers to all source files."""
+    """Add SPDX headers to all source files, or check with --check."""
+    parser = argparse.ArgumentParser(description="Manage SPDX license headers.")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check for missing headers without modifying files (exit 1 if any are missing).",
+    )
+    args = parser.parse_args()
+
     files = find_files()
+    print(f"Found {len(files)} source files to check\n")
+
+    if args.check:
+        missing = check_headers(files)
+        if missing:
+            print(
+                f"\n{missing} file(s) missing SPDX headers. Run 'make update-spdx-headers' to fix."
+            )
+            return 1
+        print("\nAll files have SPDX headers.")
+        return 0
+
     modified = 0
     skipped = 0
     errors = 0
-
-    print(f"Found {len(files)} source files to check\n")
 
     for fpath in files:
         rel = fpath.relative_to(REPO_ROOT)

--- a/scripts/check_md_links.py
+++ b/scripts/check_md_links.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
 """Validate that relative links in markdown files point to existing targets.
 
 Checks all [text](path) links in tracked .md files, resolving relative paths


### PR DESCRIPTION
## Summary

- **Disable Makefile Trivy targets** (`security-trivy`, `security-trivy-detail`) that pull the compromised `aquasec/trivy` Docker Hub image. Running them now prints an error referencing the advisory. The `ci-security` aggregate target no longer depends on Trivy.
- **Pin commented-out image reference** to the last known-good digest (`0.69.3`, `sha256:bcc376de...`) with a note to verify against a trusted source before re-enabling.
- **Add `--check` mode to `add_spdx_headers.py`** — exits non-zero when files are missing SPDX headers, without modifying them.
- **Wire it as a pre-commit hook** (`check-spdx-headers`) so missing headers are caught automatically on commit.
- **Add missing SPDX header** to `scripts/check_md_links.py` (the one file that was out of compliance).

## References

- Trivy advisory: [GHSA-69fq-xp46-6x23](https://github.com/advisories/GHSA-69fq-xp46-6x23)
- Related CI workflow PR: #157

## Test plan

- [x] `python3 scripts/add_spdx_headers.py --check` passes (665 files)
- [x] All pre-commit hooks pass, including the new `check-spdx-headers` hook
- [x] `make security-trivy` prints error and exits 1
- [x] `make ci-security` runs only TruffleHog

Made with [Cursor](https://cursor.com)