### PR TITLE
docs: expand AWS domain guides and add index READMEs

### DIFF
--- a/isvctl/configs/providers/aws/README.md
+++ b/isvctl/configs/providers/aws/README.md
@@ -1,0 +1,31 @@
+# AWS Provider Configs
+
+Provider configs that wire the [provider-agnostic test suites](../../tests/README.md) to AWS-specific [stub scripts](../../stubs/aws/). Each YAML imports a test suite and overrides commands with `boto3`/Terraform implementations.
+
+## Configs
+
+| Config | Domain | Guide |
+|--------|--------|-------|
+| [`iam.yaml`](iam.yaml) | User lifecycle (create → verify → delete) | [AWS IAM Guide](../../stubs/aws/iam/docs/aws-iam.md) |
+| [`network.yaml`](network.yaml) | VPC CRUD, subnets, isolation, security, connectivity | [AWS Network Guide](../../stubs/aws/network/docs/aws-network.md) |
+| [`vm.yaml`](vm.yaml) | GPU VM lifecycle (launch → stop/start → reboot → NIM) | [AWS VM Guide](../../stubs/aws/vm/docs/aws-vm.md) |
+| [`bare_metal.yaml`](bare_metal.yaml) | BMaaS lifecycle (launch → topology → serial → NIM) | [AWS Bare Metal Guide](../../stubs/aws/bare_metal/docs/aws-bm.md) |
+| [`eks.yaml`](eks.yaml) | Kubernetes GPU cluster (nodes, GPU operator, workloads) | [AWS EKS Guide](../../stubs/aws/eks/docs/aws-eks.md) |
+| [`control-plane.yaml`](control-plane.yaml) | API health, access keys, tenant lifecycle | [AWS Control Plane Guide](../../stubs/aws/control-plane/docs/aws-control-plane.md) |
+| [`image-registry.yaml`](image-registry.yaml) | Image upload, CRUD, VM launch, install config | [AWS Image Registry Guide](../../stubs/aws/image-registry/docs/aws-image-registry.md) |
+
+## Quick Start
+
+```bash
+# Prerequisites: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION set
+
+uv run isvctl test run -f isvctl/configs/providers/aws/iam.yaml
+uv run isvctl test run -f isvctl/configs/providers/aws/network.yaml
+uv run isvctl test run -f isvctl/configs/providers/aws/vm.yaml
+```
+
+## See Also
+
+- [AWS Reference Implementation](../../../../docs/references/aws.md) — Full overview of templates vs AWS, usage patterns
+- [Test Suites](../../tests/README.md) — Provider-agnostic test definitions
+- [AWS Stub Scripts](../../stubs/aws/) — The scripts these configs invoke

--- a/isvctl/configs/stubs/aws/README.md
+++ b/isvctl/configs/stubs/aws/README.md
@@ -1,0 +1,24 @@
+# AWS Stub Scripts
+
+AWS implementations of the [provider-agnostic stub scripts](../). Each domain folder contains Python/Bash scripts that perform cloud operations via `boto3` or Terraform and output structured JSON to stdout.
+
+These scripts are invoked by the [AWS provider configs](../../providers/aws/).
+
+## Domains
+
+| Domain | Scripts | Guide |
+|--------|---------|-------|
+| [`iam/`](iam/) | User create/delete, credential testing | [AWS IAM Guide](iam/docs/aws-iam.md) |
+| [`network/`](network/) | VPC CRUD, subnets, isolation, security, connectivity | [AWS Network Guide](network/docs/aws-network.md) |
+| [`vm/`](vm/) | Instance launch, stop/start, reboot, serial console | [AWS VM Guide](vm/docs/aws-vm.md) |
+| [`bare_metal/`](bare_metal/) | BM launch, topology, serial console, reinstall | [AWS Bare Metal Guide](bare_metal/docs/aws-bm.md) |
+| [`eks/`](eks/) | EKS cluster setup/teardown (Terraform) | [AWS EKS Guide](eks/docs/aws-eks.md) |
+| [`control-plane/`](control-plane/) | API checks, access keys, tenant management | [AWS Control Plane Guide](control-plane/docs/aws-control-plane.md) |
+| [`image-registry/`](image-registry/) | Image upload/CRUD, install configs, BM provisioning | [AWS Image Registry Guide](image-registry/docs/aws-image-registry.md) |
+| [`common/`](common/) | Shared utilities (error handling, EC2/VPC helpers) | — |
+
+## See Also
+
+- [AWS Reference Implementation](../../../../docs/references/aws.md) — Full overview, how templates map to AWS
+- [AWS Provider Configs](../../providers/aws/) — YAML configs that invoke these scripts
+- [External Validation Guide](../../../../docs/guides/external-validation-guide.md) — Writing scripts, JSON output format

--- a/isvctl/configs/stubs/aws/bare_metal/docs/aws-bm.md
+++ b/isvctl/configs/stubs/aws/bare_metal/docs/aws-bm.md
@@ -6,13 +6,19 @@ Validates AWS EC2 bare-metal GPU instances using the ISV validation framework.
 
 The AWS BM validation tests verify:
 
-1. **Instance Lifecycle** - Provisioning, state verification, instance listing, deletion
-2. **SSH Access** - Remote connectivity via SSH
-3. **Host OS Validation** - Kernel, BIOS, NVIDIA drivers
-4. **GPU Tests** - GPU visibility, stress workloads
-5. **Reboot Resilience** - Instance reboot, recovery, full host OS persistence
-6. **NIM Inference** - NIM container deployment, health, model listing, inference
-7. **Sanitization** - Resource cleanup verification after teardown
+1. **Instance Lifecycle** - Provisioning, state verification, instance listing
+2. **Topology Placement** - Placement group support (cluster strategy)
+3. **Serial Console** - Console output accessibility
+4. **Image Registry** - OS image verification, install config validation (cross-domain)
+5. **SSH Access** - Remote connectivity via SSH, cloud-init completion
+6. **Host OS Validation** - Kernel, BIOS, NVIDIA drivers
+7. **GPU Tests** - GPU visibility, stress, NCCL, training, NVLink
+8. **Networking** - InfiniBand, Ethernet connectivity
+9. **Stop/Start Resilience** - Power off, power on, SSH/GPU re-validation
+10. **Reboot Resilience** - Instance reboot, recovery, full host OS persistence
+11. **Reinstall** - OS reinstall from stock image (skipped by default)
+12. **NIM Inference** - NIM container deployment, health, model listing, inference
+13. **Sanitization** - Resource cleanup verification after teardown
 
 ## Prerequisites
 
@@ -49,6 +55,70 @@ uv run isvctl test run -f isvctl/configs/providers/aws/bare_metal.yaml -- -k "Ss
 # Run only reboot validations
 uv run isvctl test run -f isvctl/configs/providers/aws/bare_metal.yaml -- -k "reboot"
 ```
+
+## Steps
+
+| # | Step | Phase | Script | Description |
+|---|------|-------|--------|-------------|
+| 1 | `launch_instance` | setup | `stubs/aws/bare_metal/launch_instance.py` | Provision bare-metal GPU instance |
+| 2 | `list_instances` | test | `stubs/aws/vm/list_instances.py` | List instances in VPC (reuses VM script) |
+| 3 | `topology_placement` | test | `stubs/aws/bare_metal/topology_placement.py` | Validate placement group support |
+| 4 | `serial_console` | test | `stubs/aws/bare_metal/serial_console.py` | Retrieve serial console output |
+| 5 | `verify_image` | test | `stubs/aws/image-registry/verify_image_installed.py` | Verify OS image installed on BM |
+| 6 | `verify_config` | test | `stubs/aws/image-registry/verify_config_installable.py` | Verify install config can provision BM |
+| 7 | `stop_instance` | test | `stubs/aws/bare_metal/stop_instance.py` | Power off node, verify stopped state |
+| 8 | `start_instance` | test | `stubs/aws/bare_metal/start_instance.py` | Power on node, verify recovery |
+| 9 | `describe_instance` | test | `stubs/aws/bare_metal/describe_instance.py` | Describe post-start state + SSH info |
+| 10 | `reboot_instance` | test | `stubs/aws/bare_metal/reboot_instance.py` | Reboot instance, validate recovery |
+| 11 | `reinstall_instance` | test | `stubs/aws/bare_metal/reinstall_instance.py` | Reinstall OS (skip: true by default) |
+| 12 | `deploy_nim` | test | `stubs/common/deploy_nim.py` | Deploy NIM container via SSH |
+| 13 | `teardown_nim` | teardown | `stubs/common/teardown_nim.py` | Stop NIM container |
+| 14 | `teardown` | teardown | `stubs/aws/bare_metal/teardown.py` | Terminate instance, delete resources |
+| 15 | `verify_teardown` | teardown | `stubs/aws/bare_metal/verify_terminated.py` | Confirm instance terminated + SG deleted |
+
+Steps 5-6 (`verify_image`, `verify_config`) cross-reference the image-registry domain to validate
+BM provisioning from OS images. Step 11 (`reinstall_instance`) is skipped by default because
+root volume replacement is slow on AWS metal (~30-45 min).
+
+## Validations
+
+| Validation Group | Check | Step | Description |
+|------------------|-------|------|-------------|
+| `setup_checks` | `InstanceStateCheck` | launch_instance | Instance is running |
+| `list_instances` | `InstanceListCheck` | list_instances | Target instance found in VPC |
+| `topology_placement` | `TopologyPlacementCheck` | topology_placement | Placement group CRUD operations |
+| `serial_console` | `SerialConsoleCheck` | serial_console | Console output available |
+| `cloud_init` | `SshCloudInitCheck` | launch_instance | Cloud-init completed |
+| `image_installed` | `StepSuccessCheck`, `FieldExistsCheck`, `InstanceStateCheck` | verify_image | OS image verified on BM |
+| `config_installable` | `StepSuccessCheck`, `FieldExistsCheck` | verify_config | Install config dry-run passed |
+| `instance_info` | `InstanceStateCheck` | describe_instance | Post-start state is running |
+| `ssh` | `SshConnectivityCheck`, `SshOsCheck` | describe_instance | SSH works, OS is ubuntu |
+| `gpu` | `SshGpuCheck` | describe_instance | GPU visibility (8 GPUs) |
+| `host_os` | `SshHostSoftwareCheck` | describe_instance | Kernel, drivers, BIOS |
+| `gpu_stress` | `SshGpuStressCheck` | describe_instance | PyTorch matrix multiply on all 8 GPUs |
+| `nccl` | `SshNcclCheck` | describe_instance | NCCL AllReduce (NVLink/NVSwitch) |
+| `training` | `SshTrainingCheck` | describe_instance | DDP training workload (50 steps) |
+| `nvlink` | `SshNvlinkCheck` | describe_instance | NVLink topology and bandwidth |
+| `infiniband` | `SshInfiniBandCheck` | describe_instance | InfiniBand device presence |
+| `ethernet` | `SshEthernetCheck` | describe_instance | Network connectivity (ping 8.8.8.8) |
+| `stop_checks` | `InstanceStopCheck` | stop_instance | Power-off confirmed |
+| `start_checks` | `InstanceStartCheck` | start_instance | Power-on confirmed |
+| `start_ssh` | `SshConnectivityCheck`, `SshOsCheck` | start_instance | SSH works after start |
+| `start_gpu` | `SshGpuCheck` | start_instance | GPUs visible after start (8 GPUs) |
+| `reboot_checks` | `InstanceRebootCheck` | reboot_instance | Reboot confirmed (uptime < 600s) |
+| `reboot_state` | `InstanceStateCheck` | reboot_instance | Instance running after reboot |
+| `reboot_ssh` | `SshConnectivityCheck`, `SshOsCheck` | reboot_instance | SSH works after reboot |
+| `reboot_gpu` | `SshGpuCheck` | reboot_instance | GPUs visible after reboot (8 GPUs) |
+| `reboot_host_os` | `SshHostSoftwareCheck` | reboot_instance | Host OS persisted after reboot |
+| `reinstall_state` | `InstanceStateCheck` | reinstall_instance | Running after reinstall (if enabled) |
+| `reinstall_ssh` | `SshConnectivityCheck`, `SshOsCheck` | reinstall_instance | SSH works after reinstall |
+| `reinstall_gpu` | `SshGpuCheck` | reinstall_instance | GPUs visible after reinstall |
+| `nim_health` | `SshNimHealthCheck` | deploy_nim | NIM `/v1/health/ready` |
+| `nim_models` | `SshNimModelCheck` | deploy_nim | NIM `/v1/models` returns model |
+| `nim_inference` | `SshNimInferenceCheck` | deploy_nim | Chat completion works |
+| `nim_teardown` | `StepSuccessCheck` | teardown_nim | NIM container removed |
+| `teardown_checks` | `StepSuccessCheck` | teardown | Instance terminated |
+| `sanitization` | `StepSuccessCheck` | verify_teardown | SG, key pair confirmed deleted |
 
 ## Dev Workflow (Instance Reuse)
 
@@ -89,12 +159,19 @@ AWS_BM_INSTANCE_ID=i-xxx AWS_BM_KEY_FILE=/tmp/isv-bm-test-key.pem \
 |-------|----------|-------------|
 | Launch Instance | 3-5 min | Create key, SG, launch bare-metal EC2, wait for running |
 | List Instances | ~5s | Verify instance visible in VPC |
-| SSH/GPU/Host OS | ~30s | SSH connectivity, GPU, kernel, drivers |
+| Topology Placement | ~10s | Placement group CRUD |
+| Serial Console | ~5s | Retrieve console output |
+| Image/Config Verify | ~15s | Cross-check image registry (verify_image, verify_config) |
+| SSH/GPU/Host OS | ~1 min | SSH, GPU, kernel, drivers, cloud-init |
+| GPU Stress/NCCL/Training | 2-5 min | All GPU workload validations |
+| NVLink/IB/Ethernet | ~30s | Interconnect and network checks |
+| Stop + Start | 5-15 min | Power off, wait, power on, re-validate SSH/GPU |
 | Reboot Instance | 10-20 min | Reboot via API, wait for status checks, SSH |
 | NIM Deploy | 5-15 min | Pull + start NIM container |
 | NIM Validation | ~30s | Health, models, inference |
 | Teardown | 15-25 min | Terminate bare-metal instance, delete resources |
-| **Total** | **35-70 min** | Full test cycle |
+| Verify Teardown | ~5s | Confirm instance terminated, SG/key deleted |
+| **Total** | **45-90 min** | Full test cycle |
 
 ## Cost & Cleanup
 

--- a/isvctl/configs/stubs/aws/image-registry/docs/aws-image-registry.md
+++ b/isvctl/configs/stubs/aws/image-registry/docs/aws-image-registry.md
@@ -7,8 +7,10 @@ This guide provides a complete walkthrough for validating AWS VM Import capabili
 The AWS ISO/VMDK import validation tests verify:
 
 1. **upload_image** - Download VMDK, upload to S3, import as AMI
-2. **launch_instance** - Launch GPU instance from imported AMI
-3. **teardown** - Clean up all resources (instance, AMI, S3, IAM roles)
+2. **crud_image** - Get, list, copy, delete AMI lifecycle
+3. **launch_instance** - Launch GPU instance from imported AMI
+4. **crud_install_config** - EC2 Launch Template CRUD lifecycle
+5. **teardown** - Clean up all resources (instance, AMI, S3, IAM roles)
 
 **Key Features:**
 
@@ -20,79 +22,92 @@ The AWS ISO/VMDK import validation tests verify:
 
 ## Architecture
 
-### New Step-Based Architecture
+### Step-Based Architecture
 
 ```text
-┌────────────────────────────────────────────────────────────────────┐
-│  Scripts (Platform-Specific - boto3)                               │
-│  ┌──────────────────┐ ┌──────────────────┐ ┌──────────────────┐    │
-│  │  upload_image.py │ │ launch_instance  │ │   teardown.py    │    │
-│  │                  │ │       .py        │ │                  │    │
-│  │ - Download VMDK  │ │ - Create keypair │ │ - Terminate EC2  │    │
-│  │ - Upload to S3   │ │ - Create SG      │ │ - Delete AMI     │    │
-│  │ - Import as AMI  │ │ - Launch EC2     │ │ - Delete bucket  │    │
-│  │ - Output JSON    │ │ - Output JSON    │ │ - Cleanup IAM    │    │
-│  └──────────────────┘ └──────────────────┘ └──────────────────┘    │
-└────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────────┐
+│  Scripts (Platform-Specific - boto3)                                     │
+│  ┌──────────────────┐ ┌──────────────────┐ ┌─────────────────────────┐   │
+│  │  upload_image.py │ │  crud_image.py   │ │  crud_install_config.py │   │
+│  │ - Download VMDK  │ │ - Get AMI        │ │ - Create template       │   │
+│  │ - Upload to S3   │ │ - List AMIs      │ │ - Read template         │   │
+│  │ - Import as AMI  │ │ - Copy AMI       │ │ - Update template       │   │
+│  │                  │ │ - Delete copy    │ │ - Delete template       │   │
+│  └──────────────────┘ └──────────────────┘ └─────────────────────────┘   │
+│  ┌──────────────────┐ ┌──────────────────┐                               │
+│  │launch_instance.py│ │   teardown.py    │                               │
+│  │ - Create keypair │ │ - Terminate EC2  │                               │
+│  │ - Create SG      │ │ - Delete AMI     │                               │
+│  │ - Launch EC2     │ │ - Delete bucket  │                               │
+│  │                  │ │ - Cleanup IAM    │                               │
+│  └──────────────────┘ └──────────────────┘                               │
+└──────────────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼
-┌────────────────────────────────────────────────────────────────────┐
-│  Validations (Platform-Agnostic)                                   │
-│  ┌──────────────────┐ ┌──────────────────┐ ┌──────────────────┐    │
-│  │ StepSuccessCheck │ │  SshGpuCheck     │ │ InstanceState    │    │
-│  │ FieldExistsCheck │ │  SshOsCheck      │ │     Check        │    │
-│  │ FieldValueCheck  │ │  SshConnectivity │ │                  │    │
-│  └──────────────────┘ └──────────────────┘ └──────────────────┘    │
-└────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────────┐
+│  Validations (Platform-Agnostic)                                         │
+│  ┌──────────────────┐ ┌──────────────────┐ ┌──────────────────────────┐  │
+│  │ StepSuccessCheck │ │ CrudOperations   │ │ SshConnectivityCheck     │  │
+│  │ FieldExistsCheck │ │     Check        │ │ SshOsCheck, SshGpuCheck  │  │
+│  │ InstanceState    │ │                  │ │                          │  │
+│  │     Check        │ │                  │ │                          │  │
+│  └──────────────────┘ └──────────────────┘ └──────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────────┘
 ```
 
 ### Test Flow
 
 ```text
-┌─────────────────────────────────────────────────────────────────────┐
-│  uv run isvctl test run -f isvctl/configs/providers/aws/image-registry.yaml   │
-└─────────────────────────────────────────────────────────────────────┘
+uv run isvctl test run -f isvctl/configs/providers/aws/image-registry.yaml
                                    │
                                    ▼
 ┌────────────────────────────────────────────────────────────────────┐
 │  1. upload_image (SETUP phase)                                     │
-│  ┌─────────────────────────────────────────────────────────────┐   │
-│  │ Download VMDK ─▶ Create S3 Bucket ─▶ Upload ─▶ Import AMI   │   │
-│  │ (or use local)   (isv-iso-xxx)       to S3    via VM Import │   │
-│  │                                                             │   │
-│  │ Output: {image_id, storage_bucket, disk_ids, ...}           │   │
-│  └─────────────────────────────────────────────────────────────┘   │
-│                                                                    │
-│  Validations: StepSuccessCheck, FieldExistsCheck                   │
+│     Download VMDK ─▶ Create S3 Bucket ─▶ Upload ─▶ Import AMI      │
+│     Output: {image_id, storage_bucket, disk_ids}                   │
+│     Validations: StepSuccessCheck, FieldExistsCheck                │
 └────────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼
 ┌────────────────────────────────────────────────────────────────────┐
-│  2. launch_instance (SETUP phase)                                  │
-│  ┌─────────────────────────────────────────────────────────────┐   │
-│  │ Create Key Pair ─▶ Create SG ─▶ Launch g4dn.xlarge          │   │
-│  │                                  from imported AMI          │   │
-│  │                                                             │   │
-│  │ Output: {instance_id, public_ip, key_path, ...}             │   │
-│  └─────────────────────────────────────────────────────────────┘   │
-│                                                                    │
-│  Validations: InstanceStateCheck, SshConnectivityCheck,            │
-│               SshGpuCheck, SshOsCheck                              │
+│  2. crud_image (TEST phase)                                        │
+│     Get AMI ─▶ List AMIs ─▶ Copy AMI ─▶ Delete copy                │
+│     Output: {image_id, operations: {get, list, create, delete}}    │
+│     Validations: StepSuccessCheck, CrudOperationsCheck             │
 └────────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼
 ┌────────────────────────────────────────────────────────────────────┐
-│  3. teardown (TEARDOWN phase)                                      │
-│  ┌─────────────────────────────────────────────────────────────┐   │
-│  │ Terminate Instance ─▶ Delete AMI ─▶ Delete Snapshots        │   │
-│  │ Delete Bucket ─▶ Delete Key Pair ─▶ Delete SG ─▶ Delete IAM │   │
-│  │                                                             │   │
-│  │ Output: {deleted: {instance, ami, bucket, ...}}             │   │
-│  └─────────────────────────────────────────────────────────────┘   │
-│                                                                    │
-│  Validations: StepSuccessCheck                                     │
+│  3. launch_instance (TEST phase)                                   │
+│     Create Key Pair ─▶ Create SG ─▶ Launch from imported AMI       │
+│     Output: {instance_id, public_ip, key_path}                     │
+│     Validations: InstanceStateCheck, SshConnectivityCheck,         │
+│                  SshOsCheck, SshGpuCheck                           │
+└────────────────────────────────────────────────────────────────────┘
+                                   │
+                                   ▼
+┌────────────────────────────────────────────────────────────────────┐
+│  4. crud_install_config (TEST phase)                               │
+│     Create template ─▶ Read ─▶ Update ─▶ Delete                    │
+│     Output: {config_id, config_name, operations: {create, read,    │
+│              update, delete}}                                      │
+│     Validations: StepSuccessCheck, FieldExistsCheck                │
+└────────────────────────────────────────────────────────────────────┘
+                                   │
+                                   ▼
+┌────────────────────────────────────────────────────────────────────┐
+│  5. teardown (TEARDOWN phase)                                      │
+│     Terminate Instance ─▶ Delete AMI ─▶ Delete Snapshots           │
+│     Delete Bucket ─▶ Delete Key Pair ─▶ Delete SG ─▶ Delete IAM    │
+│     Validations: StepSuccessCheck                                  │
 └────────────────────────────────────────────────────────────────────┘
 ```
+
+> **Note**: The canonical image-registry config also defines `install_image_bm` and
+> `install_config_bm` steps for bare-metal provisioning. On AWS, these are implemented
+> in the [bare_metal.yaml](../../../../providers/aws/bare_metal.yaml) config instead
+> (as `verify_image` and `verify_config` steps). They are auto-skipped here since
+> this config doesn't define those steps.
 
 ## Prerequisites
 
@@ -204,10 +219,12 @@ uv run isvctl test run -f isvctl/configs/providers/aws/image-registry.yaml
 | Download VMDK | 2-5 min | ~700MB from Ubuntu cloud |
 | Upload to S3 | 2-5 min | Depends on network speed |
 | VM Import | 15-30 min | AWS import_image processing |
+| CRUD Image | 2-5 min | AMI get/list/copy/delete lifecycle |
 | Launch Instance | 5-8 min | Instance + status checks |
 | GPU Validation | 1-2 min | SSH + nvidia-smi |
+| CRUD Install Config | ~30s | Launch Template CRUD |
 | Cleanup | 1-2 min | Delete all resources |
-| **Total** | **25-50 min** | Full test cycle |
+| **Total** | **28-55 min** | Full test cycle |
 
 ---
 
@@ -215,98 +232,58 @@ uv run isvctl test run -f isvctl/configs/providers/aws/image-registry.yaml
 
 ### image-registry.yaml Structure
 
+The AWS provider config imports the canonical image-registry test suite and overrides commands with boto3 scripts:
+
 ```yaml
+import:
+  - ../../tests/image-registry.yaml
+
 version: "1.0"
 
 commands:
   image_registry:
     phases: ["setup", "test", "teardown"]
     steps:
-      # Step 1: Upload VMDK and import as AMI
-      - name: upload_image
+      - name: upload_image          # Setup: Download VMDK, upload to S3, import as AMI
         phase: setup
-        command: "python3 ./stubs/aws/image-registry/upload_image.py"
-        args:
-          - "--image-url"
-          - "{{image_url}}"
-          - "--image-format"
-          - "{{image_format}}"
-          - "--region"
-          - "{{region}}"
+        command: "python3 ../../stubs/aws/image-registry/upload_image.py"
+        args: ["--image-url", "{{image_url}}", "--image-format", "{{image_format}}", "--region", "{{region}}"]
         timeout: 3600
 
-      # Step 2: Launch GPU instance from imported AMI
-      - name: launch_instance
+      - name: crud_image            # Test: AMI get/list/copy/delete lifecycle
         phase: test
-        command: "python3 ./stubs/aws/image-registry/launch_instance.py"
-        args:
-          - "--ami-id"
-          - "{{steps.upload_image.image_id}}"  # Use generic field name
-          - "--instance-type"
-          - "{{instance_type}}"
-          - "--region"
-          - "{{region}}"
+        command: "python3 ../../stubs/aws/image-registry/crud_image.py"
+        args: ["--image-id", "{{steps.upload_image.image_id}}", "--region", "{{region}}"]
         timeout: 600
 
-      # Step 3: Cleanup all resources
-      - name: teardown
+      - name: launch_instance       # Test: Launch GPU instance from imported AMI
+        phase: test
+        command: "python3 ../../stubs/aws/image-registry/launch_instance.py"
+        args: ["--ami-id", "{{steps.upload_image.image_id}}", "--instance-type", "{{instance_type}}", "--region", "{{region}}"]
+        timeout: 600
+
+      - name: crud_install_config   # Test: EC2 Launch Template CRUD
+        phase: test
+        command: "python3 ../../stubs/aws/image-registry/crud_install_config.py"
+        args: ["--region", "{{region}}"]
+        timeout: 120
+
+      - name: teardown              # Teardown: Clean up all resources
         phase: teardown
-        command: "python3 ./stubs/aws/image-registry/teardown.py"
-        args:
-          - "--instance-id"
-          - "{{steps.launch_instance.instance_id}}"
-          - "--ami-id"
-          - "{{steps.upload_image.image_id}}"  # Use generic field name
-          - "--snapshot-ids"
-          - "{{steps.upload_image.disk_ids | join(',')}}"  # Use generic field name
-          - "--bucket-name"
-          - "{{steps.upload_image.storage_bucket}}"  # Use generic field name
-          # ... other cleanup args
-        timeout: 300
+        command: "python3 ../../stubs/aws/image-registry/teardown.py"
+        # ... instance, AMI, snapshots, bucket, key, SG, IAM cleanup
+        timeout: 1800
 
 tests:
-  platform: image_registry
   cluster_name: "aws-image-registry-validation"
-
   settings:
     region: "us-west-2"
     image_url: "https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.vmdk"
     image_format: "vmdk"
     instance_type: "g4dn.xlarge"
-
-  validations:
-    iso_import:
-      step: upload_image
-      checks:
-        - StepSuccessCheck: {}
-        - FieldExistsCheck:
-            fields: ["image_id", "storage_bucket", "disk_ids"]
-
-    instance_launch:
-      step: launch_instance
-      checks:
-        - StepSuccessCheck: {}
-        - InstanceStateCheck:
-            expected_state: "running"
-
-    ssh:
-      step: launch_instance
-      checks:
-        - SshConnectivityCheck: {}
-        - SshOsCheck:
-            expected_os: "ubuntu"
-
-    gpu:
-      step: launch_instance
-      checks:
-        - SshGpuCheck:
-            expected_gpus: 1
-
-    teardown_checks:
-      step: teardown
-      checks:
-        - StepSuccessCheck: {}
 ```
+
+See [`providers/aws/image-registry.yaml`](../../../../providers/aws/image-registry.yaml) for the full config with all arguments and timeouts.
 
 ### Settings Reference
 
@@ -367,23 +344,21 @@ uv run isvctl test run -f isvctl/configs/providers/aws/image-registry.yaml -v
 
 ## Validations
 
-### Generic Validations Used
+### Validations by Step
 
-| Validation | Purpose | From Step |
-|------------|---------|-----------|
-| `StepSuccessCheck` | Verify step completed successfully | All steps |
-| `FieldExistsCheck` | Verify required output fields exist | upload_image, launch_instance |
-| `FieldValueCheck` | Verify specific field values | upload_image |
-| `InstanceStateCheck` | Verify EC2 instance state | launch_instance |
-| `SshConnectivityCheck` | Verify SSH access works | launch_instance |
-| `SshOsCheck` | Verify OS type | launch_instance |
-| `SshGpuCheck` | Verify GPU via nvidia-smi | launch_instance |
-| `SshGpuStressCheck` | Run GPU stress test (optional) | launch_instance |
+| Validation Group | Checks | Step |
+|------------------|--------|------|
+| `image_upload` | `StepSuccessCheck`, `FieldExistsCheck` (image_id, storage_bucket, disk_ids) | upload_image |
+| `image_crud` | `StepSuccessCheck`, `FieldExistsCheck`, `CrudOperationsCheck` (get, list, create, delete) | crud_image |
+| `vm_from_image` | `StepSuccessCheck`, `FieldExistsCheck`, `InstanceStateCheck` (running) | launch_instance |
+| `vm_ssh` | `SshConnectivityCheck`, `SshOsCheck` (ubuntu) | launch_instance |
+| `install_config_crud` | `StepSuccessCheck`, `FieldExistsCheck` (config_id, config_name, operations) | crud_install_config |
+| `teardown_checks` | `StepSuccessCheck` | teardown |
 
-### Validation Timing
-
-- **Default (no `phase`)**: Runs after setup steps complete
-- **`phase: teardown`**: Runs after teardown steps complete
+The canonical config also defines `bm_from_image` and `bm_from_config` validation groups
+for bare-metal provisioning steps. These are auto-skipped in this config since the
+`install_image_bm` and `install_config_bm` steps are not defined here (they live in
+[`bare_metal.yaml`](../../../../providers/aws/bare_metal.yaml) instead).
 
 ---
 

--- a/isvctl/configs/stubs/aws/network/docs/aws-network.md
+++ b/isvctl/configs/stubs/aws/network/docs/aws-network.md
@@ -4,7 +4,7 @@ This guide provides a complete walkthrough for validating AWS VPC networking cap
 
 ## Overview
 
-The network validation suite includes 6 comprehensive test suites:
+The network validation suite includes 13 comprehensive test suites:
 
 | Test Suite | Duration | Description |
 |------------|----------|-------------|
@@ -14,8 +14,15 @@ The network validation suite includes 6 comprehensive test suites:
 | **Security Blocking** | ~30s | SG/NACL blocking rules (negative tests) |
 | **Connectivity** | ~3 min | Instance network assignment via SSM |
 | **Traffic Validation** | ~5-7 min | Real ping tests - allowed/blocked traffic |
+| **VPC IP Config** | ~10s | DHCP options, subnet CIDRs, auto-assign IP (DDI) |
+| **DHCP IP Management** | ~3 min | DHCP lease, IP match, DNS options via SSH (DDI) |
+| **BYOIP** | ~30s | Bring-Your-Own-IP with custom CIDRs |
+| **Stable Private IP** | ~5 min | IP persistence across stop/start |
+| **Floating IP** | ~5 min | Atomic IP switch between instances (<10s) |
+| **Localized DNS** | ~60s | Custom internal domain resolution |
+| **VPC Peering** | ~30s | Cross-VPC connectivity with full bandwidth |
 
-**Total runtime**: ~10-12 minutes for all tests
+**Total runtime**: ~25-30 minutes for all tests
 
 **Key Features:**
 
@@ -34,15 +41,22 @@ The network validation suite includes 6 comprehensive test suites:
 │                    AWS Network Validation Suite                 │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
-│  Scripts (boto3)              Validations (JSON check)          │
-│  ┌──────────────────┐         ┌─────────────────────────┐       │
-│  │ vpc_crud_test.py │ ──────▶ │ VpcCrudCheck            │       │
-│  │ subnet_test.py   │ ──────▶ │ SubnetConfigCheck       │       │
-│  │ isolation_test.py│ ──────▶ │ VpcIsolationCheck       │       │
-│  │ security_test.py │ ──────▶ │ SecurityBlockingCheck   │       │
-│  │ test_connectivity│ ──────▶ │ NetworkConnectivityCheck│       │
-│  │ traffic_test.py  │ ──────▶ │ TrafficFlowCheck        │       │
-│  └──────────────────┘         └─────────────────────────┘       │
+│  Scripts (boto3)                Validations (JSON check)        │
+│  ┌────────────────────────┐    ┌──────────────────────────┐     │
+│  │ vpc_crud_test.py       │───▶│ VpcCrudCheck             │     │
+│  │ subnet_test.py         │───▶│ SubnetConfigCheck        │     │
+│  │ isolation_test.py      │───▶│ VpcIsolationCheck        │     │
+│  │ security_test.py       │───▶│ SecurityBlockingCheck    │     │
+│  │ test_connectivity.py   │───▶│ NetworkConnectivityCheck │     │
+│  │ traffic_test.py        │───▶│ TrafficFlowCheck         │     │
+│  │ vpc_ip_config_test.py  │───▶│ VpcIpConfigCheck         │     │
+│  │ dhcp_ip_test.py        │───▶│ DhcpIpManagementCheck    │     │
+│  │ byoip_test.py          │───▶│ ByoipCheck               │     │
+│  │ stable_ip_test.py      │───▶│ StablePrivateIpCheck     │     │
+│  │ floating_ip_test.py    │───▶│ FloatingIpCheck          │     │
+│  │ dns_test.py            │───▶│ LocalizedDnsCheck        │     │
+│  │ peering_test.py        │───▶│ VpcPeeringCheck          │     │
+│  └────────────────────────┘    └──────────────────────────┘     │
 │                                                                 │
 │  Platform-specific            Platform-agnostic                 │
 │  (AWS boto3 SDK)              (checks JSON output)              │
@@ -83,13 +97,20 @@ All scripts are located in `isvctl/configs/stubs/aws/network/`:
 
 | Script | Purpose | Output Schema |
 |--------|---------|---------------|
+| `create_vpc.py` | Create shared VPC for tests | `network` |
 | `vpc_crud_test.py` | VPC create/read/update/delete | `vpc_crud` |
 | `subnet_test.py` | Multi-AZ subnet configuration | `subnet_config` |
 | `isolation_test.py` | VPC isolation verification | `vpc_isolation` |
 | `security_test.py` | SG/NACL blocking rules | `security_blocking` |
 | `test_connectivity.py` | Instance connectivity via SSM | `connectivity_result` |
 | `traffic_test.py` | Real ping traffic tests | `traffic_flow` |
-| `create_vpc.py` | Create shared VPC for tests | `network` |
+| `vpc_ip_config_test.py` | DHCP options, subnet CIDRs, auto-assign IP | `vpc_ip_config` |
+| `dhcp_ip_test.py` | DHCP lease, IP match, DNS options via SSH | `dhcp_ip` |
+| `byoip_test.py` | Bring-Your-Own-IP with custom CIDRs | `byoip` |
+| `stable_ip_test.py` | IP persistence across stop/start | `stable_ip` |
+| `floating_ip_test.py` | Atomic IP switch between instances | `floating_ip` |
+| `dns_test.py` | Custom internal domain resolution | `localized_dns` |
+| `peering_test.py` | Cross-VPC connectivity | `vpc_peering` |
 | `teardown.py` | Clean up VPC resources | `teardown` |
 
 ## Quick Start
@@ -215,6 +236,93 @@ The most comprehensive test - sends real network traffic:
 - Tests internet ICMP (ping 8.8.8.8)
 - Tests internet HTTPS (curl checkip.amazonaws.com)
 
+### 7. VPC IP Configuration Check (DDI)
+
+**Script**: `vpc_ip_config_test.py`
+**Validation**: `VpcIpConfigCheck`
+
+Tests IP address management configuration on the shared VPC:
+
+- Verify VPC CIDR block
+- Check subnet CIDRs and available IP counts
+- Verify auto-assign public IP settings
+- Check DHCP options set (domain name servers, domain name)
+
+### 8. DHCP IP Management Check (DDI)
+
+**Script**: `dhcp_ip_test.py`
+**Validation**: `DhcpIpManagementCheck`
+
+Tests DHCP-assigned IP management via SSH on a live instance:
+
+- Launch instance in the shared VPC
+- Verify DHCP lease is active
+- Check assigned IP matches AWS metadata
+- Verify DNS options are configured correctly
+
+### 9. BYOIP Check
+
+**Script**: `byoip_test.py`
+**Validation**: `ByoipCheck`
+
+Tests Bring-Your-Own-IP with non-standard CIDR ranges:
+
+- Create VPC with custom CIDR (e.g., `100.64.0.0/16`)
+- Create VPC with standard CIDR (e.g., `10.90.0.0/16`)
+- Verify both VPCs are functional
+- Verify subnets can be created in custom CIDR ranges
+- Clean up both VPCs
+
+### 10. Stable Private IP Check
+
+**Script**: `stable_ip_test.py`
+**Validation**: `StablePrivateIpCheck`
+
+Tests that private IPs persist across instance stop/start cycles:
+
+- Create VPC and launch instance
+- Record private IP address
+- Stop instance, then start it
+- Verify private IP is unchanged after restart
+
+### 11. Floating IP Check
+
+**Script**: `floating_ip_test.py`
+**Validation**: `FloatingIpCheck`
+
+Tests atomic IP reassignment between instances:
+
+- Create VPC and launch two instances
+- Allocate Elastic IP and associate with instance A
+- Reassociate Elastic IP to instance B
+- Verify switch completes within the `max_switch_seconds` threshold (default 10s)
+- Clean up all resources
+
+### 12. Localized DNS Check
+
+**Script**: `dns_test.py`
+**Validation**: `LocalizedDnsCheck`
+
+Tests custom internal domain resolution via Route 53 private hosted zones:
+
+- Create VPC and private hosted zone (e.g., `internal.isv.test`)
+- Create DNS records pointing to instance IPs
+- Verify forward resolution works from within the VPC
+- Clean up hosted zone and VPC
+
+### 13. VPC Peering Check
+
+**Script**: `peering_test.py`
+**Validation**: `VpcPeeringCheck`
+
+Tests cross-VPC connectivity via VPC peering:
+
+- Create two VPCs with non-overlapping CIDRs
+- Create and accept VPC peering connection
+- Update route tables in both VPCs
+- Verify connectivity between peered VPCs
+- Clean up peering connection and VPCs
+
 ## Prerequisites
 
 ### AWS Credentials
@@ -288,47 +396,50 @@ export AWS_REGION=us-west-2
 
 ### network.yaml Structure
 
+The AWS provider config imports the canonical network test suite and overrides commands with boto3 scripts:
+
 ```yaml
+import:
+  - ../../tests/network.yaml
+
 version: "1.0"
 
 commands:
   network:
+    phases: ["setup", "test", "teardown"]
     steps:
-      # Test 1: VPC CRUD
-      - name: vpc_crud
-        phase: test
-        command: "python3 ./stubs/aws/network/vpc_crud_test.py"
-        args:
-          - "--region"
-          - "{{region}}"
-          - "--cidr"
-          - "10.99.0.0/16"
-        timeout: 120
-        output_schema: vpc_crud
-        validations:
-          - VpcCrudCheck: {}
-
-      # ... more test steps ...
-
-      # Setup: Create shared VPC
-      - name: create_network
+      - name: create_network      # Setup: shared VPC
         phase: setup
-        command: "python3 ./stubs/aws/network/create_vpc.py"
-        validations:
-          - NetworkProvisionedCheck: {}
+        command: "python3 ../../stubs/aws/network/create_vpc.py"
+        args: ["--name", "isv-shared-vpc", "--region", "{{region}}", "--cidr", "10.0.0.0/16"]
+        timeout: 300
 
-      # Teardown
-      - name: teardown
+      - name: vpc_crud             # Test 1: VPC CRUD (~30s)
+      - name: subnet_config        # Test 2: Subnet Config (~30s)
+      - name: vpc_isolation         # Test 3: VPC Isolation (~30s)
+      - name: security_blocking     # Test 4: Security Blocking (~30s)
+      - name: connectivity_test     # Test 5: Connectivity (~3 min)
+      - name: traffic_validation    # Test 6: Traffic Validation (~5-7 min)
+      - name: vpc_ip_config         # Test 7: VPC IP Config - DDI (~10s)
+      - name: dhcp_ip_test          # Test 8: DHCP IP Management - DDI (~3 min)
+      - name: byoip_test            # Test 9: BYOIP (~30s)
+      - name: stable_ip_test        # Test 10: Stable Private IP (~5 min)
+      - name: floating_ip_test      # Test 11: Floating IP (~5 min)
+      - name: dns_test              # Test 12: Localized DNS (~60s)
+      - name: peering_test          # Test 13: VPC Peering (~30s)
+
+      - name: teardown             # Teardown: shared VPC cleanup
         phase: teardown
-        command: "python3 ./stubs/aws/network/teardown.py"
-        validations:
-          - StepSuccessCheck: {}
+        command: "python3 ../../stubs/aws/network/teardown.py"
+        # ...
 
 tests:
-  platform: network
+  cluster_name: "aws-network-validation"
   settings:
     region: "us-west-2"
 ```
+
+See [`providers/aws/network.yaml`](../../../../providers/aws/network.yaml) for the full config with all arguments and timeouts.
 
 ### Environment Variables
 
@@ -348,13 +459,23 @@ ORCHESTRATION RESULTS
 ============================================================
 [PASS] SETUP   : create_network: passed
   [create_network] NetworkProvisionedCheck: PASSED - Network vpc-xxx provisioned: CIDR=10.0.0.0/16, subnets=2
-[PASS] TEST    : vpc_crud: passed; subnet_config: passed; vpc_isolation: passed; security_blocking: passed; connectivity_test: passed; traffic_validation: passed
+[PASS] TEST    : vpc_crud: passed; subnet_config: passed; vpc_isolation: passed; security_blocking: passed;
+                 connectivity_test: passed; traffic_validation: passed; vpc_ip_config: passed;
+                 dhcp_ip_test: passed; byoip_test: passed; stable_ip_test: passed;
+                 floating_ip_test: passed; dns_test: passed; peering_test: passed
   [vpc_crud] VpcCrudCheck: PASSED - All 5 CRUD tests passed
   [subnet_config] SubnetConfigCheck: PASSED - 4 subnets across 2 AZs
   [vpc_isolation] VpcIsolationCheck: PASSED - VPCs vpc-a and vpc-b are properly isolated
   [security_blocking] SecurityBlockingCheck: PASSED - All 5 security blocking tests passed
   [connectivity_test] NetworkConnectivityCheck: PASSED - 2 instances with network connectivity
   [traffic_validation] TrafficFlowCheck: PASSED - All 4 traffic tests passed (latency: 0.5ms)
+  [vpc_ip_config] VpcIpConfigCheck: PASSED - CIDR, subnets, DHCP options verified
+  [dhcp_ip_test] DhcpIpManagementCheck: PASSED - DHCP lease active, IP matches metadata
+  [byoip_test] ByoipCheck: PASSED - Custom CIDR 100.64.0.0/16 and standard CIDR functional
+  [stable_ip_test] StablePrivateIpCheck: PASSED - Private IP unchanged after stop/start
+  [floating_ip_test] FloatingIpCheck: PASSED - IP switched in 1.2s (threshold: 10s)
+  [dns_test] LocalizedDnsCheck: PASSED - internal.isv.test resolves correctly
+  [peering_test] VpcPeeringCheck: PASSED - Cross-VPC connectivity verified
 [PASS] TEARDOWN: teardown: passed
   [teardown] StepSuccessCheck: PASSED - Teardown successful
 ------------------------------------------------------------

--- a/isvctl/configs/stubs/aws/vm/docs/aws-vm.md
+++ b/isvctl/configs/stubs/aws/vm/docs/aws-vm.md
@@ -6,20 +6,22 @@ Validates AWS EC2 VM-as-a-Service capabilities using the ISV validation framewor
 
 The AWS VM validation tests verify:
 
-1. **Instance Lifecycle** - Provisioning, state verification, instance listing
-2. **SSH Access** - Remote connectivity via SSH
+1. **Instance Lifecycle** - Provisioning, state verification, instance listing, tagging
+2. **SSH Access** - Remote connectivity via SSH, cloud-init completion
 3. **Host OS Validation** - OS image, kernel, libvirt/QEMU, SBIOS, NVIDIA drivers
 4. **GPU Tests** - GPU visibility, stress workloads
 5. **vCPU Pinning** - vCPU count, NUMA topology, CPU-GPU locality
 6. **PCI Bus Config** - PCIe link speed/width, IOMMU groups, BAR memory
-7. **Reboot Resilience** - Instance reboot, recovery, full host OS persistence
-8. **NIM Inference** - NIM container deployment, health, model listing, inference (optional)
+7. **Stop/Start Resilience** - Instance stop, start, SSH/GPU re-validation
+8. **Reboot Resilience** - Instance reboot, recovery, full host OS persistence
+9. **Serial Console** - Console output accessibility
+10. **NIM Inference** - NIM container deployment, health, model listing, inference (optional)
 
 ## Architecture
 
 Scripts perform cloud/SSH operations and output JSON. Validations assert on the JSON.
 
-```
+```text
 Config (YAML) -> Script (boto3/paramiko) -> JSON output -> Validations (assertions)
 ```
 
@@ -29,10 +31,14 @@ Config (YAML) -> Script (boto3/paramiko) -> JSON output -> Validations (assertio
 |---|------|-------|--------|-------------|
 | 1 | `launch_instance` | setup | `stubs/aws/vm/launch_instance.py` | Provision EC2 GPU instance |
 | 2 | `list_instances` | test | `stubs/aws/vm/list_instances.py` | List instances in VPC |
-| 3 | `reboot_instance` | test | `stubs/aws/vm/reboot_instance.py` | Reboot and validate recovery |
-| 4 | `deploy_nim` | test | `stubs/common/deploy_nim.py` | Deploy NIM container via SSH (skipped if no NGC key) |
-| 5 | `teardown_nim` | teardown | `stubs/common/teardown_nim.py` | Stop NIM container |
-| 6 | `teardown` | teardown | `stubs/aws/vm/teardown.py` | Terminate instance, delete key pair + SG |
+| 3 | `verify_tags` | test | `stubs/aws/vm/describe_tags.py` | Verify user-defined tags on instance |
+| 4 | `stop_instance` | test | `stubs/aws/vm/stop_instance.py` | Stop VM, verify stopped state |
+| 5 | `start_instance` | test | `stubs/aws/vm/start_instance.py` | Start stopped VM, verify recovery + SSH |
+| 6 | `reboot_instance` | test | `stubs/aws/vm/reboot_instance.py` | Reboot and validate recovery |
+| 7 | `serial_console` | test | `stubs/aws/vm/serial_console.py` | Retrieve serial console output |
+| 8 | `deploy_nim` | test | `stubs/common/deploy_nim.py` | Deploy NIM container via SSH (skipped if no NGC key) |
+| 9 | `teardown_nim` | teardown | `stubs/common/teardown_nim.py` | Stop NIM container |
+| 10 | `teardown` | teardown | `stubs/aws/vm/teardown.py` | Terminate instance, delete key pair + SG |
 
 Only `launch_instance` is in the **setup** phase. If any test step fails, teardown still runs
 to prevent resource leaks. NIM steps are shared and reusable across VMaaS and BMaaS.
@@ -43,13 +49,17 @@ to prevent resource leaks. NIM steps are shared and reusable across VMaaS and BM
 |------------|------|-------------|
 | `InstanceStateCheck` | launch_instance, reboot_instance | Verify instance is running |
 | `InstanceListCheck` | list_instances | Verify instances in VPC, target found |
-| `SshConnectivityCheck` | launch_instance, reboot_instance | SSH connectivity and command execution |
-| `SshOsCheck` | launch_instance, reboot_instance | Verify OS type |
-| `SshGpuCheck` | launch_instance, reboot_instance | GPU visibility via nvidia-smi |
+| `InstanceTagCheck` | verify_tags | Verify required tags (Name, CreatedBy) |
+| `SshConnectivityCheck` | launch_instance, start_instance, reboot_instance | SSH connectivity and command execution |
+| `SshOsCheck` | launch_instance, start_instance, reboot_instance | Verify OS type |
+| `SshCloudInitCheck` | launch_instance | Cloud-init completed successfully |
+| `SshGpuCheck` | launch_instance, start_instance, reboot_instance | GPU visibility via nvidia-smi |
 | `SshVcpuPinningCheck` | launch_instance, reboot_instance | vCPU count, NUMA topology, CPU-GPU locality |
 | `SshPciBusCheck` | launch_instance, reboot_instance | PCI GPU enumeration, PCIe link, IOMMU, BAR memory |
 | `SshHostSoftwareCheck` | launch_instance, reboot_instance | Kernel, libvirt/QEMU, SBIOS, NVIDIA drivers |
-| `SshGpuStressCheck` | launch_instance | GPU stress test (excluded by default) |
+| `InstanceStopCheck` | stop_instance | Stop API call, state transitions to stopped |
+| `InstanceStartCheck` | start_instance | Start API call, state recovery to running |
+| `SerialConsoleCheck` | serial_console | Serial console output available and accessible |
 | `InstanceRebootCheck` | reboot_instance | Reboot API call, state recovery, SSH, uptime reset |
 | `SshNimHealthCheck` | deploy_nim | NIM `/v1/health/ready` (skipped if no NGC key) |
 | `SshNimModelCheck` | deploy_nim | NIM `/v1/models` returns expected model |
@@ -118,12 +128,15 @@ Full config: [`isvctl/configs/providers/aws/vm.yaml`](../../../../providers/aws/
 | Phase | Duration | Description |
 |-------|----------|-------------|
 | Launch Instance | 3-5 min | Create key, SG, launch EC2, wait for running |
-| SSH + GPU + Host OS | ~2 min | All SSH-based validations |
+| SSH + GPU + Host OS | ~2 min | All SSH-based validations (including cloud-init) |
+| Verify Tags | ~5s | Check instance tags |
+| Stop + Start | 3-5 min | Stop VM, verify stopped, start VM, re-validate SSH/GPU |
 | Reboot + Revalidation | 3-7 min | Reboot via API, re-run SSH/GPU/host OS checks |
+| Serial Console | ~5s | Retrieve console output |
 | NIM Deploy | 5-20 min | Pull image, start container, wait for health (first run) |
 | NIM Validation | ~30s | Health, models, inference checks |
 | Teardown | ~1 min | Terminate instance, delete resources |
-| **Total** | **15-35 min** | Full test cycle (with NIM) |
+| **Total** | **20-40 min** | Full test cycle (with NIM) |
 
 ---
 
@@ -231,6 +244,58 @@ Validates that an EC2 instance rebooted successfully and fully recovered.
   "count": 1,
   "found_target": true,
   "target_instance": "i-0abc123"
+}
+```
+
+### describe_tags.py
+
+```json
+{
+  "success": true,
+  "platform": "vm",
+  "instance_id": "i-0abc123def456",
+  "tags": {"Name": "isv-test-gpu", "CreatedBy": "isvtest"},
+  "tag_count": 2
+}
+```
+
+### stop_instance.py
+
+```json
+{
+  "success": true,
+  "platform": "vm",
+  "instance_id": "i-0abc123def456",
+  "state": "stopped",
+  "stop_initiated": true
+}
+```
+
+### start_instance.py
+
+```json
+{
+  "success": true,
+  "platform": "vm",
+  "instance_id": "i-0abc123def456",
+  "state": "running",
+  "public_ip": "54.1.2.3",
+  "key_file": "/tmp/isv-test-key.pem",
+  "start_initiated": true,
+  "ssh_ready": true
+}
+```
+
+### serial_console.py
+
+```json
+{
+  "success": true,
+  "platform": "vm",
+  "instance_id": "i-0abc123def456",
+  "console_available": true,
+  "serial_access_enabled": true,
+  "output_length": 4096
 }
 ```
 


### PR DESCRIPTION
## Summary
- Expand bare_metal, image-registry, network, and VM docs with new test steps (stop/start, serial console, topology placement, CRUD operations, DDI networking, BYOIP, floating IP, VPC peering, etc.)
- Modernize YAML config examples to reflect import-based architecture with relative paths
- Add index READMEs for `providers/aws/` and `stubs/aws/` directories

## Test plan
- [x] Verify all relative markdown links resolve correctly (pre-commit link checker passed)
- [x] Spot-check YAML examples match actual provider configs
- [x] Confirm new README index entries link to correct guides

🤖 Generated with [Claude Code](https://claude.com/claude-code)