### PR TITLE
Fix missing platform badges in UI by inferring platforms from class markers

### DIFF
--- a/isvctl/configs/tests/bare_metal.yaml
+++ b/isvctl/configs/tests/bare_metal.yaml
@@ -421,6 +421,21 @@ tests:
         SshEthernetCheck:
           ping_target: "8.8.8.8"
 
+    driver_info:
+      step: describe_instance
+      checks:
+        SshDriverCheck: {}
+
+    cpu_info:
+      step: describe_instance
+      checks:
+        SshCpuInfoCheck: {}
+
+    container_runtime:
+      step: describe_instance
+      checks:
+        SshContainerRuntimeCheck: {}
+
     stop_checks:
       step: stop_instance
       checks:

--- a/isvctl/configs/tests/k8s.yaml
+++ b/isvctl/configs/tests/k8s.yaml
@@ -52,6 +52,8 @@ tests:
       checks:
         K8sNodeCountCheck:
           count: "{{ steps.setup.kubernetes.node_count | default(4, true) }}"
+        K8sExpectedNodesCheck:
+          names: []
         K8sNodeReadyCheck:
           require_all_ready: true
         K8sNvidiaSmiCheck:

--- a/isvctl/configs/tests/vm.yaml
+++ b/isvctl/configs/tests/vm.yaml
@@ -270,6 +270,11 @@ tests:
         InstanceStateCheck:
           expected_state: "running"
 
+    instance_created:
+      step: launch_instance
+      checks:
+        InstanceCreatedCheck: {}
+
     list_instances:
       step: list_instances
       checks:
@@ -385,6 +390,21 @@ tests:
         SshNimInferenceCheck:
           prompt: "What is CUDA?"
           max_tokens: 50
+
+    driver_info:
+      step: launch_instance
+      checks:
+        SshDriverCheck: {}
+
+    cpu_info:
+      step: launch_instance
+      checks:
+        SshCpuInfoCheck: {}
+
+    container_runtime:
+      step: launch_instance
+      checks:
+        SshContainerRuntimeCheck: {}
 
     nim_teardown:
       step: teardown_nim

--- a/isvtest/src/isvtest/catalog.py
+++ b/isvtest/src/isvtest/catalog.py
@@ -14,8 +14,12 @@ Builds a structured catalog of all available validation tests by calling
 discover_all_tests() and serializing each BaseValidation subclass's metadata.
 The catalog is version-keyed by the installed isvtest package version.
 
-Platform tagging is derived from config files in isvctl/configs/ -- each config
-declares a platform and lists which validation checks to run for that platform.
+Platform tagging uses two sources (union of both):
+  1. Config files -- which checks appear in each isvctl/configs/tests/*.yaml
+  2. Class markers -- e.g. markers=["bare_metal"] implies BARE_METAL platform
+
+This ensures checks get a platform badge in the UI even when they aren't listed
+in a YAML config (e.g. Bm* checks that only run on-host, not via SSH).
 """
 
 import logging
@@ -40,6 +44,19 @@ PLATFORM_CONFIGS: dict[str, list[str]] = {
     "NETWORK": ["tests/network.yaml"],
     "VM": ["tests/vm.yaml"],
     "IMAGE_REGISTRY": ["tests/image-registry.yaml"],
+}
+
+# Maps class-level markers to platform strings so checks that aren't listed
+# in a YAML config still get the correct platform in the catalog.
+# Only platform-identifying markers are included; trait markers like "gpu",
+# "ssh", "workload", "slow", and "security" are intentionally omitted.
+MARKER_TO_PLATFORM: dict[str, str] = {
+    "bare_metal": "BARE_METAL",
+    "kubernetes": "KUBERNETES",
+    "slurm": "SLURM",
+    "vm": "VM",
+    "network": "NETWORK",
+    "iam": "IAM",
 }
 
 
@@ -135,11 +152,17 @@ def build_catalog() -> list[dict[str, Any]]:
     # Build class metadata lookup
     class_meta: dict[str, dict[str, Any]] = {}
     for cls in discover_all_tests():
+        markers = list(getattr(cls, "markers", []))
         class_meta[cls.__name__] = {
             "description": getattr(cls, "description", "") or "",
-            "markers": list(getattr(cls, "markers", [])),
+            "markers": markers,
             "module": cls.__module__,
         }
+        # Infer platforms from markers for classes not already covered by configs
+        for marker in markers:
+            platform = MARKER_TO_PLATFORM.get(marker)
+            if platform:
+                platform_map.setdefault(cls.__name__, set()).add(platform)
 
     catalog: list[dict[str, Any]] = []
     seen: set[str] = set()

--- a/isvtest/src/isvtest/validations/bm_driver.py
+++ b/isvtest/src/isvtest/validations/bm_driver.py
@@ -21,6 +21,7 @@ class BmDriverInstalled(BaseValidation):
 
     description: ClassVar[str] = "Verify NVIDIA driver is installed and accessible via nvidia-smi"
     timeout: ClassVar[int] = 30
+    markers: ClassVar[list[str]] = ["bare_metal"]
 
     def run(self) -> None:
         result = self.run_command("nvidia-smi")
@@ -37,6 +38,7 @@ class BmDriverVersion(BaseValidation):
 
     description: ClassVar[str] = "Query NVIDIA driver version and validate format"
     timeout: ClassVar[int] = 30
+    markers: ClassVar[list[str]] = ["bare_metal"]
 
     def run(self) -> None:
         result = self.run_command("nvidia-smi --query-gpu=driver_version --format=csv,noheader")

--- a/isvtest/src/isvtest/validations/bm_gpu.py
+++ b/isvtest/src/isvtest/validations/bm_gpu.py
@@ -21,6 +21,7 @@ class BmGpuDetection(BaseValidation):
 
     description: ClassVar[str] = "Verify at least one GPU is detected via nvidia-smi"
     timeout: ClassVar[int] = 30
+    markers: ClassVar[list[str]] = ["bare_metal", "gpu"]
 
     def run(self) -> None:
         """Query nvidia-smi and verify at least one GPU is detected."""
@@ -56,6 +57,7 @@ class BmGpuHealth(BaseValidation):
 
     description: ClassVar[str] = "Query GPU health metrics (temperature, utilization)"
     timeout: ClassVar[int] = 30
+    markers: ClassVar[list[str]] = ["bare_metal", "gpu"]
 
     def run(self) -> None:
         """Query GPU health metrics and validate temperature/utilization values."""
@@ -119,6 +121,7 @@ class BmGpuComputeCapability(BaseValidation):
 
     description: ClassVar[str] = "Query GPU compute capability (e.g., 8.0, 9.0)"
     timeout: ClassVar[int] = 30
+    markers: ClassVar[list[str]] = ["bare_metal", "gpu"]
 
     def run(self) -> None:
         """Query and validate GPU compute capability format."""


### PR DESCRIPTION
## Summary

Some validation checks (e.g. `BmDriverVersion`, `BmGpuDetection`) were missing their platform badge in the Lab UI because the catalog builder only derived platforms from YAML config listings. Checks that weren't explicitly listed in a platform YAML—even though they clearly belonged to a platform—got `platforms: []` in the catalog, causing the frontend to render no badge.

This PR fixes the root cause and adds missing validation coverage:

- **Catalog platform inference from markers** — `build_catalog()` now also derives platforms from each class's `markers` ClassVar (e.g. `markers=["bare_metal"]` → `BARE_METAL`), unioned with the existing YAML-config scan. This ensures checks get the correct platform badge without needing to be listed in a YAML config.
- **Added `markers` to bare-metal validation classes** — `BmDriverInstalled`, `BmDriverVersion` (`["bare_metal"]`) and `BmGpuDetection`, `BmGpuHealth`, `BmGpuComputeCapability` (`["bare_metal", "gpu"]`) now declare their platform affiliation.
- **Added missing checks to platform YAML configs**:
  - `bare_metal.yaml` — `SshDriverCheck`, `SshCpuInfoCheck`, `SshContainerRuntimeCheck`
  - `k8s.yaml` — `K8sExpectedNodesCheck`
  - `vm.yaml` — `InstanceCreatedCheck`, `SshDriverCheck`, `SshCpuInfoCheck`, `SshContainerRuntimeCheck`

## Design decision

The `Bm*` checks (which run `nvidia-smi` directly on the host) are intentionally **not** added to `bare_metal.yaml`. That canonical config is imported by remote providers like AWS, where the test runner is a laptop/CI box—not the GPU instance. Running `nvidia-smi` locally would check the wrong machine. Instead:
- The `Bm*` checks get their `BARE_METAL` platform tag from markers (catalog only, no execution).
- Providers that run on-host (e.g. `microk8s.yaml`) already add these checks as provider-specific overrides.
- Remote providers use the `Ssh*` equivalents which connect over SSH.

## Test plan

- [x] `isvctl catalog push --no-upload` — rebuilt catalog, verified all `Bm*` checks show `platforms: ["BARE_METAL"]`
- [x] Verified SSH-based checks show correct multi-platform tags (e.g. `SshDriverCheck` → `["BARE_METAL", "VM"]`)
- [x] Verified no regressions: checks with empty platforms are only generic building blocks and dev examples
- [x] Run `make lint` / `make test`

Made with [Cursor](https://cursor.com)