### PR TITLE
fix: remove AWS-specific defaults from canonical test configs

### DIFF
--- a/isvctl/configs/tests/bare_metal.yaml
+++ b/isvctl/configs/tests/bare_metal.yaml
@@ -108,7 +108,7 @@ commands:
       #     "platform": "bm",
       #     "instance_id": "...",
       #     "placement_supported": true,
-      #     "availability_zone": "us-west-2a",
+      #     "availability_zone": "...",
       #     "placement_group": "...",
       #     "placement_strategy": "cluster",
       #     "operations": {
@@ -324,7 +324,8 @@ tests:
   description: "Bare metal (BMaaS) GPU validation tests"
 
   settings:
-    region: "us-west-2"
+    # Provider-specific -- override in your provider config
+    region: ""
     instance_type: "{{instance_type}}" # Supply your platform-equivalent bare-metal/GPU instance type
     teardown_flag: "{{(env.BM_SKIP_TEARDOWN == 'true') | ternary('--skip-destroy', '')}}"
 

--- a/isvctl/configs/tests/control-plane.yaml
+++ b/isvctl/configs/tests/control-plane.yaml
@@ -184,8 +184,9 @@ tests:
   description: "Control plane: API health, access key lifecycle, tenant lifecycle"
 
   settings:
-    region: "us-west-2"
-    services: "compute,storage,identity"
+    # Provider-specific -- override in your provider config
+    region: ""
+    services: ""
 
   # ─── Validations ─────────────────────────────────────────────────
   # These are PROVIDER-AGNOSTIC. They only check JSON field names/values.

--- a/isvctl/configs/tests/iam.yaml
+++ b/isvctl/configs/tests/iam.yaml
@@ -111,8 +111,8 @@ tests:
   platform: iam
 
   settings:
-    # Override these for your environment
-    region: "us-west-2"
+    # Provider-specific -- override in your provider config
+    region: ""
     teardown_flag: "{{(env.IAM_SKIP_TEARDOWN == 'true') | ternary('--skip-destroy', '')}}"
 
   # ─── Validations ─────────────────────────────────────────────────

--- a/isvctl/configs/tests/image-registry.yaml
+++ b/isvctl/configs/tests/image-registry.yaml
@@ -214,10 +214,11 @@ tests:
   platform: image_registry
 
   settings:
-    region: "us-west-2"
+    # Provider-specific -- override in your provider config
+    region: ""
     image_url: "https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.vmdk"
     image_format: "vmdk"
-    instance_type: "g4dn.xlarge"
+    instance_type: ""
     teardown_flag: "{{(env.IR_SKIP_TEARDOWN == 'true') | ternary('--skip-destroy', '')}}"
 
   # ─── Validations ─────────────────────────────────────────────────

--- a/isvctl/configs/tests/network.yaml
+++ b/isvctl/configs/tests/network.yaml
@@ -305,7 +305,8 @@ tests:
   platform: network
 
   settings:
-    region: "us-west-2"
+    # Provider-specific -- override in your provider config
+    region: ""
 
   # ─── Validations ─────────────────────────────────────────────────
   # These are PROVIDER-AGNOSTIC. They only check JSON field names/values.

--- a/isvctl/configs/tests/vm.yaml
+++ b/isvctl/configs/tests/vm.yaml
@@ -257,8 +257,9 @@ tests:
   description: "VM (virtual machine) GPU validation tests"
 
   settings:
-    region: "us-west-2"
-    instance_type: "g5.xlarge"
+    # Provider-specific -- override in your provider config
+    region: ""
+    instance_type: ""
     teardown_flag: "{{(env.VM_SKIP_TEARDOWN == 'true') | ternary('--skip-destroy', '')}}"
 
   # ─── Validations ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replaced hardcoded AWS values (`region: "us-west-2"`, `instance_type: "g5.xlarge"`, etc.) with empty strings in all canonical test configs under `configs/tests/`
- Added `# Provider-specific -- override in your provider config` comment to each settings block
- Replaced `"availability_zone": "us-west-2a"` example in `bare_metal.yaml` comment with `"..."`

The canonical configs are designed to be provider-agnostic, but they were leaking AWS-specific defaults. Every AWS provider config under `configs/providers/aws/` already supplies its own values via the merge mechanism, so these defaults were redundant.

**Files changed:** `control-plane.yaml`, `network.yaml`, `iam.yaml`, `vm.yaml`, `bare_metal.yaml`, `image-registry.yaml` (all under `isvctl/configs/tests/`)

## Test plan

- [x] Verify AWS provider configs still work: `uv run isvctl test run -f isvctl/configs/providers/aws/control-plane.yaml` (provider overrides supply region/instance_type)
- [x] Verify running a canonical config directly without a provider overlay fails clearly (expected -- no region supplied)

Made with [Cursor](https://cursor.com)