### PR TITLE
fix: remove AWS-specific defaults from canonical stubs and deduplicate SSH utils

### DIFF
--- a/isvctl/configs/stubs/aws/bare_metal/power_cycle_instance.py
+++ b/isvctl/configs/stubs/aws/bare_metal/power_cycle_instance.py
@@ -39,62 +39,14 @@ Output JSON:
 import argparse
 import json
 import os
-import subprocess
 import sys
 import time
+from pathlib import Path
 from typing import Any
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 import boto3
-
-
-def wait_for_ssh(
-    host: str,
-    user: str,
-    key_file: str,
-    max_attempts: int = 60,
-    interval: int = 15,
-) -> bool:
-    """Wait for SSH to become available on the host.
-
-    Args:
-        host: Public IP or hostname
-        user: SSH username
-        key_file: Path to SSH private key
-        max_attempts: Maximum number of connection attempts (default: 60 for BM)
-        interval: Seconds between attempts (default: 15 for BM)
-
-    Returns:
-        True if SSH is ready, False if timed out
-    """
-    for attempt in range(1, max_attempts + 1):
-        try:
-            result = subprocess.run(
-                [
-                    "ssh",
-                    "-o",
-                    "StrictHostKeyChecking=no",
-                    "-o",
-                    "ConnectTimeout=5",
-                    "-o",
-                    "BatchMode=yes",
-                    "-i",
-                    key_file,
-                    f"{user}@{host}",
-                    "exit 0",
-                ],
-                capture_output=True,
-                timeout=15,
-            )
-            if result.returncode == 0:
-                print(f"  SSH ready after attempt {attempt}", file=sys.stderr)
-                return True
-        except (subprocess.TimeoutExpired, OSError):
-            pass
-
-        print(f"  Waiting for SSH... (attempt {attempt}/{max_attempts})", file=sys.stderr)
-        time.sleep(interval)
-
-    return False
+from common.ssh_utils import wait_for_ssh
 
 
 def main() -> int:

--- a/isvctl/configs/stubs/aws/bare_metal/reboot_instance.py
+++ b/isvctl/configs/stubs/aws/bare_metal/reboot_instance.py
@@ -40,62 +40,12 @@ import os
 import subprocess
 import sys
 import time
+from pathlib import Path
 from typing import Any
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 import boto3
-
-
-def wait_for_ssh(
-    host: str,
-    user: str,
-    key_file: str,
-    max_attempts: int = 60,
-    interval: int = 15,
-) -> bool:
-    """Wait for SSH to become available on the host.
-
-    Bare-metal instances can take 10-15 min to fully reboot, so defaults
-    are more generous than the VM version (60 attempts x 15s = 15 min).
-
-    Args:
-        host: Public IP or hostname
-        user: SSH username
-        key_file: Path to SSH private key
-        max_attempts: Maximum number of connection attempts
-        interval: Seconds between attempts
-
-    Returns:
-        True if SSH is ready, False if timed out
-    """
-    for attempt in range(1, max_attempts + 1):
-        try:
-            result = subprocess.run(
-                [
-                    "ssh",
-                    "-o",
-                    "StrictHostKeyChecking=no",
-                    "-o",
-                    "ConnectTimeout=5",
-                    "-o",
-                    "BatchMode=yes",
-                    "-i",
-                    key_file,
-                    f"{user}@{host}",
-                    "exit 0",
-                ],
-                capture_output=True,
-                timeout=15,
-            )
-            if result.returncode == 0:
-                print(f"  SSH ready after attempt {attempt}", file=sys.stderr)
-                return True
-        except (subprocess.TimeoutExpired, OSError):
-            pass
-
-        print(f"  Waiting for SSH... (attempt {attempt}/{max_attempts})", file=sys.stderr)
-        time.sleep(interval)
-
-    return False
+from common.ssh_utils import wait_for_ssh
 
 
 def get_uptime_via_ssh(host: str, user: str, key_file: str) -> float | None:

--- a/isvctl/configs/stubs/aws/bare_metal/reinstall_instance.py
+++ b/isvctl/configs/stubs/aws/bare_metal/reinstall_instance.py
@@ -43,63 +43,14 @@ Output JSON:
 import argparse
 import json
 import os
-import subprocess
 import sys
-import time
+from pathlib import Path
 from typing import Any
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 import boto3
 from botocore.exceptions import ClientError, WaiterError
-
-
-def wait_for_ssh(
-    host: str,
-    user: str,
-    key_file: str,
-    max_attempts: int = 60,
-    interval: int = 15,
-) -> bool:
-    """Wait for SSH to become available on the host.
-
-    Args:
-        host: Public IP or hostname
-        user: SSH username
-        key_file: Path to SSH private key
-        max_attempts: Maximum number of connection attempts
-        interval: Seconds between attempts
-
-    Returns:
-        True if SSH is ready, False if timed out
-    """
-    for attempt in range(1, max_attempts + 1):
-        try:
-            result = subprocess.run(
-                [
-                    "ssh",
-                    "-o",
-                    "StrictHostKeyChecking=no",
-                    "-o",
-                    "ConnectTimeout=5",
-                    "-o",
-                    "BatchMode=yes",
-                    "-i",
-                    key_file,
-                    f"{user}@{host}",
-                    "exit 0",
-                ],
-                capture_output=True,
-                timeout=15,
-            )
-            if result.returncode == 0:
-                print(f"  SSH ready after attempt {attempt}", file=sys.stderr)
-                return True
-        except (subprocess.TimeoutExpired, OSError):
-            pass
-
-        print(f"  Waiting for SSH... (attempt {attempt}/{max_attempts})", file=sys.stderr)
-        time.sleep(interval)
-
-    return False
+from common.ssh_utils import wait_for_ssh
 
 
 def get_ami_root_snapshot(ec2: Any, ami_id: str) -> tuple[str, str]:

--- a/isvctl/configs/stubs/aws/bare_metal/start_instance.py
+++ b/isvctl/configs/stubs/aws/bare_metal/start_instance.py
@@ -39,62 +39,13 @@ Output JSON:
 import argparse
 import json
 import os
-import subprocess
 import sys
-import time
+from pathlib import Path
 from typing import Any
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 import boto3
-
-
-def wait_for_ssh(
-    host: str,
-    user: str,
-    key_file: str,
-    max_attempts: int = 60,
-    interval: int = 15,
-) -> bool:
-    """Wait for SSH to become available on the host.
-
-    Args:
-        host: Public IP or hostname
-        user: SSH username
-        key_file: Path to SSH private key
-        max_attempts: Maximum number of connection attempts (default: 60 for BM)
-        interval: Seconds between attempts (default: 15 for BM)
-
-    Returns:
-        True if SSH is ready, False if timed out
-    """
-    for attempt in range(1, max_attempts + 1):
-        try:
-            result = subprocess.run(
-                [
-                    "ssh",
-                    "-o",
-                    "StrictHostKeyChecking=no",
-                    "-o",
-                    "ConnectTimeout=5",
-                    "-o",
-                    "BatchMode=yes",
-                    "-i",
-                    key_file,
-                    f"{user}@{host}",
-                    "exit 0",
-                ],
-                capture_output=True,
-                timeout=15,
-            )
-            if result.returncode == 0:
-                print(f"  SSH ready after attempt {attempt}", file=sys.stderr)
-                return True
-        except (subprocess.TimeoutExpired, OSError):
-            pass
-
-        print(f"  Waiting for SSH... (attempt {attempt}/{max_attempts})", file=sys.stderr)
-        time.sleep(interval)
-
-    return False
+from common.ssh_utils import wait_for_ssh
 
 
 def main() -> int:

--- a/isvctl/configs/stubs/aws/vm/reboot_instance.py
+++ b/isvctl/configs/stubs/aws/vm/reboot_instance.py
@@ -42,57 +42,11 @@ import os
 import subprocess
 import sys
 import time
+from pathlib import Path
 from typing import Any
 
-
-def wait_for_ssh(
-    host: str,
-    user: str,
-    key_file: str,
-    max_attempts: int = 30,
-    interval: int = 10,
-) -> bool:
-    """Wait for SSH to become available on the host.
-
-    Args:
-        host: Public IP or hostname
-        user: SSH username
-        key_file: Path to SSH private key
-        max_attempts: Maximum number of connection attempts
-        interval: Seconds between attempts
-
-    Returns:
-        True if SSH is ready, False if timed out
-    """
-    for attempt in range(1, max_attempts + 1):
-        try:
-            result = subprocess.run(
-                [
-                    "ssh",
-                    "-o",
-                    "StrictHostKeyChecking=no",
-                    "-o",
-                    "ConnectTimeout=5",
-                    "-o",
-                    "BatchMode=yes",
-                    "-i",
-                    key_file,
-                    f"{user}@{host}",
-                    "exit 0",
-                ],
-                capture_output=True,
-                timeout=15,
-            )
-            if result.returncode == 0:
-                print(f"  SSH ready after attempt {attempt}", file=sys.stderr)
-                return True
-        except (subprocess.TimeoutExpired, OSError):
-            pass
-
-        print(f"  Waiting for SSH... (attempt {attempt}/{max_attempts})", file=sys.stderr)
-        time.sleep(interval)
-
-    return False
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from common.ssh_utils import wait_for_ssh
 
 
 def get_uptime_via_ssh(
@@ -240,7 +194,7 @@ def main() -> int:
         # Step 6: Wait for SSH to be ready
         # ============================================================
         print("Waiting for SSH to be ready after reboot...", file=sys.stderr)
-        ssh_ready = wait_for_ssh(public_ip, args.ssh_user, args.key_file)
+        ssh_ready = wait_for_ssh(public_ip, args.ssh_user, args.key_file, max_attempts=30, interval=10)
         result["ssh_ready"] = ssh_ready
 
         if not ssh_ready:

--- a/isvctl/configs/stubs/aws/vm/start_instance.py
+++ b/isvctl/configs/stubs/aws/vm/start_instance.py
@@ -37,60 +37,12 @@ Output JSON:
 import argparse
 import json
 import os
-import subprocess
 import sys
-import time
+from pathlib import Path
 from typing import Any
 
-
-def wait_for_ssh(
-    host: str,
-    user: str,
-    key_file: str,
-    max_attempts: int = 30,
-    interval: int = 10,
-) -> bool:
-    """Wait for SSH to become available on the host.
-
-    Args:
-        host: Public IP or hostname
-        user: SSH username
-        key_file: Path to SSH private key
-        max_attempts: Maximum number of connection attempts
-        interval: Seconds between attempts
-
-    Returns:
-        True if SSH is ready, False if timed out
-    """
-    for attempt in range(1, max_attempts + 1):
-        try:
-            result = subprocess.run(
-                [
-                    "ssh",
-                    "-o",
-                    "StrictHostKeyChecking=no",
-                    "-o",
-                    "ConnectTimeout=5",
-                    "-o",
-                    "BatchMode=yes",
-                    "-i",
-                    key_file,
-                    f"{user}@{host}",
-                    "exit 0",
-                ],
-                capture_output=True,
-                timeout=15,
-            )
-            if result.returncode == 0:
-                print(f"  SSH ready after attempt {attempt}", file=sys.stderr)
-                return True
-        except (subprocess.TimeoutExpired, OSError):
-            pass
-
-        print(f"  Waiting for SSH... (attempt {attempt}/{max_attempts})", file=sys.stderr)
-        time.sleep(interval)
-
-    return False
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from common.ssh_utils import wait_for_ssh
 
 
 def main() -> int:
@@ -169,7 +121,7 @@ def main() -> int:
         # Step 5: Wait for SSH to be ready
         # ============================================================
         print("Waiting for SSH to be ready...", file=sys.stderr)
-        ssh_ready = wait_for_ssh(result["public_ip"], args.ssh_user, args.key_file)
+        ssh_ready = wait_for_ssh(result["public_ip"], args.ssh_user, args.key_file, max_attempts=30, interval=10)
         result["ssh_ready"] = ssh_ready
 
         if not ssh_ready:

--- a/isvctl/configs/stubs/bare_metal/describe_instance.py
+++ b/isvctl/configs/stubs/bare_metal/describe_instance.py
@@ -22,18 +22,18 @@ phase (so teardown always runs, even if tests fail).
 
 Required JSON output fields:
   {
-    "success": true,              # boolean - did the query succeed?
+    "success": true,             # boolean - did the query succeed?
     "platform": "bm",            # string  - always "bm"
-    "instance_id": "...",         # string  - instance identifier
-    "instance_state": "running",  # string  - current state
-    "public_ip": "54.x.x.x",    # string  - public IP for SSH access
+    "instance_id": "...",        # string  - instance identifier
+    "instance_state": "running", # string  - current state
+    "public_ip": "54.x.x.x",     # string  - public IP for SSH access
     "key_file": "/tmp/key.pem"   # string  - path to SSH private key
   }
 
 On failure, set "success": false and include an "error" field.
 
 Usage:
-    python describe_instance.py --instance-id <id> --region us-west-2 --key-file /tmp/key.pem
+    python describe_instance.py --instance-id <id> --region <region> --key-file /tmp/key.pem
 
 Reference implementation: ../aws/bm/describe_instance.py
 """
@@ -46,7 +46,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Describe bare-metal instance (template)")
     parser.add_argument("--instance-id", required=True, help="Instance identifier")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--key-file", required=True, help="Path to SSH private key")
     args = parser.parse_args()
 

--- a/isvctl/configs/stubs/bare_metal/launch_instance.py
+++ b/isvctl/configs/stubs/bare_metal/launch_instance.py
@@ -44,7 +44,8 @@ Usage:
     python launch_instance.py --name isv-bm-test-gpu --instance-type <type> --region <region>
 
     # Reuse existing instance:
-    BM_INSTANCE_ID=i-xxx BM_KEY_FILE=/tmp/key.pem python launch_instance.py
+    BM_INSTANCE_ID=i-xxx BM_KEY_FILE=/tmp/key.pem python launch_instance.py \
+        --name isv-bm-test-gpu --instance-type <type> --region <region>
 
 Reference implementation: ../aws/bm/launch_instance.py
 """

--- a/isvctl/configs/stubs/bare_metal/launch_instance.py
+++ b/isvctl/configs/stubs/bare_metal/launch_instance.py
@@ -27,10 +27,10 @@ Instance reuse (dev workflow):
 
 Required JSON output fields:
   {
-    "success": true,                # boolean - did the operation succeed?
+    "success": true,               # boolean - did the operation succeed?
     "platform": "bm",              # string  - always "bm"
-    "instance_id": "...",           # string  - unique instance identifier
-    "public_ip": "54.x.x.x",      # string  - public IP for SSH access
+    "instance_id": "...",          # string  - unique instance identifier
+    "public_ip": "54.x.x.x",       # string  - public IP for SSH access
     "key_file": "/tmp/key.pem",    # string  - path to SSH private key
     "vpc_id": "vpc-xxx",           # string  - network/VPC identifier
     "instance_state": "running",   # string  - must be "running"
@@ -41,7 +41,7 @@ Required JSON output fields:
 On failure, set "success": false and include an "error" field.
 
 Usage:
-    python launch_instance.py --name isv-bm-test-gpu --instance-type g4dn.metal --region us-west-2
+    python launch_instance.py --name isv-bm-test-gpu --instance-type <type> --region <region>
 
     # Reuse existing instance:
     BM_INSTANCE_ID=i-xxx BM_KEY_FILE=/tmp/key.pem python launch_instance.py
@@ -58,8 +58,8 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Launch bare-metal GPU instance (template)")
     parser.add_argument("--name", default="isv-bm-test-gpu", help="Instance name tag")
-    parser.add_argument("--instance-type", default="g4dn.metal", help="Bare-metal instance type")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--instance-type", required=True, help="Bare-metal instance type")
+    parser.add_argument("--region", required=True, help="Cloud region")
     args = parser.parse_args()  # noqa: F841 — used in TODO block below
 
     result: dict = {

--- a/isvctl/configs/stubs/bare_metal/launch_instance.py
+++ b/isvctl/configs/stubs/bare_metal/launch_instance.py
@@ -57,10 +57,17 @@ import sys
 
 
 def main() -> int:
+    """Launch a bare-metal GPU instance and emit structured JSON result."""
     parser = argparse.ArgumentParser(description="Launch bare-metal GPU instance (template)")
     parser.add_argument("--name", default="isv-bm-test-gpu", help="Instance name tag")
     parser.add_argument("--instance-type", required=True, help="Bare-metal instance type")
     parser.add_argument("--region", required=True, help="Cloud region")
+
+    def _arg_error(message: str) -> None:
+        print(json.dumps({"success": False, "platform": "bm", "error": message}, indent=2))
+        raise SystemExit(2)
+
+    parser.error = _arg_error  # type: ignore[assignment]
     args = parser.parse_args()  # noqa: F841 — used in TODO block below
 
     result: dict = {

--- a/isvctl/configs/stubs/bare_metal/power_cycle_instance.py
+++ b/isvctl/configs/stubs/bare_metal/power_cycle_instance.py
@@ -30,11 +30,11 @@ Power-cycle vs reboot:
 Required JSON output fields:
   {
     "success": true,                # boolean - did the full cycle succeed?
-    "platform": "bm",              # string  - always "bm"
+    "platform": "bm",               # string  - always "bm"
     "instance_id": "...",           # string  - instance identifier
     "state": "running",             # string  - must be "running" after recovery
-    "public_ip": "54.x.x.x",      # string  - public IP (may change after cycle)
-    "key_file": "/tmp/key.pem",    # string  - path to SSH private key
+    "public_ip": "54.x.x.x",        # string  - public IP (may change after cycle)
+    "key_file": "/tmp/key.pem",     # string  - path to SSH private key
     "power_cycle_initiated": true,  # boolean - was the power-off API call made?
     "power_was_off": true,          # boolean - did the node actually power off?
     "ssh_ready": true,              # boolean - can we SSH after recovery?
@@ -56,7 +56,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Power-cycle bare-metal node (template)")
     parser.add_argument("--instance-id", required=True, help="Instance identifier")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--key-file", required=True, help="Path to SSH private key")
     parser.add_argument("--public-ip", required=True, help="Instance public IP")
     args = parser.parse_args()

--- a/isvctl/configs/stubs/bare_metal/reboot_instance.py
+++ b/isvctl/configs/stubs/bare_metal/reboot_instance.py
@@ -22,11 +22,11 @@ This script is called during the "test" phase. It must:
 
 Required JSON output fields:
   {
-    "success": true,              # boolean - did the reboot + recovery succeed?
+    "success": true,             # boolean - did the reboot + recovery succeed?
     "platform": "bm",            # string  - always "bm"
-    "instance_id": "...",         # string  - instance identifier
-    "instance_state": "running",  # string  - must be "running" after reboot
-    "public_ip": "54.x.x.x",    # string  - public IP (may change after reboot)
+    "instance_id": "...",        # string  - instance identifier
+    "instance_state": "running", # string  - must be "running" after reboot
+    "public_ip": "54.x.x.x",     # string  - public IP (may change after reboot)
     "key_file": "/tmp/key.pem",  # string  - path to SSH private key
     "uptime_seconds": 45,        # int     - system uptime after reboot (should be low)
     "ssh_connectivity": true     # boolean - can we SSH after reboot?
@@ -35,7 +35,7 @@ Required JSON output fields:
 On failure, set "success": false and include an "error" field.
 
 Usage:
-    python reboot_instance.py --instance-id <id> --region us-west-2 \
+    python reboot_instance.py --instance-id <id> --region <region> \
         --key-file /tmp/key.pem --public-ip 54.x.x.x
 
 Reference implementation: ../aws/bm/reboot_instance.py
@@ -49,7 +49,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Reboot bare-metal instance (template)")
     parser.add_argument("--instance-id", required=True, help="Instance identifier")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--key-file", required=True, help="Path to SSH private key")
     parser.add_argument("--public-ip", required=True, help="Instance public IP")
     args = parser.parse_args()

--- a/isvctl/configs/stubs/bare_metal/serial_console.py
+++ b/isvctl/configs/stubs/bare_metal/serial_console.py
@@ -26,7 +26,7 @@ Required JSON output fields:
   }
 
 Usage:
-    python serial_console.py --instance-id <id> --region us-west-2
+    python serial_console.py --instance-id <id> --region <region>
 
 Reference implementation: ../aws/bare_metal/serial_console.py
 """
@@ -39,7 +39,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Serial console access test (template)")
     parser.add_argument("--instance-id", required=True, help="Instance ID")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     args = parser.parse_args()
 
     result: dict = {

--- a/isvctl/configs/stubs/bare_metal/start_instance.py
+++ b/isvctl/configs/stubs/bare_metal/start_instance.py
@@ -47,7 +47,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Power on stopped bare-metal node and verify recovery")
     parser.add_argument("--instance-id", required=True, help="Node ID to power on")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--key-file", required=True, help="Path to SSH private key")
     parser.add_argument("--public-ip", required=True, help="Node public IP address")
     args = parser.parse_args()

--- a/isvctl/configs/stubs/bare_metal/stop_instance.py
+++ b/isvctl/configs/stubs/bare_metal/stop_instance.py
@@ -42,7 +42,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Power off bare-metal node without destroying it")
     parser.add_argument("--instance-id", required=True, help="Node ID to power off")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     args = parser.parse_args()
 
     result = {

--- a/isvctl/configs/stubs/bare_metal/stop_instance.py
+++ b/isvctl/configs/stubs/bare_metal/stop_instance.py
@@ -40,6 +40,7 @@ import sys
 
 
 def main() -> int:
+    """Power off a bare-metal node and emit structured JSON result."""
     parser = argparse.ArgumentParser(description="Power off bare-metal node without destroying it")
     parser.add_argument("--instance-id", required=True, help="Node ID to power off")
     parser.add_argument("--region", required=True, help="Cloud region")

--- a/isvctl/configs/stubs/bare_metal/teardown.py
+++ b/isvctl/configs/stubs/bare_metal/teardown.py
@@ -21,17 +21,17 @@ This script is called during the "teardown" phase. It must:
 Required JSON output fields:
   {
     "success": true,                              # boolean - did teardown succeed?
-    "platform": "bm",                            # string  - always "bm"
+    "platform": "bm",                             # string  - always "bm"
     "resources_deleted": ["instance:i-xxx", ...], # list    - what was cleaned up
-    "message": "Teardown completed"              # string  - human-readable status
+    "message": "Teardown completed"               # string  - human-readable status
   }
 
 On failure, set "success": false and include an "error" field.
 If resources don't exist, return success (idempotent teardown).
 
 Usage:
-    python teardown.py --instance-id <id> --region us-west-2 --delete-key-pair --delete-security-group
-    python teardown.py --instance-id <id> --region us-west-2 --skip-destroy
+    python teardown.py --instance-id <id> --region <region> --delete-key-pair --delete-security-group
+    python teardown.py --instance-id <id> --region <region> --skip-destroy
 
     # Also supports env var:
     BM_SKIP_TEARDOWN=true python teardown.py --instance-id <id>
@@ -48,7 +48,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Teardown bare-metal instance (template)")
     parser.add_argument("--instance-id", required=True, help="Instance identifier")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--delete-key-pair", action="store_true", help="Also delete key pair")
     parser.add_argument("--delete-security-group", action="store_true", help="Also delete security group")
     parser.add_argument("--skip-destroy", action="store_true", help="Skip actual destruction")

--- a/isvctl/configs/stubs/bare_metal/teardown.py
+++ b/isvctl/configs/stubs/bare_metal/teardown.py
@@ -34,7 +34,7 @@ Usage:
     python teardown.py --instance-id <id> --region <region> --skip-destroy
 
     # Also supports env var:
-    BM_SKIP_TEARDOWN=true python teardown.py --instance-id <id>
+    BM_SKIP_TEARDOWN=true python teardown.py --instance-id <id> --region <region>
 
 Reference implementation: ../aws/bm/teardown.py
 """
@@ -46,6 +46,7 @@ import sys
 
 
 def main() -> int:
+    """Teardown bare-metal instance and associated resources, emitting JSON result."""
     parser = argparse.ArgumentParser(description="Teardown bare-metal instance (template)")
     parser.add_argument("--instance-id", required=True, help="Instance identifier")
     parser.add_argument("--region", required=True, help="Cloud region")

--- a/isvctl/configs/stubs/bare_metal/topology_placement.py
+++ b/isvctl/configs/stubs/bare_metal/topology_placement.py
@@ -21,7 +21,7 @@ Required JSON output:
     "platform": "bm",
     "instance_id": "<id>",
     "placement_supported": true,
-    "availability_zone": "us-west-2a",
+    "availability_zone": "...",
     "placement_group": "<group-name>",
     "placement_strategy": "cluster",
     "operations": {
@@ -33,7 +33,7 @@ Required JSON output:
 }
 
 Usage:
-    python topology_placement.py --instance-id <id> --region us-west-2
+    python topology_placement.py --instance-id <id> --region <region>
 
 Reference implementation: ../aws/bare_metal/topology_placement.py
 """
@@ -46,7 +46,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Topology-based placement test (template)")
     parser.add_argument("--instance-id", required=True, help="Instance ID")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     args = parser.parse_args()
 
     result: dict = {

--- a/isvctl/configs/stubs/bare_metal/verify_terminated.py
+++ b/isvctl/configs/stubs/bare_metal/verify_terminated.py
@@ -19,7 +19,7 @@ It is a post-teardown sanitization check that confirms:
 
 Required JSON output fields:
   {
-    "success": true,              # boolean - did all checks pass?
+    "success": true,             # boolean - did all checks pass?
     "platform": "bm",            # string  - always "bm"
     "checks": {                  # object  - individual check results
       "instance_terminated": {
@@ -37,7 +37,7 @@ Required JSON output fields:
 On failure, set "success": false and include an "error" field.
 
 Usage:
-    python verify_terminated.py --instance-id <id> --region us-west-2 \
+    python verify_terminated.py --instance-id <id> --region <region> \
         --security-group-id <sg-id> --key-name <key-name>
 
 Reference implementation: ../aws/bm/verify_terminated.py
@@ -52,7 +52,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Verify instance terminated (template)")
     parser.add_argument("--instance-id", required=True, help="Instance identifier")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--security-group-id", nargs="?", default=None, help="Security group to verify deleted")
     parser.add_argument("--key-name", nargs="?", default=None, help="Key pair name to verify deleted")
     args = parser.parse_args()

--- a/isvctl/configs/stubs/common/ssh_utils.py
+++ b/isvctl/configs/stubs/common/ssh_utils.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Shared SSH utilities for stub scripts.
+
+Provides wait_for_ssh() used by bare-metal and VM stubs that need to
+poll for SSH readiness after instance state changes (start, reboot,
+power-cycle, reinstall).
+"""
+
+import subprocess
+import sys
+import time
+
+
+def wait_for_ssh(
+    host: str,
+    user: str,
+    key_file: str,
+    max_attempts: int = 60,
+    interval: int = 15,
+) -> bool:
+    """Wait for SSH to become available on the host.
+
+    Args:
+        host: Public IP or hostname
+        user: SSH username
+        key_file: Path to SSH private key
+        max_attempts: Maximum number of connection attempts
+        interval: Seconds between attempts
+
+    Returns:
+        True if SSH is ready, False if timed out
+    """
+    for attempt in range(1, max_attempts + 1):
+        try:
+            result = subprocess.run(
+                [
+                    "ssh",
+                    "-o",
+                    "StrictHostKeyChecking=no",
+                    "-o",
+                    "ConnectTimeout=5",
+                    "-o",
+                    "BatchMode=yes",
+                    "-i",
+                    key_file,
+                    f"{user}@{host}",
+                    "exit 0",
+                ],
+                capture_output=True,
+                timeout=15,
+            )
+            if result.returncode == 0:
+                print(f"  SSH ready after attempt {attempt}", file=sys.stderr)
+                return True
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+
+        print(f"  Waiting for SSH... (attempt {attempt}/{max_attempts})", file=sys.stderr)
+        time.sleep(interval)
+
+    return False

--- a/isvctl/configs/stubs/control-plane/check_api.py
+++ b/isvctl/configs/stubs/control-plane/check_api.py
@@ -28,7 +28,7 @@ Required JSON output:
 }
 
 Usage:
-    python check_api.py --region us-west-2 --services compute,storage,identity
+    python check_api.py --region <region> --services compute,storage,identity
 
 AWS reference implementation:
     ../aws/control-plane/check_api.py

--- a/isvctl/configs/stubs/control-plane/create_access_key.py
+++ b/isvctl/configs/stubs/control-plane/create_access_key.py
@@ -25,7 +25,7 @@ Required JSON output:
 }
 
 Usage:
-    python create_access_key.py --region us-west-2
+    python create_access_key.py --region <region>
 
 AWS reference implementation:
     ../aws/control-plane/create_access_key.py

--- a/isvctl/configs/stubs/control-plane/create_tenant.py
+++ b/isvctl/configs/stubs/control-plane/create_tenant.py
@@ -25,7 +25,7 @@ Required JSON output:
 }
 
 Usage:
-    python create_tenant.py --region us-west-2
+    python create_tenant.py --region <region>
 
 AWS reference implementation:
     ../aws/control-plane/create_tenant.py

--- a/isvctl/configs/stubs/control-plane/delete_tenant.py
+++ b/isvctl/configs/stubs/control-plane/delete_tenant.py
@@ -24,7 +24,7 @@ Required JSON output:
 }
 
 Usage:
-    python delete_tenant.py --group-name my-tenant --region us-west-2
+    python delete_tenant.py --group-name my-tenant --region <region>
 
 AWS reference implementation:
     ../aws/control-plane/delete_tenant.py

--- a/isvctl/configs/stubs/control-plane/get_tenant.py
+++ b/isvctl/configs/stubs/control-plane/get_tenant.py
@@ -25,7 +25,7 @@ Required JSON output:
 }
 
 Usage:
-    python get_tenant.py --group-name my-tenant --region us-west-2
+    python get_tenant.py --group-name my-tenant --region <region>
 
 AWS reference implementation:
     ../aws/control-plane/get_tenant.py

--- a/isvctl/configs/stubs/control-plane/list_tenants.py
+++ b/isvctl/configs/stubs/control-plane/list_tenants.py
@@ -24,7 +24,7 @@ Required JSON output:
 }
 
 Usage:
-    python list_tenants.py --region us-west-2 --target-group my-tenant
+    python list_tenants.py --region <region> --target-group my-tenant
 
 AWS reference implementation:
     ../aws/control-plane/list_tenants.py

--- a/isvctl/configs/stubs/control-plane/test_access_key.py
+++ b/isvctl/configs/stubs/control-plane/test_access_key.py
@@ -24,7 +24,7 @@ Required JSON output:
 }
 
 Usage:
-    python test_access_key.py --access-key-id AKID --secret-access-key SECRET --region us-west-2
+    python test_access_key.py --access-key-id AKID --secret-access-key SECRET --region <region>
 
 AWS reference implementation:
     ../aws/control-plane/test_access_key.py

--- a/isvctl/configs/stubs/control-plane/verify_key_rejected.py
+++ b/isvctl/configs/stubs/control-plane/verify_key_rejected.py
@@ -25,7 +25,7 @@ Required JSON output:
 }
 
 Usage:
-    python verify_key_rejected.py --access-key-id AKID --secret-access-key SECRET --region us-west-2
+    python verify_key_rejected.py --access-key-id AKID --secret-access-key SECRET --region <region>
 
 AWS reference implementation:
     ../aws/control-plane/verify_key_rejected.py

--- a/isvctl/configs/stubs/iam/create_user.py
+++ b/isvctl/configs/stubs/iam/create_user.py
@@ -18,12 +18,12 @@ This script is called during the "setup" phase. It must:
 
 Required JSON output fields:
   {
-    "success": true,          # boolean - did the operation succeed?
-    "platform": "iam",        # string  - always "iam"
+    "success": true,           # boolean - did the operation succeed?
+    "platform": "iam",         # string  - always "iam"
     "username": "...",         # string  - the created username
     "user_id":  "...",         # string  - unique user identifier
-    "access_key_id": "...",   # string  - credential identifier (optional)
-    "secret_access_key": "..."# string  - credential secret (optional)
+    "access_key_id": "...",    # string  - credential identifier (optional)
+    "secret_access_key": "..." # string  - credential secret (optional)
   }
 
 On failure, set "success": false and include an "error" field:

--- a/isvctl/configs/stubs/image-registry/crud_image.py
+++ b/isvctl/configs/stubs/image-registry/crud_image.py
@@ -33,7 +33,7 @@ Required JSON output:
 }
 
 Usage:
-    python crud_image.py --image-id <id> --region us-west-2
+    python crud_image.py --image-id <id> --region <region>
 
 Reference implementation: ../aws/image-registry/crud_image.py
 """
@@ -46,7 +46,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="CRUD custom OS images (template)")
     parser.add_argument("--image-id", required=True, help="Source image ID from upload_image step")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     args = parser.parse_args()
 
     result: dict = {

--- a/isvctl/configs/stubs/image-registry/crud_install_config.py
+++ b/isvctl/configs/stubs/image-registry/crud_install_config.py
@@ -33,7 +33,7 @@ Required JSON output:
 }
 
 Usage:
-    python crud_install_config.py --region us-west-2
+    python crud_install_config.py --region <region>
 
 AWS reference implementation:
     ../aws/image-registry/upload_image.py (similar pattern)

--- a/isvctl/configs/stubs/image-registry/install_config_bm.py
+++ b/isvctl/configs/stubs/image-registry/install_config_bm.py
@@ -26,7 +26,7 @@ Required JSON output:
 }
 
 Usage:
-    python install_config_bm.py --config-id cfg-xxx --region us-west-2
+    python install_config_bm.py --config-id cfg-xxx --region <region>
 
 AWS reference implementation:
     ../aws/image-registry/install_config_bm.py

--- a/isvctl/configs/stubs/image-registry/install_image_bm.py
+++ b/isvctl/configs/stubs/image-registry/install_image_bm.py
@@ -25,7 +25,7 @@ Required JSON output:
 }
 
 Usage:
-    python install_image_bm.py --image-id img-xxx --region us-west-2
+    python install_image_bm.py --image-id img-xxx --region <region>
 
 AWS reference implementation:
     ../aws/image-registry/install_image_bm.py

--- a/isvctl/configs/stubs/image-registry/launch_instance.py
+++ b/isvctl/configs/stubs/image-registry/launch_instance.py
@@ -29,7 +29,7 @@ Required JSON output:
 }
 
 Usage:
-    python launch_instance.py --image-id <image-id> --instance-type g4dn.xlarge --region us-west-2
+    python launch_instance.py --image-id <image-id> --instance-type <type> --region <region>
 
 AWS reference implementation:
     ../aws/image-registry/launch_instance.py
@@ -43,7 +43,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Launch GPU instance from imported image")
     parser.add_argument("--image-id", required=True, help="Imported machine image ID")
-    parser.add_argument("--instance-type", required=True, help="Instance type / flavor (e.g. g4dn.xlarge)")
+    parser.add_argument("--instance-type", required=True, help="Instance type / flavor")
     parser.add_argument("--region", required=True, help="Cloud region / availability zone")
     args = parser.parse_args()  # noqa: F841 — used in TODO block below
 

--- a/isvctl/configs/stubs/image-registry/teardown.py
+++ b/isvctl/configs/stubs/image-registry/teardown.py
@@ -27,7 +27,7 @@ Required JSON output:
 Usage:
     python teardown.py --instance-id i-xxx --image-id img-xxx --disk-ids disk-a,disk-b \\
         --bucket-name my-bucket --key-name my-key --security-group-id sg-xxx \\
-        --instance-profile my-profile --region us-west-2
+        --instance-profile my-profile --region <region>
 
     Pass --skip-destroy to skip actual deletion (dry-run).
 

--- a/isvctl/configs/stubs/image-registry/upload_image.py
+++ b/isvctl/configs/stubs/image-registry/upload_image.py
@@ -26,7 +26,7 @@ Required JSON output:
 }
 
 Usage:
-    python upload_image.py --image-url <url> --image-format vmdk --region us-west-2
+    python upload_image.py --image-url <url> --image-format vmdk --region <region>
 
 AWS reference implementation:
     ../aws/image-registry/upload_image.py

--- a/isvctl/configs/stubs/network/byoip_test.py
+++ b/isvctl/configs/stubs/network/byoip_test.py
@@ -33,7 +33,7 @@ Required JSON output fields:
   }
 
 Usage:
-    python byoip_test.py --region us-west-2 --custom-cidr 100.64.0.0/16
+    python byoip_test.py --region <region> --custom-cidr 100.64.0.0/16
 
 Reference implementation: ../aws/network/byoip_test.py
 """
@@ -45,7 +45,7 @@ import sys
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="BYOIP test (template)")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--custom-cidr", default="100.64.0.0/16", help="Custom CIDR to test")
     parser.add_argument("--standard-cidr", default="10.90.0.0/16", help="Standard CIDR for conflict check")
     args = parser.parse_args()  # noqa: F841

--- a/isvctl/configs/stubs/network/create_vpc.py
+++ b/isvctl/configs/stubs/network/create_vpc.py
@@ -22,15 +22,15 @@ Required JSON output fields:
     "success": true,                       # boolean - did the operation succeed?
     "platform": "network",                 # string  - always "network"
     "network_id": "vpc-abc123",            # string  - VPC / network identifier
-    "cidr": "10.0.0.0/16",                # string  - the CIDR block assigned
+    "cidr": "10.0.0.0/16",                 # string  - the CIDR block assigned
     "subnets": [                           # list    - created subnets
-      {"subnet_id": "subnet-abc123", "cidr": "10.0.1.0/24", "az": "us-west-2a",
+      {"subnet_id": "subnet-abc123", "cidr": "10.0.1.0/24", "az": "<az>",
        "auto_assign_public_ip": true, "available_ips": 251}
     ],
     "security_group_id": "sg-abc123",      # string  - default security group ID
     "dhcp_options": {                      # object  - DHCP options configuration
       "dhcp_options_id": "dopt-abc",       # string  - DHCP options set ID
-      "domain_name": "ec2.internal",       # string  - domain name
+      "domain_name": "internal.example",   # string  - domain name
       "domain_name_servers": ["..."],      # list    - DNS servers
       "ntp_servers": []                    # list    - NTP servers (may be empty)
     }
@@ -44,7 +44,7 @@ On failure, set "success": false and include an "error" field:
   }
 
 Usage:
-    python create_vpc.py --name isv-shared-vpc --region us-west-2 --cidr 10.0.0.0/16
+    python create_vpc.py --name isv-shared-vpc --region <region> --cidr 10.0.0.0/16
 
 Reference implementation: ../aws/network/create_vpc.py
 """
@@ -57,7 +57,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Create VPC / virtual network (template)")
     parser.add_argument("--name", default="isv-shared-vpc", help="Name tag for the VPC")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--cidr", default="10.0.0.0/16", help="CIDR block for the VPC")
     args = parser.parse_args()
 

--- a/isvctl/configs/stubs/network/dhcp_ip_test.py
+++ b/isvctl/configs/stubs/network/dhcp_ip_test.py
@@ -27,10 +27,10 @@ Required JSON output fields:
     "success": true,                           # boolean - did the instance launch?
     "platform": "network",                     # string  - always "network"
     "test_name": "dhcp_ip",                    # string  - always "dhcp_ip"
-    "public_ip": "3.1.2.3",                   # string  - SSH target address
-    "private_ip": "10.0.1.5",                 # string  - expected private IP
-    "key_file": "/tmp/isv-dhcp-test-key.pem", # string  - SSH private key path
-    "key_name": "isv-dhcp-test-key",          # string  - key pair name
+    "public_ip": "3.1.2.3",                    # string  - SSH target address
+    "private_ip": "10.0.1.5",                  # string  - expected private IP
+    "key_file": "/tmp/isv-dhcp-test-key.pem",  # string  - SSH private key path
+    "key_name": "isv-dhcp-test-key",           # string  - key pair name
     "ssh_user": "ubuntu",                      # string  - SSH username
     "instance_id": "i-abc123"                  # string  - instance identifier
   }
@@ -39,7 +39,7 @@ On failure, set "success": false and include an "error" field.
 
 Usage:
     python dhcp_ip_test.py --vpc-id vpc-abc123 --subnet-id subnet-abc \\
-        --sg-id sg-abc123 --region us-west-2
+        --sg-id sg-abc123 --region <region>
 
 Reference implementation: ../aws/network/dhcp_ip_test.py
 """
@@ -55,7 +55,7 @@ def main() -> int:
     parser.add_argument("--subnet-id", required=True, help="Subnet to launch instance in")
     parser.add_argument("--sg-id", required=True, help="Security group ID")
     parser.add_argument("--ssh-user", default="ubuntu", help="SSH username")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     args = parser.parse_args()
 
     result: dict = {

--- a/isvctl/configs/stubs/network/dns_test.py
+++ b/isvctl/configs/stubs/network/dns_test.py
@@ -34,7 +34,7 @@ Required JSON output fields:
   }
 
 Usage:
-    python dns_test.py --region us-west-2 --cidr 10.89.0.0/16
+    python dns_test.py --region <region> --cidr 10.89.0.0/16
 
 Reference implementation: ../aws/network/dns_test.py
 """
@@ -46,7 +46,7 @@ import sys
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Localized DNS test (template)")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--cidr", default="10.89.0.0/16", help="CIDR for test VPC")
     parser.add_argument("--domain", default="internal.isv.test", help="Internal domain")
     args = parser.parse_args()  # noqa: F841

--- a/isvctl/configs/stubs/network/floating_ip_test.py
+++ b/isvctl/configs/stubs/network/floating_ip_test.py
@@ -35,7 +35,7 @@ Required JSON output fields:
   }
 
 Usage:
-    python floating_ip_test.py --region us-west-2 --cidr 10.92.0.0/16
+    python floating_ip_test.py --region <region> --cidr 10.92.0.0/16
 
 Reference implementation: ../aws/network/floating_ip_test.py
 """
@@ -47,7 +47,7 @@ import sys
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Floating IP test (template)")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--cidr", default="10.92.0.0/16", help="CIDR for test VPC")
     parser.add_argument("--max-switch-seconds", type=int, default=10, help="Max switch time")
     args = parser.parse_args()  # noqa: F841

--- a/isvctl/configs/stubs/network/isolation_test.py
+++ b/isvctl/configs/stubs/network/isolation_test.py
@@ -40,7 +40,7 @@ Required JSON output fields:
 On failure, set "success": false and include an "error" field.
 
 Usage:
-    python isolation_test.py --region us-west-2 --cidr-a 10.97.0.0/16 --cidr-b 10.96.0.0/16
+    python isolation_test.py --region <region> --cidr-a 10.97.0.0/16 --cidr-b 10.96.0.0/16
 
 Reference implementation: ../aws/network/isolation_test.py
 """
@@ -52,7 +52,7 @@ import sys
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="VPC isolation test (template)")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--cidr-a", default="10.97.0.0/16", help="CIDR block for VPC A")
     parser.add_argument("--cidr-b", default="10.96.0.0/16", help="CIDR block for VPC B")
     args = parser.parse_args()  # noqa: F841 — used in TODO block below

--- a/isvctl/configs/stubs/network/peering_test.py
+++ b/isvctl/configs/stubs/network/peering_test.py
@@ -35,7 +35,7 @@ Required JSON output fields:
   }
 
 Usage:
-    python peering_test.py --region us-west-2 --cidr-a 10.88.0.0/16 --cidr-b 10.87.0.0/16
+    python peering_test.py --region <region> --cidr-a 10.88.0.0/16 --cidr-b 10.87.0.0/16
 
 Reference implementation: ../aws/network/peering_test.py
 """
@@ -47,7 +47,7 @@ import sys
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="VPC peering test (template)")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--cidr-a", default="10.88.0.0/16", help="CIDR for VPC A")
     parser.add_argument("--cidr-b", default="10.87.0.0/16", help="CIDR for VPC B")
     args = parser.parse_args()  # noqa: F841

--- a/isvctl/configs/stubs/network/security_test.py
+++ b/isvctl/configs/stubs/network/security_test.py
@@ -40,7 +40,7 @@ Required JSON output fields:
 On failure, set "success": false and include an "error" field.
 
 Usage:
-    python security_test.py --region us-west-2 --cidr 10.94.0.0/16
+    python security_test.py --region <region> --cidr 10.94.0.0/16
 
 Reference implementation: ../aws/network/security_test.py
 """
@@ -52,7 +52,7 @@ import sys
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Security blocking test (template)")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--cidr", default="10.94.0.0/16", help="CIDR block for test VPC")
     args = parser.parse_args()  # noqa: F841 — used in TODO block below
 

--- a/isvctl/configs/stubs/network/stable_ip_test.py
+++ b/isvctl/configs/stubs/network/stable_ip_test.py
@@ -34,7 +34,7 @@ Required JSON output fields:
   }
 
 Usage:
-    python stable_ip_test.py --region us-west-2 --cidr 10.91.0.0/16
+    python stable_ip_test.py --region <region> --cidr 10.91.0.0/16
 
 Reference implementation: ../aws/network/stable_ip_test.py
 """
@@ -46,7 +46,7 @@ import sys
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Stable private IP test (template)")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--cidr", default="10.91.0.0/16", help="CIDR for test VPC")
     args = parser.parse_args()  # noqa: F841
 

--- a/isvctl/configs/stubs/network/subnet_test.py
+++ b/isvctl/configs/stubs/network/subnet_test.py
@@ -20,24 +20,24 @@ This script is called during the "test" phase. It is SELF-CONTAINED:
 
 Required JSON output fields:
   {
-    "success": true,                              # boolean - did all checks pass?
-    "platform": "network",                        # string  - always "network"
-    "test_name": "subnet_config",                 # string  - always "subnet_config"
-    "network_id": "vpc-abc123",                   # string  - VPC used for the test
-    "subnets": [                                  # list    - created subnets
+    "success": true,                        # boolean - did all checks pass?
+    "platform": "network",                  # string  - always "network"
+    "test_name": "subnet_config",           # string  - always "subnet_config"
+    "network_id": "vpc-abc123",             # string  - VPC used for the test
+    "subnets": [                            # list    - created subnets
       {
-        "subnet_id": "subnet-abc123",             # string  - subnet identifier
-        "cidr": "10.98.0.0/24",                   # string  - subnet CIDR
-        "availability_zone": "us-west-2a"         # string  - AZ placement
+        "subnet_id": "subnet-abc123",       # string  - subnet identifier
+        "cidr": "10.98.0.0/24",             # string  - subnet CIDR
+        "availability_zone": "<az>"         # string  - AZ placement
       }
     ],
-    "route_tables_verified": true                 # boolean - route tables OK?
+    "route_tables_verified": true           # boolean - route tables OK?
   }
 
 On failure, set "success": false and include an "error" field.
 
 Usage:
-    python subnet_test.py --region us-west-2 --cidr 10.98.0.0/16 --subnet-count 4
+    python subnet_test.py --region <region> --cidr 10.98.0.0/16 --subnet-count 4
 
 Reference implementation: ../aws/network/subnet_test.py
 """
@@ -49,7 +49,7 @@ import sys
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Subnet configuration test (template)")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--cidr", default="10.98.0.0/16", help="CIDR block for test VPC")
     parser.add_argument("--subnet-count", type=int, default=4, help="Number of subnets to create")
     args = parser.parse_args()  # noqa: F841 — used in TODO block below

--- a/isvctl/configs/stubs/network/teardown.py
+++ b/isvctl/configs/stubs/network/teardown.py
@@ -40,8 +40,8 @@ On failure, set "success": false and include an "error" field.
 If the VPC doesn't exist, return success (idempotent teardown).
 
 Usage:
-    python teardown.py --vpc-id vpc-abc123 --region us-west-2
-    python teardown.py --vpc-id vpc-abc123 --region us-west-2 --skip-destroy
+    python teardown.py --vpc-id vpc-abc123 --region <region>
+    python teardown.py --vpc-id vpc-abc123 --region <region> --skip-destroy
 
 Reference implementation: ../aws/network/teardown.py
 """
@@ -54,7 +54,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Teardown VPC / virtual network (template)")
     parser.add_argument("--vpc-id", required=True, help="VPC / network ID to delete")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--skip-destroy", action="store_true", help="Skip actual deletion")
     args = parser.parse_args()
 

--- a/isvctl/configs/stubs/network/test_connectivity.py
+++ b/isvctl/configs/stubs/network/test_connectivity.py
@@ -34,7 +34,7 @@ On failure, set "success": false and include an "error" field.
 
 Usage:
     python test_connectivity.py --vpc-id vpc-abc123 \\
-        --subnet-ids subnet-abc,subnet-def --sg-id sg-abc123 --region us-west-2
+        --subnet-ids subnet-abc,subnet-def --sg-id sg-abc123 --region <region>
 
 Reference implementation: ../aws/network/test_connectivity.py
 """
@@ -49,7 +49,7 @@ def main() -> int:
     parser.add_argument("--vpc-id", required=True, help="VPC / network ID to test in")
     parser.add_argument("--subnet-ids", required=True, help="Comma-separated subnet IDs")
     parser.add_argument("--sg-id", required=True, help="Security group ID")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     args = parser.parse_args()
 
     _subnet_ids = [s.strip() for s in args.subnet_ids.split(",") if s.strip()]

--- a/isvctl/configs/stubs/network/traffic_test.py
+++ b/isvctl/configs/stubs/network/traffic_test.py
@@ -41,7 +41,7 @@ Required JSON output fields:
 On failure, set "success": false and include an "error" field.
 
 Usage:
-    python traffic_test.py --region us-west-2 --cidr 10.93.0.0/16
+    python traffic_test.py --region <region> --cidr 10.93.0.0/16
 
 Reference implementation: ../aws/network/traffic_test.py
 """
@@ -53,7 +53,7 @@ import sys
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Traffic flow test (template)")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--cidr", default="10.93.0.0/16", help="CIDR block for test VPC")
     args = parser.parse_args()  # noqa: F841 — used in TODO block below
 

--- a/isvctl/configs/stubs/network/vpc_crud_test.py
+++ b/isvctl/configs/stubs/network/vpc_crud_test.py
@@ -45,7 +45,7 @@ Required JSON output fields:
 On failure, set "success": false and include an "error" field.
 
 Usage:
-    python vpc_crud_test.py --region us-west-2 --cidr 10.99.0.0/16
+    python vpc_crud_test.py --region <region> --cidr 10.99.0.0/16
 
 Reference implementation: ../aws/network/vpc_crud_test.py
 """
@@ -57,7 +57,7 @@ import sys
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="VPC CRUD lifecycle test (template)")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--cidr", default="10.99.0.0/16", help="CIDR block for test VPC")
     args = parser.parse_args()  # noqa: F841 — used in TODO block below
 

--- a/isvctl/configs/stubs/network/vpc_ip_config_test.py
+++ b/isvctl/configs/stubs/network/vpc_ip_config_test.py
@@ -24,20 +24,20 @@ Required JSON output fields:
     "platform": "network",                     # string  - always "network"
     "test_name": "vpc_ip_config",              # string  - always "vpc_ip_config"
     "network_id": "vpc-abc123",                # string  - VPC identifier
-    "cidr": "10.0.0.0/16",                    # string  - VPC CIDR block
+    "cidr": "10.0.0.0/16",                     # string  - VPC CIDR block
     "subnets": [                               # list    - subnet details
       {
         "subnet_id": "subnet-abc",             # string  - subnet identifier
-        "cidr": "10.0.1.0/24",                # string  - subnet CIDR
-        "az": "us-west-2a",                   # string  - availability zone
+        "cidr": "10.0.1.0/24",                 # string  - subnet CIDR
+        "az": "<az>",                          # string  - availability zone
         "auto_assign_public_ip": true,         # boolean - auto-assign public IP?
         "available_ips": 251                   # int     - available IP addresses
       }
     ],
     "dhcp_options": {                          # object  - DHCP options set
       "dhcp_options_id": "dopt-abc",           # string  - DHCP options set ID
-      "domain_name": "ec2.internal",           # string  - domain name
-      "domain_name_servers": ["AmazonProvidedDNS"],  # list - DNS servers
+      "domain_name": "internal.example",       # string  - domain name
+      "domain_name_servers": ["..."],          # list - DNS servers
       "ntp_servers": []                        # list    - NTP servers (may be empty)
     }
   }
@@ -45,7 +45,7 @@ Required JSON output fields:
 On failure, set "success": false and include an "error" field.
 
 Usage:
-    python vpc_ip_config_test.py --vpc-id vpc-abc123 --region us-west-2
+    python vpc_ip_config_test.py --vpc-id vpc-abc123 --region <region>
 
 Reference implementation: ../aws/network/vpc_ip_config_test.py
 """
@@ -58,7 +58,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="VPC IP configuration test (template)")
     parser.add_argument("--vpc-id", required=True, help="VPC / network ID to inspect")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     args = parser.parse_args()
 
     result: dict = {

--- a/isvctl/configs/stubs/vm/describe_tags.py
+++ b/isvctl/configs/stubs/vm/describe_tags.py
@@ -41,7 +41,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Describe VM instance tags")
     parser.add_argument("--instance-id", required=True, help="Instance ID")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     args = parser.parse_args()
 
     result = {

--- a/isvctl/configs/stubs/vm/launch_instance.py
+++ b/isvctl/configs/stubs/vm/launch_instance.py
@@ -34,7 +34,7 @@ Required JSON output fields:
   error             (str, optional) - error message provided when success is false
 
 Usage:
-    python launch_instance.py --name isv-test-gpu --instance-type g5.xlarge --region us-west-2
+    python launch_instance.py --name isv-test-gpu --instance-type <type> --region <region>
 
 Reference implementation (AWS):
     ../aws/vm/launch_instance.py
@@ -48,8 +48,8 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Launch GPU VM instance")
     parser.add_argument("--name", default="isv-test-gpu", help="Instance name tag")
-    parser.add_argument("--instance-type", default="g5.xlarge", help="GPU instance type")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--instance-type", required=True, help="GPU instance type")
+    parser.add_argument("--region", required=True, help="Cloud region")
     args = parser.parse_args()  # noqa: F841 — used in TODO block below
 
     result = {

--- a/isvctl/configs/stubs/vm/list_instances.py
+++ b/isvctl/configs/stubs/vm/list_instances.py
@@ -27,8 +27,8 @@ Required JSON output fields:
   error        (str, optional) - error message provided when success is false
 
 Usage:
-    python list_instances.py --vpc-id vpc-xxx --region us-west-2
-    python list_instances.py --vpc-id vpc-xxx --instance-id i-xxx --region us-west-2
+    python list_instances.py --vpc-id vpc-xxx --region <region>
+    python list_instances.py --vpc-id vpc-xxx --instance-id i-xxx --region <region>
 
 Reference implementation (AWS):
     ../aws/vm/list_instances.py
@@ -43,7 +43,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="List VM instances in a VPC/network")
     parser.add_argument("--vpc-id", required=True, help="VPC or network identifier")
     parser.add_argument("--instance-id", help="Filter to a specific instance ID")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     args = parser.parse_args()  # noqa: F841 — used in TODO block below
 
     result = {

--- a/isvctl/configs/stubs/vm/reboot_instance.py
+++ b/isvctl/configs/stubs/vm/reboot_instance.py
@@ -32,7 +32,7 @@ Required JSON output fields:
   error             (str, optional) - human-readable error message provided when success is false
 
 Usage:
-    python reboot_instance.py --instance-id i-xxx --region us-west-2 \\
+    python reboot_instance.py --instance-id i-xxx --region <region> \\
         --key-file /tmp/key.pem --public-ip 54.x.x.x
 
 Reference implementation (AWS):
@@ -47,7 +47,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Reboot VM instance and verify recovery")
     parser.add_argument("--instance-id", required=True, help="Instance ID to reboot")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--key-file", required=True, help="Path to SSH private key")
     parser.add_argument("--public-ip", required=True, help="Instance public IP address")
     args = parser.parse_args()

--- a/isvctl/configs/stubs/vm/serial_console.py
+++ b/isvctl/configs/stubs/vm/serial_console.py
@@ -26,7 +26,7 @@ Required JSON output fields:
   }
 
 Usage:
-    python serial_console.py --instance-id <id> --region us-west-2
+    python serial_console.py --instance-id <id> --region <region>
 
 Reference implementation: ../aws/vm/serial_console.py
 """
@@ -39,7 +39,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Serial console access test (template)")
     parser.add_argument("--instance-id", required=True, help="Instance ID")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     args = parser.parse_args()
 
     result: dict = {

--- a/isvctl/configs/stubs/vm/serial_console.py
+++ b/isvctl/configs/stubs/vm/serial_console.py
@@ -37,9 +37,16 @@ import sys
 
 
 def main() -> int:
+    """Retrieve serial console output from a running instance and emit JSON."""
     parser = argparse.ArgumentParser(description="Serial console access test (template)")
     parser.add_argument("--instance-id", required=True, help="Instance ID")
     parser.add_argument("--region", required=True, help="Cloud region")
+
+    def _arg_error(message: str) -> None:
+        print(json.dumps({"success": False, "platform": "vm", "error": message}, indent=2))
+        raise SystemExit(2)
+
+    parser.error = _arg_error  # type: ignore[assignment]
     args = parser.parse_args()
 
     result: dict = {

--- a/isvctl/configs/stubs/vm/serial_console.py
+++ b/isvctl/configs/stubs/vm/serial_console.py
@@ -34,6 +34,7 @@ Reference implementation: ../aws/vm/serial_console.py
 import argparse
 import json
 import sys
+from typing import NoReturn
 
 
 def main() -> int:
@@ -42,7 +43,7 @@ def main() -> int:
     parser.add_argument("--instance-id", required=True, help="Instance ID")
     parser.add_argument("--region", required=True, help="Cloud region")
 
-    def _arg_error(message: str) -> None:
+    def _arg_error(message: str) -> NoReturn:
         print(json.dumps({"success": False, "platform": "vm", "error": message}, indent=2))
         raise SystemExit(2)
 

--- a/isvctl/configs/stubs/vm/start_instance.py
+++ b/isvctl/configs/stubs/vm/start_instance.py
@@ -46,7 +46,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Start stopped VM instance and verify recovery")
     parser.add_argument("--instance-id", required=True, help="Instance ID to start")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--key-file", required=True, help="Path to SSH private key")
     parser.add_argument("--public-ip", required=True, help="Instance public IP address")
     args = parser.parse_args()

--- a/isvctl/configs/stubs/vm/stop_instance.py
+++ b/isvctl/configs/stubs/vm/stop_instance.py
@@ -42,7 +42,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Stop VM instance without destroying it")
     parser.add_argument("--instance-id", required=True, help="Instance ID to stop")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     args = parser.parse_args()
 
     result = {

--- a/isvctl/configs/stubs/vm/teardown.py
+++ b/isvctl/configs/stubs/vm/teardown.py
@@ -28,7 +28,7 @@ Required JSON output fields:
   error              (str, optional) - error message provided when success is false
 
 Usage:
-    python teardown.py --instance-id i-xxx --region us-west-2 \\
+    python teardown.py --instance-id i-xxx --region <region> \\
         --delete-key-pair --delete-security-group
 
 Reference implementation (AWS):
@@ -43,7 +43,7 @@ import sys
 def main() -> int:
     parser = argparse.ArgumentParser(description="Tear down VM instance and resources")
     parser.add_argument("--instance-id", required=True, help="Instance ID to terminate")
-    parser.add_argument("--region", default="us-west-2", help="Cloud region")
+    parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument(
         "--delete-key-pair",
         action="store_true",

--- a/isvtest/src/isvtest/core/ssh.py
+++ b/isvtest/src/isvtest/core/ssh.py
@@ -25,6 +25,8 @@ Requires paramiko: pip install paramiko
 from __future__ import annotations
 
 import logging
+import threading
+import time
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -88,10 +90,8 @@ def run_ssh_command(
         Tuple of (exit_code, stdout, stderr)
 
     Raises:
-        socket.timeout: If the command does not complete within timeout
+        TimeoutError: If the command does not complete within timeout
     """
-    import threading
-
     _, stdout, _stderr = ssh.exec_command(command)
     channel = stdout.channel
 
@@ -102,8 +102,10 @@ def run_ssh_command(
         while not channel.exit_status_ready():
             if channel.recv_ready():
                 stdout_data.append(channel.recv(65536))
-            if channel.recv_stderr_ready():
+            elif channel.recv_stderr_ready():
                 stderr_data.append(channel.recv_stderr(65536))
+            else:
+                time.sleep(0.1)
         while channel.recv_ready():
             stdout_data.append(channel.recv(65536))
         while channel.recv_stderr_ready():

--- a/isvtest/src/isvtest/validations/instance.py
+++ b/isvtest/src/isvtest/validations/instance.py
@@ -186,10 +186,10 @@ class InstancePowerCycleCheck(BaseValidation):
 
         recovery = step_output.get("recovery_seconds")
         if recovery is not None and recovery > max_recovery_time:
-            self.set_failed(f"Instance {instance_id} recovery took {recovery:.0f}s > {max_recovery_time}s")
+            self.set_failed(f"Instance {instance_id} recovery took {recovery}s > {max_recovery_time}s")
             return
 
-        recovery_str = f", recovery={recovery:.0f}s" if recovery is not None else ""
+        recovery_str = f", recovery={recovery}s" if recovery is not None else ""
         self.set_passed(f"Instance {instance_id} recovered from power-cycle (state={state}{recovery_str})")
 
 


### PR DESCRIPTION
## Summary
- Replace hardcoded AWS defaults (`--region default="us-west-2"`) with `required=True` in all non-AWS canonical stub templates (bare_metal, vm, network, control-plane, image-registry, iam) so ISV implementations aren't silently pinned to an AWS region.
- Extract the duplicated `wait_for_ssh()` helper from 6 AWS stubs into a shared `stubs/common/ssh_utils.py` module (-217 lines net). VM stubs use shorter poll intervals (30 × 10s) vs bare-metal defaults (60 × 15s).
- Fix `InstancePowerCycleCheck` format string that called `:.0f` on an int (`recovery_seconds`).
- Fix busy-loop in `isvtest/core/ssh.py` `run_ssh_command()` — add `time.sleep(0.1)` when no data is ready.

## Test plan
- [x] `cd isvtest && uv run pytest -m unit` passes (covers `InstancePowerCycleCheck` and `ssh.py` changes)
- [x] Verify canonical stubs reject missing `--region` (e.g. `python3 stubs/bare_metal/power_cycle_instance.py --instance-id test --key-file /dev/null --public-ip 1.2.3.4`)
- [x] Full AWS bare-metal suite passes with existing instance (`AWS_BM_INSTANCE_ID=... uv run isvctl test run -f isvctl/configs/providers/aws/bare_metal.yaml`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated SSH readiness logic into a shared utility used by multiple stub scripts.

* **Chores**
  * Made --region required across many stub scripts.
  * Improved SSH channel reading efficiency and refined recovery-time formatting in validation messages.

* **Documentation**
  * Updated CLI usage examples to use placeholders instead of a hardcoded region.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->