### PR TITLE
fix: exclude example and utility checks from test catalog

### DIFF
--- a/isvtest/src/isvtest/catalog.py
+++ b/isvtest/src/isvtest/catalog.py
@@ -149,9 +149,11 @@ def build_catalog() -> list[dict[str, Any]]:
     """
     platform_map = _build_platform_map()
 
-    # Build class metadata lookup
+    # Build class metadata lookup, skipping classes marked for exclusion
     class_meta: dict[str, dict[str, Any]] = {}
     for cls in discover_all_tests():
+        if getattr(cls, "catalog_exclude", False):
+            continue
         markers = list(getattr(cls, "markers", []))
         class_meta[cls.__name__] = {
             "description": getattr(cls, "description", "") or "",

--- a/isvtest/src/isvtest/catalog.py
+++ b/isvtest/src/isvtest/catalog.py
@@ -151,8 +151,10 @@ def build_catalog() -> list[dict[str, Any]]:
 
     # Build class metadata lookup, skipping classes marked for exclusion
     class_meta: dict[str, dict[str, Any]] = {}
+    excluded_names: set[str] = set()
     for cls in discover_all_tests():
         if getattr(cls, "catalog_exclude", False):
+            excluded_names.add(cls.__name__)
             continue
         markers = list(getattr(cls, "markers", []))
         class_meta[cls.__name__] = {
@@ -186,9 +188,10 @@ def build_catalog() -> list[dict[str, Any]]:
     for name, platforms in platform_map.items():
         if name in seen:
             continue
-        seen.add(name)
-        # Inherit metadata from base class
         base = name.split("-")[0] if "-" in name else name
+        if name in excluded_names or base in excluded_names:
+            continue
+        seen.add(name)
         meta = class_meta.get(base, {})
         variant_suffix = name[len(base) :] if base != name else ""
         desc = meta.get("description", "")

--- a/isvtest/src/isvtest/core/validation.py
+++ b/isvtest/src/isvtest/core/validation.py
@@ -34,6 +34,7 @@ class BaseValidation(ABC):
     description: ClassVar[str] = ""
     timeout: ClassVar[int] = 60
     markers: ClassVar[list[str]] = []
+    catalog_exclude: ClassVar[bool] = False
 
     def __init__(self, runner: Runner | None = None, config: dict[str, Any] | None = None):
         self.config = config or {}

--- a/isvtest/src/isvtest/validations/cluster.py
+++ b/isvtest/src/isvtest/validations/cluster.py
@@ -129,6 +129,7 @@ class PerformanceCheck(BaseValidation):
 
     description: ClassVar[str] = "Check workload performance meets requirements"
     markers: ClassVar[list[str]] = ["workload"]
+    catalog_exclude: ClassVar[bool] = True
 
     def run(self) -> None:
         step_output = self.config.get("step_output", {})

--- a/isvtest/src/isvtest/validations/example.py
+++ b/isvtest/src/isvtest/validations/example.py
@@ -18,6 +18,7 @@ class ExampleCheck(BaseValidation):
 
     description = "An example check that verifies echo works."
     markers: ClassVar[list[str]] = []
+    catalog_exclude: ClassVar[bool] = True
 
     def run(self) -> None:
         result = self.run_command("echo 'hello world'")
@@ -38,6 +39,7 @@ class SecondExampleCheck(BaseValidation):
 
     description = "An example check that verifies echo works."
     markers: ClassVar[list[str]] = []
+    catalog_exclude: ClassVar[bool] = True
 
     def run(self) -> None:
         result = self.run_command("echo 'another example'")

--- a/isvtest/src/isvtest/validations/generic.py
+++ b/isvtest/src/isvtest/validations/generic.py
@@ -155,6 +155,7 @@ class SchemaValidation(BaseValidation):
 
     description: ClassVar[str] = "Validate output matches JSON schema"
     markers: ClassVar[list[str]] = []
+    catalog_exclude: ClassVar[bool] = True
 
     def run(self) -> None:
         step_output = self.config.get("step_output", {})


### PR DESCRIPTION
## Summary

- Adds `catalog_exclude` ClassVar to `BaseValidation` (default `False`). Classes marked `True` are skipped by `build_catalog()`.
- Marks 4 checks as excluded: `ExampleCheck`, `SecondExampleCheck`, `PerformanceCheck`, `SchemaValidation`
- These are library utilities or demo checks that inflate the catalog without contributing real validation coverage, and appear as "UNCATEGORIZED" in the Lab UI coverage dashboard

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [x] `isvctl catalog push --no-upload` produces 103 entries (down from 107), with 0 empty-platform entries

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validations can now be marked to be excluded from generated catalogs, giving finer control over catalog contents.
  * Several built-in validations are now configured to be excluded by default, so they no longer appear in catalog outputs or variant listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->