### PR TITLE
feat: add tag validation to bare-metal test suite (CNP05)

### DIFF
--- a/isvctl/configs/providers/aws/bare_metal.yaml
+++ b/isvctl/configs/providers/aws/bare_metal.yaml
@@ -85,6 +85,18 @@ commands:
           - "{{region}}"
         timeout: 120
 
+      # Verify user-defined tags on BM instance (boto3)
+      # Reuses the VM describe_tags pattern (generic EC2 API)
+      - name: verify_tags
+        phase: test
+        command: "python3 ../../stubs/aws/bare_metal/describe_tags.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 60
+
       # Topology-based placement validation (boto3)
       - name: topology_placement
         phase: test

--- a/isvctl/configs/stubs/aws/bare_metal/describe_tags.py
+++ b/isvctl/configs/stubs/aws/bare_metal/describe_tags.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Retrieve user-defined tags on an AWS bare-metal EC2 instance.
+
+Fetches all tags applied to the instance via the EC2 API and returns them
+as a flat key→value dict. Validates that the expected isvtest tags
+(Name, CreatedBy) are present.
+
+Usage:
+    python describe_tags.py --instance-id i-xxx --region us-west-2
+
+Output JSON:
+{
+    "success": true,
+    "platform": "bm",
+    "instance_id": "i-xxx",
+    "tags": {
+        "Name": "isv-bm-test-gpu",
+        "CreatedBy": "isvtest"
+    },
+    "tag_count": 2
+}
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+import boto3
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Describe bare-metal EC2 instance tags")
+    parser.add_argument("--instance-id", required=True, help="EC2 instance ID")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    args = parser.parse_args()
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "bm",
+        "instance_id": args.instance_id,
+        "tags": {},
+        "tag_count": 0,
+    }
+
+    try:
+        response = ec2.describe_instances(InstanceIds=[args.instance_id])
+        reservations = response.get("Reservations", [])
+        if not reservations or not reservations[0].get("Instances"):
+            result["error"] = f"Instance {args.instance_id} not found"
+            print(json.dumps(result, indent=2))
+            return 1
+
+        instance = reservations[0]["Instances"][0]
+        raw_tags = instance.get("Tags", [])
+
+        # Convert [{Key: k, Value: v}, ...] → {k: v}
+        tags = {t["Key"]: t["Value"] for t in raw_tags}
+        result["tags"] = tags
+        result["tag_count"] = len(tags)
+        result["success"] = True
+
+    except Exception as e:
+        result["error"] = str(e)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/aws/bare_metal/describe_tags.py
+++ b/isvctl/configs/stubs/aws/bare_metal/describe_tags.py
@@ -12,8 +12,8 @@
 """Retrieve user-defined tags on an AWS bare-metal EC2 instance.
 
 Fetches all tags applied to the instance via the EC2 API and returns them
-as a flat key→value dict. Validates that the expected isvtest tags
-(Name, CreatedBy) are present.
+as a flat key→value dict. Required-key validation is handled by
+InstanceTagCheck in the validation layer.
 
 Usage:
     python describe_tags.py --instance-id i-xxx --region us-west-2
@@ -41,6 +41,7 @@ import boto3
 
 
 def main() -> int:
+    """Retrieve EC2 bare-metal instance tags and print structured JSON output."""
     parser = argparse.ArgumentParser(description="Describe bare-metal EC2 instance tags")
     parser.add_argument("--instance-id", required=True, help="EC2 instance ID")
     parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))

--- a/isvctl/configs/stubs/bare_metal/describe_tags.py
+++ b/isvctl/configs/stubs/bare_metal/describe_tags.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Retrieve user-defined tags on a bare-metal instance.
+
+Template stub for ISV NCP Validation. Replace the TODO section with your
+platform's API calls to fetch instance tags/labels.
+
+This script must:
+  1. Query your platform API for the tags on the given instance
+  2. Return them as a flat key→value dict in the JSON output
+
+Required JSON output fields:
+  success     (bool)  - whether the operation succeeded
+  platform    (str)   - always "bm"
+  instance_id (str)   - the queried instance ID
+  tags        (dict)  - key/value map of all instance tags
+  tag_count   (int)   - number of tags returned
+  error       (str, optional) - error message when success is false
+
+Usage:
+    python describe_tags.py --instance-id <id> --region <region>
+
+Reference implementation (AWS):
+    ../aws/bare_metal/describe_tags.py
+"""
+
+import argparse
+import json
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Describe bare-metal instance tags")
+    parser.add_argument("--instance-id", required=True, help="Instance ID")
+    parser.add_argument("--region", required=True, help="Cloud region")
+    args = parser.parse_args()
+
+    result = {
+        "success": False,
+        "platform": "bm",
+        "instance_id": args.instance_id,
+        "tags": {},
+        "tag_count": 0,
+    }
+
+    try:
+        # ╔══════════════════════════════════════════════════════════════╗
+        # ║  TODO: Replace this block with your platform's API calls     ║
+        # ║                                                              ║
+        # ║  1. Query your API for the instance's tags                   ║
+        # ║     tags = get_instance_tags(args.instance_id, args.region)  ║
+        # ║                                                              ║
+        # ║  2. Populate the result dict:                                ║
+        # ║     result["tags"] = tags          # dict: {key: value}      ║
+        # ║     result["tag_count"] = len(tags)                          ║
+        # ║     result["success"] = True                                 ║
+        # ╚══════════════════════════════════════════════════════════════╝
+
+        result["error"] = "Not implemented - replace with your platform's tag retrieval logic"
+
+    except Exception as e:
+        result["error"] = str(e)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/bare_metal/describe_tags.py
+++ b/isvctl/configs/stubs/bare_metal/describe_tags.py
@@ -39,6 +39,7 @@ import sys
 
 
 def main() -> int:
+    """Parse CLI args and emit bare-metal tag metadata as structured JSON."""
     parser = argparse.ArgumentParser(description="Describe bare-metal instance tags")
     parser.add_argument("--instance-id", required=True, help="Instance ID")
     parser.add_argument("--region", required=True, help="Cloud region")

--- a/isvctl/configs/tests/bare_metal.yaml
+++ b/isvctl/configs/tests/bare_metal.yaml
@@ -25,19 +25,20 @@
 # Steps:
 #   1. launch_instance      (setup)    - Provision bare-metal GPU instance
 #   2. list_instances       (test)     - List instances, verify target exists
-#   3. topology_placement   (test)     - Validate topology-based placement support
-#   4. serial_console       (test)     - Retrieve serial console output (read-only)
-#   5. stop_instance        (test)     - Power off node, verify stopped state
-#   6. start_instance       (test)     - Power on node, verify recovery
-#   7. reboot_instance      (test)     - Reboot instance, validate recovery
-#   8. power_cycle_instance (test)     - Hard power off + on, validate cold-start recovery
-#   9. describe_instance    (test)     - Describe current state + SSH info
+#   3. verify_tags          (test)     - Verify user-defined tags on instance
+#   4. topology_placement   (test)     - Validate topology-based placement support
+#   5. serial_console       (test)     - Retrieve serial console output (read-only)
+#   6. stop_instance        (test)     - Power off node, verify stopped state
+#   7. start_instance       (test)     - Power on node, verify recovery
+#   8. reboot_instance      (test)     - Reboot instance, validate recovery
+#   9. power_cycle_instance (test)     - Hard power off + on, validate cold-start recovery
+#  10. describe_instance    (test)     - Describe current state + SSH info
 #                                        (runs after power_cycle so IP is current)
-#  10. reinstall_instance   (test)     - Reinstall OS from stock image [skip: true by default]
-#  11. deploy_nim           (test)     - Deploy NIM container via SSH
-#  12. teardown_nim         (teardown) - Stop NIM container
-#  13. teardown             (teardown) - Terminate instance
-#  14. verify_teardown      (teardown) - Confirm resources deleted
+#  11. reinstall_instance   (test)     - Reinstall OS from stock image [skip: true by default]
+#  12. deploy_nim           (test)     - Deploy NIM container via SSH
+#  13. teardown_nim         (teardown) - Stop NIM container
+#  14. teardown             (teardown) - Terminate instance
+#  15. verify_teardown      (teardown) - Confirm resources deleted
 #
 # Dev workflow (reuse existing instance):
 #   # Run 1: launch + test, keep instance alive
@@ -102,7 +103,27 @@ commands:
           - "{{region}}"
         timeout: 120
 
-      # ─── Step 3: Topology Placement ──────────────────────────────
+      # ─── Step 3: Verify Tags ────────────────────────────────────
+      # Reuses the VM describe_tags stub (generic instance tag retrieval).
+      # YOUR SCRIPT must output JSON with at minimum:
+      #   {
+      #     "success": true,
+      #     "platform": "bm",
+      #     "instance_id": "...",
+      #     "tags": {"Name": "...", "CreatedBy": "isvtest"},
+      #     "tag_count": 2
+      #   }
+      - name: verify_tags
+        phase: test
+        command: "python3 ../stubs/bare_metal/describe_tags.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 60
+
+      # ─── Step 4: Topology Placement ──────────────────────────────
       # YOUR SCRIPT must validate topology-based placement support.
       #   {
       #     "success": true,
@@ -377,6 +398,12 @@ tests:
       checks:
         InstanceListCheck:
           min_count: 1
+
+    tag_checks:
+      step: verify_tags
+      checks:
+        InstanceTagCheck:
+          required_keys: ["Name", "CreatedBy"]
 
     topology_placement:
       step: topology_placement

--- a/isvctl/configs/tests/bare_metal.yaml
+++ b/isvctl/configs/tests/bare_metal.yaml
@@ -104,7 +104,7 @@ commands:
         timeout: 120
 
       # ─── Step 3: Verify Tags ────────────────────────────────────
-      # Reuses the VM describe_tags stub (generic instance tag retrieval).
+      # Uses the bare-metal describe_tags stub (provider implements retrieval).
       # YOUR SCRIPT must output JSON with at minimum:
       #   {
       #     "success": true,
@@ -150,7 +150,7 @@ commands:
           - "{{region}}"
         timeout: 120
 
-      # ─── Step 4: Serial Console Access ──────────────────────────────
+      # ─── Step 5: Serial Console Access ──────────────────────────────
       # YOUR SCRIPT must output JSON with at minimum:
       #   {
       #     "success": true,
@@ -170,7 +170,7 @@ commands:
           - "{{region}}"
         timeout: 60
 
-      # ─── Step 5: Stop Instance ────────────────────────────────────
+      # ─── Step 6: Stop Instance ────────────────────────────────────
       # YOUR SCRIPT must output JSON with at minimum:
       #   {
       #     "success": true,
@@ -189,7 +189,7 @@ commands:
           - "{{region}}"
         timeout: 1800
 
-      # ─── Step 6: Start Instance ───────────────────────────────────
+      # ─── Step 7: Start Instance ───────────────────────────────────
       # YOUR SCRIPT must output JSON with at minimum:
       #   {
       #     "success": true,
@@ -215,7 +215,7 @@ commands:
           - "{{steps.launch_instance.public_ip}}"
         timeout: 2700
 
-      # ─── Step 7: Reboot Instance ──────────────────────────────────
+      # ─── Step 8: Reboot Instance ──────────────────────────────────
       # BM-specific: longer waits for hardware POST/BIOS/OS boot.
       # YOUR SCRIPT must output JSON with at minimum:
       #   {
@@ -243,7 +243,7 @@ commands:
           - "{{steps.start_instance.public_ip}}"
         timeout: 1800
 
-      # ─── Step 8: Power-Cycle Instance ────────────────────────────────
+      # ─── Step 9: Power-Cycle Instance ────────────────────────────────
       # Hard power off + power on (cold start). Unlike reboot (OS-level),
       # this exercises firmware init, BIOS POST, and a cold OS boot.
       # YOUR SCRIPT must output JSON with at minimum:
@@ -298,7 +298,7 @@ commands:
           - "{{steps.launch_instance.key_file}}"
         timeout: 120
 
-      # ─── Step 10: Reinstall Instance ────────────────────────────────
+      # ─── Step 11: Reinstall Instance ────────────────────────────────
       # Reinstall the node from its configured stock OS.
       # Skipped by default: can be very slow depending on platform.
       # Set skip: false and implement stubs/bare_metal/reinstall_instance.py to enable.
@@ -318,7 +318,7 @@ commands:
           - "{{steps.power_cycle_instance.public_ip}}"
         timeout: 3600
 
-      # ─── Step 11: Deploy NIM Container ───────────────────────────
+      # ─── Step 12: Deploy NIM Container ───────────────────────────
       # Uses post-power-cycle IP/key since power-cycle may reassign the public IP
       - name: deploy_nim
         phase: test
@@ -330,7 +330,7 @@ commands:
           - "{{steps.power_cycle_instance.key_file}}"
         timeout: 1800
 
-      # ─── Step 12: Teardown NIM ───────────────────────────────────
+      # ─── Step 13: Teardown NIM ───────────────────────────────────
       # Uses post-power-cycle IP/key to match what deploy_nim used
       - name: teardown_nim
         phase: teardown
@@ -342,7 +342,7 @@ commands:
           - "{{steps.power_cycle_instance.key_file}}"
         timeout: 120
 
-      # ─── Step 13: Teardown Instance ──────────────────────────────
+      # ─── Step 14: Teardown Instance ──────────────────────────────
       - name: teardown
         phase: teardown
         command: "python3 ../stubs/bare_metal/teardown.py"
@@ -356,7 +356,7 @@ commands:
           - "{{teardown_flag}}"
         timeout: 1800
 
-      # ─── Step 14: Verify Teardown ────────────────────────────────
+      # ─── Step 15: Verify Teardown ────────────────────────────────
       # Post-teardown sanitization: verify instance terminated and
       # resources deleted.
       - name: verify_teardown

--- a/isvtest/src/isvtest/validations/host.py
+++ b/isvtest/src/isvtest/validations/host.py
@@ -1120,7 +1120,7 @@ class GpuStressCheck(BaseValidation):
                 f"Running GPU stress on {host}: runtime={runtime}s, memory={memory_gb}GB, mode={container_runtime}"
             )
 
-            _, stdout, stderr = run_ssh_command(ssh, cmd)
+            _, stdout, stderr = run_ssh_command(ssh, cmd, timeout=self.timeout)
             ssh.close()
 
             output = f"{stdout}\n{stderr}".strip()
@@ -1250,7 +1250,7 @@ class NcclCheck(BaseValidation):
             )
 
             self.log.info(f"Running NCCL AllReduce on {host} with {gpu_count} GPUs")
-            exit_code, stdout, stderr = run_ssh_command(ssh, nccl_cmd)
+            exit_code, stdout, stderr = run_ssh_command(ssh, nccl_cmd, timeout=self.timeout)
             ssh.close()
 
             output = f"{stdout}\n{stderr}".strip()
@@ -1398,7 +1398,7 @@ class TrainingCheck(BaseValidation):
                 f"batch={batch_size}, hidden={hidden_size}, mode={container_runtime}"
             )
 
-            _, stdout, stderr = run_ssh_command(ssh, cmd)
+            _, stdout, stderr = run_ssh_command(ssh, cmd, timeout=self.timeout)
             ssh.close()
 
             output = f"{stdout}\n{stderr}".strip()

--- a/isvtest/src/isvtest/validations/instance.py
+++ b/isvtest/src/isvtest/validations/instance.py
@@ -326,7 +326,7 @@ class InstanceTagCheck(BaseValidation):
     """
 
     description: ClassVar[str] = "Check instance tags are present"
-    markers: ClassVar[list[str]] = ["vm"]
+    markers: ClassVar[list[str]] = ["vm", "bare_metal"]
 
     def run(self) -> None:
         step_output = self.config.get("step_output", {})


### PR DESCRIPTION
## Summary

- Extend `InstanceTagCheck` to bare-metal instances — VM test suite already validates user-defined tags via `describe_tags`; this adds the same coverage to bare metal so CNP05 (Tagging) is fully covered for both instance types
- New template stub + AWS reference implementation for `describe_tags` on bare metal
- New `verify_tags` step wired into the bare-metal test suite (step 3, after `list_instances`)
- Fix GPU workload validations (GpuStressCheck, NcclCheck, TrainingCheck) timing out after 120s because `run_ssh_command` was called without propagating the 900s class timeout

Closes #181
Closes #182

## Test plan

- [x] Full AWS bare-metal orchestration: **22 passed, 5 skipped, 67 subtests passed**
- [x] `InstanceTagCheck: PASSED - Instance i-03cdd1f8c12707f37 has 3 tag(s): ['CreatedBy', 'Name', 'Platform']`
- [x] GPU timeout fix confirmed: GpuStress (1024 loops/8 GPUs), NCCL (5.20 GB/s), Training (50 DDP steps)
- [x] Pre-commit hooks pass (`ruff`, `ruff-format`, `yamlfmt`, SPDX headers)
- [x] Template stub returns expected "not implemented" output

🤖 Generated with [Claude Code](https://claude.com/claude-code)