### PR TITLE
feat: add stable identifier validation across lifecycle events (CNP08)

### DIFF
--- a/isvctl/configs/tests/bare_metal.yaml
+++ b/isvctl/configs/tests/bare_metal.yaml
@@ -507,6 +507,8 @@ tests:
       step: start_instance
       checks:
         InstanceStartCheck: {}
+        StableIdentifierCheck:
+          reference_id: "{{steps.launch_instance.instance_id}}"
 
     start_ssh:
       step: start_instance
@@ -525,6 +527,8 @@ tests:
       checks:
         InstanceRebootCheck:
           max_uptime: 600
+        StableIdentifierCheck:
+          reference_id: "{{steps.launch_instance.instance_id}}"
 
     reboot_state:
       step: reboot_instance
@@ -550,6 +554,8 @@ tests:
       checks:
         InstancePowerCycleCheck:
           max_recovery_time: 900
+        StableIdentifierCheck:
+          reference_id: "{{steps.launch_instance.instance_id}}"
 
     power_cycle_state:
       step: power_cycle_instance

--- a/isvctl/configs/tests/vm.yaml
+++ b/isvctl/configs/tests/vm.yaml
@@ -323,6 +323,8 @@ tests:
       step: start_instance
       checks:
         InstanceStartCheck: {}
+        StableIdentifierCheck:
+          reference_id: "{{steps.launch_instance.instance_id}}"
 
     start_ssh:
       step: start_instance
@@ -342,6 +344,8 @@ tests:
       checks:
         InstanceRebootCheck:
           max_uptime: 600
+        StableIdentifierCheck:
+          reference_id: "{{steps.launch_instance.instance_id}}"
 
     reboot_state:
       step: reboot_instance

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -56,6 +56,7 @@ from isvtest.validations.instance import (
     InstanceStateCheck,
     InstanceStopCheck,
     InstanceTagCheck,
+    StableIdentifierCheck,
 )
 from isvtest.validations.network import (
     ByoipCheck,
@@ -115,6 +116,7 @@ __all__ = [
     "SchemaValidation",
     "SecurityBlockingCheck",
     "SgCrudCheck",
+    "StableIdentifierCheck",
     "StablePrivateIpCheck",
     "StepSuccessCheck",
     "SubnetConfigCheck",

--- a/isvtest/src/isvtest/validations/instance.py
+++ b/isvtest/src/isvtest/validations/instance.py
@@ -193,6 +193,43 @@ class InstancePowerCycleCheck(BaseValidation):
         self.set_passed(f"Instance {instance_id} recovered from power-cycle (state={state}{recovery_str})")
 
 
+class StableIdentifierCheck(BaseValidation):
+    """Validate that an instance ID persists across lifecycle events.
+
+    Compares the instance_id from a lifecycle step (stop, start, reboot,
+    power-cycle) against the original ID from launch to confirm it is
+    stable and did not change.
+
+    Config:
+        step_output: The lifecycle step output to check
+        reference_id: The original instance ID from launch (via Jinja2 template)
+
+    Step output:
+        instance_id: Instance identifier after the lifecycle event
+    """
+
+    description: ClassVar[str] = "Check instance ID is stable across lifecycle events"
+    markers: ClassVar[list[str]] = ["vm", "bare_metal"]
+
+    def run(self) -> None:
+        step_output = self.config.get("step_output", {})
+        reference_id = self.config.get("reference_id", "")
+
+        instance_id = step_output.get("instance_id")
+        if not instance_id:
+            self.set_failed("No 'instance_id' in step output")
+            return
+
+        if not reference_id:
+            self.set_failed("No 'reference_id' configured — cannot verify stability")
+            return
+
+        if instance_id == reference_id:
+            self.set_passed(f"Instance ID {instance_id} is stable")
+        else:
+            self.set_failed(f"Instance ID changed: expected {reference_id}, got {instance_id}")
+
+
 class InstanceCreatedCheck(BaseValidation):
     """Validate instance was created successfully.
 


### PR DESCRIPTION
## Summary

- Adds `StableIdentifierCheck` validation that verifies instance IDs persist through stop/start, reboot, and power-cycle operations
- Wired into bare-metal test suite (3 checkpoints: start, reboot, power-cycle) and VM test suite (2 checkpoints: start, reboot)
- Uses Jinja2 `{{steps.launch_instance.instance_id}}` to compare against the original launch ID — no new stubs needed

## Test plan

- [x] `uv run pytest tests/test_validation.py` — 79 passed
- [x] AWS bare-metal full suite (g4dn.metal) — 26 passed, 5 skipped, 68 subtests
- [x] AWS VM full suite (g5.xlarge) — 27 passed, 3 skipped, 90 subtests
- [x] `StableIdentifierCheck` PASSED on all lifecycle events for both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added instance identifier stability validation to test suite configurations for both bare metal and virtual machine environments.
  * New validation checks verify instance identifiers remain consistent across start, reboot, and power cycle operations.
  * Extended test coverage for instance recovery scenarios and comprehensive instance lifecycle validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->