### PR TITLE
docs: update stale validation references

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -238,21 +238,21 @@ A validation check can be run multiple times with different parameters by append
 validations:
   k8s_workloads:
     checks:
-      - K8sNimHelmWorkload-1b:
-          model: "meta/llama-3.2-1b-instruct"
-          gpu_count: 1
-          timeout: 900
-      - K8sNimHelmWorkload-3b:
-          model: "meta/llama-3.2-3b-instruct"
-          gpu_count: 4
-          timeout: 1800
+      K8sNimHelmWorkload-1b:
+        model: "meta/llama-3.2-1b-instruct"
+        gpu_count: 1
+        timeout: 900
+      K8sNimHelmWorkload-3b:
+        model: "meta/llama-3.2-3b-instruct"
+        gpu_count: 4
+        timeout: 1800
 
   slurm:
     checks:
-      - SlurmPartition-cpu:
-          partition_name: "cpu"
-      - SlurmPartition-gpu:
-          partition_name: "gpu"
+      SlurmPartition-cpu:
+        partition_name: "cpu"
+      SlurmPartition-gpu:
+        partition_name: "gpu"
 ```
 
 The part before the dash must match an existing validation class name (e.g., `K8sNimHelmWorkload`, `SlurmPartition`). The suffix after the dash is a label -- it can be any descriptive string. Each variant runs as a separate test case with its own parameters and appears independently in test results and coverage.
@@ -265,7 +265,7 @@ The part before the dash must match an existing validation class name (e.g., `K8
 
 ## Import and Override
 
-Provider configs can import a canonical test suite and override only the commands (scripts), while inheriting all validations:
+Provider configs can import a canonical test suite and override command definitions while inheriting validations (unless explicitly overridden):
 
 ```yaml
 # isvctl/configs/providers/my-isv/vm.yaml
@@ -278,7 +278,7 @@ commands:
         command: "python3 ../../stubs/my-isv/vm/launch_instance.py"
       - name: stop_instance
         command: "python3 ../../stubs/my-isv/vm/stop_instance.py"
-      # ... override only the commands, validations stay the same
+      # ... list the full set of steps you need
 
 tests:
   settings:
@@ -286,7 +286,7 @@ tests:
     instance_type: "gpu.large"
 ```
 
-The import path is relative to the importing file. The imported config provides the full step list, phases, and validations. The provider config overrides specific steps and settings. See the [AWS reference implementation](../references/aws.md) for working examples.
+The import path is relative to the importing file. The imported config provides the base step list, phases, and validations. Nested dictionaries (like `tests.settings`) are deep-merged, but list fields (like `commands.<platform>.steps`) are **replaced as a whole** — if you set `steps:` in the provider config, include the full desired list. See the [AWS reference implementation](../references/aws.md) for working examples.
 
 ## Template Variables
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -129,15 +129,19 @@ tests:
   # Centralized validations grouped by category
   validations:
     network:
-      - NetworkProvisionedCheck:
-          step: create_network
-      - StepSuccessCheck:
-          step: test_connectivity
-          check_success: true
+      step: create_network
+      checks:
+        NetworkProvisionedCheck: {}
+
+    connectivity:
+      step: test_connectivity
+      checks:
+        StepSuccessCheck: {}
 
     teardown_checks:
-      - StepSuccessCheck:
-          step: teardown
+      step: teardown
+      checks:
+        StepSuccessCheck: {}
 ```
 
 ### Platform Configuration
@@ -190,20 +194,32 @@ Each step defines a command to execute:
 
 ### Validation Configuration
 
-Validations are centralized in `tests.validations`, grouped by category:
+Validations are centralized in `tests.validations`, grouped by category. Each group binds to a step and lists checks as a dict:
 
 ```yaml
 tests:
   validations:
-    # Category name (any meaningful name)
+    # Group name (any meaningful name)
     network:
-      - NetworkProvisionedCheck:
-          step: create_network
+      step: create_network       # Step whose JSON output is checked
+      checks:
+        NetworkProvisionedCheck: {}
 
-    # Validations can specify when to run
     teardown_checks:
-      - StepSuccessCheck:
-          step: teardown
+      step: teardown
+      checks:
+        StepSuccessCheck: {}
+```
+
+For Kubernetes/Slurm configs where validations don't bind to individual step outputs, the `step:` field is omitted:
+
+```yaml
+tests:
+  validations:
+    kubernetes:
+      checks:
+        K8sNodeCountCheck:
+          count: "{{steps.setup.kubernetes.node_count}}"
 ```
 
 **Validation Timing (`phase`):**
@@ -246,6 +262,31 @@ The part before the dash must match an existing validation class name (e.g., `K8
 - Validation class names **cannot** contain dashes, so the first dash always marks the start of a variant suffix.
 - The suffix is free-form: `K8sNimHelmWorkload-small`, `SlurmPartition-cpu`, `SlurmGpuAllocation-1gpu` are all valid.
 - Each variant is a distinct test entry in coverage tracking.
+
+## Import and Override
+
+Provider configs can import a canonical test suite and override only the commands (scripts), while inheriting all validations:
+
+```yaml
+# isvctl/configs/providers/my-isv/vm.yaml
+import: ../../tests/vm.yaml
+
+commands:
+  vm:
+    steps:
+      - name: launch_instance
+        command: "python3 ../../stubs/my-isv/vm/launch_instance.py"
+      - name: stop_instance
+        command: "python3 ../../stubs/my-isv/vm/stop_instance.py"
+      # ... override only the commands, validations stay the same
+
+tests:
+  settings:
+    region: "us-east-1"
+    instance_type: "gpu.large"
+```
+
+The import path is relative to the importing file. The imported config provides the full step list, phases, and validations. The provider config overrides specific steps and settings. See the [AWS reference implementation](../references/aws.md) for working examples.
 
 ## Template Variables
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -433,61 +433,105 @@ EOF
 
 ## Available Validations
 
-### Generic Validations
+For the full list of validations with descriptions and platform markers, see [isvtest package docs](../packages/isvtest.md#available-validations).
 
-| Validation | Parameters | Description |
-| ---------- | ---------- | ----------- |
-| `FieldExistsCheck` | `step`, `field` or `fields` | Check field(s) exist in output |
-| `FieldValueCheck` | `step`, `field`, `expected`, `operator` | Check field value (eq, gt, gte, lt, lte) |
-| `StepSuccessCheck` | `step` | Check `success: true` (auto-detects teardown) |
+Below is a summary by category.
 
-### Network Validations
+### Generic (`validations/generic.py`)
 
-| Validation | Parameters | Description |
-| ---------- | ---------- | ----------- |
-| `NetworkProvisionedCheck` | `step` | Check network created with ID |
-| `VpcCrudCheck` | `step` | Validate VPC CRUD operations |
-| `SubnetConfigCheck` | `step` | Validate subnet configuration |
-| `VpcIsolationCheck` | `step` | Validate VPC isolation |
-| `SecurityBlockingCheck` | `step` | Validate security blocking |
-| `NetworkConnectivityCheck` | `step` | Validate connectivity tests |
-| `TrafficFlowCheck` | `step` | Validate traffic flow tests |
+| Validation | Description |
+| ---------- | ----------- |
+| `StepSuccessCheck` | Check step completed successfully |
+| `FieldExistsCheck` | Check required fields exist in output |
+| `FieldValueCheck` | Check field has expected value (eq, gt, gte, lt, lte, contains, min/max) |
+| `CrudOperationsCheck` | Check all CRUD operations passed |
+| `SchemaValidation` | Validate output matches JSON schema |
 
-### Instance Validations
+### Instance (`validations/instance.py`)
 
-| Validation | Parameters | Description |
-| ---------- | ---------- | ----------- |
-| `InstanceStateCheck` | `step`, `expected_state` | Check instance state |
-| `InstanceCreatedCheck` | `step` | Check instance was created |
+| Validation | Description |
+| ---------- | ----------- |
+| `InstanceCreatedCheck` | Check instance was created |
+| `InstanceStateCheck` | Check instance is in expected state |
+| `InstanceListCheck` | Check instance list from VPC |
+| `InstanceTagCheck` | Check instance tags are present |
+| `InstanceStopCheck` | Check instance stopped successfully |
+| `InstanceStartCheck` | Check stopped instance started successfully |
+| `InstanceRebootCheck` | Check instance rebooted successfully |
+| `InstancePowerCycleCheck` | Check instance recovered from power-cycle |
+| `StableIdentifierCheck` | Check instance ID is stable across lifecycle events |
+| `SerialConsoleCheck` | Check serial console access |
+| `TopologyPlacementCheck` | Check topology-based placement support |
 
-### IAM Validations
+### Network (`validations/network.py`)
 
-| Validation | Parameters | Description |
-| ---------- | ---------- | ----------- |
-| `AccessKeyCreatedCheck` | `step` | Check access key was created |
-| `AccessKeyAuthenticatedCheck` | `step` | Check access key authenticated |
-| `AccessKeyDisabledCheck` | `step` | Check access key was disabled |
-| `AccessKeyRejectedCheck` | `step` | Check disabled key was rejected |
-| `TenantCreatedCheck` | `step` | Check tenant was created |
-| `TenantListedCheck` | `step` | Check tenant in list |
-| `TenantInfoCheck` | `step` | Check tenant info retrieved |
+| Validation | Description |
+| ---------- | ----------- |
+| `NetworkProvisionedCheck` | Check network was provisioned |
+| `VpcCrudCheck` | Check VPC CRUD operations |
+| `SubnetConfigCheck` | Check subnet configuration |
+| `VpcIsolationCheck` | Check VPC isolation |
+| `VpcIpConfigCheck` | Check VPC IP configuration |
+| `VpcPeeringCheck` | Check VPC peering |
+| `SgCrudCheck` | Check security group CRUD operations |
+| `SecurityBlockingCheck` | Check security blocking rules |
+| `FloatingIpCheck` | Check floating IP switch |
+| `LocalizedDnsCheck` | Check localized DNS |
+| `ByoipCheck` | Check BYOIP support |
+| `StablePrivateIpCheck` | Check private IP stability |
+| `NetworkConnectivityCheck` | Check network connectivity |
+| `TrafficFlowCheck` | Check traffic flow |
+| `DhcpIpManagementCheck` | Check DHCP/IP management via SSH |
 
-### Kubernetes Validations
+### Host (`validations/host.py`)
 
-| Validation | Parameters | Description |
-| ---------- | ---------- | ----------- |
-| `K8sNodeCountCheck` | `count` | Verify node count |
-| `K8sNodeReadyCheck` | - | Verify all nodes are Ready |
-| `K8sGpuOperatorPodsCheck` | `namespace` | Verify GPU Operator pods running |
-| `K8sGpuCapacityCheck` | `expected_per_node`, `expected_total` | Verify GPU capacity |
+| Validation | Description |
+| ---------- | ----------- |
+| `ConnectivityCheck` | Validates SSH connectivity |
+| `OsCheck` | Validates OS via SSH |
+| `CpuInfoCheck` | Validates CPU, NUMA topology, and PCI configuration |
+| `VcpuPinningCheck` | Validates vCPU pinning and NUMA affinity |
+| `PciBusCheck` | Validates PCI bus configuration for GPU devices |
+| `HostSoftwareCheck` | Validates kernel, libvirt, SBIOS, and NVIDIA drivers |
+| `GpuCheck` | Validates GPU via SSH |
+| `DriverCheck` | Validates kernel and NVIDIA drivers |
+| `ContainerRuntimeCheck` | Tests container runtime and NVIDIA Docker support |
+| `CloudInitCheck` | Validates cloud-init completed and metadata service is reachable |
+| `GpuStressCheck` | GPU stress test via SSH |
+| `NcclCheck` | NCCL AllReduce test via SSH |
+| `TrainingCheck` | DDP training workload via SSH |
+| `NvlinkCheck` | NVLink topology and status via SSH |
+| `InfiniBandCheck` | InfiniBand interface status via SSH |
+| `EthernetCheck` | Ethernet interfaces and connectivity via SSH |
 
-### Slurm Validations
+### NIM (`validations/nim.py`)
 
-| Validation | Parameters | Description |
-| ---------- | ---------- | ----------- |
-| `SlurmInfoAvailable` | - | Verify sinfo command works |
-| `SlurmPartition` | `partition_name`, `expected_nodes` | Verify partition exists |
-| `SlurmJobSubmission` | `partition` | Test job submission |
+| Validation | Description |
+| ---------- | ----------- |
+| `NimHealthCheck` | Validates NIM health endpoint |
+| `NimModelCheck` | Validates NIM model listing |
+| `NimInferenceCheck` | Validates NIM inference via chat completions |
+
+### Cluster (`validations/cluster.py`)
+
+| Validation | Description |
+| ---------- | ----------- |
+| `ClusterHealthCheck` | Check cluster is healthy |
+| `NodeCountCheck` | Check cluster node count matches expected |
+| `GpuOperatorInstalledCheck` | Check GPU operator installation |
+| `PerformanceCheck` | Check workload performance meets requirements |
+
+### IAM (`validations/iam.py`)
+
+| Validation | Description |
+| ---------- | ----------- |
+| `AccessKeyCreatedCheck` | Check access key was created |
+| `AccessKeyAuthenticatedCheck` | Check access key can authenticate |
+| `AccessKeyDisabledCheck` | Check access key was disabled |
+| `AccessKeyRejectedCheck` | Check disabled key is rejected |
+| `TenantCreatedCheck` | Check tenant was created |
+| `TenantListedCheck` | Check tenant appears in list |
+| `TenantInfoCheck` | Check tenant info retrieved |
 
 ## Test Markers
 
@@ -501,7 +545,7 @@ isvctl test run -f config.yaml -- -k "vpc_crud"
 isvctl test run -f config.yaml -- -m kubernetes
 ```
 
-Available markers: `bare_metal`, `kubernetes`, `slurm`, `gpu`, `network`, `hardware`, `software`, `workload`, `l2`, `slow`
+Available markers: `bare_metal`, `vm`, `kubernetes`, `slurm`, `gpu`, `network`, `ssh`, `security`, `iam`, `workload`, `slow`
 
 ## Related Documentation
 

--- a/docs/packages/isvctl.md
+++ b/docs/packages/isvctl.md
@@ -47,23 +47,24 @@ isvctl test run -f isvctl/configs/tests/k8s.yaml -- -v -s -k "NodeCount"
 
 ```text
 isvctl/
-├── configs/           # Unified configuration files
-│   ├── tests/        # Test configs (k8s.yaml, slurm.yaml, bare_metal.yaml)
-│   └── providers/    # Provider configs (microk8s.yaml, minikube.yaml, k3s.yaml, aws/)
-├── stubs/            # Inventory and lifecycle scripts
-│   ├── k8s/
-│   │   ├── _common.sh         # Shared K8s inventory logic
-│   │   ├── setup.sh           # Generic kubectl setup
-│   │   ├── setup_microk8s.sh  # MicroK8s setup
-│   │   ├── setup_minikube.sh  # Minikube setup
-│   │   └── setup_k3s.sh       # k3s setup
-│   └── slurm/
-│       └── ...
-├── schemas/          # JSON Schema for validation
-│   ├── config.schema.json
-│   └── command_output.schema.json
-└── scripts/          # Helper scripts
-    └── yaml2json.py
+├── configs/
+│   ├── tests/         # Canonical test suites (vm.yaml, bare_metal.yaml, network.yaml, ...)
+│   ├── providers/     # Provider configs (aws/, microk8s.yaml, minikube.yaml, k3s.yaml)
+│   └── stubs/         # Lifecycle scripts (provider-agnostic templates + aws/ reference)
+│       ├── vm/                # VM lifecycle stubs
+│       ├── bare_metal/        # Bare metal lifecycle stubs
+│       ├── network/           # Network validation stubs
+│       ├── control-plane/     # API/IAM/tenant stubs
+│       ├── iam/               # User lifecycle stubs
+│       ├── image-registry/    # Image CRUD stubs
+│       ├── common/            # Shared stubs (NIM deploy/teardown)
+│       ├── k8s/               # Kubernetes setup/teardown
+│       ├── slurm/             # Slurm setup/teardown
+│       └── aws/               # AWS reference implementations
+├── schemas/           # JSON Schema for validation
+├── scripts/           # Helper scripts
+├── src/               # isvctl Python source
+└── tests/             # Unit tests
 ```
 
 ## Usage
@@ -112,27 +113,30 @@ See [Configuration Guide](../guides/configuration.md) for full details.
 ```yaml
 version: "1.0"
 
-# Lifecycle commands - grouped by platform
 commands:
   kubernetes:
-    setup:
-      command: "./isvctl/stubs/k8s/setup.sh"
-      timeout: 120
-    teardown:
-      command: "./isvctl/stubs/k8s/teardown.sh"
-      timeout: 30
+    phases: ["setup", "test", "teardown"]
+    steps:
+      - name: setup
+        phase: setup
+        command: "../stubs/k8s/setup.sh"
+        timeout: 120
+      - name: teardown
+        phase: teardown
+        command: "../stubs/k8s/teardown.sh"
+        timeout: 30
 
-# Test configuration
 tests:
   platform: kubernetes
-  cluster_name: "{{inventory.cluster_name}}"
+  cluster_name: "{{steps.setup.cluster_name}}"
 
   validations:
     kubernetes:
-      - K8sNodeCountCheck:
-          count: "{{inventory.kubernetes.node_count}}"
-      - K8sGpuCapacityCheck:
-          expected_total: "{{inventory.kubernetes.total_gpus}}"
+      checks:
+        K8sNodeCountCheck:
+          count: "{{steps.setup.kubernetes.node_count}}"
+        K8sGpuCapacityCheck:
+          expected_total: "{{steps.setup.kubernetes.total_gpus}}"
 ```
 
 ### Inventory Output Schema

--- a/docs/packages/isvtest.md
+++ b/docs/packages/isvtest.md
@@ -7,7 +7,7 @@
 > isvctl test run -f isvctl/configs/tests/k8s.yaml
 > ```
 
-A validation framework for NVIDIA ISV Lab environments supporting Kubernetes clusters, Slurm HPC systems, and bare metal servers.
+A validation framework for NVIDIA ISV Lab environments supporting bare metal servers, virtual machines, Kubernetes clusters, and Slurm HPC systems.
 
 ## Quick Start
 
@@ -17,148 +17,235 @@ uv sync
 
 # Use via isvctl (recommended)
 isvctl test run -f isvctl/configs/tests/k8s.yaml
+isvctl test run -f isvctl/configs/providers/my-isv/vm.yaml
+isvctl test run -f isvctl/configs/providers/my-isv/bare_metal.yaml
 ```
 
 ## Architecture
 
 ```text
 isvtest/src/isvtest/
-├── config/
-│   ├── inventory.py     # Cluster inventory schema
-│   ├── loader.py        # Config loader
-│   └── settings.py      # Global settings
+├── config/              # Configuration loading
 ├── core/                # Framework core
 │   ├── validation.py    # BaseValidation class
 │   ├── workload.py      # BaseWorkloadCheck class
 │   ├── runners.py       # Command runners
-│   └── discovery.py     # Test discovery
-├── validations/         # Quick validation tests
-│   ├── bm_*.py          # Bare metal validations
-│   ├── k8s_*.py         # Kubernetes validations
-│   ├── slurm_*.py       # Slurm validations
-│   └── reframe_*.py     # ReFrame validations
+│   ├── discovery.py     # Test discovery
+│   ├── ssh.py           # SSH client utilities
+│   ├── k8s.py           # Kubernetes helpers
+│   ├── slurm.py         # Slurm helpers
+│   └── nvidia.py        # NVIDIA driver/GPU helpers
+├── validations/         # Platform-agnostic validation checks
+│   ├── generic.py       # Field checks, schema validation, step success
+│   ├── instance.py      # Instance lifecycle (stop/start/reboot/power-cycle)
+│   ├── network.py       # VPC, subnet, security group, DNS, peering
+│   ├── host.py          # SSH-based host checks (GPU, driver, OS, NCCL, NVLink)
+│   ├── nim.py           # NIM container health/inference/models
+│   ├── cluster.py       # Kubernetes cluster validations
+│   ├── iam.py           # Access key and tenant validations
+│   ├── bm_*.py          # Legacy bare metal validations
+│   ├── k8s_*.py         # Legacy Kubernetes validations
+│   └── slurm_*.py       # Legacy Slurm validations
 ├── workloads/           # Workload-based tests (longer running)
 │   ├── k8s_*.py         # K8s workloads (NCCL, stress, NIM)
 │   ├── slurm_*.py       # Slurm workloads (NCCL, stress, sbatch)
 │   └── reframe_*.py     # ReFrame tests
+├── catalog.py           # Test catalog generation
 └── main.py              # CLI entry point
 ```
 
 ## Available Validations
 
-### Bare Metal (`validations/bm_*.py`)
+Validations are platform-agnostic checks that inspect JSON step output. They are organized by category and referenced by class name in YAML test configs. Each validation has a `description` and `markers` that indicate which platforms it applies to.
 
-| Validation | Description |
-| ---------- | ----------- |
-| `BmDriverInstalled` | Verify NVIDIA driver is installed |
-| `BmDriverVersion` | Check driver version meets minimum |
-| `BmGpuDetection` | Detect GPUs and verify count |
-| `BmGpuHealth` | Check GPU temperature and health |
-| `BmGpuComputeCapability` | Verify compute capability |
-| `BmCudaVersion` | Check CUDA version |
+### Generic (`validations/generic.py`)
 
-### Kubernetes (`validations/k8s_*.py`)
+Utility checks that work with any step output.
 
-| Validation | Description |
-| ---------- | ----------- |
-| `K8sNodeCountCheck` | Verify node count |
-| `K8sNodeReadyCheck` | Verify all nodes are Ready |
-| `K8sNvidiaSmiCheck` | Run nvidia-smi on all GPU nodes |
-| `K8sDriverVersionCheck` | Verify driver version across nodes |
-| `K8sGpuPodAccessCheck` | Verify GPU access from pods (nvidia-smi) |
-| `K8sGpuOperatorNamespaceCheck` | Verify GPU Operator namespace |
-| `K8sGpuOperatorPodsCheck` | Verify GPU Operator pods running |
-| `K8sPodHealthCheck` | Check pod health status |
-| `K8sGpuLabelsCheck` | Verify GPU node labels |
-| `K8sGpuCapacityCheck` | Verify node GPU capacity |
-| `K8sMigConfigCheck` | Check MIG configuration |
+| Validation | Platforms | Description |
+| ---------- | --------- | ----------- |
+| `StepSuccessCheck` | all | Check step completed successfully |
+| `FieldExistsCheck` | all | Check required fields exist in output |
+| `FieldValueCheck` | all | Check field has expected value |
+| `CrudOperationsCheck` | all | Check all CRUD operations passed |
+| `SchemaValidation` | all | Validate output matches JSON schema |
 
-### Slurm (`validations/slurm_*.py`)
+### Instance (`validations/instance.py`)
 
-| Validation | Description |
-| ---------- | ----------- |
-| `SlurmInfoAvailable` | Verify sinfo command works |
-| `SlurmPartition` | Verify a Slurm partition exists and has expected nodes |
-| `SlurmJobSubmission` | Test job submission |
-| `SlurmGpuAllocation` | Test GPU allocation |
+Instance lifecycle validations for VMs and bare metal.
 
-### Workloads (`workloads/`)
+| Validation | Platforms | Description |
+| ---------- | --------- | ----------- |
+| `InstanceCreatedCheck` | vm | Check instance was created |
+| `InstanceStateCheck` | vm, bare_metal | Check instance is in expected state |
+| `InstanceListCheck` | vm, bare_metal | Check instance list from VPC |
+| `InstanceTagCheck` | vm, bare_metal | Check instance tags are present |
+| `InstanceStopCheck` | vm, bare_metal | Check instance stopped successfully |
+| `InstanceStartCheck` | vm, bare_metal | Check stopped instance started successfully |
+| `InstanceRebootCheck` | vm, bare_metal | Check instance rebooted successfully |
+| `InstancePowerCycleCheck` | bare_metal | Check instance recovered from power-cycle |
+| `StableIdentifierCheck` | vm, bare_metal | Check instance ID is stable across lifecycle events |
+| `SerialConsoleCheck` | vm, bare_metal | Check serial console access |
+| `TopologyPlacementCheck` | bare_metal | Check topology-based placement support |
 
-| Workload | Description |
-| -------- | ----------- |
-| `K8sNcclWorkload` | Single-node NCCL AllReduce validation |
-| `K8sNcclMultiNodeWorkload` | Multi-node NCCL AllReduce via MPIJob |
-| `K8sGpuStressWorkload` | GPU stress test |
-| `K8sNimHelmWorkload` | NIM Helm deployment + GenAI-Perf KPIs |
-| `K8sNimInferenceWorkload` | NIM inference validation |
-| `SlurmNcclMultiNodeWorkload` | Multi-node NCCL AllReduce via Slurm |
-| `SlurmGpuStressWorkload` | GPU stress test across Slurm partition |
-| `SlurmSbatchWorkload` | Run arbitrary sbatch script |
+### Network (`validations/network.py`)
 
-Each workload class has detailed docstrings covering config options, environment variables, and troubleshooting.
+VPC, subnet, security group, DNS, and connectivity checks.
 
-#### Workload Prerequisites
+| Validation | Platforms | Description |
+| ---------- | --------- | ----------- |
+| `NetworkProvisionedCheck` | network | Check network was provisioned |
+| `VpcCrudCheck` | network | Check VPC CRUD operations |
+| `SubnetConfigCheck` | network | Check subnet configuration |
+| `VpcIsolationCheck` | network, security | Check VPC isolation |
+| `VpcIpConfigCheck` | network | Check VPC IP configuration |
+| `VpcPeeringCheck` | network | Check VPC peering |
+| `SgCrudCheck` | network, security | Check security group CRUD operations |
+| `SecurityBlockingCheck` | network, security | Check security blocking rules |
+| `FloatingIpCheck` | network | Check floating IP switch |
+| `LocalizedDnsCheck` | network | Check localized DNS |
+| `ByoipCheck` | network | Check BYOIP support |
+| `StablePrivateIpCheck` | network | Check private IP stability |
+| `NetworkConnectivityCheck` | network | Check network connectivity |
+| `TrafficFlowCheck` | network | Check traffic flow |
+| `DhcpIpManagementCheck` | network, ssh | Check DHCP/IP management via SSH |
 
-Some workloads require additional cluster components beyond the base GPU Operator:
+### Host (`validations/host.py`)
+
+SSH-based host validations for GPU, driver, OS, networking, and workloads.
+
+| Validation | Platforms | Description |
+| ---------- | --------- | ----------- |
+| `ConnectivityCheck` | vm, bare_metal | Validates SSH connectivity |
+| `OsCheck` | vm, bare_metal | Validates OS via SSH |
+| `CpuInfoCheck` | vm, bare_metal | Validates CPU, NUMA topology, and PCI configuration |
+| `VcpuPinningCheck` | vm | Validates vCPU pinning and NUMA affinity |
+| `PciBusCheck` | vm | Validates PCI bus configuration for GPU devices |
+| `HostSoftwareCheck` | vm, bare_metal | Validates kernel, libvirt, SBIOS, and NVIDIA drivers |
+| `GpuCheck` | vm, bare_metal | Validates GPU via SSH |
+| `DriverCheck` | vm, bare_metal | Validates kernel and NVIDIA drivers |
+| `ContainerRuntimeCheck` | vm, bare_metal | Tests container runtime and NVIDIA Docker support |
+| `CloudInitCheck` | vm, bare_metal | Validates cloud-init completed and metadata service is reachable |
+| `GpuStressCheck` | bare_metal | GPU stress test via SSH |
+| `NcclCheck` | bare_metal | NCCL AllReduce test via SSH |
+| `TrainingCheck` | bare_metal | DDP training workload via SSH |
+| `NvlinkCheck` | bare_metal | NVLink topology and status via SSH |
+| `InfiniBandCheck` | bare_metal | InfiniBand interface status via SSH |
+| `EthernetCheck` | bare_metal | Ethernet interfaces and connectivity via SSH |
+
+### NIM (`validations/nim.py`)
+
+NIM container validations via SSH.
+
+| Validation | Platforms | Description |
+| ---------- | --------- | ----------- |
+| `NimHealthCheck` | vm, bare_metal | Validates NIM health endpoint |
+| `NimModelCheck` | vm, bare_metal | Validates NIM model listing |
+| `NimInferenceCheck` | vm, bare_metal | Validates NIM inference via chat completions |
+
+### Cluster (`validations/cluster.py`)
+
+Kubernetes cluster validations.
+
+| Validation | Platforms | Description |
+| ---------- | --------- | ----------- |
+| `ClusterHealthCheck` | kubernetes | Check cluster is healthy |
+| `NodeCountCheck` | kubernetes | Check cluster node count matches expected |
+| `GpuOperatorInstalledCheck` | kubernetes | Check GPU operator installation |
+| `PerformanceCheck` | workload | Check workload performance meets requirements |
+
+### IAM (`validations/iam.py`)
+
+Access key and tenant validations.
+
+| Validation | Platforms | Description |
+| ---------- | --------- | ----------- |
+| `AccessKeyCreatedCheck` | iam | Check access key was created |
+| `AccessKeyAuthenticatedCheck` | iam | Check access key can authenticate |
+| `AccessKeyDisabledCheck` | iam | Check access key was disabled |
+| `AccessKeyRejectedCheck` | iam | Check disabled key is rejected |
+| `TenantCreatedCheck` | iam | Check tenant was created |
+| `TenantListedCheck` | iam | Check tenant appears in list |
+| `TenantInfoCheck` | iam | Check tenant info retrieved |
+
+## Workloads
+
+Workloads are longer-running tests that deploy containers or run multi-node jobs.
+
+| Workload | Platform | Description |
+| -------- | -------- | ----------- |
+| `K8sNcclWorkload` | kubernetes | Single-node NCCL AllReduce validation |
+| `K8sNcclMultiNodeWorkload` | kubernetes | Multi-node NCCL AllReduce via MPIJob |
+| `K8sGpuStressWorkload` | kubernetes | GPU stress test |
+| `K8sNimHelmWorkload` | kubernetes | NIM Helm deployment + GenAI-Perf KPIs |
+| `K8sNimInferenceWorkload` | kubernetes | NIM inference validation |
+| `SlurmNcclMultiNodeWorkload` | slurm | Multi-node NCCL AllReduce via Slurm |
+| `SlurmGpuStressWorkload` | slurm | GPU stress test across Slurm partition |
+| `SlurmSbatchWorkload` | slurm | Run arbitrary sbatch script |
+
+### Workload Prerequisites
 
 | Workload | Requirement | Notes |
 | -------- | ----------- | ----- |
-| `K8sNcclMultiNodeWorkload` | [Kubeflow MPI Operator](https://github.com/kubeflow/mpi-operator) | Provides the `MPIJob` CRD (`kubeflow.org/v2beta1`) used to orchestrate multi-node runs |
-| `K8sNcclMultiNodeWorkload` | NVIDIA DRA driver (optional) | When the `ComputeDomain` CRD is present, MNNVL/IMEX channels are enabled automatically for full NVLink bandwidth across nodes. Controlled by `use_compute_domain: auto\|true\|false` |
+| `K8sNcclMultiNodeWorkload` | [Kubeflow MPI Operator](https://github.com/kubeflow/mpi-operator) | Provides the `MPIJob` CRD (`kubeflow.org/v2beta1`) |
+| `K8sNcclMultiNodeWorkload` | NVIDIA DRA driver (optional) | MNNVL/IMEX channels for full NVLink bandwidth. `use_compute_domain: auto\|true\|false` |
 | `K8sNimHelmWorkload` | `NGC_API_KEY` env var | Required to pull NIM models from NGC |
 
 ## Configuration Format
 
 See [Configuration Guide](../guides/configuration.md) for full details.
 
-The `tests:` section in isvctl configs uses this format (also used by legacy isvtest YAML):
+Validations are referenced in YAML test configs by class name under `tests.validations`. Each validation group is bound to a step and lists one or more checks:
 
 ```yaml
-cluster_name: "MY_CLUSTER"
-platform: kubernetes  # or slurm, bare_metal
+version: "1.0"
 
-validations:
-  bare_metal:
-    - BmDriverInstalled: {}
-    - BmDriverVersion:
-        min_version: "580.0"
-    - BmGpuDetection:
-        expected_count: 8
+commands:
+  vm:
+    phases: ["setup", "test", "teardown"]
+    steps:
+      - name: launch_instance
+        phase: setup
+        command: "python3 ../stubs/vm/launch_instance.py"
+        timeout: 600
 
-  kubernetes:
-    - K8sNodeCountCheck:
-        count: 3
-    - K8sNodeReadyCheck: {}
-    - K8sGpuOperatorPodsCheck:
-        namespace: "gpu-operator"
-    - K8sGpuPodAccessCheck:
-        gpu_count: 1
-    - K8sGpuCapacityCheck:
-        expected_per_node: 8
-        expected_total: 24
+      - name: stop_instance
+        phase: test
+        command: "python3 ../stubs/vm/stop_instance.py"
+        timeout: 600
 
-  slurm:
-    - SlurmInfoAvailable: {}
-    - SlurmPartition:
-        partition_name: "gpu"
+tests:
+  platform: vm
+  validations:
+    setup_checks:
+      step: launch_instance
+      checks:
+        InstanceStateCheck:
+          expected_state: "running"
 
-exclude:
-  markers: [slow, workload]
+    stop_checks:
+      step: stop_instance
+      checks:
+        InstanceStopCheck: {}
 
-settings:
-  timeout: 60
-  show_skipped_tests: true
+    start_checks:
+      step: start_instance
+      checks:
+        InstanceStartCheck: {}
+        StableIdentifierCheck:
+          reference_id: "{{steps.launch_instance.instance_id}}"
 ```
+
+Canonical test configs live in `isvctl/configs/tests/` (vm.yaml, bare_metal.yaml, network.yaml, etc.). Provider-specific configs in `isvctl/configs/providers/<provider>/` import the canonical config and override commands with platform stubs.
 
 ## Test Markers
 
 Filter tests using pytest markers:
 
-- `bare_metal`, `kubernetes`, `slurm` - Platform-specific
-- `gpu`, `network`, `hardware`, `software` - Component-specific
+- `bare_metal`, `vm`, `kubernetes`, `slurm` - Platform-specific
+- `gpu`, `network`, `ssh`, `security`, `iam` - Component-specific
 - `workload` - Workload-based tests (longer running)
 - `slow` - Tests that take longer than 5 minutes
-- `validation` - All validation tests (auto-applied)
 
 **Note:** By default, `workload` and `slow` markers are excluded. Use `-k` to explicitly run them.
 
@@ -174,7 +261,8 @@ uvx pre-commit run -a
 
 ## Related Documentation
 
-- [Local Development with MicroK8s](../guides/local-development.md) - Running K8s tests locally
+- [Configuration Guide](../guides/configuration.md)
+- [Local Development with MicroK8s](../guides/local-development.md)
 
 ## License
 

--- a/docs/packages/isvtest.md
+++ b/docs/packages/isvtest.md
@@ -7,7 +7,7 @@
 > isvctl test run -f isvctl/configs/tests/k8s.yaml
 > ```
 
-A validation framework for NVIDIA ISV Lab environments supporting bare metal servers, virtual machines, Kubernetes clusters, and Slurm HPC systems.
+A validation framework for NVIDIA ISV Lab environments supporting bare-metal servers, virtual machines, Kubernetes clusters, and Slurm HPC systems.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- **isvtest.md**: Complete rewrite — replaced old `bm_*.py`/`k8s_*.py` validation tables with all 48 checks across 7 categories (generic, instance, network, host, NIM, cluster, IAM), updated architecture tree, replaced flat-list config example with current step-based format
- **configuration.md**: Replaced incomplete "Available Validations" section (was missing ~30 checks) with full tables for all categories, updated marker list
- **isvctl.md**: Fixed stale directory tree (`stubs/` path, missing domains), updated config example to current step-based format

## Test plan
- [x] CodeRabbit review: no findings
- [x] Pre-commit hooks pass (markdown link checker, trailing whitespace, etc.)
- [x] Verify rendered markdown looks correct on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded platform coverage to VMs, bare metal, Kubernetes and Slurm
  * Reorganized validations into a consolidated category-based catalog (generic/instance/network/host/nim/cluster/iam) and link to canonical catalog
  * Updated configuration examples to phased, step-based commands, templated step outputs, and provider-specific overrides with import/override semantics
  * Revised lifecycle stub/layout guidance and unified example schemas
  * Updated pytest marker names to vm, ssh, security, iam and removed legacy markers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->