### PR TITLE
fix: use gpu_per_node instead of total_gpus for K8sNimHelmWorkload-3b

### DIFF
--- a/isvctl/configs/tests/k8s.yaml
+++ b/isvctl/configs/tests/k8s.yaml
@@ -117,7 +117,7 @@ tests:
         K8sNimHelmWorkload-3b:
           model: "meta/llama-3.2-3b-instruct"
           model_tag: "latest"
-          gpu_count: "{{ steps.setup.kubernetes.total_gpus | default(4, true) }}"
+          gpu_count: "{{ steps.setup.kubernetes.gpu_per_node | default(4, true) }}"
           timeout: 1800
           genai_perf_requests: 200
           genai_perf_concurrency: 8


### PR DESCRIPTION
The K8sNimHelmWorkload-3b test config sets gpu_count to total_gpus, which is the sum of GPUs across all nodes in the cluster. This value is passed to resources.limits.nvidia.com/gpu on a single NIM pod. On multi-node clusters (e.g. 2 nodes × 4 GPUs = 8 total), the pod requests more GPUs than any single node has, leaving it permanently in Pending state with "Insufficient nvidia.com/gpu".

Replace total_gpus with gpu_per_node so the NIM pod only requests GPUs available on a single node. The 1b variant already uses a hardcoded gpu_count of 1 and is unaffected.

Closes #187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes workload configuration to adjust GPU count calculation from an alternative source while maintaining default fallback values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->