### PR TITLE
fix: exclude superseded cluster checks from test catalog

### DIFF
--- a/isvtest/src/isvtest/validations/cluster.py
+++ b/isvtest/src/isvtest/validations/cluster.py
@@ -21,6 +21,8 @@ from isvtest.core.validation import BaseValidation
 class NodeCountCheck(BaseValidation):
     """Validate that the cluster has the expected number of nodes.
 
+    Superseded by K8sNodeCountCheck which queries the cluster directly.
+
     Config:
         step_output: The step output to check
         expected: Expected node count (required)
@@ -31,6 +33,7 @@ class NodeCountCheck(BaseValidation):
 
     description: ClassVar[str] = "Check cluster node count matches expected"
     markers: ClassVar[list[str]] = ["kubernetes"]
+    catalog_exclude: ClassVar[bool] = True
 
     def run(self) -> None:
         step_output = self.config.get("step_output", {})
@@ -54,6 +57,9 @@ class NodeCountCheck(BaseValidation):
 class ClusterHealthCheck(BaseValidation):
     """Validate that the cluster is healthy and accessible.
 
+    Superseded by K8sNodeReadyCheck and K8sPodHealthCheck which query
+    the cluster directly.
+
     Config:
         step_output: The step output to check
 
@@ -65,6 +71,7 @@ class ClusterHealthCheck(BaseValidation):
 
     description: ClassVar[str] = "Check cluster is healthy"
     markers: ClassVar[list[str]] = ["kubernetes"]
+    catalog_exclude: ClassVar[bool] = True
 
     def run(self) -> None:
         step_output = self.config.get("step_output", {})
@@ -86,6 +93,9 @@ class ClusterHealthCheck(BaseValidation):
 class GpuOperatorInstalledCheck(BaseValidation):
     """Validate that GPU operator is installed.
 
+    Superseded by K8sGpuOperatorNamespaceCheck and K8sGpuOperatorPodsCheck
+    which query the cluster directly.
+
     Config:
         step_output: The step output to check
 
@@ -97,6 +107,7 @@ class GpuOperatorInstalledCheck(BaseValidation):
 
     description: ClassVar[str] = "Check GPU operator installation"
     markers: ClassVar[list[str]] = ["kubernetes", "gpu"]
+    catalog_exclude: ClassVar[bool] = True
 
     def run(self) -> None:
         step_output = self.config.get("step_output", {})


### PR DESCRIPTION
## Summary

- Marks `NodeCountCheck`, `ClusterHealthCheck`, and `GpuOperatorInstalledCheck` in `cluster.py` with `catalog_exclude = True` so they no longer appear in the uploaded test catalog
- These three legacy step-output validators carry the `kubernetes` marker, which auto-tags them as `KUBERNETES` platform in the catalog. Since they've been superseded by direct-query K8s checks (`K8sNodeCountCheck`, `K8sNodeReadyCheck`/`K8sPodHealthCheck`, `K8sGpuOperatorNamespaceCheck`/`K8sGpuOperatorPodsCheck`), they inflate the denominator and prevent ISVs from reaching 100% Kubernetes coverage even when all 20 configured tests pass (20/23 → 20/20)

## Test plan

- [x] `make test` — all 211 unit tests pass
- [x] Verified catalog: KUBERNETES entries drop from 23 → 21, all 21 are covered when the full K8s config is run (100% coverage)
- [ ] After merge + version bump, push new catalog and confirm coverage in UI


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Marked legacy cluster validation checks as superseded and excluded from the catalog. These have been replaced by improved validation methods that query the cluster directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->