### PR TITLE
docs: document tests.exclude configuration options

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -574,6 +574,71 @@ Below is a summary by category.
 | `TenantListedCheck` | Check tenant appears in list |
 | `TenantInfoCheck` | Check tenant info retrieved |
 
+## Excluding Tests
+
+Use the `tests.exclude` section to deselect tests before they run. Excluded tests are removed from collection entirely (they do not appear as skipped or failed).
+
+```yaml
+tests:
+  exclude:
+    platforms: []   # Deselect all tests with these platform markers
+    markers: []     # Deselect all tests with these markers
+    tests: []       # Deselect specific tests by name
+    files: []       # Deselect all tests in these files
+```
+
+### Exclusion Types
+
+| Key | Behavior | Bypassed by `-k` / `-m`? |
+| --- | -------- | ------------------------ |
+| `platforms` | Removes tests whose markers include the listed platform (e.g., `bare_metal`, `kubernetes`) | No -- always applied |
+| `markers` | Removes tests whose markers include any of the listed values (e.g., `workload`, `slow`) | Yes -- explicit `-k` or `-m` overrides |
+| `tests` | Removes tests matching by exact name, prefix, or parametrized ID (e.g., `K8sNcclWorkload`, `K8sNimHelmWorkload-3b`) | No -- always applied |
+| `files` | Removes tests whose source file matches (e.g., `test_host.py`) | No -- always applied |
+
+### Examples
+
+Skip all workload and slow tests (the most common use case):
+
+```yaml
+tests:
+  exclude:
+    markers:
+      - workload
+      - slow
+```
+
+Skip specific tests by name:
+
+```yaml
+tests:
+  exclude:
+    tests:
+      - K8sNcclWorkload
+      - K8sNimHelmWorkload-3b
+```
+
+### Override File
+
+You can keep exclusions in a separate file and merge it on top of any config:
+
+```bash
+isvctl test run -f isvctl/configs/tests/k8s.yaml -f my-overrides.yaml
+```
+
+A template is provided in `isvctl/configs/overrides.yaml`. Note that `exclude` lists from later `-f` files **replace** earlier lists (they are not appended).
+
+### Interaction with `-k` and `-m`
+
+When you pass explicit pytest selectors via `--`:
+
+```bash
+isvctl test run -f config.yaml -- -k "K8sNcclWorkload"
+isvctl test run -f config.yaml -- -m "workload"
+```
+
+**Marker exclusions are bypassed**, allowing you to explicitly run tests that would normally be excluded. Platform, test name, and file exclusions still apply.
+
 ## Test Markers
 
 Filter tests using pytest markers:


### PR DESCRIPTION
## Summary

- Documents the `tests.exclude` configuration section in `docs/guides/configuration.md`
- Covers all four exclusion types: `platforms`, `markers`, `tests`, and `files`
- Explains `-k` / `-m` interaction (marker exclusions are bypassed by explicit selection)
- Includes practical examples and references the `overrides.yaml` template

## Context

The `exclude` feature was fully implemented in conftest.py and used across configs (k8s.yaml, slurm.yaml, microk8s.yaml, k3s.yaml, overrides.yaml, etc.) but had no user-facing documentation.

## Test plan

- Documentation-only change, no code changes
- [x] Markdown link checker passed (pre-commit hook)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for configuring test exclusions. Describes four exclusion keys—platforms, markers, tests, and files—and explains that excluded tests are omitted from test collection. Clarifies how marker exclusions can be bypassed by explicit pytest selectors while other exclusions always apply, shows examples for marker- and test-name-based exclusion, and documents how multiple config files merge exclusion settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->