### PR TITLE
fix: detect silent template fallbacks from ChainableUndefined and fix EKS step name mismatch

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -325,7 +325,7 @@ The schema is automatically detected from the step name using a mapping system:
 
 | Step Name Pattern | Schema | Required Fields |
 | ----------------- | ------ | --------------- |
-| `create_cluster`, `provision_cluster` | `cluster` | `success`, `platform`, `cluster_name`, `node_count` |
+| `setup`, `create_cluster`, `provision_cluster` | `cluster` | `success`, `platform`, `cluster_name`, `node_count` |
 | `create_network`, `create_vpc` | `network` | `success`, `platform` |
 | `launch_instance`, `create_vm` | `instance` | `success`, `platform`, `instance_id` |
 | `run_workload`, `run_test` | `workload_result` | `success`, `platform`, `status` |
@@ -378,7 +378,7 @@ steps:
 }
 ```
 
-**Cluster schema (`provision_cluster`):**
+**Cluster schema (`setup`):**
 
 ```json
 {

--- a/docs/guides/external-validation-guide.md
+++ b/docs/guides/external-validation-guide.md
@@ -168,14 +168,14 @@ Validations are grouped by meaningful category names. Set `step` at the group le
 validations:
   # Group-level step applies to all checks in the group
   setup_checks:
-    step: provision_cluster
+    step: setup
     checks:
       - StepSuccessCheck: {}
       - ClusterHealthCheck: {}
 
   # Per-check step overrides
   mixed:
-    step: provision_cluster       # default
+    step: setup                   # default
     checks:
       - ClusterHealthCheck: {}    # uses default step
       - StepSuccessCheck:

--- a/isvctl/configs/providers/aws/eks.yaml
+++ b/isvctl/configs/providers/aws/eks.yaml
@@ -36,7 +36,7 @@ version: "1.0"
 commands:
   kubernetes:
     steps:
-      - name: provision_cluster
+      - name: setup
         phase: setup
         command: "../../stubs/aws/eks/setup.sh"
         timeout: 1800 # 30 min for Terraform provisioning
@@ -48,7 +48,7 @@ commands:
           # Override with your IP for security
           TF_VAR_cluster_endpoint_public_access_cidrs: '["0.0.0.0/0"]'
 
-      - name: teardown_cluster
+      - name: teardown
         phase: teardown
         command: "../../stubs/aws/eks/teardown.sh"
         timeout: 1800 # 30 min for Terraform destroy

--- a/isvctl/configs/providers/aws/eks.yaml
+++ b/isvctl/configs/providers/aws/eks.yaml
@@ -43,7 +43,7 @@ commands:
         env:
           TF_AUTO_APPROVE: "true"
           TF_VAR_region: "us-west-2"
-          TF_VAR_gpu_node_instance_types: '["g5.xlarge"]'
+          TF_VAR_gpu_node_instance_types: '["g5.2xlarge"]'
           TF_VAR_gpu_node_desired_size: "1"
           # Override with your IP for security
           TF_VAR_cluster_endpoint_public_access_cidrs: '["0.0.0.0/0"]'

--- a/isvctl/configs/stubs/aws/eks/docs/aws-eks.md
+++ b/isvctl/configs/stubs/aws/eks/docs/aws-eks.md
@@ -97,7 +97,7 @@ The setup phase uses Terraform to provision:
 
 - VPC with public/private subnets and NAT Gateway
 - EKS cluster (Kubernetes 1.32)
-- GPU node group (g5.xlarge by default)
+- GPU node group (g5.2xlarge by default)
 - System node group (m5.large)
 - NVIDIA GPU Operator
 - EFS storage for NIM model cache
@@ -160,7 +160,7 @@ uv run isvctl test run -f isvctl/configs/providers/aws/eks.yaml -f my-aws-config
 | `TF_VAR_cluster_name_prefix` | isv-gpu | Cluster name prefix |
 | `TF_VAR_environment` | dev | Environment suffix (cluster name = prefix-env) |
 | `TF_VAR_kubernetes_version` | 1.32 | EKS Kubernetes version |
-| `TF_VAR_gpu_node_instance_types` | ["g5.xlarge"] | GPU instance types (JSON array) |
+| `TF_VAR_gpu_node_instance_types` | ["g5.2xlarge"] | GPU instance types (JSON array) |
 | `TF_VAR_gpu_node_desired_size` | 1 | Number of GPU nodes |
 | `TF_VAR_system_node_instance_types` | ["m5.large"] | System node instance types |
 | `TF_VAR_system_node_desired_size` | 2 | Number of system nodes |
@@ -324,7 +324,7 @@ set -e
 # Configuration
 export NGC_API_KEY=nvapi-XXXXX
 export TF_VAR_region=us-west-2
-export TF_VAR_gpu_node_instance_types='["g5.xlarge"]'
+export TF_VAR_gpu_node_instance_types='["g5.2xlarge"]'
 export TF_VAR_gpu_node_desired_size=1
 
 # Run all phases: setup -> test -> teardown

--- a/isvctl/configs/stubs/aws/eks/setup.sh
+++ b/isvctl/configs/stubs/aws/eks/setup.sh
@@ -201,6 +201,7 @@ if [ "$SKIP_PREFLIGHT" != "true" ]; then
     # Wait for GPU capacity and driver labels to be populated
     # These are set by the GPU Operator after driver installation completes
     echo "  Waiting for GPU driver and capacity labels..." >&2
+    GPU_READY=false
     for i in {1..30}; do
         GPU_CAP=$(kubectl get nodes -l nvidia.com/gpu.present=true \
             -o jsonpath='{.items[0].status.capacity.nvidia\.com/gpu}' 2>/dev/null || echo "")
@@ -208,11 +209,20 @@ if [ "$SKIP_PREFLIGHT" != "true" ]; then
             -o jsonpath='{.items[0].metadata.labels.nvidia\.com/cuda\.driver\.major}' 2>/dev/null || echo "")
         if [ -n "$GPU_CAP" ] && [ "$GPU_CAP" != "0" ] && [ -n "$DRIVER_LABEL" ]; then
             echo "    GPU capacity: $GPU_CAP, driver label: $DRIVER_LABEL" >&2
+            GPU_READY=true
             break
         fi
         echo "    Waiting for GPU operator to finish driver setup... ($i/30)" >&2
         sleep 10
     done
+
+    if [ "$GPU_READY" != "true" ]; then
+        echo "" >&2
+        echo "Error: GPU capacity/driver labels not ready after waiting 5 minutes." >&2
+        echo "Check GPU Operator status: kubectl get pods -n gpu-operator" >&2
+        echo "Check node labels: kubectl get nodes -l nvidia.com/gpu.present=true -o yaml" >&2
+        exit 1
+    fi
 
     # Check GPU Operator
     GPU_OP_NS=""

--- a/isvctl/configs/stubs/aws/eks/setup.sh
+++ b/isvctl/configs/stubs/aws/eks/setup.sh
@@ -176,8 +176,9 @@ if [ "$SKIP_PREFLIGHT" != "true" ]; then
     echo "" >&2
     echo "Running preflight checks..." >&2
 
-    # Wait for GPU nodes to be ready (GPU operator takes time)
+    # Wait for GPU nodes to be labeled by GPU Operator
     echo "  Waiting for GPU nodes..." >&2
+    GPU_NODES=0
     for i in {1..30}; do
         GPU_NODES=$(kubectl get nodes -l nvidia.com/gpu.present=true -o name 2>/dev/null | wc -l || echo "0")
         if [ "$GPU_NODES" -gt 0 ]; then
@@ -188,7 +189,6 @@ if [ "$SKIP_PREFLIGHT" != "true" ]; then
         sleep 10
     done
 
-    # Fail if no GPU nodes were detected after waiting
     if [ "$GPU_NODES" -eq 0 ]; then
         echo "" >&2
         echo "Error: No GPU nodes detected after waiting 5 minutes." >&2
@@ -197,6 +197,22 @@ if [ "$SKIP_PREFLIGHT" != "true" ]; then
         echo "Check GPU Operator: kubectl get pods -n gpu-operator" >&2
         exit 1
     fi
+
+    # Wait for GPU capacity and driver labels to be populated
+    # These are set by the GPU Operator after driver installation completes
+    echo "  Waiting for GPU driver and capacity labels..." >&2
+    for i in {1..30}; do
+        GPU_CAP=$(kubectl get nodes -l nvidia.com/gpu.present=true \
+            -o jsonpath='{.items[0].status.capacity.nvidia\.com/gpu}' 2>/dev/null || echo "")
+        DRIVER_LABEL=$(kubectl get nodes -l nvidia.com/gpu.present=true \
+            -o jsonpath='{.items[0].metadata.labels.nvidia\.com/cuda\.driver\.major}' 2>/dev/null || echo "")
+        if [ -n "$GPU_CAP" ] && [ "$GPU_CAP" != "0" ] && [ -n "$DRIVER_LABEL" ]; then
+            echo "    GPU capacity: $GPU_CAP, driver label: $DRIVER_LABEL" >&2
+            break
+        fi
+        echo "    Waiting for GPU operator to finish driver setup... ($i/30)" >&2
+        sleep 10
+    done
 
     # Check GPU Operator
     GPU_OP_NS=""

--- a/isvctl/configs/stubs/aws/eks/terraform/README.md
+++ b/isvctl/configs/stubs/aws/eks/terraform/README.md
@@ -23,6 +23,7 @@ This Terraform module deploys an AWS EKS cluster configured for GPU workloads an
 ### AWS Permissions
 
 Your AWS credentials need permissions for:
+
 - EKS cluster management
 - EC2 instances and Auto Scaling Groups
 - VPC, subnets, security groups
@@ -80,22 +81,25 @@ uv run isvctl test run -f isvctl/configs/providers/aws/eks.yaml
 ### Example Configurations
 
 **Development (minimal cost):**
+
 ```hcl
-gpu_node_instance_types = ["g5.xlarge"]
+gpu_node_instance_types = ["g5.2xlarge"]
 gpu_node_desired_size   = 1
 single_nat_gateway      = true
 enable_efs              = false  # Use node-local storage
 ```
 
 **Testing (balanced):**
+
 ```hcl
-gpu_node_instance_types = ["g5.xlarge"]
+gpu_node_instance_types = ["g5.2xlarge"]
 gpu_node_desired_size   = 2
 single_nat_gateway      = true
 enable_efs              = true
 ```
 
 **Production (high availability):**
+
 ```hcl
 gpu_node_instance_types = ["p4d.24xlarge"]
 gpu_node_desired_size   = 4
@@ -152,6 +156,7 @@ terraform destroy
 ```
 
 **Warning:** This will delete:
+
 - EKS cluster and all workloads
 - VPC and networking components
 - EFS file system and data
@@ -219,7 +224,7 @@ Approximate monthly costs (us-west-2, as of 2024):
 |-----------|---------------|-----------------|
 | EKS Control Plane | 1 cluster | $73 |
 | System Nodes | 2x m5.large | $140 |
-| GPU Nodes (g5.xlarge) | 1 node | $800 |
+| GPU Nodes (g5.2xlarge) | 1 node | $1,000 |
 | GPU Nodes (p4d.24xlarge) | 1 node | $24,000 |
 | NAT Gateway | 1 gateway | $45 + data |
 | EFS | 100GB | $30 |

--- a/isvctl/configs/stubs/aws/eks/terraform/main.tf
+++ b/isvctl/configs/stubs/aws/eks/terraform/main.tf
@@ -587,7 +587,7 @@ resource "helm_release" "efs_csi_driver" {
 }
 
 # EFS StorageClass
-resource "kubernetes_storage_class" "efs" {
+resource "kubernetes_storage_class_v1" "efs" {
   count = var.enable_efs ? 1 : 0
 
   metadata {
@@ -610,7 +610,7 @@ resource "kubernetes_storage_class" "efs" {
 # Default gp3 StorageClass
 # -----------------------------------------------------------------------------
 
-resource "kubernetes_storage_class" "gp3" {
+resource "kubernetes_storage_class_v1" "gp3" {
   metadata {
     name = "gp3"
     annotations = {

--- a/isvctl/configs/stubs/aws/eks/terraform/terraform.tfvars.example
+++ b/isvctl/configs/stubs/aws/eks/terraform/terraform.tfvars.example
@@ -49,7 +49,7 @@ system_node_desired_size   = 2
 # -----------------------------------------------------------------------------
 
 # Development configuration (1 small GPU node)
-gpu_node_instance_types = ["g5.xlarge"]  # 1x A10G, 24GB
+gpu_node_instance_types = ["g5.2xlarge"]  # 1x A10G, 32GB RAM (NIM requires 32GB)
 gpu_node_min_size       = 0
 gpu_node_max_size       = 2
 gpu_node_desired_size   = 1

--- a/isvctl/configs/stubs/aws/eks/terraform/variables.tf
+++ b/isvctl/configs/stubs/aws/eks/terraform/variables.tf
@@ -102,8 +102,8 @@ variable "gpu_node_instance_types" {
     Instance types for GPU node group.
     Common options:
     - g4dn.xlarge   (1x T4, 16GB)     - Development, small models
-    - g5.xlarge     (1x A10G, 16GB)   - Development, small models (no NIM)
-    - g5.2xlarge    (1x A10G, 32GB)   - Development, NIM inference
+    - g5.xlarge     (1x A10G, 24GB)   - Development, small models (16GB RAM, no NIM)
+    - g5.2xlarge    (1x A10G, 24GB)   - Development, NIM inference (32GB RAM)
     - g5.12xlarge   (4x A10G, 24GB)   - Multi-GPU workloads
     - p4d.24xlarge  (8x A100, 40GB)   - Large models, training
     - p5.48xlarge   (8x H100, 80GB)   - LLM inference, training

--- a/isvctl/configs/stubs/aws/eks/terraform/variables.tf
+++ b/isvctl/configs/stubs/aws/eks/terraform/variables.tf
@@ -102,13 +102,14 @@ variable "gpu_node_instance_types" {
     Instance types for GPU node group.
     Common options:
     - g4dn.xlarge   (1x T4, 16GB)     - Development, small models
-    - g5.xlarge     (1x A10G, 24GB)   - Development, medium models
+    - g5.xlarge     (1x A10G, 16GB)   - Development, small models (no NIM)
+    - g5.2xlarge    (1x A10G, 32GB)   - Development, NIM inference
     - g5.12xlarge   (4x A10G, 24GB)   - Multi-GPU workloads
     - p4d.24xlarge  (8x A100, 40GB)   - Large models, training
     - p5.48xlarge   (8x H100, 80GB)   - LLM inference, training
   EOT
   type        = list(string)
-  default     = ["g5.xlarge"]
+  default     = ["g5.2xlarge"]
 }
 
 variable "gpu_node_min_size" {

--- a/isvctl/src/isvctl/cli/test.py
+++ b/isvctl/src/isvctl/cli/test.py
@@ -430,6 +430,11 @@ def run(
                         vr_status = typer.style("FAILED", fg=typer.colors.RED)
                     typer.echo(f"  {category_prefix}{vr_name}: {vr_status} - {vr_message}")
 
+    if result.context_warnings:
+        typer.echo(typer.style("WARNINGS", fg=typer.colors.YELLOW))
+        for w in result.context_warnings:
+            typer.echo(typer.style(f"  - {w}", fg=typer.colors.YELLOW))
+
     typer.echo("-" * 60)
     if result.success:
         status = typer.style("[PASS]", fg=typer.colors.GREEN)

--- a/isvctl/src/isvctl/config/output_schemas.py
+++ b/isvctl/src/isvctl/config/output_schemas.py
@@ -22,7 +22,7 @@ Example usage:
     from isvctl.config.output_schemas import get_schema_for_step, validate_output
 
     # Auto-detect schema from step name
-    schema_name = get_schema_for_step("provision_cluster")  # Returns "cluster"
+    schema_name = get_schema_for_step("setup")  # Returns "cluster"
 
     # Validate output against schema
     is_valid, errors = validate_output(output_json, schema_name)
@@ -36,6 +36,7 @@ import jsonschema
 # The step name determines which schema is used for validation
 STEP_SCHEMA_MAPPING: dict[str, str | None] = {
     # Cluster operations -> "cluster" schema
+    "setup": "cluster",
     "provision_cluster": "cluster",
     "create_cluster": "cluster",
     "setup_cluster": "cluster",
@@ -828,7 +829,7 @@ def get_schema_for_step(step_name: str) -> str | None:
         Schema name for validation
 
     Examples:
-        >>> get_schema_for_step("provision_cluster")
+        >>> get_schema_for_step("setup")
         "cluster"
         >>> get_schema_for_step("my_custom_cluster_setup")
         "cluster"  # Partial match - contains "cluster"

--- a/isvctl/src/isvctl/orchestrator/context.py
+++ b/isvctl/src/isvctl/orchestrator/context.py
@@ -17,7 +17,9 @@ enriched with inventory data from command outputs.
 
 import copy
 import json
+import logging
 import os
+import re
 from datetime import UTC, datetime
 from typing import Any
 
@@ -26,6 +28,8 @@ from jinja2 import ChainableUndefined, Environment
 
 from isvctl.config.schema import CommandOutput, RunConfig
 from isvctl.redaction import filter_env
+
+logger = logging.getLogger(__name__)
 
 
 def _create_jinja_env() -> Environment:
@@ -94,6 +98,9 @@ class Context:
 
         # Step phases (for inferring validation phase from step)
         self._step_phases: dict[str, str] = {}
+
+        # Track which missing steps have already been warned about
+        self._warned_missing_steps: set[str] = set()
 
         # Layer 6: Environment variables (for {{env.VAR}} access)
         # Must be loaded before settings so settings can reference env vars.
@@ -234,9 +241,38 @@ class Context:
         if "{{" not in template_str or "}}" not in template_str:
             return template_str
 
+        self._warn_missing_step_defaults(template_str)
+
         env = _create_jinja_env()
         template = env.from_string(template_str)
         return template.render(**self.data)
+
+    _STEP_REF_RE = re.compile(r"steps\.(\w+)")
+
+    def _warn_missing_step_defaults(self, template_str: str) -> None:
+        """Warn when a template references a step that hasn't produced output.
+
+        When running with ``--phase test``, setup steps don't execute so their
+        outputs are empty.  Templates with ``| default(...)`` will silently
+        fall back, which can mask configuration errors (e.g., using
+        ``total_gpus`` instead of ``gpu_per_node``).  This emits a one-time
+        warning per missing step so the operator knows defaults are in effect.
+        """
+        steps_data = self.data.get("steps", {})
+        for match in self._STEP_REF_RE.finditer(template_str):
+            step_name = match.group(1)
+            if step_name in self._warned_missing_steps:
+                continue
+            if step_name not in steps_data or not steps_data[step_name]:
+                self._warned_missing_steps.add(step_name)
+                logger.warning(
+                    "Template references 'steps.%s' but step '%s' has no output "
+                    "(step may not have run). Default values will be used. "
+                    "Template: %s",
+                    step_name,
+                    step_name,
+                    template_str.strip(),
+                )
 
     def render_dict(self, data: dict[str, Any]) -> dict[str, Any]:
         """Recursively render all string values in a dictionary.

--- a/isvctl/src/isvctl/orchestrator/context.py
+++ b/isvctl/src/isvctl/orchestrator/context.py
@@ -301,14 +301,13 @@ class Context:
                     self._context_warnings.append(msg)
                     break
                 else:
-                    if i + 1 < len(parts):
-                        self._warned_missing_steps.add(warn_key)
-                        msg = (
-                            f"cannot descend into steps.{'.'.join(parts[: i + 1])} "
-                            f"(found {type(node).__name__}), using defaults for: steps.{full_path}"
-                        )
-                        logger.warning(msg)
-                        self._context_warnings.append(msg)
+                    self._warned_missing_steps.add(warn_key)
+                    msg = (
+                        f"cannot descend into steps.{'.'.join(parts[:i])} "
+                        f"(found {type(node).__name__}), using defaults for: steps.{full_path}"
+                    )
+                    logger.warning(msg)
+                    self._context_warnings.append(msg)
                     break
 
     def render_dict(self, data: dict[str, Any]) -> dict[str, Any]:

--- a/isvctl/src/isvctl/orchestrator/context.py
+++ b/isvctl/src/isvctl/orchestrator/context.py
@@ -301,6 +301,14 @@ class Context:
                     self._context_warnings.append(msg)
                     break
                 else:
+                    if i + 1 < len(parts):
+                        self._warned_missing_steps.add(warn_key)
+                        msg = (
+                            f"cannot descend into steps.{'.'.join(parts[: i + 1])} "
+                            f"(found {type(node).__name__}), using defaults for: steps.{full_path}"
+                        )
+                        logger.warning(msg)
+                        self._context_warnings.append(msg)
                     break
 
     def render_dict(self, data: dict[str, Any]) -> dict[str, Any]:

--- a/isvctl/src/isvctl/orchestrator/context.py
+++ b/isvctl/src/isvctl/orchestrator/context.py
@@ -103,6 +103,9 @@ class Context:
         self._warned_missing_steps: set[str] = set()
         self._context_warnings: list[str] = []
 
+        # Phases that were actually requested (set by orchestrator)
+        self._requested_phases: set[str] | None = None
+
         # Layer 6: Environment variables (for {{env.VAR}} access)
         # Must be loaded before settings so settings can reference env vars.
         # Sensitive variables (API keys, secrets) are excluded to prevent
@@ -154,6 +157,17 @@ class Context:
             >>> args: ["--cluster", "{{ steps.setup.cluster_name }}"]
         """
         self.data.setdefault("steps", {})[step_name] = output
+
+    def set_requested_phases(self, phases: set[str]) -> None:
+        """Record which phases were requested for this run.
+
+        Used to suppress warnings for steps in phases that were
+        intentionally skipped (e.g., ``--phase teardown``).
+
+        Args:
+            phases: Set of phase names that were requested
+        """
+        self._requested_phases = phases
 
     def set_step_phase(self, step_name: str, phase: str) -> None:
         """Record the phase a step belongs to.
@@ -281,6 +295,10 @@ class Context:
                 continue
 
             if step_name not in steps_data or not steps_data[step_name]:
+                # Suppress warning if the step's phase wasn't requested
+                step_phase = self._step_phases.get(step_name)
+                if self._requested_phases and step_phase and step_phase not in self._requested_phases:
+                    continue
                 self._warned_missing_steps.add(warn_key)
                 msg = f"step '{step_name}' has no output (not run?), using defaults for: steps.{full_path}"
                 logger.warning(msg)

--- a/isvctl/src/isvctl/orchestrator/context.py
+++ b/isvctl/src/isvctl/orchestrator/context.py
@@ -101,6 +101,7 @@ class Context:
 
         # Track which missing steps have already been warned about
         self._warned_missing_steps: set[str] = set()
+        self._context_warnings: list[str] = []
 
         # Layer 6: Environment variables (for {{env.VAR}} access)
         # Must be loaded before settings so settings can reference env vars.
@@ -229,6 +230,10 @@ class Context:
         """
         return self.data
 
+    def get_warnings(self) -> list[str]:
+        """Return any warnings about missing step data or fields."""
+        return list(self._context_warnings)
+
     def render_string(self, template_str: str) -> str:
         """Render a Jinja2 template string with context.
 
@@ -247,32 +252,53 @@ class Context:
         template = env.from_string(template_str)
         return template.render(**self.data)
 
-    _STEP_REF_RE = re.compile(r"steps\.(\w+)")
+    _STEP_PATH_RE = re.compile(r"steps\.([\w.]+)")
 
     def _warn_missing_step_defaults(self, template_str: str) -> None:
-        """Warn when a template references a step that hasn't produced output.
+        """Warn when a template references missing step data.
 
-        When running with ``--phase test``, setup steps don't execute so their
-        outputs are empty.  Templates with ``| default(...)`` will silently
-        fall back, which can mask configuration errors (e.g., using
-        ``total_gpus`` instead of ``gpu_per_node``).  This emits a one-time
-        warning per missing step so the operator knows defaults are in effect.
+        Detects two cases that ``ChainableUndefined`` would silently absorb:
+
+        1. **Step not run** — ``steps.setup`` is empty because ``--phase test``
+           skipped setup.
+        2. **Field not found** — ``steps.setup`` has output but the referenced
+           field doesn't exist (typo, rename, wrong variable).
+
+        Emits a one-time warning per unique path so operators know defaults
+        are in effect and can verify they're correct.
         """
         steps_data = self.data.get("steps", {})
-        for match in self._STEP_REF_RE.finditer(template_str):
-            step_name = match.group(1)
-            if step_name in self._warned_missing_steps:
+        for match in self._STEP_PATH_RE.finditer(template_str):
+            full_path = match.group(1)
+            parts = full_path.split(".")
+            step_name = parts[0]
+            warn_key = f"steps.{full_path}"
+
+            if warn_key in self._warned_missing_steps:
                 continue
+
             if step_name not in steps_data or not steps_data[step_name]:
-                self._warned_missing_steps.add(step_name)
-                logger.warning(
-                    "Template references 'steps.%s' but step '%s' has no output "
-                    "(step may not have run). Default values will be used. "
-                    "Template: %s",
-                    step_name,
-                    step_name,
-                    template_str.strip(),
-                )
+                self._warned_missing_steps.add(warn_key)
+                msg = f"step '{step_name}' has no output (not run?), using defaults for: steps.{full_path}"
+                logger.warning(msg)
+                self._context_warnings.append(msg)
+                continue
+
+            # Step has output — walk the path to check for missing fields
+            node = steps_data
+            for i, part in enumerate(parts):
+                if isinstance(node, dict) and part in node:
+                    node = node[part]
+                elif isinstance(node, dict):
+                    missing = parts[i]
+                    available = ", ".join(sorted(node.keys())) if node else "(empty)"
+                    self._warned_missing_steps.add(warn_key)
+                    msg = f"'{missing}' not found in steps.{'.'.join(parts[:i])} (available: {available})"
+                    logger.warning(msg)
+                    self._context_warnings.append(msg)
+                    break
+                else:
+                    break
 
     def render_dict(self, data: dict[str, Any]) -> dict[str, Any]:
         """Recursively render all string values in a dictionary.

--- a/isvctl/src/isvctl/orchestrator/context.py
+++ b/isvctl/src/isvctl/orchestrator/context.py
@@ -147,11 +147,11 @@ class Context:
             output: JSON output from the step command
 
         Example:
-            After provision_cluster step:
-            >>> context.set_step_output("provision_cluster", {"cluster_name": "my-cluster"})
+            After setup step:
+            >>> context.set_step_output("setup", {"cluster_name": "my-cluster"})
 
             Subsequent step can reference:
-            >>> args: ["--cluster", "{{ steps.provision_cluster.cluster_name }}"]
+            >>> args: ["--cluster", "{{ steps.setup.cluster_name }}"]
         """
         self.data.setdefault("steps", {})[step_name] = output
 

--- a/isvctl/src/isvctl/orchestrator/context.py
+++ b/isvctl/src/isvctl/orchestrator/context.py
@@ -266,6 +266,9 @@ class Context:
 
         Emits a one-time warning per unique path so operators know defaults
         are in effect and can verify they're correct.
+
+        Args:
+            template_str: Jinja2 template string to scan for step references
         """
         steps_data = self.data.get("steps", {})
         for match in self._STEP_PATH_RE.finditer(template_str):

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -281,6 +281,11 @@ class Orchestrator:
         # Build set of requested phase names for filtering
         requested_phase_names = {p.value for p in requested_phases}
 
+        # Tell context which phases were requested so it can suppress
+        # warnings for steps in intentionally skipped phases
+        if Phase.ALL not in requested_phases:
+            self.context.set_requested_phases(requested_phase_names)
+
         # Per-phase JUnit XML: use temp files per phase, merge at the end
         # This prevents later phases from overwriting earlier phases' results
         junit_tmpdir: str | None = None

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -19,7 +19,7 @@ import logging
 import shutil
 import tempfile
 import xml.etree.ElementTree as ET
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -72,6 +72,7 @@ class OrchestratorResult:
     success: bool
     phases: list[PhaseResult]
     inventory: dict[str, Any] | None = None
+    context_warnings: list[str] = field(default_factory=list)
 
 
 def _merge_junit_xmls(phase_files: list[Path], output_path: Path) -> None:
@@ -393,6 +394,7 @@ class Orchestrator:
             success=overall_success,
             phases=phase_results,
             inventory=self.context.get_accumulated_context().get("steps", {}),
+            context_warnings=self.context.get_warnings(),
         )
 
     def _create_phase_result(

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -67,6 +67,7 @@ class OrchestratorResult:
         success: Whether all phases succeeded
         phases: Results for each phase that was executed
         inventory: Final inventory data (step outputs)
+        context_warnings: Template/context warnings collected during orchestration
     """
 
     success: bool

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -283,7 +283,9 @@ class Orchestrator:
 
         # Tell context which phases were requested so it can suppress
         # warnings for steps in intentionally skipped phases
-        if Phase.ALL not in requested_phases:
+        if Phase.ALL in requested_phases:
+            self.context.set_requested_phases(set(config_phases))
+        else:
             self.context.set_requested_phases(requested_phase_names)
 
         # Per-phase JUnit XML: use temp files per phase, merge at the end

--- a/isvctl/src/isvctl/orchestrator/step_executor.py
+++ b/isvctl/src/isvctl/orchestrator/step_executor.py
@@ -26,9 +26,9 @@ Example config:
     commands:
       kubernetes:
         steps:
-          - name: provision_cluster
+          - name: setup
             phase: setup
-            command: "./provision.sh"
+            command: "./setup.sh"
           - name: teardown
             phase: teardown
             command: "./teardown.sh"
@@ -37,7 +37,7 @@ Example config:
       validations:
         cluster:
           - NodeCountCheck:
-              step: provision_cluster
+              step: setup
               expected: 4
 """
 

--- a/isvctl/tests/test_orchestrator.py
+++ b/isvctl/tests/test_orchestrator.py
@@ -345,8 +345,8 @@ class TestContext:
 
         assert result == "4"
         assert len(caplog.records) == 1
-        assert "steps.setup" in caplog.records[0].message
-        assert "has no output" in caplog.records[0].message
+        assert "step 'setup' has no output" in caplog.records[0].message
+        assert len(context.get_warnings()) == 1
 
     def test_no_warning_when_step_output_present(self, caplog: logging.LogRecord) -> None:
         """Template referencing a step with output should not warn."""
@@ -361,12 +361,40 @@ class TestContext:
         assert len(caplog.records) == 0
 
     def test_missing_step_warning_deduplicates(self, caplog: logging.LogRecord) -> None:
-        """Multiple templates referencing the same missing step should warn only once."""
+        """Same path referenced twice should warn only once."""
         config = RunConfig()
         context = Context(config)
 
         with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
             context.render_string("{{ steps.setup.kubernetes.total_gpus | default(16, true) }}")
-            context.render_string("{{ steps.setup.kubernetes.gpu_per_node | default(4, true) }}")
+            context.render_string("{{ steps.setup.kubernetes.total_gpus | default(4, true) }}")
 
         assert len(caplog.records) == 1
+
+    def test_warns_when_field_missing_in_step_output(self, caplog: logging.LogRecord) -> None:
+        """Typo or wrong field name in a populated step should warn."""
+        config = RunConfig()
+        context = Context(config)
+        context.set_step_output("setup", {"kubernetes": {"total_gpus": 1, "gpu_per_node": 1}})
+
+        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
+            result = context.render_string("{{ steps.setup.kubernetes._total_gpus | default(1, true) }}")
+
+        assert result == "1"
+        assert len(caplog.records) == 1
+        assert "'_total_gpus' not found" in caplog.records[0].message
+        assert "total_gpus" in caplog.records[0].message  # listed in available keys
+        assert len(context.get_warnings()) == 1
+
+    def test_warns_with_available_keys(self, caplog: logging.LogRecord) -> None:
+        """Warning for missing field should list available keys at that level."""
+        config = RunConfig()
+        context = Context(config)
+        context.set_step_output("setup", {"kubernetes": {"gpu_per_node": 4, "total_gpus": 16}})
+
+        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
+            context.render_string("{{ steps.setup.kubernetes.typo_field | default(1, true) }}")
+
+        assert len(caplog.records) == 1
+        assert "'typo_field' not found" in caplog.records[0].message
+        assert "gpu_per_node" in caplog.records[0].message

--- a/isvctl/tests/test_orchestrator.py
+++ b/isvctl/tests/test_orchestrator.py
@@ -14,6 +14,8 @@ import logging
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from isvctl.config.schema import CommandConfig, CommandOutput, RunConfig
 from isvctl.orchestrator.commands import CommandExecutor
 from isvctl.orchestrator.context import Context
@@ -335,7 +337,7 @@ class TestContext:
         assert result["items"][4] is True
         assert result["items"][5] is None
 
-    def test_warns_when_step_output_missing(self, caplog: logging.LogRecord) -> None:
+    def test_warns_when_step_output_missing(self, caplog: pytest.LogCaptureFixture) -> None:
         """Template referencing a step that hasn't run should warn."""
         config = RunConfig()
         context = Context(config)
@@ -348,7 +350,7 @@ class TestContext:
         assert "step 'setup' has no output" in caplog.records[0].message
         assert len(context.get_warnings()) == 1
 
-    def test_no_warning_when_step_output_present(self, caplog: logging.LogRecord) -> None:
+    def test_no_warning_when_step_output_present(self, caplog: pytest.LogCaptureFixture) -> None:
         """Template referencing a step with output should not warn."""
         config = RunConfig()
         context = Context(config)
@@ -360,7 +362,7 @@ class TestContext:
         assert result == "16"
         assert len(caplog.records) == 0
 
-    def test_missing_step_warning_deduplicates(self, caplog: logging.LogRecord) -> None:
+    def test_missing_step_warning_deduplicates(self, caplog: pytest.LogCaptureFixture) -> None:
         """Same path referenced twice should warn only once."""
         config = RunConfig()
         context = Context(config)
@@ -371,7 +373,7 @@ class TestContext:
 
         assert len(caplog.records) == 1
 
-    def test_warns_when_field_missing_in_step_output(self, caplog: logging.LogRecord) -> None:
+    def test_warns_when_field_missing_in_step_output(self, caplog: pytest.LogCaptureFixture) -> None:
         """Typo or wrong field name in a populated step should warn."""
         config = RunConfig()
         context = Context(config)
@@ -386,7 +388,7 @@ class TestContext:
         assert "total_gpus" in caplog.records[0].message  # listed in available keys
         assert len(context.get_warnings()) == 1
 
-    def test_warns_with_available_keys(self, caplog: logging.LogRecord) -> None:
+    def test_warns_with_available_keys(self, caplog: pytest.LogCaptureFixture) -> None:
         """Warning for missing field should list available keys at that level."""
         config = RunConfig()
         context = Context(config)

--- a/isvctl/tests/test_orchestrator.py
+++ b/isvctl/tests/test_orchestrator.py
@@ -10,6 +10,7 @@
 
 """Tests for orchestration components."""
 
+import logging
 import tempfile
 from pathlib import Path
 
@@ -333,3 +334,39 @@ class TestContext:
         assert result["items"][3] == 123
         assert result["items"][4] is True
         assert result["items"][5] is None
+
+    def test_warns_when_step_output_missing(self, caplog: logging.LogRecord) -> None:
+        """Template referencing a step that hasn't run should warn."""
+        config = RunConfig()
+        context = Context(config)
+
+        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
+            result = context.render_string("{{ steps.setup.kubernetes.total_gpus | default(4, true) }}")
+
+        assert result == "4"
+        assert len(caplog.records) == 1
+        assert "steps.setup" in caplog.records[0].message
+        assert "has no output" in caplog.records[0].message
+
+    def test_no_warning_when_step_output_present(self, caplog: logging.LogRecord) -> None:
+        """Template referencing a step with output should not warn."""
+        config = RunConfig()
+        context = Context(config)
+        context.set_step_output("setup", {"kubernetes": {"total_gpus": 16}})
+
+        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
+            result = context.render_string("{{ steps.setup.kubernetes.total_gpus | default(4, true) }}")
+
+        assert result == "16"
+        assert len(caplog.records) == 0
+
+    def test_missing_step_warning_deduplicates(self, caplog: logging.LogRecord) -> None:
+        """Multiple templates referencing the same missing step should warn only once."""
+        config = RunConfig()
+        context = Context(config)
+
+        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
+            context.render_string("{{ steps.setup.kubernetes.total_gpus | default(16, true) }}")
+            context.render_string("{{ steps.setup.kubernetes.gpu_per_node | default(4, true) }}")
+
+        assert len(caplog.records) == 1

--- a/isvtest/src/isvtest/validations/host.py
+++ b/isvtest/src/isvtest/validations/host.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import base64
 import os
 import re
+import shlex
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
@@ -1876,7 +1877,7 @@ class CloudInitCheck(BaseValidation):
         host = ssh_cfg["ssh_host"]
         user = ssh_cfg["ssh_user"]
         key_path = ssh_cfg["ssh_key_path"]
-        metadata_url = self.config.get("metadata_url", "http://169.254.169.254/latest/meta-data/")
+        metadata_url = str(self.config.get("metadata_url", "http://169.254.169.254/latest/meta-data/"))
         metadata_headers: dict[str, str] = self.config.get("metadata_headers", {})
 
         if not host or not key_path:
@@ -1895,8 +1896,8 @@ class CloudInitCheck(BaseValidation):
                 self.report_subtest("cloud_init", done, stdout.strip())
 
             # Check metadata service reachability
-            header_flags = " ".join(f"-H '{k}: {v}'" for k, v in metadata_headers.items())
-            curl_cmd = f"curl -s -o /dev/null -w '%{{http_code}}' --max-time 5 {header_flags} {metadata_url}".strip()
+            header_flags = " ".join(f"-H {shlex.quote(f'{k}: {v}')}" for k, v in metadata_headers.items())
+            curl_cmd = f"curl -s -o /dev/null -w '%{{http_code}}' --max-time 5 {header_flags} {shlex.quote(metadata_url)}".strip()
             exit_code, stdout, _ = run_ssh_command(ssh, curl_cmd)
             http_code = stdout.strip()
             metadata_ok = exit_code == 0 and http_code in ("200", "301")

--- a/isvtest/src/isvtest/validations/host.py
+++ b/isvtest/src/isvtest/validations/host.py
@@ -1897,7 +1897,7 @@ class CloudInitCheck(BaseValidation):
 
             # Check metadata service reachability
             header_flags = " ".join(f"-H {shlex.quote(f'{k}: {v}')}" for k, v in metadata_headers.items())
-            curl_cmd = f"curl -s -o /dev/null -w '%{{http_code}}' --max-time 5 {header_flags} {shlex.quote(metadata_url)}".strip()
+            curl_cmd = f"curl -s -o /dev/null -w '%{{http_code}}' --max-time 5 {header_flags} -- {shlex.quote(metadata_url)}".strip()
             exit_code, stdout, _ = run_ssh_command(ssh, curl_cmd)
             http_code = stdout.strip()
             metadata_ok = exit_code == 0 and http_code in ("200", "301")

--- a/isvtest/src/isvtest/validations/k8s_mig.py
+++ b/isvtest/src/isvtest/validations/k8s_mig.py
@@ -12,6 +12,8 @@ import json
 import shlex
 from typing import ClassVar
 
+import pytest
+
 from isvtest.core.k8s import get_kubectl_command
 from isvtest.core.validation import BaseValidation
 
@@ -48,21 +50,18 @@ class K8sMigConfigCheck(BaseValidation):
             name = node.get("metadata", {}).get("name", "unknown")
             labels = node.get("metadata", {}).get("labels", {})
 
-            # Check if node has any MIG labels
-            has_mig = any("nvidia.com/mig" in k for k in labels.keys())
+            # A node has MIG enabled when nvidia.com/mig.capable is explicitly "true"
+            mig_capable = labels.get("nvidia.com/mig.capable", "false")
+            has_mig = str(mig_capable).lower() == "true"
             if has_mig:
                 mig_nodes.append(name)
 
-            # Verify specific expected labels if configured
-            if expected_labels:
+            # Verify expected labels only on nodes that have MIG enabled,
+            # or on all nodes when require_mig is set.
+            if expected_labels and (require_mig or has_mig):
                 for key, expected_value in expected_labels.items():
-                    # Only check if the key exists or if we expect it to exist?
-                    # Generally, if we expect a label value, we expect the label to be there.
                     if key not in labels:
-                        # Only report missing label if we require MIG or if the node has other MIG labels
-                        # (Assuming mixed cluster: non-MIG nodes shouldn't fail this unless we target them specifically)
-                        if require_mig or has_mig:
-                            mismatch_nodes.append(f"{name} (missing label {key})")
+                        mismatch_nodes.append(f"{name} (missing label {key})")
                     elif str(labels[key]) != str(expected_value):
                         mismatch_nodes.append(f"{name} ({key}: {labels[key]} != {expected_value})")
 
@@ -79,4 +78,4 @@ class K8sMigConfigCheck(BaseValidation):
             if require_mig:
                 self.set_failed("No MIG labels found on any node")
             else:
-                self.set_passed("No MIG labels found (MIG not configured)")
+                pytest.skip("No MIG-capable nodes found (require_mig is false)")

--- a/isvtest/src/isvtest/workloads/k8s_nccl_multinode.py
+++ b/isvtest/src/isvtest/workloads/k8s_nccl_multinode.py
@@ -28,6 +28,8 @@ import uuid
 from pathlib import Path
 from typing import ClassVar
 
+import pytest
+
 from isvtest.config.settings import (
     get_k8s_namespace,
     get_nccl_hpc_image,
@@ -111,11 +113,10 @@ class K8sNcclMultiNodeWorkload(BaseWorkloadCheck):
         quick_mode = self.config.get("quick_mode", False)
 
         if not self._check_mpi_operator():
-            self.set_failed(
+            pytest.skip(
                 "MPI Operator not found. Install the Kubeflow MPI Operator "
-                "(https://github.com/kubeflow/mpi-operator) to run multi-node NCCL tests on K8s."
+                "(https://github.com/kubeflow/mpi-operator) to run multi-node NCCL tests."
             )
-            return
 
         gpu_nodes = get_gpu_nodes()
         if not gpu_nodes:

--- a/isvtest/src/isvtest/workloads/k8s_nim.py
+++ b/isvtest/src/isvtest/workloads/k8s_nim.py
@@ -60,8 +60,9 @@ class K8sNimInferenceWorkload(BaseWorkloadCheck):
             self.set_passed("Skipped: No GPU nodes found in cluster")
             return
 
-        # Ensure PVC for model cache exists
-        self._ensure_pvc(namespace)
+        # Ensure PVC for model cache exists and is usable
+        if not self._ensure_pvc(namespace):
+            return
 
         # Generate unique job name
         job_name = f"nim-llama-3b-test-{uuid.uuid4().hex[:8]}"
@@ -132,20 +133,28 @@ class K8sNimInferenceWorkload(BaseWorkloadCheck):
             # Cleanup
             self.run_command(f"{kubectl_base} delete job {job_name} -n {namespace} --wait=false")
 
-    def _ensure_pvc(self, namespace: str) -> None:
-        """Ensure PVC for model cache exists."""
+    def _ensure_pvc(self, namespace: str) -> bool:
+        """Ensure PVC for model cache exists.
+
+        With ``WaitForFirstConsumer`` storage classes (e.g. EKS gp3), the PVC
+        stays Pending until a pod references it, so we only verify the resource
+        exists — not that it's Bound.
+
+        Returns:
+            True if PVC exists or was created, False on error.
+        """
         pvc_name = "nim-model-cache"
         kubectl_base = get_kubectl_base()
 
         res = self.run_command(f"{kubectl_base} get pvc {pvc_name} -n {namespace}")
         if res.exit_code == 0:
-            return
+            return True
 
         self.log.info(f"Creating PVC {pvc_name}...")
         pvc_path = Path(__file__).parent / "manifests" / "k8s" / "nim_cache_pvc.yaml"
         if not pvc_path.exists():
-            self.log.warning(f"PVC manifest not found: {pvc_path}")
-            return
+            self.set_failed(f"PVC manifest not found: {pvc_path}")
+            return False
 
         kubectl_parts = get_kubectl_command()
         try:
@@ -155,9 +164,13 @@ class K8sNimInferenceWorkload(BaseWorkloadCheck):
                 capture_output=True,
                 text=True,
                 timeout=30,
+                check=True,
             )
         except Exception as e:
-            self.log.warning(f"Failed to create PVC: {e}")
+            self.set_failed(f"Failed to create PVC: {e}")
+            return False
+
+        return True
 
     def _dump_nim_logs(self, job_name: str, namespace: str) -> None:
         """Dump logs from NIM containers for debugging."""

--- a/isvtest/src/isvtest/workloads/manifests/k8s/nim_cache_pvc.yaml
+++ b/isvtest/src/isvtest/workloads/manifests/k8s/nim_cache_pvc.yaml
@@ -14,7 +14,7 @@ metadata:
   name: nim-model-cache
 spec:
   accessModes:
-    - ReadWriteMany # Allows multiple pods to access the cache
+    - ReadWriteOnce
   resources:
     requests:
       storage: 20Gi # Enough for Llama 3.2 3B model (~6-8GB) plus overhead


### PR DESCRIPTION
## Summary

Investigating PR #188 revealed that Jinja2's `ChainableUndefined` silently absorbs missing template data at multiple levels, masking configuration errors across the entire EKS validation suite.

### Root causes found and fixed

1. **EKS step name mismatch**: The EKS config named its setup step `provision_cluster` but `k8s.yaml` templates all reference `steps.setup`. Every template silently fell back to `| default()` values — the cluster inventory was never used.

2. **GPU Operator race condition**: The EKS setup script gathered inventory before GPU Operator finished labeling nodes, producing `gpu_per_node=0` and `driver_version=unknown`. The `default(X, true)` Jinja2 filter treats `0` as undefined, silently replacing it with wrong values.

3. **Instance sizing**: Default g5.xlarge (16GB RAM) was too small for the NIM inference job manifest (32GB memory request).

### Detection layer added

- Warn in the orchestration results summary (yellow) when templates reference step data that doesn't exist — both when a step hasn't run and when a field name is wrong (typo, rename). Warnings list available keys to guide the fix.
- Suppress warnings for steps in phases that were intentionally skipped (e.g., `--phase teardown`).

### Additional fixes

- **K8sMigConfigCheck**: Skip on non-MIG nodes instead of failing on label mismatches.
- **K8sNcclMultiNodeWorkload**: `pytest.skip()` when MPI Operator missing instead of `set_failed()`.
- **K8sNimInferenceWorkload**: Simplify PVC check for `WaitForFirstConsumer` storage classes; change PVC to `ReadWriteOnce`.
- **EKS setup script**: Wait for GPU capacity and driver labels before gathering inventory; fail fast if labels never appear.
- **Default GPU instance**: Upgrade from g5.xlarge to g5.2xlarge (32GB RAM) for NIM compatibility.
- **CloudInitCheck**: Sanitize `metadata_url` with `shlex.quote()` and `--` separator.
- **Terraform**: Use `kubernetes_storage_class_v1` to fix deprecation warnings.

Closes #187

## Test plan

- [x] All 238 isvctl unit tests pass, 211 isvtest unit tests pass
- [x] Full EKS pipeline (provision + test + teardown): 18 passed, 2 skipped, 0 failed
- [x] `steps.setup` resolves to real cluster data — no warnings in summary
- [x] K8sMigConfigCheck: SKIPPED on non-MIG cluster
- [x] K8sNcclMultiNodeWorkload: SKIPPED when MPI Operator missing
- [x] K8sNimInferenceWorkload: PASSED with g5.2xlarge and RWO PVC
- [x] K8sNimHelmWorkload-3b: PASSED with gpu_per_node=1 from real inventory
- [x] `--phase teardown` runs cleanly without spurious warnings
- [x] EKS cluster teardown confirmed (ResourceNotFoundException)