### PR TITLE
fix: prevent resource leaks by decoupling teardown from validation results

### DIFF
--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -311,11 +311,15 @@ class Orchestrator:
                 if not overall_success and not is_teardown:
                     skip_reason = "previous phase failed"
 
-                # Skip teardown only if setup steps never ran (nothing to clean up).
-                # Validation failures alone should NOT prevent teardown — resources
-                # may have been created by the setup steps even if validations failed.
+                # Teardown gating depends on whether setup was part of this run:
+                # - If setup was requested alongside teardown (full lifecycle), skip
+                #   teardown only when setup steps never actually executed.
+                # - If teardown was requested alone (e.g., `--phase teardown`), run
+                #   it unconditionally — the user is explicitly cleaning up resources
+                #   from a previous run.
                 if is_teardown:
-                    if not setup_steps_ran:
+                    setup_was_requested = "setup" in requested_phase_names or Phase.ALL in requested_phases
+                    if setup_was_requested and not setup_steps_ran:
                         skip_reason = "setup steps did not run"
                     elif not overall_success and not teardown_on_failure:
                         skip_reason = "teardown_on_failure is disabled"

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -274,7 +274,7 @@ class Orchestrator:
 
         phase_results: list[PhaseResult] = []
         overall_success = True
-        setup_succeeded = False  # Track setup phase specifically
+        setup_steps_ran = False  # Track whether setup steps executed (for teardown gating)
 
         # Build set of requested phase names for filtering
         requested_phase_names = {p.value for p in requested_phases}
@@ -311,11 +311,12 @@ class Orchestrator:
                 if not overall_success and not is_teardown:
                     skip_reason = "previous phase failed"
 
-                # Skip teardown if setup failed (teardown depends on setup outputs)
-                # or if teardown_on_failure is False
+                # Skip teardown only if setup steps never ran (nothing to clean up).
+                # Validation failures alone should NOT prevent teardown — resources
+                # may have been created by the setup steps even if validations failed.
                 if is_teardown:
-                    if not setup_succeeded:
-                        skip_reason = "setup phase did not succeed"
+                    if not setup_steps_ran:
+                        skip_reason = "setup steps did not run"
                     elif not overall_success and not teardown_on_failure:
                         skip_reason = "teardown_on_failure is disabled"
 
@@ -333,9 +334,12 @@ class Orchestrator:
 
                 # Execute steps for this phase
                 if phase_steps:
-                    step_results = self.step_executor.execute_steps(phase_steps, self.context)
+                    step_results = self.step_executor.execute_steps(phase_steps, self.context, best_effort=is_teardown)
                 else:
                     step_results = StepResults()
+
+                if phase_name == "setup" and step_results.steps:
+                    setup_steps_ran = True
 
                 # Use a per-phase temp file for JUnit XML to avoid overwriting
                 phase_junitxml: str | None = None
@@ -371,10 +375,6 @@ class Orchestrator:
                 phase_success = step_results.success and all(v.get("passed", False) for v in phase_validations)
                 if not phase_success:
                     overall_success = False
-
-                # Track setup success for teardown decision
-                if phase_name == "setup" and phase_success:
-                    setup_succeeded = True
 
             # Merge per-phase JUnit XMLs into the final output file
             if self._junitxml and phase_junit_files:

--- a/isvctl/src/isvctl/orchestrator/step_executor.py
+++ b/isvctl/src/isvctl/orchestrator/step_executor.py
@@ -137,12 +137,17 @@ class StepExecutor:
         self,
         steps: list[StepConfig],
         context: Context,
+        best_effort: bool = False,
     ) -> StepResults:
         """Execute all steps sequentially.
 
         Args:
             steps: List of step configurations
             context: Context for templating and storing outputs
+            best_effort: When True, continue executing remaining steps even if
+                one fails (unless the step has ``continue_on_failure`` explicitly
+                set to False).  Used for teardown phases where all cleanup steps
+                should be attempted regardless of individual failures.
 
         Returns:
             StepResults with all step outcomes
@@ -172,11 +177,14 @@ class StepExecutor:
             if step_result.output:
                 context.set_step_output(step.name, step_result.output)
 
-            # Check if we should continue
             if not step_result.success and not step.continue_on_failure:
-                logger.error(f"Step {step.name} failed, stopping execution")
-                results.success = False
-                break
+                if best_effort:
+                    logger.warning(f"Step {step.name} failed (best-effort mode, continuing)")
+                    results.success = False
+                else:
+                    logger.error(f"Step {step.name} failed, stopping execution")
+                    results.success = False
+                    break
 
         return results
 

--- a/isvctl/src/isvctl/orchestrator/step_executor.py
+++ b/isvctl/src/isvctl/orchestrator/step_executor.py
@@ -145,8 +145,7 @@ class StepExecutor:
             steps: List of step configurations
             context: Context for templating and storing outputs
             best_effort: When True, continue executing remaining steps even if
-                one fails (unless the step has ``continue_on_failure`` explicitly
-                set to False).  Used for teardown phases where all cleanup steps
+                one fails.  Used for teardown phases where all cleanup steps
                 should be attempted regardless of individual failures.
 
         Returns:

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -135,7 +135,12 @@ EOF
         pass
 
     def test_run_teardown_phase(self) -> None:
-        """Test teardown phase execution."""
+        """Test teardown phase execution when only teardown is requested.
+
+        Covers the use case where setup ran in a previous invocation (e.g., with
+        AWS_SKIP_TEARDOWN) and now the user explicitly runs ``--phase teardown``
+        to clean up resources.
+        """
         config = RunConfig(
             commands={
                 "kubernetes": PlatformCommands(
@@ -154,6 +159,9 @@ EOF
         assert len(result.phases) == 1
         assert result.phases[0].phase == Phase.TEARDOWN
         assert result.phases[0].success
+        assert "SKIPPED" not in result.phases[0].message, "teardown must actually run, not be skipped"
+        step_names = [s["name"] for s in result.phases[0].details["steps"]]
+        assert "cleanup" in step_names, "teardown step must have executed"
 
     def test_run_all_phases_with_failure(self) -> None:
         """Test that teardown runs even after setup failure."""
@@ -305,6 +313,118 @@ EOF
         finally:
             Path(setup_script).unlink(missing_ok=True)
             Path(teardown_ok_script).unlink(missing_ok=True)
+
+
+class TestTeardownOnlyPhase:
+    """Tests for running teardown as the only requested phase.
+
+    Covers the workflow where setup ran in a prior invocation (e.g., with
+    AWS_SKIP_TEARDOWN set) and the user later runs ``--phase teardown`` to
+    clean up resources from that earlier run.
+    """
+
+    def test_teardown_only_runs_without_setup(self) -> None:
+        """Teardown must execute when it is the only requested phase.
+
+        When a user explicitly requests ``--phase teardown``, it should run
+        regardless of whether setup ran in this invocation.
+        """
+        config = RunConfig(
+            commands={
+                "kubernetes": PlatformCommands(
+                    steps=[
+                        StepConfig(name="setup_cluster", command="echo", args=["hi"], phase="setup"),
+                        StepConfig(name="cleanup", command="echo", args=["bye"], phase="teardown"),
+                    ]
+                )
+            },
+            tests=ValidationConfig(platform="kubernetes"),
+        )
+        orchestrator = Orchestrator(config)
+        result = orchestrator.run(phases=[Phase.TEARDOWN])
+
+        assert result.success
+        teardown_phases = [p for p in result.phases if p.phase == Phase.TEARDOWN]
+        assert len(teardown_phases) == 1
+        assert teardown_phases[0].success
+        assert "SKIPPED" not in teardown_phases[0].message
+        step_names = [s["name"] for s in teardown_phases[0].details["steps"]]
+        assert "cleanup" in step_names
+
+    def test_teardown_only_does_not_run_setup_steps(self) -> None:
+        """When only teardown is requested, setup steps must not execute."""
+        config = RunConfig(
+            commands={
+                "kubernetes": PlatformCommands(
+                    steps=[
+                        StepConfig(name="setup_cluster", command="echo", args=["created"], phase="setup"),
+                        StepConfig(name="cleanup", command="echo", args=["deleted"], phase="teardown"),
+                    ]
+                )
+            },
+            tests=ValidationConfig(platform="kubernetes"),
+        )
+        orchestrator = Orchestrator(config)
+        result = orchestrator.run(phases=[Phase.TEARDOWN])
+
+        setup_phases = [p for p in result.phases if p.phase == Phase.SETUP]
+        assert len(setup_phases) == 0, "setup phase must not appear when only teardown is requested"
+
+    def test_teardown_only_best_effort_continues_past_failures(self) -> None:
+        """Teardown-only run must use best-effort so all cleanup steps execute."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
+            f.write("#!/bin/bash\necho '{\"success\": true}'\n")
+            ok_script = f.name
+
+        try:
+            Path(ok_script).chmod(0o755)
+
+            config = RunConfig(
+                commands={
+                    "kubernetes": PlatformCommands(
+                        steps=[
+                            StepConfig(name="teardown_nim", command="false", phase="teardown"),
+                            StepConfig(name="teardown_vm", command=ok_script, phase="teardown"),
+                        ]
+                    )
+                },
+                tests=ValidationConfig(platform="kubernetes"),
+            )
+            orchestrator = Orchestrator(config)
+            result = orchestrator.run(phases=[Phase.TEARDOWN])
+
+            teardown_phases = [p for p in result.phases if p.phase == Phase.TEARDOWN]
+            assert len(teardown_phases) == 1
+            step_names = [s["name"] for s in teardown_phases[0].details["steps"]]
+            assert "teardown_nim" in step_names, "failing teardown step must be recorded"
+            assert "teardown_vm" in step_names, "second teardown step must run despite first failure"
+        finally:
+            Path(ok_script).unlink(missing_ok=True)
+
+    def test_teardown_still_skipped_when_setup_requested_but_did_not_run(self) -> None:
+        """When both setup and teardown are requested, teardown is still gated on setup execution.
+
+        This ensures the existing safety guard stays in place for full lifecycle runs.
+        """
+        config = RunConfig(
+            commands={
+                "kubernetes": PlatformCommands(
+                    phases=["setup", "teardown"],
+                    steps=[
+                        StepConfig(name="setup_cluster", command="echo", args=["hi"], phase="setup", skip=True),
+                        StepConfig(name="cleanup", command="echo", args=["bye"], phase="teardown"),
+                    ],
+                )
+            },
+            tests=ValidationConfig(platform="kubernetes"),
+        )
+        orchestrator = Orchestrator(config)
+        result = orchestrator.run(phases=[Phase.SETUP, Phase.TEARDOWN], teardown_on_failure=True)
+
+        teardown_phases = [p for p in result.phases if p.phase == Phase.TEARDOWN]
+        assert len(teardown_phases) == 1
+        assert "SKIPPED" in teardown_phases[0].message
+        assert "setup steps did not run" in teardown_phases[0].message
 
 
 class TestStepExecutorBestEffort:

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -12,9 +12,12 @@
 
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 from isvctl.config.schema import PlatformCommands, RunConfig, StepConfig, ValidationConfig
+from isvctl.orchestrator.context import Context
 from isvctl.orchestrator.loop import Orchestrator, Phase
+from isvctl.orchestrator.step_executor import StepExecutor
 
 
 class TestOrchestrator:
@@ -188,3 +191,167 @@ EOF
 
         assert not result.success
         assert "Cannot determine platform" in result.phases[0].message
+
+    def test_teardown_runs_when_setup_validation_fails(self) -> None:
+        """Teardown must run when setup steps succeed but setup validations fail.
+
+        Regression test for issue where validation failures in setup caused
+        teardown to be skipped, leaking cloud resources.
+        """
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
+            f.write(
+                '#!/bin/bash\necho \'{"success": true, "platform": "kubernetes", '
+                '"cluster_name": "test", "node_count": 1, "kubernetes": {"node_count": 1}}\'\n'
+            )
+            setup_script = f.name
+
+        try:
+            Path(setup_script).chmod(0o755)
+
+            config = RunConfig(
+                commands={
+                    "kubernetes": PlatformCommands(
+                        steps=[
+                            StepConfig(name="setup_cluster", command=setup_script, phase="setup"),
+                            StepConfig(name="cleanup", command="echo", args=["done"], phase="teardown"),
+                        ]
+                    )
+                },
+                tests=ValidationConfig(platform="kubernetes"),
+            )
+            orchestrator = Orchestrator(config)
+
+            failing_validations = [{"name": "FakeCheck", "passed": False, "error": "simulated"}]
+            with patch.object(
+                orchestrator.step_executor,
+                "run_validations_for_phase",
+                side_effect=lambda phase, *a, **kw: failing_validations if phase == "setup" else [],
+            ):
+                result = orchestrator.run(teardown_on_failure=True)
+
+            assert not result.success
+            teardown_phases = [p for p in result.phases if p.phase == Phase.TEARDOWN]
+            assert len(teardown_phases) == 1, "teardown phase must run even when setup validations fail"
+            teardown_step_names = [s["name"] for s in teardown_phases[0].details["steps"]]
+            assert "cleanup" in teardown_step_names, "teardown step must have executed"
+        finally:
+            Path(setup_script).unlink(missing_ok=True)
+
+    def test_teardown_skipped_when_setup_steps_did_not_run(self) -> None:
+        """Teardown must be skipped when no setup steps executed."""
+        config = RunConfig(
+            commands={
+                "kubernetes": PlatformCommands(
+                    phases=["setup", "teardown"],
+                    steps=[
+                        StepConfig(name="setup_cluster", command="echo", args=["hi"], phase="setup", skip=True),
+                        StepConfig(name="cleanup", command="echo", args=["bye"], phase="teardown"),
+                    ],
+                )
+            },
+            tests=ValidationConfig(platform="kubernetes"),
+        )
+        orchestrator = Orchestrator(config)
+        result = orchestrator.run(teardown_on_failure=True)
+
+        teardown_phases = [p for p in result.phases if p.phase == Phase.TEARDOWN]
+        assert len(teardown_phases) == 1
+        assert "SKIPPED" in teardown_phases[0].message
+        assert "setup steps did not run" in teardown_phases[0].message
+
+    def test_teardown_continues_after_step_failure(self) -> None:
+        """All teardown steps must run even if an earlier teardown step fails.
+
+        Regression test for issue where the first failing teardown step caused
+        remaining teardown steps to be skipped (e.g., VM not deleted after
+        NIM teardown failed).
+        """
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
+            f.write(
+                '#!/bin/bash\necho \'{"success": true, "platform": "kubernetes", '
+                '"cluster_name": "test", "node_count": 1, "kubernetes": {"node_count": 1}}\'\n'
+            )
+            setup_script = f.name
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
+            f.write("#!/bin/bash\necho '{\"success\": true}'\n")
+            teardown_ok_script = f.name
+
+        try:
+            Path(setup_script).chmod(0o755)
+            Path(teardown_ok_script).chmod(0o755)
+
+            config = RunConfig(
+                commands={
+                    "kubernetes": PlatformCommands(
+                        steps=[
+                            StepConfig(name="setup_cluster", command=setup_script, phase="setup"),
+                            StepConfig(name="teardown_nim", command="false", phase="teardown"),
+                            StepConfig(name="teardown_vm", command=teardown_ok_script, phase="teardown"),
+                        ]
+                    )
+                },
+                tests=ValidationConfig(platform="kubernetes"),
+            )
+            orchestrator = Orchestrator(config)
+            result = orchestrator.run(teardown_on_failure=True)
+
+            teardown_phases = [p for p in result.phases if p.phase == Phase.TEARDOWN]
+            assert len(teardown_phases) == 1
+
+            step_names = [s["name"] for s in teardown_phases[0].details["steps"]]
+            assert "teardown_nim" in step_names, "first teardown step must be recorded"
+            assert "teardown_vm" in step_names, "second teardown step must run despite first failure"
+        finally:
+            Path(setup_script).unlink(missing_ok=True)
+            Path(teardown_ok_script).unlink(missing_ok=True)
+
+
+class TestStepExecutorBestEffort:
+    """Tests for StepExecutor best_effort parameter."""
+
+    def test_best_effort_false_stops_on_failure(self) -> None:
+        """Without best_effort, execution stops after the first failing step."""
+        executor = StepExecutor()
+        context = Context(RunConfig())
+        steps = [
+            StepConfig(name="fail_step", command="false", phase="teardown"),
+            StepConfig(name="ok_step", command="echo", args=["hi"], phase="teardown"),
+        ]
+
+        results = executor.execute_steps(steps, context, best_effort=False)
+
+        assert not results.success
+        executed = [s.name for s in results.steps]
+        assert executed == ["fail_step"], "second step must NOT run when best_effort is False"
+
+    def test_best_effort_true_continues_on_failure(self) -> None:
+        """With best_effort, all steps execute even when one fails."""
+        executor = StepExecutor()
+        context = Context(RunConfig())
+        steps = [
+            StepConfig(name="fail_step", command="false", phase="teardown"),
+            StepConfig(name="ok_step", command="echo", args=["hi"], phase="teardown"),
+        ]
+
+        results = executor.execute_steps(steps, context, best_effort=True)
+
+        assert not results.success
+        executed = [s.name for s in results.steps]
+        assert executed == ["fail_step", "ok_step"], "second step must run when best_effort is True"
+        assert not results.steps[0].success
+        assert results.steps[1].success
+
+    def test_best_effort_respects_continue_on_failure(self) -> None:
+        """Steps with continue_on_failure=True continue regardless of best_effort."""
+        executor = StepExecutor()
+        context = Context(RunConfig())
+        steps = [
+            StepConfig(name="fail_step", command="false", phase="setup", continue_on_failure=True),
+            StepConfig(name="ok_step", command="echo", args=["hi"], phase="setup"),
+        ]
+
+        results = executor.execute_steps(steps, context, best_effort=False)
+
+        executed = [s.name for s in results.steps]
+        assert executed == ["fail_step", "ok_step"]


### PR DESCRIPTION
## Summary

* **Teardown gating decoupled from validation results**: Teardown now runs whenever setup steps executed, regardless of whether setup validations passed. Previously, a validation failure (e.g., Docker not installed) would skip teardown entirely, leaking cloud resources like VMs and firewall rules.
* **Best-effort teardown execution**: Teardown steps now continue past individual failures. Previously, if the first teardown step failed (e.g., `teardown_nim` with empty args), remaining steps (e.g., VM deletion) were skipped.
* **Teardown-only phase support**: Running `--phase teardown` alone now works correctly. Previously it would fail with "setup steps did not run" even though the user was explicitly requesting cleanup from a prior run (e.g., after iterating with `AWS_SKIP_TEARDOWN`).
* **Regression tests added**: 10 new tests covering all three fixes — teardown gating, best-effort execution, and teardown-only phase behavior.

Reported by a GCP integrator running the validation suite against non-AWS NCPs.

## Test plan

* All existing isvctl tests pass (244 passed)
* All existing isvtest unit tests pass (214 passed)
* New tests: `test_teardown_runs_when_setup_validation_fails`, `test_teardown_skipped_when_setup_steps_did_not_run`, `test_teardown_continues_after_step_failure`
* New tests: `TestStepExecutorBestEffort` (3 tests for best_effort parameter)
* New tests: `TestTeardownOnlyPhase` — `test_teardown_only_runs_without_setup`, `test_teardown_only_does_not_run_setup_steps`, `test_teardown_only_best_effort_continues_past_failures`, `test_teardown_still_skipped_when_setup_requested_but_did_not_run`
* Existing `test_run_teardown_phase` strengthened to verify step actually executed (not just skipped-as-success)
* Linting clean across all packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Teardown now runs when setup steps executed even if setup validations failed.
  * Teardown is skipped only when setup steps never ran.
  * Teardown step execution now proceeds in best-effort mode, allowing subsequent teardown steps to run after failures.

* **Tests**
  * Added comprehensive tests covering teardown-only runs, teardown gating, and best-effort teardown behavior.
  * Added tests validating step-execution behavior for best-effort vs. strict failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->