### PR TITLE
feat: add metadata_headers config to CloudInitCheck for non-AWS providers

### DIFF
--- a/isvtest/src/isvtest/validations/host.py
+++ b/isvtest/src/isvtest/validations/host.py
@@ -1857,6 +1857,8 @@ class CloudInitCheck(BaseValidation):
     Config:
         host, key_file, user: SSH connection details
         metadata_url: Metadata endpoint to probe (default: http://169.254.169.254/latest/meta-data/)
+        metadata_headers: Dict of extra HTTP headers to send with the metadata
+            request (e.g. ``{"Metadata-Flavor": "Google"}`` for GCP).
     """
 
     description: ClassVar[str] = "Validates cloud-init completed and metadata service is reachable"
@@ -1875,6 +1877,7 @@ class CloudInitCheck(BaseValidation):
         user = ssh_cfg["ssh_user"]
         key_path = ssh_cfg["ssh_key_path"]
         metadata_url = self.config.get("metadata_url", "http://169.254.169.254/latest/meta-data/")
+        metadata_headers: dict[str, str] = self.config.get("metadata_headers", {})
 
         if not host or not key_path:
             self.set_failed("Missing host or key_file")
@@ -1892,7 +1895,8 @@ class CloudInitCheck(BaseValidation):
                 self.report_subtest("cloud_init", done, stdout.strip())
 
             # Check metadata service reachability
-            curl_cmd = f"curl -s -o /dev/null -w '%{{http_code}}' --max-time 5 {metadata_url}"
+            header_flags = " ".join(f"-H '{k}: {v}'" for k, v in metadata_headers.items())
+            curl_cmd = f"curl -s -o /dev/null -w '%{{http_code}}' --max-time 5 {header_flags} {metadata_url}".strip()
             exit_code, stdout, _ = run_ssh_command(ssh, curl_cmd)
             http_code = stdout.strip()
             metadata_ok = exit_code == 0 and http_code in ("200", "301")

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -1192,3 +1192,105 @@ class TestValidationResultCapture:
         assert r["name"] == "FailingValidation"
         assert r["skipped"] is False
         assert r["passed"] is False
+
+
+class TestCloudInitCheckMetadataHeaders:
+    """Tests for CloudInitCheck metadata_headers parameter."""
+
+    @patch("isvtest.validations.host.get_ssh_client")
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_no_headers_uses_default_curl(
+        self, mock_ssh_cfg: MagicMock, mock_run: MagicMock, mock_ssh: MagicMock
+    ) -> None:
+        """Without metadata_headers, curl command must not contain -H flags."""
+        from isvtest.validations.host import CloudInitCheck
+
+        mock_ssh_cfg.return_value = {"ssh_host": "10.0.0.1", "ssh_user": "ubuntu", "ssh_key_path": "/tmp/k.pem"}
+        mock_ssh.return_value = MagicMock()
+        mock_run.return_value = (0, "200", "")
+
+        captured_cmds: list[str] = []
+
+        def _capture(ssh: MagicMock, cmd: str) -> tuple[int, str, str]:
+            captured_cmds.append(cmd)
+            if "cloud-init" in cmd:
+                return (0, "status: done", "")
+            return (0, "200", "")
+
+        mock_run.side_effect = _capture
+
+        v = CloudInitCheck(config={})
+        v.execute()
+
+        curl_cmds = [c for c in captured_cmds if "curl" in c]
+        assert len(curl_cmds) == 1
+        assert "-H" not in curl_cmds[0]
+        assert "169.254.169.254" in curl_cmds[0]
+
+    @patch("isvtest.validations.host.get_ssh_client")
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_gcp_headers_included_in_curl(
+        self, mock_ssh_cfg: MagicMock, mock_run: MagicMock, mock_ssh: MagicMock
+    ) -> None:
+        """With metadata_headers set, curl must include -H flags for each header."""
+        from isvtest.validations.host import CloudInitCheck
+
+        mock_ssh_cfg.return_value = {"ssh_host": "10.0.0.1", "ssh_user": "ubuntu", "ssh_key_path": "/tmp/k.pem"}
+        mock_ssh.return_value = MagicMock()
+
+        captured_cmds: list[str] = []
+
+        def _capture(ssh: MagicMock, cmd: str) -> tuple[int, str, str]:
+            captured_cmds.append(cmd)
+            if "cloud-init" in cmd:
+                return (0, "status: done", "")
+            return (0, "200", "")
+
+        mock_run.side_effect = _capture
+
+        v = CloudInitCheck(
+            config={
+                "metadata_url": "http://metadata.google.internal/computeMetadata/v1/",
+                "metadata_headers": {"Metadata-Flavor": "Google"},
+            }
+        )
+        v.execute()
+
+        curl_cmds = [c for c in captured_cmds if "curl" in c]
+        assert len(curl_cmds) == 1
+        assert "-H 'Metadata-Flavor: Google'" in curl_cmds[0]
+        assert "metadata.google.internal" in curl_cmds[0]
+
+    @patch("isvtest.validations.host.get_ssh_client")
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_multiple_headers(self, mock_ssh_cfg: MagicMock, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        """Multiple metadata_headers entries must each produce a -H flag."""
+        from isvtest.validations.host import CloudInitCheck
+
+        mock_ssh_cfg.return_value = {"ssh_host": "10.0.0.1", "ssh_user": "ubuntu", "ssh_key_path": "/tmp/k.pem"}
+        mock_ssh.return_value = MagicMock()
+
+        captured_cmds: list[str] = []
+
+        def _capture(ssh: MagicMock, cmd: str) -> tuple[int, str, str]:
+            captured_cmds.append(cmd)
+            if "cloud-init" in cmd:
+                return (0, "status: done", "")
+            return (0, "200", "")
+
+        mock_run.side_effect = _capture
+
+        v = CloudInitCheck(
+            config={
+                "metadata_headers": {"X-Custom": "value1", "X-Other": "value2"},
+            }
+        )
+        v.execute()
+
+        curl_cmds = [c for c in captured_cmds if "curl" in c]
+        assert len(curl_cmds) == 1
+        assert "-H 'X-Custom: value1'" in curl_cmds[0]
+        assert "-H 'X-Other: value2'" in curl_cmds[0]


### PR DESCRIPTION
## Summary

- **CloudInitCheck now supports custom metadata headers**: Added a `metadata_headers` dict config parameter that appends `-H` flags to the curl command used to probe the instance metadata service. This enables non-AWS providers (e.g., GCP) to specify required headers like `Metadata-Flavor: Google`.
- **No breaking changes**: Without `metadata_headers`, behavior is identical to before (default AWS endpoint, no extra headers).
- **Tests added**: 3 new tests verifying header flag generation for no-headers, single-header (GCP), and multi-header cases.

Example GCP provider config:
```yaml
validations:
  host:
    - CloudInitCheck:
        metadata_url: "http://metadata.google.internal/computeMetadata/v1/"
        metadata_headers:
          Metadata-Flavor: "Google"
```

Reported by a GCP integrator running the validation suite against non-AWS NCPs.

## Test plan

- [x] All existing isvtest unit tests pass (214 passed)
- [x] New tests: `TestCloudInitCheckMetadataHeaders` (3 tests)
- [x] Linting clean across all packages

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metadata service validation now supports custom HTTP headers through a new `metadata_headers` configuration parameter, enabling users to customize requests for different metadata service endpoints and authentication requirements.

* **Tests**
  * Added comprehensive test coverage for the metadata headers feature, validating behavior across default configuration, single header entries, and multiple header configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->