### PR TITLE
feat: support KUBECTL env var to override kubectl CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,6 +339,7 @@ tests:
 | `AWS_ACCESS_KEY_ID` | AWS access key | AWS scripts |
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key | AWS scripts |
 | `AWS_REGION` | AWS region | AWS scripts |
+| `KUBECTL` | Optional kubectl-compatible CLI prefix (parsed with POSIX shlex in Python, word-split in shell stubs; overrides `K8S_PROVIDER` detection) | isvtest (`get_kubectl_command`), isvctl k8s stubs |
 
 ## Directory Structure Notes
 

--- a/isvctl/configs/stubs/k8s/setup.sh
+++ b/isvctl/configs/stubs/k8s/setup.sh
@@ -19,12 +19,14 @@
 set -eo pipefail
 
 # Detect kubectl command
-if command -v kubectl &> /dev/null; then
+if [[ "${KUBECTL:-}" =~ [^[:space:]] ]]; then
+    :  # already set from environment; skip detection
+elif command -v kubectl &> /dev/null; then
     KUBECTL="kubectl"
 elif command -v microk8s &> /dev/null; then
     KUBECTL="microk8s kubectl"
 else
-    echo "Error: Neither kubectl nor microk8s found" >&2
+    echo "Error: Neither kubectl nor microk8s found. Set KUBECTL to override." >&2
     exit 1
 fi
 

--- a/isvctl/configs/stubs/k8s/setup_k3s.sh
+++ b/isvctl/configs/stubs/k8s/setup_k3s.sh
@@ -19,12 +19,14 @@
 set -eo pipefail
 
 # Prefer k3s kubectl (reads its own kubeconfig automatically)
-if command -v k3s &> /dev/null; then
+if [[ "${KUBECTL:-}" =~ [^[:space:]] ]]; then
+    :  # already set from environment; skip detection
+elif command -v k3s &> /dev/null; then
     KUBECTL="k3s kubectl"
 elif command -v kubectl &> /dev/null; then
     KUBECTL="kubectl"
 else
-    echo "Error: Neither k3s nor kubectl found" >&2
+    echo "Error: Neither k3s nor kubectl found. Set KUBECTL to override." >&2
     exit 1
 fi
 

--- a/isvctl/configs/stubs/k8s/setup_microk8s.sh
+++ b/isvctl/configs/stubs/k8s/setup_microk8s.sh
@@ -18,12 +18,14 @@
 set -eo pipefail
 
 # Detect kubectl command (microk8s or regular)
-if command -v microk8s &> /dev/null; then
+if [[ "${KUBECTL:-}" =~ [^[:space:]] ]]; then
+    :  # already set from environment; skip detection
+elif command -v microk8s &> /dev/null; then
     KUBECTL="microk8s kubectl"
 elif command -v kubectl &> /dev/null; then
     KUBECTL="kubectl"
 else
-    echo "Error: Neither microk8s nor kubectl found" >&2
+    echo "Error: Neither microk8s nor kubectl found. Set KUBECTL to override." >&2
     exit 1
 fi
 

--- a/isvctl/configs/stubs/k8s/setup_minikube.sh
+++ b/isvctl/configs/stubs/k8s/setup_minikube.sh
@@ -17,12 +17,15 @@
 
 set -eo pipefail
 
-if ! command -v kubectl &> /dev/null; then
-    echo "Error: kubectl not found (minikube should configure it automatically)" >&2
+# Detect kubectl command
+if [[ "${KUBECTL:-}" =~ [^[:space:]] ]]; then
+    :  # already set from environment; skip detection
+elif command -v kubectl &> /dev/null; then
+    KUBECTL="kubectl"
+else
+    echo "Error: kubectl not found. Set KUBECTL to override." >&2
     exit 1
 fi
-
-KUBECTL="kubectl"
 
 # Get cluster name from minikube profile or kubectl context
 if command -v minikube &> /dev/null; then

--- a/isvctl/configs/tests/k8s.yaml
+++ b/isvctl/configs/tests/k8s.yaml
@@ -10,7 +10,9 @@
 
 # Kubernetes Cluster Validation Configuration
 # This unified config contains all settings for validating a K8s cluster
-# K8S_PROVIDER is auto-detected (microk8s vs kubectl)
+# K8S_PROVIDER is auto-detected (microk8s vs kubectl).
+# To use OpenShift `oc` or another kubectl-compatible CLI, set KUBECTL
+# in the environment or under `env` for commands.
 #
 # Usage:
 #   isvctl test run -f isvctl/configs/tests/k8s.yaml

--- a/isvtest/src/isvtest/core/k8s.py
+++ b/isvtest/src/isvtest/core/k8s.py
@@ -147,13 +147,9 @@ def get_kubectl_command() -> list[str]:
                     raise FileNotFoundError(msg)
                 logger.info("Using kubectl-compatible CLI from KUBECTL: %s", parts)
                 return parts
-            logger.warning(
-                "KUBECTL did not yield usable command tokens; falling through to K8S_PROVIDER detection"
-            )
+            logger.warning("KUBECTL did not yield usable command tokens; falling through to K8S_PROVIDER detection")
         else:
-            logger.warning(
-                "KUBECTL is set but empty after stripping; falling through to K8S_PROVIDER detection"
-            )
+            logger.warning("KUBECTL is set but empty after stripping; falling through to K8S_PROVIDER detection")
 
     k8s_provider = get_k8s_provider()
 

--- a/isvtest/src/isvtest/core/k8s.py
+++ b/isvtest/src/isvtest/core/k8s.py
@@ -12,6 +12,8 @@
 
 import functools
 import os
+import shlex
+import shutil
 import subprocess
 import time
 from typing import Any
@@ -106,15 +108,53 @@ def get_k8s_provider() -> str:
 def get_kubectl_command() -> list[str]:
     """Get the kubectl command based on environment configuration.
 
+    This function is intentionally not cached (unlike ``get_k8s_provider()``)
+    so that the ``KUBECTL`` override is re-read on each call, which is
+    consistent with its current behaviour and allows mid-process override in
+    tests.
+
     Returns:
         List of command parts for kubectl execution.
         For microk8s: ["microk8s", "kubectl"]
         For standard k8s: ["kubectl"]
+        When ``KUBECTL`` is set: tokens from ``shlex.split`` (e.g.
+        ``["oc"]``, ``["/path/to/oc"]``, ``["microk8s", "kubectl"]``).
 
     Environment Variables:
+        KUBECTL: Optional kubectl-compatible CLI prefix (parsed with POSIX
+            shlex; takes precedence over ``K8S_PROVIDER``).
         K8S_PROVIDER: Set to "microk8s" for local microk8s development,
                      leave unset or set to "kubectl" for standard kubectl.
+
+    Raises:
+        FileNotFoundError: If ``KUBECTL`` is set but the binary is not on PATH.
+        ValueError: If ``KUBECTL`` contains malformed shell syntax
+            (e.g. unterminated quotes).
     """
+    raw = os.environ.get("KUBECTL")
+    if raw is not None:
+        trimmed = raw.strip()
+        if trimmed:
+            try:
+                parts = shlex.split(trimmed, posix=True)
+            except ValueError as exc:
+                msg = f"KUBECTL has invalid shell syntax: {trimmed!r}"
+                raise ValueError(msg) from exc
+            if parts and all(token for token in parts):
+                if shutil.which(parts[0]) is None:
+                    msg = f"KUBECTL is set to '{parts[0]}' but it was not found on PATH"
+                    logger.error(msg)
+                    raise FileNotFoundError(msg)
+                logger.info("Using kubectl-compatible CLI from KUBECTL: %s", parts)
+                return parts
+            logger.warning(
+                "KUBECTL did not yield usable command tokens; falling through to K8S_PROVIDER detection"
+            )
+        else:
+            logger.warning(
+                "KUBECTL is set but empty after stripping; falling through to K8S_PROVIDER detection"
+            )
+
     k8s_provider = get_k8s_provider()
 
     if k8s_provider == "microk8s":

--- a/isvtest/tests/test_k8s.py
+++ b/isvtest/tests/test_k8s.py
@@ -32,32 +32,36 @@ class TestGetKubectlCommandOverride:
 
     def test_simple_override(self) -> None:
         """KUBECTL=oc returns ["oc"]."""
-        with patch.dict(os.environ, {"KUBECTL": "oc"}, clear=True), patch(
-            "isvtest.core.k8s.shutil.which", return_value="/usr/bin/oc"
+        with (
+            patch.dict(os.environ, {"KUBECTL": "oc"}, clear=True),
+            patch("isvtest.core.k8s.shutil.which", return_value="/usr/bin/oc"),
         ):
             result = get_kubectl_command()
         assert result == ["oc"]
 
     def test_override_with_leading_trailing_whitespace(self) -> None:
         """KUBECTL="  oc  " strips whitespace and returns ["oc"]."""
-        with patch.dict(os.environ, {"KUBECTL": "  oc  "}, clear=True), patch(
-            "isvtest.core.k8s.shutil.which", return_value="/usr/bin/oc"
+        with (
+            patch.dict(os.environ, {"KUBECTL": "  oc  "}, clear=True),
+            patch("isvtest.core.k8s.shutil.which", return_value="/usr/bin/oc"),
         ):
             result = get_kubectl_command()
         assert result == ["oc"]
 
     def test_multi_token_prefix(self) -> None:
         """KUBECTL="microk8s kubectl" returns ["microk8s", "kubectl"]."""
-        with patch.dict(os.environ, {"KUBECTL": "microk8s kubectl"}, clear=True), patch(
-            "isvtest.core.k8s.shutil.which", return_value="/snap/bin/microk8s"
+        with (
+            patch.dict(os.environ, {"KUBECTL": "microk8s kubectl"}, clear=True),
+            patch("isvtest.core.k8s.shutil.which", return_value="/snap/bin/microk8s"),
         ):
             result = get_kubectl_command()
         assert result == ["microk8s", "kubectl"]
 
     def test_quoted_path_with_spaces(self) -> None:
         """KUBECTL with a quoted path containing spaces is handled by shlex."""
-        with patch.dict(os.environ, {"KUBECTL": '"/tmp/with space/oc"'}, clear=True), patch(
-            "isvtest.core.k8s.shutil.which", return_value="/tmp/with space/oc"
+        with (
+            patch.dict(os.environ, {"KUBECTL": '"/tmp/with space/oc"'}, clear=True),
+            patch("isvtest.core.k8s.shutil.which", return_value="/tmp/with space/oc"),
         ):
             result = get_kubectl_command()
         assert result == ["/tmp/with space/oc"]
@@ -65,8 +69,9 @@ class TestGetKubectlCommandOverride:
     def test_precedence_over_k8s_provider(self) -> None:
         """KUBECTL takes precedence over K8S_PROVIDER."""
         env = {"KUBECTL": "oc", "K8S_PROVIDER": "microk8s"}
-        with patch.dict(os.environ, env, clear=True), patch(
-            "isvtest.core.k8s.shutil.which", return_value="/usr/bin/oc"
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("isvtest.core.k8s.shutil.which", return_value="/usr/bin/oc"),
         ):
             get_k8s_provider.cache_clear()
             result = get_kubectl_command()
@@ -98,16 +103,18 @@ class TestGetKubectlCommandOverride:
 
     def test_get_kubectl_base_round_trip(self) -> None:
         """get_kubectl_base() returns shell-safe string from KUBECTL override."""
-        with patch.dict(os.environ, {"KUBECTL": "microk8s kubectl"}, clear=True), patch(
-            "isvtest.core.k8s.shutil.which", return_value="/snap/bin/microk8s"
+        with (
+            patch.dict(os.environ, {"KUBECTL": "microk8s kubectl"}, clear=True),
+            patch("isvtest.core.k8s.shutil.which", return_value="/snap/bin/microk8s"),
         ):
             result = get_kubectl_base()
         assert result == "microk8s kubectl"
 
     def test_binary_not_on_path_raises(self) -> None:
         """KUBECTL=nonexistent raises FileNotFoundError with clear message."""
-        with patch.dict(os.environ, {"KUBECTL": "nonexistent"}, clear=True), patch(
-            "isvtest.core.k8s.shutil.which", return_value=None
+        with (
+            patch.dict(os.environ, {"KUBECTL": "nonexistent"}, clear=True),
+            patch("isvtest.core.k8s.shutil.which", return_value=None),
         ):
             with pytest.raises(FileNotFoundError, match="not found on PATH"):
                 get_kubectl_command()

--- a/isvtest/tests/test_k8s.py
+++ b/isvtest/tests/test_k8s.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Tests for Kubernetes utility functions (KUBECTL override)."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from isvtest.core.k8s import get_k8s_provider, get_kubectl_command
+from isvtest.core.ngc import get_kubectl_base
+
+
+class TestGetKubectlCommandOverride:
+    """Tests for KUBECTL environment variable override in get_kubectl_command()."""
+
+    def test_unset_defaults_to_provider_detection(self) -> None:
+        """Unset KUBECTL falls through to K8S_PROVIDER / auto-detection."""
+        env = {"K8S_PROVIDER": "kubectl"}
+        with patch.dict(os.environ, env, clear=True):
+            get_k8s_provider.cache_clear()
+            result = get_kubectl_command()
+        assert result == ["kubectl"]
+
+    def test_simple_override(self) -> None:
+        """KUBECTL=oc returns ["oc"]."""
+        with patch.dict(os.environ, {"KUBECTL": "oc"}, clear=True), patch(
+            "isvtest.core.k8s.shutil.which", return_value="/usr/bin/oc"
+        ):
+            result = get_kubectl_command()
+        assert result == ["oc"]
+
+    def test_override_with_leading_trailing_whitespace(self) -> None:
+        """KUBECTL="  oc  " strips whitespace and returns ["oc"]."""
+        with patch.dict(os.environ, {"KUBECTL": "  oc  "}, clear=True), patch(
+            "isvtest.core.k8s.shutil.which", return_value="/usr/bin/oc"
+        ):
+            result = get_kubectl_command()
+        assert result == ["oc"]
+
+    def test_multi_token_prefix(self) -> None:
+        """KUBECTL="microk8s kubectl" returns ["microk8s", "kubectl"]."""
+        with patch.dict(os.environ, {"KUBECTL": "microk8s kubectl"}, clear=True), patch(
+            "isvtest.core.k8s.shutil.which", return_value="/snap/bin/microk8s"
+        ):
+            result = get_kubectl_command()
+        assert result == ["microk8s", "kubectl"]
+
+    def test_quoted_path_with_spaces(self) -> None:
+        """KUBECTL with a quoted path containing spaces is handled by shlex."""
+        with patch.dict(os.environ, {"KUBECTL": '"/tmp/with space/oc"'}, clear=True), patch(
+            "isvtest.core.k8s.shutil.which", return_value="/tmp/with space/oc"
+        ):
+            result = get_kubectl_command()
+        assert result == ["/tmp/with space/oc"]
+
+    def test_precedence_over_k8s_provider(self) -> None:
+        """KUBECTL takes precedence over K8S_PROVIDER."""
+        env = {"KUBECTL": "oc", "K8S_PROVIDER": "microk8s"}
+        with patch.dict(os.environ, env, clear=True), patch(
+            "isvtest.core.k8s.shutil.which", return_value="/usr/bin/oc"
+        ):
+            get_k8s_provider.cache_clear()
+            result = get_kubectl_command()
+        assert result == ["oc"]
+
+    def test_empty_string_falls_through(self) -> None:
+        """KUBECTL="" falls through to K8S_PROVIDER detection."""
+        env = {"KUBECTL": "", "K8S_PROVIDER": "kubectl"}
+        with patch.dict(os.environ, env, clear=True):
+            get_k8s_provider.cache_clear()
+            result = get_kubectl_command()
+        assert result == ["kubectl"]
+
+    def test_whitespace_only_falls_through(self) -> None:
+        """KUBECTL="   \\t  " falls through to K8S_PROVIDER detection."""
+        env = {"KUBECTL": "   \t  ", "K8S_PROVIDER": "kubectl"}
+        with patch.dict(os.environ, env, clear=True):
+            get_k8s_provider.cache_clear()
+            result = get_kubectl_command()
+        assert result == ["kubectl"]
+
+    def test_empty_quoted_value_falls_through(self) -> None:
+        """KUBECTL='""' yields [""] from shlex.split; treated as invalid, falls through."""
+        env = {"KUBECTL": '""', "K8S_PROVIDER": "kubectl"}
+        with patch.dict(os.environ, env, clear=True):
+            get_k8s_provider.cache_clear()
+            result = get_kubectl_command()
+        assert result == ["kubectl"]
+
+    def test_get_kubectl_base_round_trip(self) -> None:
+        """get_kubectl_base() returns shell-safe string from KUBECTL override."""
+        with patch.dict(os.environ, {"KUBECTL": "microk8s kubectl"}, clear=True), patch(
+            "isvtest.core.k8s.shutil.which", return_value="/snap/bin/microk8s"
+        ):
+            result = get_kubectl_base()
+        assert result == "microk8s kubectl"
+
+    def test_binary_not_on_path_raises(self) -> None:
+        """KUBECTL=nonexistent raises FileNotFoundError with clear message."""
+        with patch.dict(os.environ, {"KUBECTL": "nonexistent"}, clear=True), patch(
+            "isvtest.core.k8s.shutil.which", return_value=None
+        ):
+            with pytest.raises(FileNotFoundError, match="not found on PATH"):
+                get_kubectl_command()


### PR DESCRIPTION
## Summary

- Add `KUBECTL` environment variable support to `get_kubectl_command()` in Python: parses with `shlex.split()`, validates binary on PATH via `shutil.which()`, falls through to existing `K8S_PROVIDER` detection for empty/whitespace values
- Add inline `${KUBECTL:-}` guard to all four k8s shell stubs (`setup.sh`, `setup_microk8s.sh`, `setup_k3s.sh`, `setup_minikube.sh`) so an env-provided value skips auto-detection
- Document `KUBECTL` in `AGENTS.md` env table and `k8s.yaml` config header

Closes #216

## Test plan

- [x] 11 unit tests covering all edge cases: simple override, whitespace stripping, multi-token prefix, quoted paths with spaces, precedence over `K8S_PROVIDER`, empty/whitespace-only/empty-quoted fallthrough, `get_kubectl_base()` round-trip, binary-not-on-PATH error
- [x] Manual smoke test — verify the override is picked up end-to-end without a cluster:
  ```
  KUBECTL=oc uv run --project isvtest python -c \
      "from isvtest.core.k8s import run_kubectl; r = run_kubectl(['version', '--client']); print(r.stdout)"
  ```
- [x] Manual: verify unset `KUBECTL` preserves existing detection behavior on vanilla k8s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KUBECTL environment override: specify a kubectl-compatible CLI (including multi-token commands and quoted paths) that takes precedence over auto-detection; clearer guidance shown when none is found.

* **Documentation**
  * Updated autodetection guidance and docs to explain KUBECTL usage and precedence.

* **Tests**
  * Added tests covering override precedence, parsing, fallbacks, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->