### PR TITLE
docs: fix documentation drift from PRs #179–#229

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,9 +80,15 @@ The framework uses a **step-based execution model** where:
 2. **Scripts output JSON** - All operations output structured JSON to stdout
 3. **Validations check JSON** - Simple assertions verify the JSON output
 
-```
+```text
 Config (YAML) -> Script (any language) -> JSON output -> Validations (assertions)
 ```
+
+**Lifecycle phases** run in order: `setup -> test -> teardown`. Key behaviors:
+
+- **Teardown runs after failures** - If setup or test validations fail, teardown still executes so cloud resources are cleaned up
+- **Best-effort teardown** - Individual teardown step failures don't block remaining teardown steps
+- **Standalone teardown** - `isvctl test run -f config.yaml --phase teardown` runs cleanup independently (e.g., after a previous `AWS_SKIP_TEARDOWN` run)
 
 **Benefits:**
 
@@ -99,10 +105,10 @@ Config (YAML) -> Script (any language) -> JSON output -> Validations (assertions
 
 - `cli/` - Subcommand implementations (test, deploy, clean, docs, report)
 - `orchestrator/` - Lifecycle orchestration engine
-  - `loop.py` - Main orchestration loop (setup -> test -> teardown phases)
-  - `step_executor.py` - Step execution and validation orchestration (delegates to pytest)
+  - `loop.py` - Main orchestration loop (setup -> test -> teardown phases); teardown runs even after earlier phase failures and uses best-effort execution
+  - `step_executor.py` - Step execution and validation orchestration (delegates to pytest); supports `best_effort` mode for teardown
   - `commands.py` - Command execution with timeout handling
-  - `context.py` - Jinja2 templating context for config variables and step outputs
+  - `context.py` - Jinja2 templating context for config variables and step outputs; warns when templates reference missing step data or fields (catches `ChainableUndefined` silent fallbacks)
 - `config/` - Configuration schema and validation
   - `schema.py` - Pydantic models for config structure (including StepConfig)
   - `output_schemas.py` - JSON schema definitions for step outputs (auto-detection + validation)
@@ -116,12 +122,13 @@ Config (YAML) -> Script (any language) -> JSON output -> Validations (assertions
 **Configuration Files**: Located in `isvctl/configs/tests/` (test definitions) and `isvctl/configs/providers/` (provider implementations)
 
 - Configs define step-based commands with phases and validations
-- Support Jinja2 templating: `"{{steps.create_network.vpc_id}}"`, `"{{region}}"`
+- Support Jinja2 templating: `"{{steps.create_network.vpc_id}}"`, `"{{region}}"` — the orchestrator warns when templates reference steps that haven't run or fields that don't exist, helping catch typos and rename mismatches
 - Multiple configs can be merged with later files overriding earlier ones
 
 **Stubs (ISV Scripts)**: Located in `isvctl/configs/stubs/`
 
 - Platform setup/teardown shell scripts: `stubs/k8s/setup.sh`, `stubs/slurm/setup.sh`, etc.
+- Tag verification scripts: `stubs/vm/describe_tags.py`, `stubs/bare_metal/describe_tags.py`
 - AWS Python scripts organized by domain: `stubs/aws/network/`, `stubs/aws/vm/`, `stubs/aws/iam/`, etc.
 - Shared AWS utilities: `stubs/aws/common/` (error handling, EC2 helpers, VPC helpers)
 - Each script is self-contained and can be run manually for debugging
@@ -154,10 +161,10 @@ Organized by category:
 
 - `generic.py` - `StepSuccessCheck`, `FieldExistsCheck`, `FieldValueCheck`, `SchemaValidation`
 - `cluster.py` - `ClusterHealthCheck`, `NodeCountCheck`, `GpuOperatorInstalledCheck`, `PerformanceCheck`
-- `instance.py` - `InstanceStateCheck`, `InstanceCreatedCheck`, `InstanceRebootCheck`
-- `network.py` - `NetworkProvisionedCheck`, `VpcCrudCheck`, `SubnetConfigCheck`, `SecurityBlockingCheck`, etc.
+- `instance.py` - `InstanceStateCheck`, `InstanceCreatedCheck`, `InstanceRebootCheck`, `InstancePowerCycleCheck`, `StableIdentifierCheck`, etc.
+- `network.py` - `NetworkProvisionedCheck`, `VpcCrudCheck`, `SubnetConfigCheck`, `SgCrudCheck`, `SecurityBlockingCheck`, etc.
 - `iam.py` - `AccessKeyCreatedCheck`, `TenantCreatedCheck`, etc.
-- `host.py` - Host-level validations (connectivity, OS, CPU, GPU, drivers, containers)
+- `host.py` - Host-level validations (connectivity, OS, CPU, GPU, drivers, containers, cloud-init/metadata with optional `metadata_headers` for non-AWS providers)
 - `ssh_helpers.py` - SSH connection and utility helpers (used by `host.py`)
 - `k8s_*.py` - Kubernetes-specific validations (nodes, GPU operator, scheduling, MIG)
 - `slurm_*.py` - Slurm-specific validations (partitions, jobs, GPU allocation)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -113,6 +113,8 @@ See [Remote Deployment Guide](guides/remote-deployment.md) for details.
 | `ISV_CLIENT_ID` | Required for result upload to ISV Lab Service |
 | `ISV_CLIENT_SECRET` | Required for result upload to ISV Lab Service |
 | `NGC_API_KEY` | Required for NIM model benchmarks |
+| `KUBECTL` | Optional kubectl-compatible CLI prefix (overrides auto-detection; for Kubernetes tests) |
+| `K8S_PROVIDER` | Kubernetes provider hint — `microk8s`, `k3s`, `minikube`, or `kubectl` (auto-detected if unset; overridden by `KUBECTL`) |
 
 ## Next Steps
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -315,6 +315,8 @@ steps:
 | `{{env.VAR_NAME}}` | Environment variable |
 | `{{steps.name.field}}` | Step output field |
 
+> **Template warnings:** The orchestrator logs warnings when a template references a step that hasn't run or a field that doesn't exist in the step output. This catches typos, renames, and missing data that Jinja2's `ChainableUndefined` would otherwise silently absorb. Warnings are suppressed for steps in phases that were intentionally skipped (e.g., `--phase teardown`).
+
 ## Script Output and Schema Validation
 
 Scripts must output valid JSON to stdout. The output is validated against schemas defined in `output_schemas.py`.
@@ -537,7 +539,7 @@ Below is a summary by category.
 | `GpuCheck` | Validates GPU via SSH |
 | `DriverCheck` | Validates kernel and NVIDIA drivers |
 | `ContainerRuntimeCheck` | Tests container runtime and NVIDIA Docker support |
-| `CloudInitCheck` | Validates cloud-init completed and metadata service is reachable |
+| `CloudInitCheck` | Validates cloud-init completed and metadata service is reachable (supports non-AWS providers; see [isvtest docs](../packages/isvtest.md#available-validations) for `metadata_headers` and `metadata_url` options) |
 | `GpuStressCheck` | GPU stress test via SSH |
 | `NcclCheck` | NCCL AllReduce test via SSH |
 | `TrainingCheck` | DDP training workload via SSH |

--- a/docs/guides/external-validation-guide.md
+++ b/docs/guides/external-validation-guide.md
@@ -198,6 +198,9 @@ isvctl test run -f config.yaml -v
 # Run specific phase
 isvctl test run -f config.yaml --phase setup
 
+# Run only teardown (cleanup from a previous run)
+isvctl test run -f config.yaml --phase teardown
+
 # Merge configs (later overrides earlier)
 isvctl test run -f base.yaml -f overrides.yaml
 
@@ -209,6 +212,8 @@ isvctl test run -f config.yaml -- -m "not slow"
 # Debug: full output on failure
 isvctl test run -f config.yaml -v -- -s --tb=long
 ```
+
+> **Teardown behavior:** By default, teardown runs even when setup or test validations fail, ensuring cloud resources are cleaned up. Individual teardown step failures don't block remaining teardown steps (best-effort execution).
 
 ---
 
@@ -252,7 +257,7 @@ For common validation scenarios, **pre-built test suites** are available in [`is
 | [`iam.yaml`](../../isvctl/configs/tests/iam.yaml) | User create → verify credentials → delete | 3 scripts |
 | [`network.yaml`](../../isvctl/configs/tests/network.yaml) | VPC CRUD, subnets, isolation, security, connectivity, traffic | 8 scripts |
 | [`vm.yaml`](../../isvctl/configs/tests/vm.yaml) | Launch GPU VM → list → reboot → NIM deploy → teardown | 4 scripts + 2 shared |
-| [`bare_metal.yaml`](../../isvctl/configs/tests/bare_metal.yaml) | Launch bare-metal → describe → reboot → NIM → teardown → verify | 5 scripts + 2 shared |
+| [`bare_metal.yaml`](../../isvctl/configs/tests/bare_metal.yaml) | Launch bare-metal → tags → topology → stop/start → reboot → power-cycle → NIM → teardown | 13 scripts + 2 shared |
 | [`k8s.yaml`](../../isvctl/configs/tests/k8s.yaml) | Provision K8s GPU cluster → validate nodes/GPU/workloads → teardown | 2 scripts |
 | [`control-plane.yaml`](../../isvctl/configs/tests/control-plane.yaml) | API health, access key lifecycle, tenant lifecycle | 10 scripts |
 | [`image-registry.yaml`](../../isvctl/configs/tests/image-registry.yaml) | Image upload → VM launch → install config CRUD → BMaaS install → teardown | 6 scripts |

--- a/docs/packages/isvctl.md
+++ b/docs/packages/isvctl.md
@@ -9,7 +9,7 @@ internal `isvtest` engine and provides:
 
 1. **Setup**: Run inventory stubs that query or setup clusters
 2. **Test**: Execute validation tests against the cluster
-3. **Teardown**: Clean up (optional)
+3. **Teardown**: Clean up resources (runs by default, even after test failures; see [teardown behavior](../guides/external-validation-guide.md#running-validations))
 
 ## Installation
 
@@ -77,6 +77,9 @@ isvctl test run -f isvctl/configs/tests/k8s.yaml
 
 # Run only the test phase (skip inventory query)
 isvctl test run -f isvctl/configs/tests/k8s.yaml --phase test
+
+# Run only teardown (cleanup from a previous run)
+isvctl test run -f isvctl/configs/tests/k8s.yaml --phase teardown
 
 # Dry run - validate config without executing
 isvctl test run -f isvctl/configs/tests/k8s.yaml --dry-run

--- a/docs/packages/isvtest.md
+++ b/docs/packages/isvtest.md
@@ -125,7 +125,7 @@ SSH-based host validations for GPU, driver, OS, networking, and workloads.
 | `GpuCheck` | vm, bare_metal | Validates GPU via SSH |
 | `DriverCheck` | vm, bare_metal | Validates kernel and NVIDIA drivers |
 | `ContainerRuntimeCheck` | vm, bare_metal | Tests container runtime and NVIDIA Docker support |
-| `CloudInitCheck` | vm, bare_metal | Validates cloud-init completed and metadata service is reachable |
+| `CloudInitCheck` | vm, bare_metal | Validates cloud-init completed and metadata service is reachable. Supports `metadata_headers` (custom HTTP headers for non-AWS providers) and optional `metadata_url` override |
 | `GpuStressCheck` | bare_metal | GPU stress test via SSH |
 | `NcclCheck` | bare_metal | NCCL AllReduce test via SSH |
 | `TrainingCheck` | bare_metal | DDP training workload via SSH |

--- a/isvctl/configs/providers/aws/README.md
+++ b/isvctl/configs/providers/aws/README.md
@@ -7,7 +7,7 @@ Provider configs that wire the [provider-agnostic test suites](../../tests/READM
 | Config | Domain | Guide |
 |--------|--------|-------|
 | [`iam.yaml`](iam.yaml) | User lifecycle (create → verify → delete) | [AWS IAM Guide](../../stubs/aws/iam/docs/aws-iam.md) |
-| [`network.yaml`](network.yaml) | VPC CRUD, subnets, isolation, security, connectivity | [AWS Network Guide](../../stubs/aws/network/docs/aws-network.md) |
+| [`network.yaml`](network.yaml) | VPC CRUD, subnets, isolation, SG CRUD, security, connectivity | [AWS Network Guide](../../stubs/aws/network/docs/aws-network.md) |
 | [`vm.yaml`](vm.yaml) | GPU VM lifecycle (launch → stop/start → reboot → NIM) | [AWS VM Guide](../../stubs/aws/vm/docs/aws-vm.md) |
 | [`bare_metal.yaml`](bare_metal.yaml) | BMaaS lifecycle (launch → topology → serial → NIM) | [AWS Bare Metal Guide](../../stubs/aws/bare_metal/docs/aws-bm.md) |
 | [`eks.yaml`](eks.yaml) | Kubernetes GPU cluster (nodes, GPU operator, workloads) | [AWS EKS Guide](../../stubs/aws/eks/docs/aws-eks.md) |

--- a/isvctl/configs/stubs/aws/README.md
+++ b/isvctl/configs/stubs/aws/README.md
@@ -9,7 +9,7 @@ These scripts are invoked by the [AWS provider configs](../../providers/aws/).
 | Domain | Scripts | Guide |
 |--------|---------|-------|
 | [`iam/`](iam/) | User create/delete, credential testing | [AWS IAM Guide](iam/docs/aws-iam.md) |
-| [`network/`](network/) | VPC CRUD, subnets, isolation, security, connectivity | [AWS Network Guide](network/docs/aws-network.md) |
+| [`network/`](network/) | VPC CRUD, subnets, isolation, SG CRUD, security, connectivity | [AWS Network Guide](network/docs/aws-network.md) |
 | [`vm/`](vm/) | Instance launch, stop/start, reboot, serial console | [AWS VM Guide](vm/docs/aws-vm.md) |
 | [`bare_metal/`](bare_metal/) | BM launch, topology, serial console, reinstall | [AWS Bare Metal Guide](bare_metal/docs/aws-bm.md) |
 | [`eks/`](eks/) | EKS cluster setup/teardown (Terraform) | [AWS EKS Guide](eks/docs/aws-eks.md) |

--- a/isvctl/configs/stubs/aws/bare_metal/docs/aws-bm.md
+++ b/isvctl/configs/stubs/aws/bare_metal/docs/aws-bm.md
@@ -116,6 +116,7 @@ root volume replacement is slow on AWS metal (~30-45 min).
 | `reboot_gpu` | `GpuCheck` | reboot_instance | GPUs visible after reboot (8 GPUs) |
 | `reboot_host_os` | `HostSoftwareCheck` | reboot_instance | Host OS persisted after reboot |
 | `power_cycle_checks` | `InstancePowerCycleCheck`, `StableIdentifierCheck` | power_cycle_instance | Power-cycle recovery, instance ID stable |
+| `power_cycle_state` | `InstanceStateCheck` | power_cycle_instance | Instance running after power-cycle |
 | `power_cycle_ssh` | `ConnectivityCheck`, `OsCheck` | power_cycle_instance | SSH works after power-cycle |
 | `power_cycle_gpu` | `GpuCheck` | power_cycle_instance | GPUs visible after power-cycle |
 | `reinstall_state` | `InstanceStateCheck` | reinstall_instance | Running after reinstall (if enabled) |

--- a/isvctl/configs/stubs/aws/bare_metal/docs/aws-bm.md
+++ b/isvctl/configs/stubs/aws/bare_metal/docs/aws-bm.md
@@ -7,18 +7,20 @@ Validates AWS EC2 bare-metal GPU instances using the ISV validation framework.
 The AWS BM validation tests verify:
 
 1. **Instance Lifecycle** - Provisioning, state verification, instance listing
-2. **Topology Placement** - Placement group support (cluster strategy)
-3. **Serial Console** - Console output accessibility
-4. **Image Registry** - OS image verification, install config validation (cross-domain)
-5. **SSH Access** - Remote connectivity via SSH, cloud-init completion
-6. **Host OS Validation** - Kernel, BIOS, NVIDIA drivers
-7. **GPU Tests** - GPU visibility, stress, NCCL, training, NVLink
-8. **Networking** - InfiniBand, Ethernet connectivity
-9. **Stop/Start Resilience** - Power off, power on, SSH/GPU re-validation
-10. **Reboot Resilience** - Instance reboot, recovery, full host OS persistence
-11. **Reinstall** - OS reinstall from stock image (skipped by default)
-12. **NIM Inference** - NIM container deployment, health, model listing, inference
-13. **Sanitization** - Resource cleanup verification after teardown
+2. **Tag Validation** - Instance tag verification (Name, CreatedBy)
+3. **Topology Placement** - Placement group support (cluster strategy)
+4. **Serial Console** - Console output accessibility
+5. **Image Registry** - OS image verification, install config validation (cross-domain)
+6. **SSH Access** - Remote connectivity via SSH, cloud-init completion
+7. **Host OS Validation** - Kernel, BIOS, NVIDIA drivers
+8. **GPU Tests** - GPU visibility, stress, NCCL, training, NVLink
+9. **Networking** - InfiniBand, Ethernet connectivity
+10. **Stop/Start Resilience** - Power off, power on, SSH/GPU re-validation, stable instance ID
+11. **Reboot Resilience** - Instance reboot, recovery, full host OS persistence, stable instance ID
+12. **Power-Cycle Resilience** - Force stop + start, recovery, SSH/GPU re-validation, stable instance ID
+13. **Reinstall** - OS reinstall from stock image (skipped by default)
+14. **NIM Inference** - NIM container deployment, health, model listing, inference
+15. **Sanitization** - Resource cleanup verification after teardown
 
 ## Prerequisites
 
@@ -62,22 +64,24 @@ uv run isvctl test run -f isvctl/configs/providers/aws/bare_metal.yaml -- -k "re
 |---|------|-------|--------|-------------|
 | 1 | `launch_instance` | setup | `stubs/aws/bare_metal/launch_instance.py` | Provision bare-metal GPU instance |
 | 2 | `list_instances` | test | `stubs/aws/vm/list_instances.py` | List instances in VPC (reuses VM script) |
-| 3 | `topology_placement` | test | `stubs/aws/bare_metal/topology_placement.py` | Validate placement group support |
-| 4 | `serial_console` | test | `stubs/aws/bare_metal/serial_console.py` | Retrieve serial console output |
-| 5 | `verify_image` | test | `stubs/aws/image-registry/verify_image_installed.py` | Verify OS image installed on BM |
-| 6 | `verify_config` | test | `stubs/aws/image-registry/verify_config_installable.py` | Verify install config can provision BM |
-| 7 | `stop_instance` | test | `stubs/aws/bare_metal/stop_instance.py` | Power off node, verify stopped state |
-| 8 | `start_instance` | test | `stubs/aws/bare_metal/start_instance.py` | Power on node, verify recovery |
-| 9 | `describe_instance` | test | `stubs/aws/bare_metal/describe_instance.py` | Describe post-start state + SSH info |
+| 3 | `verify_tags` | test | `stubs/aws/bare_metal/describe_tags.py` | Verify instance tags (Name, CreatedBy) |
+| 4 | `topology_placement` | test | `stubs/aws/bare_metal/topology_placement.py` | Validate placement group support |
+| 5 | `serial_console` | test | `stubs/aws/bare_metal/serial_console.py` | Retrieve serial console output |
+| 6 | `verify_image` | test | `stubs/aws/image-registry/verify_image_installed.py` | Verify OS image installed on BM |
+| 7 | `verify_config` | test | `stubs/aws/image-registry/verify_config_installable.py` | Verify install config can provision BM |
+| 8 | `stop_instance` | test | `stubs/aws/bare_metal/stop_instance.py` | Power off node, verify stopped state |
+| 9 | `start_instance` | test | `stubs/aws/bare_metal/start_instance.py` | Power on node, verify recovery |
 | 10 | `reboot_instance` | test | `stubs/aws/bare_metal/reboot_instance.py` | Reboot instance, validate recovery |
-| 11 | `reinstall_instance` | test | `stubs/aws/bare_metal/reinstall_instance.py` | Reinstall OS (skip: true by default) |
-| 12 | `deploy_nim` | test | `stubs/common/deploy_nim.py` | Deploy NIM container via SSH |
-| 13 | `teardown_nim` | teardown | `stubs/common/teardown_nim.py` | Stop NIM container |
-| 14 | `teardown` | teardown | `stubs/aws/bare_metal/teardown.py` | Terminate instance, delete resources |
-| 15 | `verify_teardown` | teardown | `stubs/aws/bare_metal/verify_terminated.py` | Confirm instance terminated + SG deleted |
+| 11 | `power_cycle_instance` | test | `stubs/aws/bare_metal/power_cycle_instance.py` | Force stop + start, validate recovery |
+| 12 | `describe_instance` | test | `stubs/aws/bare_metal/describe_instance.py` | Describe post-power-cycle state + SSH info |
+| 13 | `reinstall_instance` | test | `stubs/aws/bare_metal/reinstall_instance.py` | Reinstall OS (skip: true by default) |
+| 14 | `deploy_nim` | test | `stubs/common/deploy_nim.py` | Deploy NIM container via SSH |
+| 15 | `teardown_nim` | teardown | `stubs/common/teardown_nim.py` | Stop NIM container |
+| 16 | `teardown` | teardown | `stubs/aws/bare_metal/teardown.py` | Terminate instance, delete resources |
+| 17 | `verify_teardown` | teardown | `stubs/aws/bare_metal/verify_terminated.py` | Confirm instance terminated + SG deleted |
 
-Steps 5-6 (`verify_image`, `verify_config`) cross-reference the image-registry domain to validate
-BM provisioning from OS images. Step 11 (`reinstall_instance`) is skipped by default because
+Steps 6-7 (`verify_image`, `verify_config`) cross-reference the image-registry domain to validate
+BM provisioning from OS images. Step 13 (`reinstall_instance`) is skipped by default because
 root volume replacement is slow on AWS metal (~30-45 min).
 
 ## Validations
@@ -86,6 +90,7 @@ root volume replacement is slow on AWS metal (~30-45 min).
 |------------------|-------|------|-------------|
 | `setup_checks` | `InstanceStateCheck` | launch_instance | Instance is running |
 | `list_instances` | `InstanceListCheck` | list_instances | Target instance found in VPC |
+| `tag_checks` | `InstanceTagCheck` | verify_tags | Instance has required tags (Name, CreatedBy) |
 | `topology_placement` | `TopologyPlacementCheck` | topology_placement | Placement group CRUD operations |
 | `serial_console` | `SerialConsoleCheck` | serial_console | Console output available |
 | `cloud_init` | `CloudInitCheck` | launch_instance | Cloud-init completed |
@@ -102,14 +107,17 @@ root volume replacement is slow on AWS metal (~30-45 min).
 | `infiniband` | `InfiniBandCheck` | describe_instance | InfiniBand device presence |
 | `ethernet` | `EthernetCheck` | describe_instance | Network connectivity (ping 8.8.8.8) |
 | `stop_checks` | `InstanceStopCheck` | stop_instance | Power-off confirmed |
-| `start_checks` | `InstanceStartCheck` | start_instance | Power-on confirmed |
+| `start_checks` | `InstanceStartCheck`, `StableIdentifierCheck` | start_instance | Power-on confirmed, instance ID stable |
 | `start_ssh` | `ConnectivityCheck`, `OsCheck` | start_instance | SSH works after start |
 | `start_gpu` | `GpuCheck` | start_instance | GPUs visible after start (8 GPUs) |
-| `reboot_checks` | `InstanceRebootCheck` | reboot_instance | Reboot confirmed (uptime < 600s) |
+| `reboot_checks` | `InstanceRebootCheck`, `StableIdentifierCheck` | reboot_instance | Reboot confirmed, instance ID stable |
 | `reboot_state` | `InstanceStateCheck` | reboot_instance | Instance running after reboot |
 | `reboot_ssh` | `ConnectivityCheck`, `OsCheck` | reboot_instance | SSH works after reboot |
 | `reboot_gpu` | `GpuCheck` | reboot_instance | GPUs visible after reboot (8 GPUs) |
 | `reboot_host_os` | `HostSoftwareCheck` | reboot_instance | Host OS persisted after reboot |
+| `power_cycle_checks` | `InstancePowerCycleCheck`, `StableIdentifierCheck` | power_cycle_instance | Power-cycle recovery, instance ID stable |
+| `power_cycle_ssh` | `ConnectivityCheck`, `OsCheck` | power_cycle_instance | SSH works after power-cycle |
+| `power_cycle_gpu` | `GpuCheck` | power_cycle_instance | GPUs visible after power-cycle |
 | `reinstall_state` | `InstanceStateCheck` | reinstall_instance | Running after reinstall (if enabled) |
 | `reinstall_ssh` | `ConnectivityCheck`, `OsCheck` | reinstall_instance | SSH works after reinstall |
 | `reinstall_gpu` | `GpuCheck` | reinstall_instance | GPUs visible after reinstall |

--- a/isvctl/configs/stubs/aws/eks/docs/aws-eks.md
+++ b/isvctl/configs/stubs/aws/eks/docs/aws-eks.md
@@ -23,7 +23,7 @@ aws --version
 # Terraform (v1.5+)
 terraform --version
 
-# kubectl
+# kubectl (or set KUBECTL env var to use an alternative CLI, e.g., "oc")
 kubectl version --client
 
 # Helm (v3)
@@ -270,7 +270,7 @@ Results are saved to:
 
 ### Phase 3: Teardown
 
-> **Important**: Teardown runs by default. Set `AWS_SKIP_TEARDOWN=true` to preserve resources.
+> **Important**: Teardown [runs by default](../../../../../../docs/guides/external-validation-guide.md#running-validations), even after test failures. Set `AWS_SKIP_TEARDOWN=true` to preserve resources.
 
 #### Check Current Resources
 

--- a/isvctl/configs/stubs/aws/network/docs/aws-network.md
+++ b/isvctl/configs/stubs/aws/network/docs/aws-network.md
@@ -4,13 +4,14 @@ This guide provides a complete walkthrough for validating AWS VPC networking cap
 
 ## Overview
 
-The network validation suite includes 13 comprehensive test suites:
+The network validation suite includes 14 comprehensive test suites:
 
 | Test Suite | Duration | Description |
 |------------|----------|-------------|
 | **VPC CRUD** | ~30s | Create, read, update, delete VPC lifecycle |
 | **Subnet Config** | ~30s | Multi-AZ subnet distribution and route tables |
 | **VPC Isolation** | ~30s | Security boundaries between separate VPCs |
+| **SG CRUD** | ~30s | Security group create, read, update rules, delete lifecycle |
 | **Security Blocking** | ~30s | SG/NACL blocking rules (negative tests) |
 | **Connectivity** | ~3 min | Instance network assignment via SSM |
 | **Traffic Validation** | ~5-7 min | Real ping tests - allowed/blocked traffic |
@@ -46,6 +47,7 @@ The network validation suite includes 13 comprehensive test suites:
 │  │ vpc_crud_test.py       │───▶│ VpcCrudCheck             │     │
 │  │ subnet_test.py         │───▶│ SubnetConfigCheck        │     │
 │  │ isolation_test.py      │───▶│ VpcIsolationCheck        │     │
+│  │ sg_crud_test.py        │───▶│ SgCrudCheck              │     │
 │  │ security_test.py       │───▶│ SecurityBlockingCheck    │     │
 │  │ test_connectivity.py   │───▶│ NetworkConnectivityCheck │     │
 │  │ traffic_test.py        │───▶│ TrafficFlowCheck         │     │
@@ -101,6 +103,7 @@ All scripts are located in `isvctl/configs/stubs/aws/network/`:
 | `vpc_crud_test.py` | VPC create/read/update/delete | `vpc_crud` |
 | `subnet_test.py` | Multi-AZ subnet configuration | `subnet_config` |
 | `isolation_test.py` | VPC isolation verification | `vpc_isolation` |
+| `sg_crud_test.py` | Security group CRUD lifecycle | `sg_crud` |
 | `security_test.py` | SG/NACL blocking rules | `security_blocking` |
 | `test_connectivity.py` | Instance connectivity via SSM | `connectivity_result` |
 | `traffic_test.py` | Real ping traffic tests | `traffic_flow` |
@@ -194,7 +197,19 @@ Verifies security boundaries between VPCs:
 - Check route tables don't reference other VPC
 - Validate default security groups block cross-VPC traffic
 
-### 4. Security Blocking Check (Negative Tests)
+### 4. Security Group CRUD Check
+
+**Script**: `sg_crud_test.py`
+**Validation**: `SgCrudCheck`
+
+Tests the complete security group lifecycle:
+
+- Create security group with description and tags
+- Read security group attributes
+- Update security group rules (add/remove ingress and egress rules)
+- Delete security group and verify removal
+
+### 5. Security Blocking Check (Negative Tests)
 
 **Script**: `security_test.py`
 **Validation**: `SecurityBlockingCheck`
@@ -207,7 +222,7 @@ Tests that security rules correctly **block** traffic:
 - **NACL explicit deny**: Creates NACL with explicit deny rule
 - **Restricted egress**: Creates SG with HTTPS-only outbound
 
-### 5. Connectivity Check
+### 6. Connectivity Check
 
 **Script**: `test_connectivity.py`
 **Validation**: `NetworkConnectivityCheck`
@@ -220,7 +235,7 @@ Tests instance network connectivity:
 - Tests ping between instances
 - Tests internet connectivity
 
-### 6. Traffic Validation Check
+### 7. Traffic Validation Check
 
 **Script**: `traffic_test.py`
 **Validation**: `TrafficFlowCheck`
@@ -236,7 +251,7 @@ The most comprehensive test - sends real network traffic:
 - Tests internet ICMP (ping 8.8.8.8)
 - Tests internet HTTPS (curl checkip.amazonaws.com)
 
-### 7. VPC IP Configuration Check (DDI)
+### 8. VPC IP Configuration Check (DDI)
 
 **Script**: `vpc_ip_config_test.py`
 **Validation**: `VpcIpConfigCheck`
@@ -248,7 +263,7 @@ Tests IP address management configuration on the shared VPC:
 - Verify auto-assign public IP settings
 - Check DHCP options set (domain name servers, domain name)
 
-### 8. DHCP IP Management Check (DDI)
+### 9. DHCP IP Management Check (DDI)
 
 **Script**: `dhcp_ip_test.py`
 **Validation**: `DhcpIpManagementCheck`
@@ -260,7 +275,7 @@ Tests DHCP-assigned IP management via SSH on a live instance:
 - Check assigned IP matches AWS metadata
 - Verify DNS options are configured correctly
 
-### 9. BYOIP Check
+### 10. BYOIP Check
 
 **Script**: `byoip_test.py`
 **Validation**: `ByoipCheck`
@@ -273,7 +288,7 @@ Tests Bring-Your-Own-IP with non-standard CIDR ranges:
 - Verify subnets can be created in custom CIDR ranges
 - Clean up both VPCs
 
-### 10. Stable Private IP Check
+### 11. Stable Private IP Check
 
 **Script**: `stable_ip_test.py`
 **Validation**: `StablePrivateIpCheck`
@@ -285,7 +300,7 @@ Tests that private IPs persist across instance stop/start cycles:
 - Stop instance, then start it
 - Verify private IP is unchanged after restart
 
-### 11. Floating IP Check
+### 12. Floating IP Check
 
 **Script**: `floating_ip_test.py`
 **Validation**: `FloatingIpCheck`
@@ -298,7 +313,7 @@ Tests atomic IP reassignment between instances:
 - Verify switch completes within the `max_switch_seconds` threshold (default 10s)
 - Clean up all resources
 
-### 12. Localized DNS Check
+### 13. Localized DNS Check
 
 **Script**: `dns_test.py`
 **Validation**: `LocalizedDnsCheck`
@@ -310,7 +325,7 @@ Tests custom internal domain resolution via Route 53 private hosted zones:
 - Verify forward resolution works from within the VPC
 - Clean up hosted zone and VPC
 
-### 13. VPC Peering Check
+### 14. VPC Peering Check
 
 **Script**: `peering_test.py`
 **Validation**: `VpcPeeringCheck`
@@ -417,7 +432,8 @@ commands:
       - name: vpc_crud             # Test 1: VPC CRUD (~30s)
       - name: subnet_config        # Test 2: Subnet Config (~30s)
       - name: vpc_isolation         # Test 3: VPC Isolation (~30s)
-      - name: security_blocking     # Test 4: Security Blocking (~30s)
+      - name: sg_crud               # Test 4a: SG CRUD (~30s)
+      - name: security_blocking     # Test 4b: Security Blocking (~30s)
       - name: connectivity_test     # Test 5: Connectivity (~3 min)
       - name: traffic_validation    # Test 6: Traffic Validation (~5-7 min)
       - name: vpc_ip_config         # Test 7: VPC IP Config - DDI (~10s)
@@ -459,13 +475,14 @@ ORCHESTRATION RESULTS
 ============================================================
 [PASS] SETUP   : create_network: passed
   [create_network] NetworkProvisionedCheck: PASSED - Network vpc-xxx provisioned: CIDR=10.0.0.0/16, subnets=2
-[PASS] TEST    : vpc_crud: passed; subnet_config: passed; vpc_isolation: passed; security_blocking: passed;
-                 connectivity_test: passed; traffic_validation: passed; vpc_ip_config: passed;
-                 dhcp_ip_test: passed; byoip_test: passed; stable_ip_test: passed;
-                 floating_ip_test: passed; dns_test: passed; peering_test: passed
+[PASS] TEST    : vpc_crud: passed; subnet_config: passed; vpc_isolation: passed; sg_crud: passed;
+                 security_blocking: passed; connectivity_test: passed; traffic_validation: passed;
+                 vpc_ip_config: passed; dhcp_ip_test: passed; byoip_test: passed;
+                 stable_ip_test: passed; floating_ip_test: passed; dns_test: passed; peering_test: passed
   [vpc_crud] VpcCrudCheck: PASSED - All 5 CRUD tests passed
   [subnet_config] SubnetConfigCheck: PASSED - 4 subnets across 2 AZs
   [vpc_isolation] VpcIsolationCheck: PASSED - VPCs vpc-a and vpc-b are properly isolated
+  [sg_crud] SgCrudCheck: PASSED - All 4 SG CRUD operations passed
   [security_blocking] SecurityBlockingCheck: PASSED - All 5 security blocking tests passed
   [connectivity_test] NetworkConnectivityCheck: PASSED - 2 instances with network connectivity
   [traffic_validation] TrafficFlowCheck: PASSED - All 4 traffic tests passed (latency: 0.5ms)

--- a/isvctl/configs/tests/README.md
+++ b/isvctl/configs/tests/README.md
@@ -37,9 +37,9 @@ commands:
 | Test Suite | Domain | Stubs | AWS Reference |
 |------------|--------|-------|---------------|
 | [`iam.yaml`](iam.yaml) | User lifecycle (create → verify → delete) | [`stubs/iam/`](../stubs/iam/) (3 scripts) | [`providers/aws/iam.yaml`](../providers/aws/iam.yaml) |
-| [`network.yaml`](network.yaml) | VPC CRUD, subnets, isolation, security, connectivity, traffic, DDI, SDN | [`stubs/network/`](../stubs/network/) (15 scripts) | [`providers/aws/network.yaml`](../providers/aws/network.yaml) |
+| [`network.yaml`](network.yaml) | VPC CRUD, subnets, isolation, SG CRUD, security, connectivity, traffic, DDI, SDN | [`stubs/network/`](../stubs/network/) (16 scripts) | [`providers/aws/network.yaml`](../providers/aws/network.yaml) |
 | [`vm.yaml`](vm.yaml) | GPU VM lifecycle: launch → tags → stop/start → reboot → NIM → teardown | [`stubs/vm/`](../stubs/vm/) (8 scripts) | [`providers/aws/vm.yaml`](../providers/aws/vm.yaml) |
-| [`bare_metal.yaml`](bare_metal.yaml) | BMaaS lifecycle: launch → topology → serial → stop/start → reboot → NIM → teardown | [`stubs/bare_metal/`](../stubs/bare_metal/) (9 scripts) | [`providers/aws/bare_metal.yaml`](../providers/aws/bare_metal.yaml) |
+| [`bare_metal.yaml`](bare_metal.yaml) | BMaaS lifecycle: launch → tags → topology → serial → stop/start → reboot → power-cycle → NIM → teardown | [`stubs/bare_metal/`](../stubs/bare_metal/) (13 scripts) | [`providers/aws/bare_metal.yaml`](../providers/aws/bare_metal.yaml) |
 | [`k8s.yaml`](k8s.yaml) | Kubernetes GPU cluster: nodes, GPU operator, scheduling, workloads | [`stubs/k8s/`](../stubs/k8s/) (2 scripts) | [`providers/aws/eks.yaml`](../providers/aws/eks.yaml) |
 | [`slurm.yaml`](slurm.yaml) | Slurm HPC cluster: partitions, jobs, GPU allocation | [`stubs/slurm/`](../stubs/slurm/) (2 scripts) | — |
 | [`control-plane.yaml`](control-plane.yaml) | API health, access key lifecycle, tenant lifecycle | [`stubs/control-plane/`](../stubs/control-plane/) (10 scripts) | [`providers/aws/control-plane.yaml`](../providers/aws/control-plane.yaml) |
@@ -63,6 +63,7 @@ commands:
 | `vpc_crud` | test | `stubs/network/vpc_crud_test.py` | Create/Read/Update/Delete lifecycle |
 | `subnet_config` | test | `stubs/network/subnet_test.py` | Multi-AZ subnet distribution |
 | `vpc_isolation` | test | `stubs/network/isolation_test.py` | Security boundaries between VPCs |
+| `sg_crud` | test | `stubs/network/sg_crud_test.py` | Security group create/read/update/delete lifecycle |
 | `security_blocking` | test | `stubs/network/security_test.py` | Firewall/ACL blocking rules |
 | `connectivity_test` | test | `stubs/network/test_connectivity.py` | Instance network assignment |
 | `traffic_validation` | test | `stubs/network/traffic_test.py` | Ping allowed/blocked, internet |
@@ -96,12 +97,14 @@ commands:
 |------|-------|--------|-----------------|
 | `launch_instance` | setup | `stubs/bare_metal/launch_instance.py` | `instance_id`, `public_ip`, `key_file`, `vpc_id` |
 | `list_instances` | test | `stubs/vm/list_instances.py` | Reuses VM script |
+| `verify_tags` | test | `stubs/bare_metal/describe_tags.py` | `instance_id`, `tags`, `tag_count` |
 | `topology_placement` | test | `stubs/bare_metal/topology_placement.py` | `placement_supported`, `operations` |
 | `serial_console` | test | `stubs/bare_metal/serial_console.py` | `console_available`, `serial_access_enabled` |
 | `stop_instance` | test | `stubs/bare_metal/stop_instance.py` | `instance_id`, `state`, `stop_initiated` |
 | `start_instance` | test | `stubs/bare_metal/start_instance.py` | `instance_id`, `state`, `public_ip`, `ssh_ready` |
-| `describe_instance` | test | `stubs/bare_metal/describe_instance.py` | `instance_state`, `public_ip`, `key_file` |
 | `reboot_instance` | test | `stubs/bare_metal/reboot_instance.py` | `uptime_seconds`, `ssh_connectivity` |
+| `power_cycle_instance` | test | `stubs/bare_metal/power_cycle_instance.py` | `instance_id`, `state`, `public_ip`, `ssh_ready` |
+| `describe_instance` | test | `stubs/bare_metal/describe_instance.py` | `instance_state`, `public_ip`, `key_file` |
 | `reinstall_instance` | test | `stubs/bare_metal/reinstall_instance.py` | `instance_state` (skipped by default) |
 | `deploy_nim` | test | `stubs/common/deploy_nim.py` | Shared NIM deployment |
 | `teardown_nim` | teardown | `stubs/common/teardown_nim.py` | Shared NIM cleanup |
@@ -115,7 +118,7 @@ commands:
 | `setup` | setup | `stubs/k8s/setup.sh` |
 | `teardown` | teardown | `stubs/k8s/teardown.sh` |
 
-Validations use `kubectl` directly: node counts, GPU operator, pod health, NCCL/NIM workloads.
+Validations use `kubectl` directly (or a custom CLI via the `KUBECTL` env var): node counts, GPU operator, pod health, NCCL/NIM workloads.
 
 ### Slurm (`slurm.yaml`)
 


### PR DESCRIPTION
## Summary

Audit of 14 PRs merged Apr 8–15 found documentation drift across 12 files where new features, validations, and behavior changes were not reflected in the docs.

- **Teardown behavior (#193)**: Document runs-after-failure, best-effort execution, and standalone `--phase teardown` in the external validation guide as the canonical source; other files link to it
- **SgCrudCheck (#179)**: Add SG CRUD lifecycle test to aws-network.md throughout (overview table, architecture diagram, scripts table, new test case section, example config, example output); update test count 13→14; add `sg_crud` step to tests/README.md
- **Bare metal steps (#180, #183)**: Add `verify_tags`, `power_cycle_instance`, and `StableIdentifierCheck` to aws-bm.md and tests/README.md; update stub counts and validation groups
- **CloudInitCheck metadata_headers (#194)**: Add `metadata_headers` and `metadata_url` parameters in isvtest.md (source of truth); configuration.md links to it rather than duplicating
- **Template warnings (#191)**: Document `ChainableUndefined` warning behavior in AGENTS.md and configuration.md
- **KUBECTL / K8S_PROVIDER (#229)**: Add both env vars to getting-started.md; mention `KUBECTL` override in tests/README.md and aws-eks.md prerequisites

## Test plan

- [x] All changes are documentation-only (markdown files)
- [x] Pre-commit hooks pass (markdown link checker, trailing whitespace, end-of-file fixes)
- [x] Cross-references verified (DRY audit: configuration.md defers to isvtest.md for validation details; isvctl.md and aws-eks.md link to external-validation-guide.md for teardown semantics)
- [x] Step tables verified against canonical YAML configs (`bare_metal.yaml`, `network.yaml`)
- [x] Stub counts verified against actual directory listings (`stubs/network/` = 16, `stubs/bare_metal/` = 13)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Teardown now documented to run by default (best-effort per step) even after failures; added a teardown-only run example.
  * Added KUBECTL and K8S_PROVIDER environment vars for Kubernetes tests.
  * Jinja2/template warnings documented for missing step outputs (suppressed for intentionally skipped phases).
  * Expanded cloud-init docs to support metadata_headers and metadata_url for non-AWS providers.
  * Added tag verification and power‑cycle resilience to bare-metal guides.
  * Added Security Group (SG) CRUD to network validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->