### PR TITLE
fix: remove overly-broad "setup" -> "cluster" schema mapping (#191 regression)

### DIFF
--- a/isvctl/configs/providers/aws/eks.yaml
+++ b/isvctl/configs/providers/aws/eks.yaml
@@ -39,6 +39,7 @@ commands:
       - name: setup
         phase: setup
         command: "../../stubs/aws/eks/setup.sh"
+        output_schema: cluster
         timeout: 1800 # 30 min for Terraform provisioning
         env:
           TF_AUTO_APPROVE: "true"

--- a/isvctl/src/isvctl/config/output_schemas.py
+++ b/isvctl/src/isvctl/config/output_schemas.py
@@ -22,7 +22,7 @@ Example usage:
     from isvctl.config.output_schemas import get_schema_for_step, validate_output
 
     # Auto-detect schema from step name
-    schema_name = get_schema_for_step("setup")  # Returns "cluster"
+    schema_name = get_schema_for_step("provision_cluster")  # Returns "cluster"
 
     # Validate output against schema
     is_valid, errors = validate_output(output_json, schema_name)
@@ -36,7 +36,6 @@ import jsonschema
 # The step name determines which schema is used for validation
 STEP_SCHEMA_MAPPING: dict[str, str | None] = {
     # Cluster operations -> "cluster" schema
-    "setup": "cluster",
     "provision_cluster": "cluster",
     "create_cluster": "cluster",
     "setup_cluster": "cluster",
@@ -829,7 +828,7 @@ def get_schema_for_step(step_name: str) -> str | None:
         Schema name for validation
 
     Examples:
-        >>> get_schema_for_step("setup")
+        >>> get_schema_for_step("provision_cluster")
         "cluster"
         >>> get_schema_for_step("my_custom_cluster_setup")
         "cluster"  # Partial match - contains "cluster"

--- a/isvctl/tests/test_schema.py
+++ b/isvctl/tests/test_schema.py
@@ -8,11 +8,19 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
-"""Tests for Pydantic schema models."""
+"""Tests for Pydantic schema models and output schema registry."""
+
+from typing import ClassVar
 
 import pytest
 from pydantic import ValidationError
 
+from isvctl.config.output_schemas import (
+    OUTPUT_SCHEMAS,
+    STEP_SCHEMA_MAPPING,
+    get_schema_for_step,
+    validate_output,
+)
 from isvctl.config.schema import CommandConfig, CommandOutput, PlatformCommands, RunConfig, StepConfig
 
 
@@ -249,3 +257,144 @@ class TestRunConfigModel:
         assert steps[0].command == "./k8s-setup.sh"
         assert steps[1].name == "teardown_cluster"
         assert steps[1].command == "./k8s-teardown.sh"
+
+
+class TestOutputSchemaMapping:
+    """Tests for step name -> schema auto-detection.
+
+    Prevents regressions where overly-broad mapping keys (like "setup")
+    silently break platforms that share generic step names.
+    """
+
+    def test_setup_does_not_map_to_cluster(self) -> None:
+        """'setup' must NOT auto-map to the cluster schema.
+
+        The name 'setup' is used by slurm, k8s, bare_metal, etc. — each with
+        different output shapes. Mapping it to 'cluster' broke every non-EKS
+        platform (#191). Configs that need cluster validation should set
+        output_schema: cluster explicitly.
+        """
+        schema = get_schema_for_step("setup")
+        assert schema != "cluster", (
+            "'setup' must not map to 'cluster' — it is used across platforms "
+            "with different output shapes. Use output_schema in step config instead."
+        )
+
+    def test_all_mapped_schemas_exist(self) -> None:
+        """Every schema referenced in STEP_SCHEMA_MAPPING must be registered."""
+        for step_name, schema_name in STEP_SCHEMA_MAPPING.items():
+            if schema_name is not None:
+                assert schema_name in OUTPUT_SCHEMAS, (
+                    f"Step '{step_name}' maps to schema '{schema_name}' which is not registered in OUTPUT_SCHEMAS"
+                )
+
+    def test_explicit_output_schema_overrides_autodetect(self) -> None:
+        """StepConfig.output_schema should take priority over name-based detection."""
+        step = StepConfig(name="setup", command="./setup.sh", output_schema="cluster")
+        assert step.output_schema == "cluster"
+        assert get_schema_for_step(step.name) != "cluster"
+
+    @pytest.mark.parametrize(
+        ("step_name", "expected_schema"),
+        [
+            ("provision_cluster", "cluster"),
+            ("create_cluster", "cluster"),
+            ("create_network", "network"),
+            ("launch_instance", "instance"),
+            ("teardown", "teardown"),
+            ("create_access_key", "access_key"),
+        ],
+    )
+    def test_specific_step_names_resolve_correctly(self, step_name: str, expected_schema: str) -> None:
+        """Verify well-known step names map to the correct schemas."""
+        assert get_schema_for_step(step_name) == expected_schema
+
+
+class TestOutputSchemaValidation:
+    """Tests that representative stub outputs conform to their resolved schemas.
+
+    Each sample mirrors the actual JSON structure produced by the corresponding
+    setup stub (e.g., slurm/setup.sh, k8s/_common.sh, aws/eks/setup.sh).
+    If a stub's output shape changes, these tests must be updated to match.
+    """
+
+    SLURM_SETUP_OUTPUT: ClassVar[dict] = {
+        "success": True,
+        "platform": "slurm",
+        "cluster_name": "demo-slurm",
+        "slurm": {
+            "partitions": {"gpu": {"nodes": ["n1", "n2"]}, "all": {"nodes": ["n1", "n2"]}},
+            "cuda_arch": "90",
+            "storage_path": "/home",
+            "default_partition": "gpu",
+            "driver_version": "560.35.03",
+            "gpu_per_node": 4,
+            "total_gpus": 8,
+        },
+    }
+
+    K8S_SETUP_OUTPUT: ClassVar[dict] = {
+        "success": True,
+        "platform": "kubernetes",
+        "cluster_name": "test-cluster",
+        "kubernetes": {
+            "driver_version": "560.35.03",
+            "node_count": 3,
+            "nodes": ["node1", "node2", "node3"],
+            "gpu_node_count": 2,
+            "gpu_per_node": 4,
+            "total_gpus": 8,
+            "gpu_operator_namespace": "nvidia-gpu-operator",
+            "runtime_class": "nvidia",
+            "gpu_resource_name": "nvidia.com/gpu",
+        },
+    }
+
+    EKS_SETUP_OUTPUT: ClassVar[dict] = {
+        "success": True,
+        "platform": "kubernetes",
+        "cluster_name": "eks-cluster",
+        "node_count": 3,
+        "endpoint": "https://eks.amazonaws.com",
+        "gpu_count": 8,
+        "gpu_per_node": 4,
+        "driver_version": "560.35.03",
+        "kubeconfig_path": "/tmp/kubeconfig",
+        "kubernetes": {
+            "driver_version": "560.35.03",
+            "node_count": 3,
+            "nodes": ["node1", "node2", "node3"],
+            "gpu_node_count": 2,
+            "gpu_per_node": 4,
+            "total_gpus": 8,
+            "gpu_operator_namespace": "nvidia-gpu-operator",
+            "runtime_class": "nvidia",
+            "gpu_resource_name": "nvidia.com/gpu",
+        },
+    }
+
+    def test_slurm_output_passes_autodetected_schema(self) -> None:
+        """Slurm setup.sh output must pass its auto-detected schema (generic)."""
+        schema = get_schema_for_step("setup")
+        is_valid, errors = validate_output(self.SLURM_SETUP_OUTPUT, schema)
+        assert is_valid, f"Slurm output failed '{schema}' schema: {errors}"
+
+    def test_k8s_output_passes_autodetected_schema(self) -> None:
+        """k8s _common.sh output must pass its auto-detected schema (generic).
+
+        Note: _common.sh does NOT put node_count at the top level, so it
+        cannot pass the 'cluster' schema without modification.
+        """
+        schema = get_schema_for_step("setup")
+        is_valid, errors = validate_output(self.K8S_SETUP_OUTPUT, schema)
+        assert is_valid, f"K8s output failed '{schema}' schema: {errors}"
+
+    def test_k8s_output_fails_cluster_schema(self) -> None:
+        """k8s _common.sh output lacks top-level node_count, so cluster schema must reject it."""
+        is_valid, _errors = validate_output(self.K8S_SETUP_OUTPUT, "cluster")
+        assert not is_valid, "K8s _common.sh output should NOT pass cluster schema (no top-level node_count)"
+
+    def test_eks_output_passes_cluster_schema(self) -> None:
+        """EKS setup.sh output has top-level node_count and must pass cluster schema."""
+        is_valid, errors = validate_output(self.EKS_SETUP_OUTPUT, "cluster")
+        assert is_valid, f"EKS output failed 'cluster' schema: {errors}"


### PR DESCRIPTION
## Summary

- **Remove `"setup": "cluster"` from `STEP_SCHEMA_MAPPING`** — the name `setup` is shared by slurm, k8s (microk8s/k3s/minikube), bare_metal, etc., each with different output shapes. Mapping it globally to the `cluster` schema (which requires top-level `node_count`) broke every non-EKS platform. Introduced in #191.
- **Add `output_schema: cluster` to `eks.yaml`** — EKS is the only config whose stub outputs `node_count` at the top level. It now opts in explicitly via the existing `output_schema` field on `StepConfig`.
- **Add regression tests** — 8 new tests in `test_schema.py` covering schema auto-detection invariants and representative stub output validation against resolved schemas.

## Root Cause

PR #191 added `"setup": "cluster"` to `STEP_SCHEMA_MAPPING` as part of renaming EKS step names from `provision_cluster` to `setup`. Before that change, `get_schema_for_step("setup")` fell through to `"generic"` (requires only `success` + `platform`). After the change, every config with `name: setup` was validated against the `cluster` schema, which requires `node_count` at the root — a field only the EKS stub provides.

## Test plan

- [x] `make test` — all 225 tests pass (including 8 new schema tests)
- [x] `uvx pre-commit run -a` — all hooks pass
- [x] `isvctl test run -f isvctl/configs/tests/slurm.yaml` — setup step no longer fails schema validation
- [x] `isvctl test run -f isvctl/configs/providers/microk8s.yaml` — setup step no longer fails schema validation


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced EKS cluster setup configuration with improved output schema mapping.

* **Tests**
  * Expanded test coverage for output schema validation and step-to-schema auto-detection mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->