### PR TITLE
fix: skip Slurm validations for partitions not present on cluster

### DIFF
--- a/isvctl/src/isvctl/cli/deploy.py
+++ b/isvctl/src/isvctl/cli/deploy.py
@@ -246,7 +246,7 @@ def run(
     setup_logging(verbose)
 
     # Collect extra pytest args from context (after --)
-    pytest_extra_args = " ".join(ctx.args) if ctx.args else ""
+    pytest_extra_args = shlex.join(ctx.args) if ctx.args else ""
 
     # Set working directory to workspace root
     working_dir = Path.cwd()

--- a/isvtest/src/isvtest/validations/slurm_node_job_execution.py
+++ b/isvtest/src/isvtest/validations/slurm_node_job_execution.py
@@ -17,10 +17,13 @@ by executing a test job on each node individually.
 from dataclasses import dataclass
 from typing import ClassVar
 
+import pytest
+
 from isvtest.core.nvidia import extract_first_gpu_info, has_gpu_output
 from isvtest.core.slurm import (
     DEFAULT_NODE_TIMEOUT,
     MANIFESTS_DIR,
+    get_partition_names,
     get_partition_nodes,
     is_gpu_partition,
 )
@@ -77,8 +80,9 @@ class SlurmNodeJobExecution(BaseValidation):
         if nodes is None:
             return  # Error already set
         if not nodes:
-            self.set_failed(f"No nodes found in partition '{partition_name}'")
-            return
+            result = self.run_command("sinfo -o '%P %a %l %D %N'")
+            available = get_partition_names(result.stdout) if result.exit_code == 0 else []
+            pytest.skip(f"Partition '{partition_name}' has no nodes (available partitions: {available})")
 
         self.log.info(f"Found {len(nodes)} nodes in partition '{partition_name}': {nodes}")
 

--- a/isvtest/src/isvtest/validations/slurm_partition.py
+++ b/isvtest/src/isvtest/validations/slurm_partition.py
@@ -13,6 +13,8 @@
 import json
 from typing import ClassVar
 
+import pytest
+
 from isvtest.core.slurm import get_partition_names, get_partitions
 from isvtest.core.validation import BaseValidation
 
@@ -119,6 +121,11 @@ class SlurmPartition(BaseValidation):
         if partition_name:
             # Check for specific partition
             if partition_name not in partitions:
+                if not expected_nodes and not required_nodes:
+                    pytest.skip(
+                        f"Partition '{partition_name}' not present on this cluster "
+                        f"(available: {list(partitions.keys())})"
+                    )
                 self.set_failed(f"Partition '{partition_name}' not found. Available: {list(partitions.keys())}")
                 return
 

--- a/isvtest/src/isvtest/validations/slurm_partition.py
+++ b/isvtest/src/isvtest/validations/slurm_partition.py
@@ -121,7 +121,8 @@ class SlurmPartition(BaseValidation):
         if partition_name:
             # Check for specific partition
             if partition_name not in partitions:
-                if not expected_nodes and not required_nodes:
+                no_nodes_expected = expected_nodes == 0 and not required_nodes and not min_nodes
+                if no_nodes_expected:
                     pytest.skip(
                         f"Partition '{partition_name}' not present on this cluster "
                         f"(available: {list(partitions.keys())})"

--- a/isvtest/src/isvtest/workloads/slurm_nccl_multinode.py
+++ b/isvtest/src/isvtest/workloads/slurm_nccl_multinode.py
@@ -347,14 +347,20 @@ class SlurmNcclMultiNodeWorkload(BaseWorkloadCheck):
 
             time.sleep(poll_interval)
 
-        # Timeout - cancel the job
+        # Timeout - cancel and collect partial output for debugging
         self.log.warning(f"Job {job_id} timed out after {timeout}s, cancelling...")
         self.run_command(f"scancel {job_id}", timeout=30)
+
+        stdout, stderr = get_job_output(self, job_id, nodelist, cleanup=True)
+        partial_output = f"{stdout}\n{stderr}".strip()
+        if partial_output:
+            self.log.info(f"Partial output from timed-out job {job_id}:\n{partial_output[-2000:]}")
 
         return SlurmNcclResult(
             success=False,
             job_id=job_id,
             error=f"Job timed out after {timeout}s",
+            output=partial_output,
         )
 
     def _parse_nccl_output(self, job_id: str, output: str) -> SlurmNcclResult:

--- a/isvtest/src/isvtest/workloads/slurm_sbatch.py
+++ b/isvtest/src/isvtest/workloads/slurm_sbatch.py
@@ -30,6 +30,7 @@ from isvtest.core.slurm import (
     JobResult,
     get_job_output,
     get_job_state,
+    get_partition_names,
     parse_sbatch_job_id,
 )
 from isvtest.core.workload import BaseWorkloadCheck
@@ -86,6 +87,15 @@ class SlurmSbatchWorkload(BaseWorkloadCheck):
         job_timeout = self.config.get("timeout", DEFAULT_JOB_TIMEOUT)
         poll_interval = self.config.get("poll_interval", DEFAULT_POLL_INTERVAL)
         cleanup = self.config.get("cleanup", True)
+
+        # Skip early if the script targets a partition that doesn't exist
+        partition = variables.get("PARTITION")
+        if partition:
+            result = self.run_command("sinfo -o '%P %a %l %D %N'")
+            if result.exit_code == 0:
+                available = get_partition_names(result.stdout)
+                if partition not in available:
+                    pytest.skip(f"Partition '{partition}' not present on this cluster (available: {available})")
 
         # Load script content
         content = self._load_script(script_name, script_content)


### PR DESCRIPTION
## Summary

- **SlurmPartition** now `pytest.skip()`s instead of failing when the target partition doesn't exist on the cluster and no nodes were expected (i.e., `expected_nodes` is explicitly 0, `required_nodes` is empty, and `min_nodes` is unset/0).
- **SlurmNodeJobExecution** now `pytest.skip()`s instead of failing when the partition has no nodes, reporting the available partitions in the skip reason.
- **SlurmSbatchWorkload** now proactively checks the PARTITION variable against `sinfo` before submitting, skipping consistently with the other Slurm validations.
- **SlurmNcclMultiNodeWorkload** now collects partial job output (stdout + stderr) on timeout, providing visibility into whether the job was stuck on container pull, NCCL init, or fabric errors.
- All skip patterns follow the existing `pytest.skip()` convention used by NIM, MIG, and other validations.
- **deploy run** now uses `shlex.join()` instead of `" ".join()` to forward extra pytest args over SSH, fixing broken `-m` marker expressions containing spaces.

## Test plan

- [x] `uv run pytest -m unit -k slurm` — all 39 isvtest tests pass
- [x] `uv run pytest` in isvctl — all 262 tests pass
- [x] `ruff check` and `ruff format` clean
- [x] Remote deploy: `SlurmPartition-cpu` and `SlurmNodeJobExecution-cpu` show SKIPPED
- [x] Remote deploy: `SlurmSbatchWorkload-cpu` shows SKIPPED (proactive sinfo check)
- [x] Remote deploy: `-m "not workload and not slow"` correctly forwards quoted args
- [x] Remote deploy: NCCL timeout now shows partial output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed CLI argument serialization for pytest commands to properly handle special characters and whitespace
  * Improved SLURM job timeout handling by capturing partial output when jobs time out

* **Improvements**
  * SLURM partition validations now skip tests gracefully when partitions are unavailable instead of failing
  * Added early validation of SLURM partitions before job submission to prevent unnecessary execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->