### PR TITLE
feat: add CNCF Kubernetes conformance validation via direct e2e Pod (K8S01)

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -577,6 +577,16 @@ Below is a summary by category.
 | `TenantListedCheck` | Check tenant appears in list |
 | `TenantInfoCheck` | Check tenant info retrieved |
 
+### Kubernetes Conformance Modes
+
+`K8sCncfConformanceCheck` (in `validations/k8s_conformance.py`) runs the upstream CNCF e2e suite in-cluster. The `mode` parameter selects which subset of tests runs:
+
+| Mode | Description |
+| ---- | ----------- |
+| `certified-conformance` (default) | Full `[Conformance]` suite, serial. Required for CNCF certification; expect multi-hour runtime. |
+| `non-disruptive-conformance` | `[Conformance]` minus `[Disruptive]` and `[Serial]` tests. Safe to run against clusters carrying other workloads. |
+| `quick` | Single ConfigMap test. Smoke-tests the harness end-to-end without exercising real conformance coverage. |
+
 ## Excluding Tests
 
 Use the `tests.exclude` section to deselect tests before they run. Excluded tests are removed from collection entirely (they do not appear as skipped or failed).

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -96,6 +96,17 @@ tests:
       checks:
         K8sOidcIssuerCheck: {}
 
+    k8s_conformance:
+      checks:
+        K8sCncfConformanceCheck:
+          # For valid `mode` values, see
+          # docs/guides/configuration.md#kubernetes-conformance-modes
+          mode: "quick"
+          timeout: 7200
+          startup_timeout: 600
+          cleanup_namespace: true
+          report_individual_tests: false
+
     k8s_workloads:
       checks:
         K8sNcclWorkload:

--- a/isvtest/src/isvtest/core/k8s.py
+++ b/isvtest/src/isvtest/core/k8s.py
@@ -11,7 +11,9 @@
 """Kubernetes utility functions for validation tests."""
 
 import functools
+import json
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -21,6 +23,23 @@ from typing import Any
 from isvtest.core.logger import setup_logger
 
 logger = setup_logger(__name__)
+
+# Container waiting reasons that kubelet only reports after it has already
+# given up retrying — callers can fast-fail instead of waiting out a timeout.
+TERMINAL_WAITING_REASONS: frozenset[str] = frozenset(
+    {
+        "ImagePullBackOff",
+        "InvalidImageName",
+        "CreateContainerConfigError",
+        "CreateContainerError",
+        "CrashLoopBackOff",
+    }
+)
+
+# Container waiting reasons that can appear transiently on the first pull
+# attempt before kubelet transitions to ImagePullBackOff; callers should fail
+# only if they persist across consecutive polls.
+TRANSIENT_WAITING_REASONS: frozenset[str] = frozenset({"ErrImagePull"})
 
 
 @functools.lru_cache(maxsize=1)
@@ -161,14 +180,66 @@ def get_kubectl_command() -> list[str]:
     return ["kubectl"]
 
 
-def get_kubectl_base_shell() -> str:
-    """Return the kubectl invocation as a shell-quoted string.
+def get_kubectl_base_shell(*args: str) -> str:
+    """Return the kubectl invocation (plus optional args) as a shell-quoted string.
 
     Use this when interpolating kubectl into a shell command string (e.g.
     passing to ``run_command`` or composing pipes). For argv-style calls
     (``subprocess.run``), use :func:`get_kubectl_command` instead.
+
+    With no args, returns just the provider-aware kubectl prefix. With args,
+    returns the fully composed, shell-quoted command — useful for callers
+    that would otherwise re-implement the quoting inline.
     """
-    return " ".join(shlex.quote(part) for part in get_kubectl_command())
+    return " ".join(shlex.quote(part) for part in (*get_kubectl_command(), *args))
+
+
+def parse_pod_state(stdout: str, stderr: str) -> tuple[str, str, str]:
+    """Parse ``kubectl get pod -o json`` output into ``(phase, waiting_reason, waiting_message)``.
+
+    ``stdout`` is the JSON output when the command succeeds; ``stderr`` is
+    inspected only when ``stdout`` is empty/invalid so NotFound errors can be
+    distinguished from generic failures.
+
+    Phase values:
+
+    - Pod phase (``"Running"``, ``"Pending"``, ``"Succeeded"``, ``"Failed"``) on success.
+    - ``"NotFound"`` when kubectl reports the pod is gone (evicted, deleted).
+    - ``"Unknown"`` on any other query failure.
+
+    Waiting reason/message describe the first container's waiting state
+    (both empty when the container is not waiting).
+    """
+    if not stdout:
+        lowered = (stderr or "").lower()
+        if "notfound" in lowered.replace(" ", "") or "not found" in lowered:
+            return "NotFound", "", ""
+        return "Unknown", "", ""
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError:
+        return "Unknown", "", ""
+    status = data.get("status") or {}
+    phase = status.get("phase") or "Unknown"
+    statuses = status.get("containerStatuses") or []
+    waiting = ((statuses[0].get("state") if statuses else {}) or {}).get("waiting") or {}
+    return phase, waiting.get("reason") or "", waiting.get("message") or ""
+
+
+def parse_server_version(stdout: str) -> str | None:
+    """Extract the ``vX.Y.Z`` server version from ``kubectl version -o json`` output.
+
+    Returns ``None`` if the JSON is malformed, ``serverVersion`` is missing, or
+    ``gitVersion`` does not match the expected pattern. Build metadata after
+    the patch number (e.g. ``v1.30.2+abc``) is stripped.
+    """
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+    git_version = ((data.get("serverVersion") or {}).get("gitVersion")) or ""
+    match = re.match(r"^(v\d+\.\d+\.\d+)", git_version)
+    return match.group(1) if match else None
 
 
 def run_kubectl(

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -58,6 +58,9 @@ from isvtest.validations.instance import (
     InstanceTagCheck,
     StableIdentifierCheck,
 )
+from isvtest.validations.k8s_conformance import (
+    K8sCncfConformanceCheck,
+)
 from isvtest.validations.network import (
     ByoipCheck,
     DhcpIpManagementCheck,
@@ -105,6 +108,7 @@ __all__ = [
     "InstanceStateCheck",
     "InstanceStopCheck",
     "InstanceTagCheck",
+    "K8sCncfConformanceCheck",
     "LocalizedDnsCheck",
     "NetworkConnectivityCheck",
     "NetworkProvisionedCheck",

--- a/isvtest/src/isvtest/validations/k8s_conformance.py
+++ b/isvtest/src/isvtest/validations/k8s_conformance.py
@@ -1,0 +1,508 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""CNCF Kubernetes conformance validation via the upstream e2e Pod.
+
+Runs the ``registry.k8s.io/conformance:<server-version>`` image directly as a
+Pod, which is functionally what Sonobuoy's e2e plugin does internally. The
+image pins ``ginkgo`` + ``e2e.test`` to a Kubernetes release, invokes them
+through ``run_e2e.sh``, and writes a JUnit report to the results directory.
+
+The image's default entrypoint exits when the suite finishes, which would let
+the Pod transition to ``Succeeded`` — after which ``kubectl exec`` can no
+longer enter the container to retrieve artifacts. To avoid that, we override
+the container command with a small shell wrapper that runs ``run_e2e.sh``,
+writes the exit code to ``/tmp/results/done``, and then ``sleep infinity`` so
+the container stays Running long enough for the harness to ``cat`` the JUnit.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import tempfile
+import time
+import uuid
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import ClassVar
+
+import yaml
+
+from isvtest.core.k8s import get_kubectl_command, is_k8s_available
+from isvtest.core.validation import BaseValidation
+
+
+@dataclass
+class _TestCase:
+    name: str
+    passed: bool
+    skipped: bool = False
+    message: str = ""
+    duration: float | None = None
+
+
+@dataclass
+class _Summary:
+    passed: int = 0
+    failed: int = 0
+    skipped: int = 0
+    cases: list[_TestCase] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return self.passed + self.failed + self.skipped
+
+
+class K8sCncfConformanceCheck(BaseValidation):
+    """Verify CNCF Kubernetes conformance by running the e2e Pod directly."""
+
+    description = "Verify CNCF Kubernetes conformance by running the registry.k8s.io/conformance Pod."
+    markers: ClassVar[list[str]] = ["kubernetes", "l2", "slow"]
+    timeout: ClassVar[int] = 120  # default for auxiliary commands
+
+    _DEFAULT_TIMEOUT = 7200
+    _DEFAULT_STARTUP_TIMEOUT = 600
+    _AUX_CMD_TIMEOUT = 60
+    _EXEC_CAT_TIMEOUT = 300
+    _POLL_INTERVAL = 10.0
+    _PROGRESS_INTERVAL = 60.0
+
+    # Resource defaults chosen to keep the pod in Burstable QoS with real
+    # ephemeral-storage accounting — a BestEffort pod is the first kubelet
+    # evicts under node pressure, which kills long conformance runs. CPU limit
+    # is intentionally omitted: CFS throttling on e2e.test causes spurious
+    # test timeouts. Memory limit is generous because ginkgo + e2e.test can
+    # spike well above steady-state during heavy SIG suites.
+    _DEFAULT_RESOURCES: ClassVar[dict[str, str]] = {
+        "cpu_request": "500m",
+        "memory_request": "1Gi",
+        "memory_limit": "4Gi",
+        "ephemeral_storage_request": "2Gi",
+        "ephemeral_storage_limit": "10Gi",
+    }
+
+    _VALID_MODES: ClassVar[set[str]] = {
+        "certified-conformance",
+        "non-disruptive-conformance",
+        "quick",
+    }
+    _MODE_PRESETS: ClassVar[dict[str, dict[str, str]]] = {
+        "certified-conformance": {
+            "focus": r"\[Conformance\]",
+            "skip": "",
+            "parallel": "false",
+        },
+        "non-disruptive-conformance": {
+            "focus": r"\[Conformance\]",
+            "skip": r"\[Disruptive\]|\[Serial\]",
+            "parallel": "false",
+        },
+        "quick": {
+            # Minimal focus for smoke-testing the harness end-to-end.
+            "focus": r"\[Conformance\]\[sig-api-machinery\].*configmap",
+            "skip": "",
+            "parallel": "false",
+        },
+    }
+
+    _RESULTS_DIR = "/tmp/results"
+    _DONE_MARKER = f"{_RESULTS_DIR}/done"
+    _JUNIT_PATH = f"{_RESULTS_DIR}/junit_01.xml"
+    _POD_NAME = "e2e-conformance"
+    _MANIFEST_TEMPLATE = Path(__file__).parent / "manifests" / "k8s" / "k8s_conformance.yaml"
+
+    # Waiting reasons that kubelet reports only after it has already given up
+    # retrying — no point burning startup_timeout on these.
+    _TERMINAL_WAITING_REASONS: ClassVar[set[str]] = {
+        "ImagePullBackOff",
+        "InvalidImageName",
+        "CreateContainerConfigError",
+        "CreateContainerError",
+        "CrashLoopBackOff",
+    }
+    # Reasons that can appear transiently on the first pull attempt before
+    # kubelet transitions to ImagePullBackOff; fail only if they persist.
+    _TRANSIENT_WAITING_REASONS: ClassVar[set[str]] = {"ErrImagePull"}
+
+    def run(self) -> None:
+        if not is_k8s_available():
+            self.set_failed("Kubernetes cluster is not available")
+            return
+
+        mode = self.config.get("mode", "certified-conformance")
+        if mode not in self._VALID_MODES:
+            self.set_failed(f"Invalid mode {mode!r} (expected one of {sorted(self._VALID_MODES)})")
+            return
+
+        version = self.config.get("kubernetes_version") or self._detect_cluster_version()
+        if not version:
+            self.set_failed("Could not detect Kubernetes server version; set kubernetes_version in config")
+            return
+
+        image = self.config.get("conformance_image") or f"registry.k8s.io/conformance:{version}"
+        namespace = self.config.get("namespace") or f"conformance-{uuid.uuid4().hex[:8]}"
+        conformance_timeout = int(self.config.get("timeout", self._DEFAULT_TIMEOUT))
+        startup_timeout = int(self.config.get("startup_timeout", self._DEFAULT_STARTUP_TIMEOUT))
+        cleanup_namespace = bool(self.config.get("cleanup_namespace", True))
+        report_individual = bool(self.config.get("report_individual_tests", True))
+
+        preset = self._MODE_PRESETS[mode]
+        env_vars = {
+            "E2E_FOCUS": self.config.get("e2e_focus", preset["focus"]),
+            "E2E_SKIP": self.config.get("e2e_skip", preset["skip"]),
+            "E2E_PARALLEL": str(self.config.get("e2e_parallel", preset["parallel"])),
+            "E2E_PROVIDER": self.config.get("e2e_provider", "skeleton"),
+            "RESULTS_DIR": self._RESULTS_DIR,
+        }
+
+        resources = {key: str(self.config.get(key, default)) for key, default in self._DEFAULT_RESOURCES.items()}
+
+        self.log.info(
+            f"Starting conformance: image={image} namespace={namespace} mode={mode} timeout={conformance_timeout}s"
+        )
+
+        manifest = self._render_manifest(
+            namespace=namespace,
+            pod_name=self._POD_NAME,
+            image=image,
+            env_vars=env_vars,
+            resources=resources,
+        )
+
+        applied = False
+        try:
+            applied = self._apply_manifest(manifest)
+            if not applied:
+                self.set_failed("Failed to apply conformance manifest to the cluster")
+                return
+
+            startup_error = self._wait_for_pod_running(namespace, self._POD_NAME, startup_timeout)
+            if startup_error is not None:
+                logs = self._get_pod_logs(namespace, self._POD_NAME)
+                self.set_failed(startup_error, output=logs[-4000:])
+                return
+
+            completion_error = self._wait_for_completion(namespace, self._POD_NAME, conformance_timeout)
+            if completion_error is not None:
+                # Logs may be empty if the pod is gone — fall back to events so
+                # the report surfaces evictions / taints.
+                output = self._get_pod_logs(namespace, self._POD_NAME)
+                if not output:
+                    output = self._get_recent_events(namespace)
+                self.set_failed(completion_error, output=output[-4000:])
+                return
+
+            junit_xml = self._exec_cat(namespace, self._POD_NAME, self._JUNIT_PATH)
+            if not junit_xml:
+                logs = self._get_pod_logs(namespace, self._POD_NAME)
+                self.set_failed(
+                    f"Could not retrieve {self._JUNIT_PATH} from conformance pod",
+                    output=logs[-4000:],
+                )
+                return
+
+            summary = self._parse_junit(junit_xml)
+
+            if report_individual:
+                for case in summary.cases:
+                    self.report_subtest(
+                        case.name,
+                        case.passed,
+                        message=case.message,
+                        skipped=case.skipped,
+                        duration=case.duration,
+                    )
+
+            msg = (
+                f"Conformance ({mode}, {version}): "
+                f"{summary.passed}/{summary.total} passed, "
+                f"{summary.failed} failed, {summary.skipped} skipped"
+            )
+            if summary.total == 0:
+                self.set_failed(f"{msg} — no testcases parsed from JUnit output")
+            elif summary.failed > 0:
+                failed_names = [c.name for c in summary.cases if not c.passed and not c.skipped][:10]
+                self.set_failed(msg, output="First failures:\n" + "\n".join(failed_names))
+            else:
+                self.set_passed(msg)
+
+        finally:
+            if applied and cleanup_namespace:
+                self._cleanup(namespace)
+
+    def _kubectl(self, *args: str) -> str:
+        parts = get_kubectl_command() + list(args)
+        return " ".join(shlex.quote(p) for p in parts)
+
+    def _detect_cluster_version(self) -> str | None:
+        cmd = self._kubectl("version", "-o", "json")
+        result = self.run_command(cmd, timeout=self._AUX_CMD_TIMEOUT)
+        if result.exit_code != 0 or not result.stdout:
+            self.log.warning(f"kubectl version failed: {result.stderr.strip()}")
+            return None
+        try:
+            data = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            self.log.warning(f"Could not parse kubectl version output: {exc}")
+            return None
+        server = data.get("serverVersion") or {}
+        git_version = server.get("gitVersion") or ""
+        match = re.match(r"^(v\d+\.\d+\.\d+)", git_version)
+        if not match:
+            self.log.warning(f"Unexpected gitVersion format: {git_version!r}")
+            return None
+        return match.group(1)
+
+    def _render_manifest(
+        self,
+        namespace: str,
+        pod_name: str,
+        image: str,
+        env_vars: dict[str, str],
+        resources: dict[str, str],
+    ) -> str:
+        docs = list(yaml.safe_load_all(self._MANIFEST_TEMPLATE.read_text()))
+        by_kind = {d["kind"]: d for d in docs}
+
+        by_kind["Namespace"]["metadata"]["name"] = namespace
+        by_kind["ServiceAccount"]["metadata"]["namespace"] = namespace
+
+        crb = by_kind["ClusterRoleBinding"]
+        crb["metadata"]["name"] = f"conformance-{namespace}"
+        crb["subjects"][0]["namespace"] = namespace
+
+        pod = by_kind["Pod"]
+        pod["metadata"]["name"] = pod_name
+        pod["metadata"]["namespace"] = namespace
+
+        container = pod["spec"]["containers"][0]
+        container["image"] = image
+        container["env"] = [{"name": k, "value": str(v)} for k, v in env_vars.items()]
+        container["resources"] = {
+            "requests": {
+                "cpu": resources["cpu_request"],
+                "memory": resources["memory_request"],
+                "ephemeral-storage": resources["ephemeral_storage_request"],
+            },
+            "limits": {
+                "memory": resources["memory_limit"],
+                "ephemeral-storage": resources["ephemeral_storage_limit"],
+            },
+        }
+
+        return yaml.safe_dump_all(docs, sort_keys=False)
+
+    def _apply_manifest(self, manifest: str) -> bool:
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as fh:
+            fh.write(manifest)
+            path = fh.name
+        try:
+            cmd = self._kubectl("apply", "-f", path)
+            result = self.run_command(cmd, timeout=self._AUX_CMD_TIMEOUT)
+            if result.exit_code != 0:
+                self.log.error(f"kubectl apply failed: {result.stderr.strip()}")
+                return False
+            self.log.info(f"Applied conformance manifest: {result.stdout.strip()}")
+            return True
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def _wait_for_pod_running(self, namespace: str, pod_name: str, timeout: int) -> str | None:
+        """Poll until the pod is Running. Return None on success, or a failure
+        message explaining why startup is doomed (image pull errors, Failed
+        phase, deletion, or timeout) — the caller surfaces it via set_failed."""
+        deadline = time.time() + timeout
+        last_progress = 0.0
+        prev_transient_reason = ""
+        while time.time() < deadline:
+            phase = self._get_pod_phase(namespace, pod_name)
+            if phase == "Running":
+                return None
+            if phase == "Succeeded":
+                # Container finished before we observed Running (very short runtime).
+                return None
+            if phase == "Failed":
+                self.log.error(f"Pod {pod_name} entered Failed phase during startup")
+                return f"Conformance pod {pod_name} entered Failed phase during startup"
+            if phase == "NotFound":
+                self.log.error(f"Pod {pod_name} disappeared during startup")
+                return f"Conformance pod {pod_name} was deleted during startup (likely evicted)"
+
+            reason, message = self._get_container_waiting(namespace, pod_name)
+            if reason in self._TERMINAL_WAITING_REASONS:
+                detail = f"{reason}: {message}" if message else reason
+                self.log.error(f"Pod {pod_name} container stuck in {detail}")
+                return f"Conformance pod {pod_name} cannot start ({detail})"
+            if reason in self._TRANSIENT_WAITING_REASONS:
+                if prev_transient_reason == reason:
+                    detail = f"{reason}: {message}" if message else reason
+                    self.log.error(f"Pod {pod_name} container persistently {detail}")
+                    return f"Conformance pod {pod_name} cannot start ({detail})"
+                prev_transient_reason = reason
+            else:
+                prev_transient_reason = ""
+
+            now = time.time()
+            if now - last_progress >= self._PROGRESS_INTERVAL:
+                self.log.info(f"Waiting for pod {pod_name} to start (phase={phase})")
+                last_progress = now
+            time.sleep(self._POLL_INTERVAL)
+        return f"Conformance pod did not reach Running state within {timeout}s"
+
+    def _wait_for_completion(self, namespace: str, pod_name: str, timeout: int) -> str | None:
+        """Poll until the done marker appears. Return None on success, or a
+        failure message (Failed phase, pod deleted, or timeout)."""
+        start = time.time()
+        deadline = start + timeout
+        last_progress = start
+        while time.time() < deadline:
+            phase = self._get_pod_phase(namespace, pod_name)
+            if phase == "Failed":
+                self.log.error(f"Pod {pod_name} entered Failed phase before completion marker")
+                return f"Conformance pod {pod_name} entered Failed phase before completion marker appeared"
+            if phase == "NotFound":
+                self.log.error(f"Pod {pod_name} disappeared before completion marker")
+                return f"Conformance pod {pod_name} was deleted before completion marker appeared (likely evicted)"
+
+            if self._done_marker_exists(namespace, pod_name):
+                self.log.info(f"Conformance completed (elapsed={int(time.time() - start)}s)")
+                return None
+
+            now = time.time()
+            if now - last_progress >= self._PROGRESS_INTERVAL:
+                elapsed = int(now - start)
+                remaining = int(deadline - now)
+                self.log.info(f"Conformance still running (elapsed={elapsed}s, remaining<={remaining}s, phase={phase})")
+                last_progress = now
+            time.sleep(self._POLL_INTERVAL)
+        return f"Conformance run did not finish within {timeout}s"
+
+    def _get_pod_phase(self, namespace: str, pod_name: str) -> str:
+        """Return the pod phase, or ``"NotFound"`` if kubectl reports the pod is
+        gone (evicted, deleted), or ``"Unknown"`` for any other query failure."""
+        cmd = self._kubectl("get", "pod", pod_name, "-n", namespace, "-o", "jsonpath={.status.phase}")
+        result = self.run_command(cmd, timeout=self._AUX_CMD_TIMEOUT)
+        if result.exit_code != 0:
+            stderr = (result.stderr or "").lower()
+            if "notfound" in stderr.replace(" ", "") or "not found" in stderr:
+                return "NotFound"
+            return "Unknown"
+        return result.stdout.strip() or "Unknown"
+
+    def _get_container_waiting(self, namespace: str, pod_name: str) -> tuple[str, str]:
+        """Return (reason, message) for the conformance container's waiting state.
+
+        Returns ("", "") when the container is not waiting or the query fails.
+        Reason and message are split on ``|`` — a delimiter kubelet won't emit
+        inside either field, so a single kubectl call covers both.
+        """
+        cmd = self._kubectl(
+            "get",
+            "pod",
+            pod_name,
+            "-n",
+            namespace,
+            "-o",
+            "jsonpath={.status.containerStatuses[0].state.waiting.reason}|{.status.containerStatuses[0].state.waiting.message}",
+        )
+        result = self.run_command(cmd, timeout=self._AUX_CMD_TIMEOUT)
+        if result.exit_code != 0:
+            return "", ""
+        reason, _, message = result.stdout.strip().partition("|")
+        return reason, message
+
+    def _done_marker_exists(self, namespace: str, pod_name: str) -> bool:
+        cmd = self._kubectl("exec", "-n", namespace, pod_name, "--", "test", "-f", self._DONE_MARKER)
+        result = self.run_command(cmd, timeout=self._AUX_CMD_TIMEOUT)
+        return result.exit_code == 0
+
+    def _exec_cat(self, namespace: str, pod_name: str, path: str) -> str:
+        cmd = self._kubectl("exec", "-n", namespace, pod_name, "--", "cat", path)
+        result = self.run_command(cmd, timeout=self._EXEC_CAT_TIMEOUT)
+        if result.exit_code != 0:
+            self.log.warning(f"kubectl exec cat {path} failed: {result.stderr.strip()}")
+            return ""
+        return result.stdout
+
+    def _get_pod_logs(self, namespace: str, pod_name: str) -> str:
+        cmd = self._kubectl("logs", "-n", namespace, pod_name, "--tail=200")
+        result = self.run_command(cmd, timeout=self._AUX_CMD_TIMEOUT)
+        if result.exit_code != 0:
+            return ""
+        return result.stdout
+
+    def _get_recent_events(self, namespace: str) -> str:
+        cmd = self._kubectl("get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
+        result = self.run_command(cmd, timeout=self._AUX_CMD_TIMEOUT)
+        if result.exit_code != 0:
+            return ""
+        return result.stdout
+
+    def _cleanup(self, namespace: str) -> None:
+        ns_cmd = self._kubectl("delete", "namespace", namespace, "--ignore-not-found=true", "--wait=false")
+        ns_result = self.run_command(ns_cmd, timeout=self._AUX_CMD_TIMEOUT)
+        if ns_result.exit_code != 0:
+            self.log.warning(f"Failed to delete namespace {namespace}: {ns_result.stderr.strip()}")
+
+        # ClusterRoleBinding is cluster-scoped and outlives the namespace deletion.
+        crb_cmd = self._kubectl("delete", "clusterrolebinding", f"conformance-{namespace}", "--ignore-not-found=true")
+        crb_result = self.run_command(crb_cmd, timeout=self._AUX_CMD_TIMEOUT)
+        if crb_result.exit_code != 0:
+            self.log.warning(f"Failed to delete clusterrolebinding: {crb_result.stderr.strip()}")
+
+    def _parse_junit(self, xml_str: str) -> _Summary:
+        summary = _Summary()
+        try:
+            root = ET.fromstring(xml_str)
+        except ET.ParseError as exc:
+            self.log.error(f"Failed to parse JUnit XML: {exc}")
+            return summary
+
+        suites = [root] if root.tag == "testsuite" else list(root.iter("testsuite"))
+
+        for suite in suites:
+            for case in suite.iter("testcase"):
+                name = (case.get("name") or "").strip() or "(unnamed)"
+                duration = _parse_duration(case.get("time"))
+
+                failure = case.find("failure")
+                error = case.find("error")
+                skipped = case.find("skipped")
+
+                if skipped is not None:
+                    summary.skipped += 1
+                    msg = (skipped.get("message") or skipped.text or "").strip()
+                    summary.cases.append(
+                        _TestCase(name=name, passed=False, skipped=True, message=msg, duration=duration)
+                    )
+                elif failure is not None or error is not None:
+                    summary.failed += 1
+                    node = failure if failure is not None else error
+                    msg = (node.get("message") or node.text or "").strip() if node is not None else ""
+                    summary.cases.append(
+                        _TestCase(name=name, passed=False, skipped=False, message=msg, duration=duration)
+                    )
+                else:
+                    summary.passed += 1
+                    summary.cases.append(_TestCase(name=name, passed=True, skipped=False, duration=duration))
+
+        return summary
+
+
+def _parse_duration(value: str | None) -> float | None:
+    if not value:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None

--- a/isvtest/src/isvtest/validations/k8s_conformance.py
+++ b/isvtest/src/isvtest/validations/k8s_conformance.py
@@ -25,9 +25,6 @@ the container stays Running long enough for the harness to ``cat`` the JUnit.
 
 from __future__ import annotations
 
-import json
-import re
-import shlex
 import tempfile
 import time
 import uuid
@@ -38,7 +35,14 @@ from typing import ClassVar
 
 import yaml
 
-from isvtest.core.k8s import get_kubectl_command, is_k8s_available
+from isvtest.core.k8s import (
+    TERMINAL_WAITING_REASONS,
+    TRANSIENT_WAITING_REASONS,
+    get_kubectl_base_shell,
+    is_k8s_available,
+    parse_pod_state,
+    parse_server_version,
+)
 from isvtest.core.validation import BaseValidation
 
 
@@ -121,19 +125,6 @@ class K8sCncfConformanceCheck(BaseValidation):
     _POD_NAME = "e2e-conformance"
     _MANIFEST_TEMPLATE = Path(__file__).parent / "manifests" / "k8s" / "k8s_conformance.yaml"
 
-    # Waiting reasons that kubelet reports only after it has already given up
-    # retrying — no point burning startup_timeout on these.
-    _TERMINAL_WAITING_REASONS: ClassVar[set[str]] = {
-        "ImagePullBackOff",
-        "InvalidImageName",
-        "CreateContainerConfigError",
-        "CreateContainerError",
-        "CrashLoopBackOff",
-    }
-    # Reasons that can appear transiently on the first pull attempt before
-    # kubelet transitions to ImagePullBackOff; fail only if they persist.
-    _TRANSIENT_WAITING_REASONS: ClassVar[set[str]] = {"ErrImagePull"}
-
     def run(self) -> None:
         if not is_k8s_available():
             self.set_failed("Kubernetes cluster is not available")
@@ -202,8 +193,8 @@ class K8sCncfConformanceCheck(BaseValidation):
                 self.set_failed(completion_error, output=output[-4000:])
                 return
 
-            junit_xml = self._exec_cat(namespace, self._POD_NAME, self._JUNIT_PATH)
-            if not junit_xml:
+            ok, junit_xml = self._exec_cat(namespace, self._POD_NAME, self._JUNIT_PATH)
+            if not ok or not junit_xml:
                 logs = self._get_pod_logs(namespace, self._POD_NAME)
                 self.set_failed(
                     f"Could not retrieve {self._JUNIT_PATH} from conformance pod",
@@ -240,28 +231,16 @@ class K8sCncfConformanceCheck(BaseValidation):
             if applied and cleanup_namespace:
                 self._cleanup(namespace)
 
-    def _kubectl(self, *args: str) -> str:
-        parts = get_kubectl_command() + list(args)
-        return " ".join(shlex.quote(p) for p in parts)
-
     def _detect_cluster_version(self) -> str | None:
-        cmd = self._kubectl("version", "-o", "json")
+        cmd = get_kubectl_base_shell("version", "-o", "json")
         result = self.run_command(cmd, timeout=self._AUX_CMD_TIMEOUT)
         if result.exit_code != 0 or not result.stdout:
             self.log.warning(f"kubectl version failed: {result.stderr.strip()}")
             return None
-        try:
-            data = json.loads(result.stdout)
-        except json.JSONDecodeError as exc:
-            self.log.warning(f"Could not parse kubectl version output: {exc}")
-            return None
-        server = data.get("serverVersion") or {}
-        git_version = server.get("gitVersion") or ""
-        match = re.match(r"^(v\d+\.\d+\.\d+)", git_version)
-        if not match:
-            self.log.warning(f"Unexpected gitVersion format: {git_version!r}")
-            return None
-        return match.group(1)
+        version = parse_server_version(result.stdout)
+        if version is None:
+            self.log.warning(f"Could not parse server version from kubectl output: {result.stdout!r}")
+        return version
 
     def _render_manifest(
         self,
@@ -307,7 +286,7 @@ class K8sCncfConformanceCheck(BaseValidation):
             fh.write(manifest)
             path = fh.name
         try:
-            cmd = self._kubectl("apply", "-f", path)
+            cmd = get_kubectl_base_shell("apply", "-f", path)
             result = self.run_command(cmd, timeout=self._AUX_CMD_TIMEOUT)
             if result.exit_code != 0:
                 self.log.error(f"kubectl apply failed: {result.stderr.strip()}")
@@ -322,10 +301,10 @@ class K8sCncfConformanceCheck(BaseValidation):
         message explaining why startup is doomed (image pull errors, Failed
         phase, deletion, or timeout) — the caller surfaces it via set_failed."""
         deadline = time.time() + timeout
-        last_progress = 0.0
+        last_progress = time.time()
         prev_transient_reason = ""
         while time.time() < deadline:
-            phase = self._get_pod_phase(namespace, pod_name)
+            phase, reason, message = self._get_pod_state(namespace, pod_name)
             if phase == "Running":
                 return None
             if phase == "Succeeded":
@@ -338,12 +317,11 @@ class K8sCncfConformanceCheck(BaseValidation):
                 self.log.error(f"Pod {pod_name} disappeared during startup")
                 return f"Conformance pod {pod_name} was deleted during startup (likely evicted)"
 
-            reason, message = self._get_container_waiting(namespace, pod_name)
-            if reason in self._TERMINAL_WAITING_REASONS:
+            if reason in TERMINAL_WAITING_REASONS:
                 detail = f"{reason}: {message}" if message else reason
                 self.log.error(f"Pod {pod_name} container stuck in {detail}")
                 return f"Conformance pod {pod_name} cannot start ({detail})"
-            if reason in self._TRANSIENT_WAITING_REASONS:
+            if reason in TRANSIENT_WAITING_REASONS:
                 if prev_transient_reason == reason:
                     detail = f"{reason}: {message}" if message else reason
                     self.log.error(f"Pod {pod_name} container persistently {detail}")
@@ -366,7 +344,7 @@ class K8sCncfConformanceCheck(BaseValidation):
         deadline = start + timeout
         last_progress = start
         while time.time() < deadline:
-            phase = self._get_pod_phase(namespace, pod_name)
+            phase, _, _ = self._get_pod_state(namespace, pod_name)
             if phase == "Failed":
                 self.log.error(f"Pod {pod_name} entered Failed phase before completion marker")
                 return f"Conformance pod {pod_name} entered Failed phase before completion marker appeared"
@@ -374,7 +352,8 @@ class K8sCncfConformanceCheck(BaseValidation):
                 self.log.error(f"Pod {pod_name} disappeared before completion marker")
                 return f"Conformance pod {pod_name} was deleted before completion marker appeared (likely evicted)"
 
-            if self._done_marker_exists(namespace, pod_name):
+            done, _ = self._exec_cat(namespace, pod_name, self._DONE_MARKER, timeout=self._AUX_CMD_TIMEOUT, quiet=True)
+            if done:
                 self.log.info(f"Conformance completed (elapsed={int(time.time() - start)}s)")
                 return None
 
@@ -387,75 +366,63 @@ class K8sCncfConformanceCheck(BaseValidation):
             time.sleep(self._POLL_INTERVAL)
         return f"Conformance run did not finish within {timeout}s"
 
-    def _get_pod_phase(self, namespace: str, pod_name: str) -> str:
-        """Return the pod phase, or ``"NotFound"`` if kubectl reports the pod is
-        gone (evicted, deleted), or ``"Unknown"`` for any other query failure."""
-        cmd = self._kubectl("get", "pod", pod_name, "-n", namespace, "-o", "jsonpath={.status.phase}")
+    def _get_pod_state(self, namespace: str, pod_name: str) -> tuple[str, str, str]:
+        """Fetch ``(phase, waiting_reason, waiting_message)`` in one kubectl call."""
+        cmd = get_kubectl_base_shell("get", "pod", pod_name, "-n", namespace, "-o", "json")
         result = self.run_command(cmd, timeout=self._AUX_CMD_TIMEOUT)
         if result.exit_code != 0:
-            stderr = (result.stderr or "").lower()
-            if "notfound" in stderr.replace(" ", "") or "not found" in stderr:
-                return "NotFound"
-            return "Unknown"
-        return result.stdout.strip() or "Unknown"
+            return parse_pod_state("", result.stderr or "")
+        return parse_pod_state(result.stdout, "")
 
-    def _get_container_waiting(self, namespace: str, pod_name: str) -> tuple[str, str]:
-        """Return (reason, message) for the conformance container's waiting state.
+    def _exec_cat(
+        self,
+        namespace: str,
+        pod_name: str,
+        path: str,
+        timeout: int | None = None,
+        quiet: bool = False,
+    ) -> tuple[bool, str]:
+        """Cat ``path`` inside the pod. Returns ``(ok, content)``.
 
-        Returns ("", "") when the container is not waiting or the query fails.
-        Reason and message are split on ``|`` — a delimiter kubelet won't emit
-        inside either field, so a single kubectl call covers both.
+        ``quiet=True`` suppresses the warning log on failure — used for
+        existence-polling where failure is the expected steady state until the
+        file appears.
         """
-        cmd = self._kubectl(
-            "get",
-            "pod",
-            pod_name,
-            "-n",
-            namespace,
-            "-o",
-            "jsonpath={.status.containerStatuses[0].state.waiting.reason}|{.status.containerStatuses[0].state.waiting.message}",
-        )
-        result = self.run_command(cmd, timeout=self._AUX_CMD_TIMEOUT)
+        cmd = get_kubectl_base_shell("exec", "-n", namespace, pod_name, "--", "cat", path)
+        result = self.run_command(cmd, timeout=timeout if timeout is not None else self._EXEC_CAT_TIMEOUT)
         if result.exit_code != 0:
-            return "", ""
-        reason, _, message = result.stdout.strip().partition("|")
-        return reason, message
-
-    def _done_marker_exists(self, namespace: str, pod_name: str) -> bool:
-        cmd = self._kubectl("exec", "-n", namespace, pod_name, "--", "test", "-f", self._DONE_MARKER)
-        result = self.run_command(cmd, timeout=self._AUX_CMD_TIMEOUT)
-        return result.exit_code == 0
-
-    def _exec_cat(self, namespace: str, pod_name: str, path: str) -> str:
-        cmd = self._kubectl("exec", "-n", namespace, pod_name, "--", "cat", path)
-        result = self.run_command(cmd, timeout=self._EXEC_CAT_TIMEOUT)
-        if result.exit_code != 0:
-            self.log.warning(f"kubectl exec cat {path} failed: {result.stderr.strip()}")
-            return ""
-        return result.stdout
+            if not quiet:
+                self.log.warning(f"kubectl exec cat {path} failed: {result.stderr.strip()}")
+            return False, ""
+        return True, result.stdout
 
     def _get_pod_logs(self, namespace: str, pod_name: str) -> str:
-        cmd = self._kubectl("logs", "-n", namespace, pod_name, "--tail=200")
+        """Return the last 200 lines of pod logs, or ``""`` on failure."""
+        cmd = get_kubectl_base_shell("logs", "-n", namespace, pod_name, "--tail=200")
         result = self.run_command(cmd, timeout=self._AUX_CMD_TIMEOUT)
         if result.exit_code != 0:
             return ""
         return result.stdout
 
     def _get_recent_events(self, namespace: str) -> str:
-        cmd = self._kubectl("get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
+        """Return namespace events sorted by ``lastTimestamp``, or ``""`` on failure."""
+        cmd = get_kubectl_base_shell("get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
         result = self.run_command(cmd, timeout=self._AUX_CMD_TIMEOUT)
         if result.exit_code != 0:
             return ""
         return result.stdout
 
     def _cleanup(self, namespace: str) -> None:
-        ns_cmd = self._kubectl("delete", "namespace", namespace, "--ignore-not-found=true", "--wait=false")
+        """Delete the run's namespace and its cluster-scoped ClusterRoleBinding; failures are logged, not raised."""
+        ns_cmd = get_kubectl_base_shell("delete", "namespace", namespace, "--ignore-not-found=true", "--wait=false")
         ns_result = self.run_command(ns_cmd, timeout=self._AUX_CMD_TIMEOUT)
         if ns_result.exit_code != 0:
             self.log.warning(f"Failed to delete namespace {namespace}: {ns_result.stderr.strip()}")
 
         # ClusterRoleBinding is cluster-scoped and outlives the namespace deletion.
-        crb_cmd = self._kubectl("delete", "clusterrolebinding", f"conformance-{namespace}", "--ignore-not-found=true")
+        crb_cmd = get_kubectl_base_shell(
+            "delete", "clusterrolebinding", f"conformance-{namespace}", "--ignore-not-found=true"
+        )
         crb_result = self.run_command(crb_cmd, timeout=self._AUX_CMD_TIMEOUT)
         if crb_result.exit_code != 0:
             self.log.warning(f"Failed to delete clusterrolebinding: {crb_result.stderr.strip()}")

--- a/isvtest/src/isvtest/validations/manifests/k8s/k8s_conformance.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/k8s_conformance.yaml
@@ -76,21 +76,6 @@ spec:
           echo "$ec" > /tmp/results/done
           echo "run_e2e.sh exited with $ec; sleeping to allow artifact retrieval"
           exec sleep infinity
-      env: []
-      # Defaults chosen to keep the pod in Burstable QoS with real
-      # ephemeral-storage accounting — a BestEffort pod is the first kubelet
-      # evicts under node pressure, which kills long conformance runs. CPU
-      # limit is intentionally omitted: CFS throttling on e2e.test causes
-      # spurious test timeouts. Memory limit is generous because ginkgo +
-      # e2e.test can spike well above steady-state during heavy SIG suites.
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "1Gi"
-          ephemeral-storage: "2Gi"
-        limits:
-          memory: "4Gi"
-          ephemeral-storage: "10Gi"
       volumeMounts:
         - name: results
           mountPath: /tmp/results

--- a/isvtest/src/isvtest/validations/manifests/k8s/k8s_conformance.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/k8s_conformance.yaml
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: PLACEHOLDER_NAMESPACE
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: conformance
+  namespace: PLACEHOLDER_NAMESPACE
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: PLACEHOLDER_CRB_NAME
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: conformance
+    namespace: PLACEHOLDER_NAMESPACE
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: PLACEHOLDER_POD_NAME
+  namespace: PLACEHOLDER_NAMESPACE
+  labels:
+    app: cncf-conformance
+spec:
+  serviceAccountName: conformance
+  restartPolicy: Never
+  nodeSelector:
+    kubernetes.io/os: linux
+  # Tolerate control-plane taints (legacy `master` + post-1.24 `control-plane`),
+  # CriticalAddonsOnly, and the taint the k8s e2e suite itself applies during
+  # eviction tests — without the last one the conformance pod can be evicted
+  # by the suite it is running.
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+    - key: CriticalAddonsOnly
+      operator: Exists
+    - key: kubernetes.io/e2e-evict-taint-key
+      operator: Exists
+  containers:
+    - name: conformance
+      image: PLACEHOLDER_IMAGE
+      imagePullPolicy: IfNotPresent
+      # The image entrypoint exits when the suite finishes, which would let the
+      # Pod transition to Succeeded — after which kubectl exec can no longer
+      # enter the container to retrieve artifacts. Wrap run_e2e.sh so we record
+      # the exit code and keep the container Running for artifact retrieval.
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          set +e
+          /run_e2e.sh
+          ec=$?
+          echo "$ec" > /tmp/results/done
+          echo "run_e2e.sh exited with $ec; sleeping to allow artifact retrieval"
+          exec sleep infinity
+      env: []
+      # Defaults chosen to keep the pod in Burstable QoS with real
+      # ephemeral-storage accounting — a BestEffort pod is the first kubelet
+      # evicts under node pressure, which kills long conformance runs. CPU
+      # limit is intentionally omitted: CFS throttling on e2e.test causes
+      # spurious test timeouts. Memory limit is generous because ginkgo +
+      # e2e.test can spike well above steady-state during heavy SIG suites.
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "1Gi"
+          ephemeral-storage: "2Gi"
+        limits:
+          memory: "4Gi"
+          ephemeral-storage: "10Gi"
+      volumeMounts:
+        - name: results
+          mountPath: /tmp/results
+  volumes:
+    - name: results
+      emptyDir: {}

--- a/isvtest/tests/test_k8s.py
+++ b/isvtest/tests/test_k8s.py
@@ -10,12 +10,21 @@
 
 """Tests for Kubernetes utility functions (KUBECTL override)."""
 
+import json
 import os
 from unittest.mock import patch
 
 import pytest
 
-from isvtest.core.k8s import get_k8s_provider, get_kubectl_base_shell, get_kubectl_command
+from isvtest.core.k8s import (
+    TERMINAL_WAITING_REASONS,
+    TRANSIENT_WAITING_REASONS,
+    get_k8s_provider,
+    get_kubectl_base_shell,
+    get_kubectl_command,
+    parse_pod_state,
+    parse_server_version,
+)
 
 
 class TestGetKubectlCommandOverride:
@@ -117,3 +126,90 @@ class TestGetKubectlCommandOverride:
         ):
             with pytest.raises(FileNotFoundError, match="not found on PATH"):
                 get_kubectl_command()
+
+
+class TestGetKubectlBaseShellArgs:
+    """Tests for get_kubectl_base_shell() args composition."""
+
+    def test_composes_args_with_quoting(self) -> None:
+        with (
+            patch.dict(os.environ, {"KUBECTL": "kubectl"}, clear=True),
+            patch("isvtest.core.k8s.shutil.which", return_value="/usr/bin/kubectl"),
+        ):
+            result = get_kubectl_base_shell("get", "pod", "my-pod", "-n", "default")
+        assert result == "kubectl get pod my-pod -n default"
+
+    def test_quotes_arg_with_spaces(self) -> None:
+        with (
+            patch.dict(os.environ, {"KUBECTL": "kubectl"}, clear=True),
+            patch("isvtest.core.k8s.shutil.which", return_value="/usr/bin/kubectl"),
+        ):
+            result = get_kubectl_base_shell("label", "node", "n1", "app=foo bar")
+        # The value with a space must be quoted so the shell sees it as one token.
+        assert "'app=foo bar'" in result
+
+
+class TestParsePodState:
+    def test_running_pod(self) -> None:
+        payload = json.dumps({"status": {"phase": "Running"}})
+        assert parse_pod_state(payload, "") == ("Running", "", "")
+
+    def test_pending_with_waiting_reason(self) -> None:
+        payload = json.dumps(
+            {
+                "status": {
+                    "phase": "Pending",
+                    "containerStatuses": [
+                        {"state": {"waiting": {"reason": "ImagePullBackOff", "message": "back-off"}}}
+                    ],
+                }
+            }
+        )
+        phase, reason, msg = parse_pod_state(payload, "")
+        assert phase == "Pending"
+        assert reason == "ImagePullBackOff"
+        assert msg == "back-off"
+
+    def test_notfound_from_stderr(self) -> None:
+        stderr = 'Error from server (NotFound): pods "my-pod" not found'
+        assert parse_pod_state("", stderr) == ("NotFound", "", "")
+
+    def test_unknown_on_generic_failure(self) -> None:
+        assert parse_pod_state("", "connection refused") == ("Unknown", "", "")
+
+    def test_unknown_on_malformed_json(self) -> None:
+        assert parse_pod_state("not json", "") == ("Unknown", "", "")
+
+    def test_missing_container_statuses(self) -> None:
+        payload = json.dumps({"status": {"phase": "Pending"}})
+        assert parse_pod_state(payload, "") == ("Pending", "", "")
+
+
+class TestParseServerVersion:
+    def test_strips_build_metadata(self) -> None:
+        assert parse_server_version(json.dumps({"serverVersion": {"gitVersion": "v1.30.2+abc"}})) == "v1.30.2"
+
+    def test_plain_git_version(self) -> None:
+        assert parse_server_version(json.dumps({"serverVersion": {"gitVersion": "v1.31.3"}})) == "v1.31.3"
+
+    def test_missing_server_version(self) -> None:
+        assert parse_server_version(json.dumps({})) is None
+
+    def test_malformed_json(self) -> None:
+        assert parse_server_version("not json") is None
+
+    def test_unexpected_format(self) -> None:
+        assert parse_server_version(json.dumps({"serverVersion": {"gitVersion": "1.x.y"}})) is None
+
+
+class TestWaitingReasonConstants:
+    def test_terminal_reasons_are_frozen(self) -> None:
+        assert "ImagePullBackOff" in TERMINAL_WAITING_REASONS
+        assert isinstance(TERMINAL_WAITING_REASONS, frozenset)
+
+    def test_transient_reasons_are_frozen(self) -> None:
+        assert "ErrImagePull" in TRANSIENT_WAITING_REASONS
+        assert isinstance(TRANSIENT_WAITING_REASONS, frozenset)
+
+    def test_terminal_and_transient_are_disjoint(self) -> None:
+        assert TERMINAL_WAITING_REASONS.isdisjoint(TRANSIENT_WAITING_REASONS)

--- a/isvtest/tests/test_k8s_conformance.py
+++ b/isvtest/tests/test_k8s_conformance.py
@@ -35,6 +35,23 @@ _DEFAULT_ENV_VARS = {
 
 VERSION_JSON = json.dumps({"serverVersion": {"gitVersion": "v1.31.3"}})
 
+
+def pod_state_json(phase: str, reason: str = "", message: str = "") -> str:
+    """Build the JSON payload returned by `kubectl get pod -o json` for tests."""
+    state: dict = {}
+    if reason or message:
+        waiting: dict = {}
+        if reason:
+            waiting["reason"] = reason
+        if message:
+            waiting["message"] = message
+        state["waiting"] = waiting
+    payload: dict = {"status": {"phase": phase}}
+    if state:
+        payload["status"]["containerStatuses"] = [{"state": state}]
+    return json.dumps(payload)
+
+
 PASSING_JUNIT = """<?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="Kubernetes e2e suite" tests="3" failures="0" skipped="1" time="120.5">
   <testcase name="[sig-api-machinery] ConfigMap create" classname="k8s.io/e2e" time="1.2"/>
@@ -133,7 +150,7 @@ def _virtual_clock() -> Iterator[_VirtualClock]:
 @pytest.fixture(autouse=True)
 def _kubectl_stub() -> Iterator[None]:
     with patch(
-        "isvtest.validations.k8s_conformance.get_kubectl_command",
+        "isvtest.core.k8s.get_kubectl_command",
         return_value=["kubectl"],
     ):
         yield
@@ -160,10 +177,9 @@ def _happy_router(
         router.add(substring, result)
     router.add("version -o json", ok(VERSION_JSON))
     router.add("apply", ok("pod/e2e-conformance created"))
-    router.add("containerStatuses", ok("|"))
-    router.add("jsonpath={.status.phase}", ok("Running"))
-    router.add("test -f", ok())
-    router.add("cat /tmp/results", ok(PASSING_JUNIT))
+    router.add("get pod", ok(pod_state_json("Running")))
+    router.add("cat /tmp/results/done", ok("0"))
+    router.add("cat /tmp/results/junit", ok(PASSING_JUNIT))
     router.add("delete namespace", ok())
     router.add("delete clusterrolebinding", ok())
     router.add("logs", ok("log tail"))
@@ -281,7 +297,7 @@ class TestRun:
         assert not any("delete " in cmd for cmd in router.seen)
 
     def test_pod_stuck_pending_times_out(self) -> None:
-        router = _happy_router({"jsonpath={.status.phase}": ok("Pending")})
+        router = _happy_router({"get pod": ok(pod_state_json("Pending"))})
         check = _run_check(router, {"startup_timeout": 30})
 
         assert not check.passed
@@ -293,10 +309,13 @@ class TestRun:
         """ImagePullBackOff is terminal — fail without burning startup_timeout."""
         router = _happy_router(
             {
-                "containerStatuses": ok(
-                    "ImagePullBackOff|Back-off pulling image 'registry.k8s.io/conformance:v1.31.3'"
+                "get pod": ok(
+                    pod_state_json(
+                        "Pending",
+                        reason="ImagePullBackOff",
+                        message="Back-off pulling image 'registry.k8s.io/conformance:v1.31.3'",
+                    )
                 ),
-                "jsonpath={.status.phase}": ok("Pending"),
             }
         )
         check = _run_check(router, {"startup_timeout": 600})
@@ -305,14 +324,19 @@ class TestRun:
         assert "ImagePullBackOff" in check.message
         assert "Back-off pulling image" in check.message
         # Should not have waited for the full startup timeout.
-        phase_polls = [cmd for cmd in router.seen if "jsonpath={.status.phase}" in cmd]
+        phase_polls = [cmd for cmd in router.seen if "get pod" in cmd]
         assert len(phase_polls) <= 2, f"Expected fast-fail, but polled phase {len(phase_polls)} times"
 
     def test_invalid_image_name_fails_fast(self) -> None:
         router = _happy_router(
             {
-                "containerStatuses": ok("InvalidImageName|couldn't parse image reference"),
-                "jsonpath={.status.phase}": ok("Pending"),
+                "get pod": ok(
+                    pod_state_json(
+                        "Pending",
+                        reason="InvalidImageName",
+                        message="couldn't parse image reference",
+                    )
+                ),
             }
         )
         check = _run_check(router)
@@ -324,10 +348,11 @@ class TestRun:
         """A single ErrImagePull poll shouldn't fail — kubelet may succeed next attempt."""
         router = _happy_router(
             {
-                # First poll: transient ErrImagePull. Subsequent polls: cleared.
-                "containerStatuses": [ok("ErrImagePull|network blip"), ok("|")],
-                # Phase: Pending during the blip, Running after.
-                "jsonpath={.status.phase}": [ok("Pending"), ok("Running")],
+                # First poll: Pending with transient ErrImagePull. Second poll: Running.
+                "get pod": [
+                    ok(pod_state_json("Pending", reason="ErrImagePull", message="network blip")),
+                    ok(pod_state_json("Running")),
+                ],
             }
         )
         check = _run_check(router)
@@ -338,27 +363,26 @@ class TestRun:
         """ErrImagePull across two consecutive polls should fail without waiting for timeout."""
         router = _happy_router(
             {
-                "containerStatuses": ok("ErrImagePull|manifest unknown"),
-                "jsonpath={.status.phase}": ok("Pending"),
+                "get pod": ok(pod_state_json("Pending", reason="ErrImagePull", message="manifest unknown")),
             }
         )
         check = _run_check(router, {"startup_timeout": 600})
 
         assert not check.passed
         assert "ErrImagePull" in check.message
-        phase_polls = [cmd for cmd in router.seen if "jsonpath={.status.phase}" in cmd]
+        phase_polls = [cmd for cmd in router.seen if "get pod" in cmd]
         # Requires at least 2 polls to confirm persistence, but far fewer than timeout/poll_interval.
         assert 2 <= len(phase_polls) <= 3
 
     def test_pod_failed_during_startup(self) -> None:
-        router = _happy_router({"jsonpath={.status.phase}": ok("Failed")})
+        router = _happy_router({"get pod": ok(pod_state_json("Failed"))})
         check = _run_check(router)
 
         assert not check.passed
         assert "entered Failed phase during startup" in check.message
 
     def test_completion_timeout(self) -> None:
-        router = _happy_router({"test -f": fail()})  # done marker never appears
+        router = _happy_router({"cat /tmp/results/done": fail()})  # done marker never appears
         check = _run_check(router, {"timeout": 90})
 
         assert not check.passed
@@ -367,8 +391,8 @@ class TestRun:
     def test_pod_failed_during_completion(self) -> None:
         router = _happy_router(
             {
-                "jsonpath={.status.phase}": [ok("Running"), ok("Failed")],
-                "test -f": fail(),
+                "get pod": [ok(pod_state_json("Running")), ok(pod_state_json("Failed"))],
+                "cat /tmp/results/done": fail(),
             }
         )
         check = _run_check(router)
@@ -383,11 +407,11 @@ class TestRun:
         which was previously mapped to "Unknown" and silently retried."""
         router = _happy_router(
             {
-                "jsonpath={.status.phase}": [
-                    ok("Running"),
+                "get pod": [
+                    ok(pod_state_json("Running")),
                     fail(stderr='Error from server (NotFound): pods "e2e-conformance" not found'),
                 ],
-                "test -f": fail(),
+                "cat /tmp/results/done": fail(),
                 "logs": fail(stderr="pod not found"),
                 "get events": ok("10m  Warning  TaintManagerEviction  pod/e2e-conformance  Marking for deletion"),
             }
@@ -397,31 +421,31 @@ class TestRun:
         assert not check.passed
         assert "deleted before completion marker" in check.message
         # Must not have polled phase hundreds of times waiting out the timeout.
-        phase_polls = [cmd for cmd in router.seen if "jsonpath={.status.phase}" in cmd]
+        phase_polls = [cmd for cmd in router.seen if "get pod" in cmd]
         assert len(phase_polls) <= 3, f"Expected fast-fail, but polled phase {len(phase_polls)} times"
         # Events fallback populated the output so evictions are visible in the report.
         assert "TaintManagerEviction" in check._output
 
     def test_pod_deleted_during_startup_fails_fast(self) -> None:
         router = _happy_router(
-            {"jsonpath={.status.phase}": fail(stderr='Error from server (NotFound): pods "e2e-conformance" not found')}
+            {"get pod": fail(stderr='Error from server (NotFound): pods "e2e-conformance" not found')}
         )
         check = _run_check(router, {"startup_timeout": 600})
 
         assert not check.passed
         assert "deleted during startup" in check.message
-        phase_polls = [cmd for cmd in router.seen if "jsonpath={.status.phase}" in cmd]
+        phase_polls = [cmd for cmd in router.seen if "get pod" in cmd]
         assert len(phase_polls) <= 2
 
     def test_junit_retrieval_failure(self) -> None:
-        router = _happy_router({"cat /tmp/results": fail(stderr="no such file")})
+        router = _happy_router({"cat /tmp/results/junit": fail(stderr="no such file")})
         check = _run_check(router)
 
         assert not check.passed
         assert "Could not retrieve" in check.message
 
     def test_malformed_junit_sets_failed(self) -> None:
-        router = _happy_router({"cat /tmp/results": ok("<<<not xml")})
+        router = _happy_router({"cat /tmp/results/junit": ok("<<<not xml")})
         check = _run_check(router)
 
         assert not check.passed

--- a/isvtest/tests/test_k8s_conformance.py
+++ b/isvtest/tests/test_k8s_conformance.py
@@ -1,0 +1,635 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Tests for K8sCncfConformanceCheck (direct-Pod conformance harness)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from isvtest.core.runners import CommandResult
+from isvtest.validations.k8s_conformance import (
+    K8sCncfConformanceCheck,
+    _parse_duration,
+)
+
+_DEFAULT_ENV_VARS = {
+    "E2E_FOCUS": r"\[Conformance\]",
+    "E2E_SKIP": "",
+    "E2E_PARALLEL": "false",
+    "E2E_PROVIDER": "skeleton",
+    "RESULTS_DIR": "/tmp/results",
+}
+
+VERSION_JSON = json.dumps({"serverVersion": {"gitVersion": "v1.31.3"}})
+
+PASSING_JUNIT = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Kubernetes e2e suite" tests="3" failures="0" skipped="1" time="120.5">
+  <testcase name="[sig-api-machinery] ConfigMap create" classname="k8s.io/e2e" time="1.2"/>
+  <testcase name="[sig-node] Pods basic" classname="k8s.io/e2e" time="3.4"/>
+  <testcase name="[sig-storage] Disruptive CSI" classname="k8s.io/e2e" time="0">
+    <skipped message="skipped: [Disruptive]"/>
+  </testcase>
+</testsuite>
+"""
+
+FAILING_JUNIT = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Kubernetes e2e suite" tests="2" failures="1" skipped="0" time="5.0">
+  <testcase name="[sig-api-machinery] OK" time="1.0"/>
+  <testcase name="[sig-node] FAILS" time="4.0">
+    <failure message="expected 200 got 500">stack trace</failure>
+  </testcase>
+</testsuite>
+"""
+
+WRAPPED_JUNIT = """<?xml version="1.0"?>
+<testsuites>
+  <testsuite name="A" tests="1" failures="0" skipped="0">
+    <testcase name="[A] one" time="0.5"/>
+  </testsuite>
+  <testsuite name="B" tests="1" failures="0" skipped="1">
+    <testcase name="[B] two" time="0">
+      <skipped/>
+    </testcase>
+  </testsuite>
+</testsuites>
+"""
+
+
+def ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.01)
+
+
+def fail(stdout: str = "", stderr: str = "", exit_code: int = 1) -> CommandResult:
+    return CommandResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration=0.01)
+
+
+class CommandRouter:
+    """Route runner.run calls to CommandResults by substring matching.
+
+    Results can be a single CommandResult or a list. Lists are consumed in
+    order; the last element is repeated once exhausted. First matching
+    substring wins — put more specific patterns before general ones.
+    """
+
+    def __init__(self) -> None:
+        self._routes: list[tuple[str, CommandResult | list[CommandResult]]] = []
+        self._list_index: dict[int, int] = {}
+        self.seen: list[str] = []
+
+    def add(self, substring: str, result: CommandResult | list[CommandResult]) -> None:
+        self._routes.append((substring, result))
+
+    def __call__(self, cmd: str, timeout: int | None = None) -> CommandResult:
+        self.seen.append(cmd)
+        for idx, (sub, res) in enumerate(self._routes):
+            if sub in cmd:
+                if isinstance(res, list):
+                    i = self._list_index.get(idx, 0)
+                    out = res[min(i, len(res) - 1)]
+                    self._list_index[idx] = i + 1
+                    return out
+                return res
+        msg = f"Unexpected command in router: {cmd}"
+        raise AssertionError(msg)
+
+
+class _VirtualClock:
+    """Deterministic clock: time.time() returns a monotonically increasing counter
+    advanced only by time.sleep() (patched to this clock's tick)."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def time(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += max(seconds, 0.0)
+
+
+@pytest.fixture(autouse=True)
+def _virtual_clock() -> Iterator[_VirtualClock]:
+    clock = _VirtualClock()
+    with (
+        patch("isvtest.validations.k8s_conformance.time.time", clock.time),
+        patch("isvtest.validations.k8s_conformance.time.sleep", clock.sleep),
+    ):
+        yield clock
+
+
+@pytest.fixture(autouse=True)
+def _kubectl_stub() -> Iterator[None]:
+    with patch(
+        "isvtest.validations.k8s_conformance.get_kubectl_command",
+        return_value=["kubectl"],
+    ):
+        yield
+
+
+def _make_check(runner: MagicMock, config: dict | None = None) -> K8sCncfConformanceCheck:
+    cfg = dict(config or {})
+    cfg.setdefault("namespace", "conformance-test")
+    cfg.setdefault("startup_timeout", 60)
+    cfg.setdefault("timeout", 120)
+    return K8sCncfConformanceCheck(runner=runner, config=cfg)
+
+
+def _happy_router(
+    overrides: dict[str, CommandResult | list[CommandResult]] | None = None,
+) -> CommandRouter:
+    """Build the happy-path router, optionally with per-substring overrides.
+
+    Overrides are registered first; CommandRouter uses first-match-wins, so
+    an overridden substring takes priority over the default happy route.
+    """
+    router = CommandRouter()
+    for substring, result in (overrides or {}).items():
+        router.add(substring, result)
+    router.add("version -o json", ok(VERSION_JSON))
+    router.add("apply", ok("pod/e2e-conformance created"))
+    router.add("containerStatuses", ok("|"))
+    router.add("jsonpath={.status.phase}", ok("Running"))
+    router.add("test -f", ok())
+    router.add("cat /tmp/results", ok(PASSING_JUNIT))
+    router.add("delete namespace", ok())
+    router.add("delete clusterrolebinding", ok())
+    router.add("logs", ok("log tail"))
+    router.add("get events", ok(""))
+    return router
+
+
+def _run_check(router: CommandRouter, config: dict | None = None) -> K8sCncfConformanceCheck:
+    runner = MagicMock()
+    runner.run.side_effect = router
+    with patch("isvtest.validations.k8s_conformance.is_k8s_available", return_value=True):
+        check = _make_check(runner, config)
+        check.run()
+    return check
+
+
+class TestGuards:
+    def test_cluster_unavailable(self) -> None:
+        runner = MagicMock()
+        with patch("isvtest.validations.k8s_conformance.is_k8s_available", return_value=False):
+            check = _make_check(runner)
+            check.run()
+        assert not check.passed
+        assert "Kubernetes cluster is not available" in check.message
+        runner.run.assert_not_called()
+
+    def test_invalid_mode(self) -> None:
+        runner = MagicMock()
+        with patch("isvtest.validations.k8s_conformance.is_k8s_available", return_value=True):
+            check = _make_check(runner, {"mode": "bogus"})
+            check.run()
+        assert not check.passed
+        assert "Invalid mode" in check.message
+
+
+class TestVersionDetection:
+    def _check_with_version_response(self, response: CommandResult) -> K8sCncfConformanceCheck:
+        router = CommandRouter()
+        router.add("version -o json", response)
+        runner = MagicMock()
+        runner.run.side_effect = router
+        return _make_check(runner)
+
+    def test_detects_from_kubectl_version(self) -> None:
+        check = self._check_with_version_response(ok(VERSION_JSON))
+        assert check._detect_cluster_version() == "v1.31.3"
+
+    def test_strips_build_metadata(self) -> None:
+        payload = json.dumps({"serverVersion": {"gitVersion": "v1.30.2+abc123"}})
+        check = self._check_with_version_response(ok(payload))
+        assert check._detect_cluster_version() == "v1.30.2"
+
+    def test_returns_none_on_nonzero_exit(self) -> None:
+        check = self._check_with_version_response(fail(stderr="boom"))
+        assert check._detect_cluster_version() is None
+
+    def test_returns_none_on_malformed_json(self) -> None:
+        check = self._check_with_version_response(ok("not json"))
+        assert check._detect_cluster_version() is None
+
+    def test_returns_none_on_missing_gitversion(self) -> None:
+        check = self._check_with_version_response(ok(json.dumps({"serverVersion": {}})))
+        assert check._detect_cluster_version() is None
+
+    def test_config_override_skips_detection(self) -> None:
+        router = _happy_router()
+        runner = MagicMock()
+        runner.run.side_effect = router
+        with patch("isvtest.validations.k8s_conformance.is_k8s_available", return_value=True):
+            check = _make_check(runner, {"kubernetes_version": "v1.29.0"})
+            check.run()
+        assert check.passed
+        assert not any("version -o json" in cmd for cmd in router.seen)
+
+    def test_run_fails_when_version_undetectable(self) -> None:
+        router = CommandRouter()
+        router.add("version -o json", fail(stderr="no server"))
+        runner = MagicMock()
+        runner.run.side_effect = router
+        with patch("isvtest.validations.k8s_conformance.is_k8s_available", return_value=True):
+            check = _make_check(runner)
+            check.run()
+        assert not check.passed
+        assert "Could not detect Kubernetes server version" in check.message
+
+
+class TestRun:
+    def test_happy_path(self) -> None:
+        router = _happy_router()
+        check = _run_check(router)
+
+        assert check.passed
+        assert "2/3 passed" in check.message  # 2 passed, 1 skipped, 0 failed
+        # Cleanup fired
+        assert any("delete namespace" in cmd for cmd in router.seen)
+        assert any("delete clusterrolebinding" in cmd for cmd in router.seen)
+        # Version was auto-detected and image pinned to server version
+        assert any("version -o json" in cmd for cmd in router.seen)
+
+    def test_failing_junit_sets_failed(self) -> None:
+        router = _happy_router({"cat /tmp/results": ok(FAILING_JUNIT)})
+        check = _run_check(router)
+
+        assert not check.passed
+        assert "1/2 passed" in check.message
+        assert "1 failed" in check.message
+        assert "[sig-node] FAILS" in check._output
+
+    def test_apply_failure_skips_cleanup(self) -> None:
+        router = _happy_router({"apply": fail(stderr="forbidden")})
+        check = _run_check(router)
+
+        assert not check.passed
+        assert "Failed to apply conformance manifest" in check.message
+        assert not any("delete " in cmd for cmd in router.seen)
+
+    def test_pod_stuck_pending_times_out(self) -> None:
+        router = _happy_router({"jsonpath={.status.phase}": ok("Pending")})
+        check = _run_check(router, {"startup_timeout": 30})
+
+        assert not check.passed
+        assert "did not reach Running state within 30s" in check.message
+        # Cleanup still fired
+        assert any("delete namespace" in cmd for cmd in router.seen)
+
+    def test_image_pull_backoff_fails_fast(self) -> None:
+        """ImagePullBackOff is terminal — fail without burning startup_timeout."""
+        router = _happy_router(
+            {
+                "containerStatuses": ok(
+                    "ImagePullBackOff|Back-off pulling image 'registry.k8s.io/conformance:v1.31.3'"
+                ),
+                "jsonpath={.status.phase}": ok("Pending"),
+            }
+        )
+        check = _run_check(router, {"startup_timeout": 600})
+
+        assert not check.passed
+        assert "ImagePullBackOff" in check.message
+        assert "Back-off pulling image" in check.message
+        # Should not have waited for the full startup timeout.
+        phase_polls = [cmd for cmd in router.seen if "jsonpath={.status.phase}" in cmd]
+        assert len(phase_polls) <= 2, f"Expected fast-fail, but polled phase {len(phase_polls)} times"
+
+    def test_invalid_image_name_fails_fast(self) -> None:
+        router = _happy_router(
+            {
+                "containerStatuses": ok("InvalidImageName|couldn't parse image reference"),
+                "jsonpath={.status.phase}": ok("Pending"),
+            }
+        )
+        check = _run_check(router)
+
+        assert not check.passed
+        assert "InvalidImageName" in check.message
+
+    def test_err_image_pull_transient_then_recovers(self) -> None:
+        """A single ErrImagePull poll shouldn't fail — kubelet may succeed next attempt."""
+        router = _happy_router(
+            {
+                # First poll: transient ErrImagePull. Subsequent polls: cleared.
+                "containerStatuses": [ok("ErrImagePull|network blip"), ok("|")],
+                # Phase: Pending during the blip, Running after.
+                "jsonpath={.status.phase}": [ok("Pending"), ok("Running")],
+            }
+        )
+        check = _run_check(router)
+
+        assert check.passed
+
+    def test_err_image_pull_persistent_fails_fast(self) -> None:
+        """ErrImagePull across two consecutive polls should fail without waiting for timeout."""
+        router = _happy_router(
+            {
+                "containerStatuses": ok("ErrImagePull|manifest unknown"),
+                "jsonpath={.status.phase}": ok("Pending"),
+            }
+        )
+        check = _run_check(router, {"startup_timeout": 600})
+
+        assert not check.passed
+        assert "ErrImagePull" in check.message
+        phase_polls = [cmd for cmd in router.seen if "jsonpath={.status.phase}" in cmd]
+        # Requires at least 2 polls to confirm persistence, but far fewer than timeout/poll_interval.
+        assert 2 <= len(phase_polls) <= 3
+
+    def test_pod_failed_during_startup(self) -> None:
+        router = _happy_router({"jsonpath={.status.phase}": ok("Failed")})
+        check = _run_check(router)
+
+        assert not check.passed
+        assert "entered Failed phase during startup" in check.message
+
+    def test_completion_timeout(self) -> None:
+        router = _happy_router({"test -f": fail()})  # done marker never appears
+        check = _run_check(router, {"timeout": 90})
+
+        assert not check.passed
+        assert "did not finish within 90s" in check.message
+
+    def test_pod_failed_during_completion(self) -> None:
+        router = _happy_router(
+            {
+                "jsonpath={.status.phase}": [ok("Running"), ok("Failed")],
+                "test -f": fail(),
+            }
+        )
+        check = _run_check(router)
+
+        assert not check.passed
+        assert "entered Failed phase before completion marker" in check.message
+
+    def test_pod_deleted_during_completion_fails_fast(self) -> None:
+        """If the pod is evicted/deleted mid-run, the harness must bail instead
+        of polling until `timeout` elapses. Regression for the case where
+        TaintManagerEviction removed the Pod and kubectl get returned NotFound,
+        which was previously mapped to "Unknown" and silently retried."""
+        router = _happy_router(
+            {
+                "jsonpath={.status.phase}": [
+                    ok("Running"),
+                    fail(stderr='Error from server (NotFound): pods "e2e-conformance" not found'),
+                ],
+                "test -f": fail(),
+                "logs": fail(stderr="pod not found"),
+                "get events": ok("10m  Warning  TaintManagerEviction  pod/e2e-conformance  Marking for deletion"),
+            }
+        )
+        check = _run_check(router, {"timeout": 7200})
+
+        assert not check.passed
+        assert "deleted before completion marker" in check.message
+        # Must not have polled phase hundreds of times waiting out the timeout.
+        phase_polls = [cmd for cmd in router.seen if "jsonpath={.status.phase}" in cmd]
+        assert len(phase_polls) <= 3, f"Expected fast-fail, but polled phase {len(phase_polls)} times"
+        # Events fallback populated the output so evictions are visible in the report.
+        assert "TaintManagerEviction" in check._output
+
+    def test_pod_deleted_during_startup_fails_fast(self) -> None:
+        router = _happy_router(
+            {"jsonpath={.status.phase}": fail(stderr='Error from server (NotFound): pods "e2e-conformance" not found')}
+        )
+        check = _run_check(router, {"startup_timeout": 600})
+
+        assert not check.passed
+        assert "deleted during startup" in check.message
+        phase_polls = [cmd for cmd in router.seen if "jsonpath={.status.phase}" in cmd]
+        assert len(phase_polls) <= 2
+
+    def test_junit_retrieval_failure(self) -> None:
+        router = _happy_router({"cat /tmp/results": fail(stderr="no such file")})
+        check = _run_check(router)
+
+        assert not check.passed
+        assert "Could not retrieve" in check.message
+
+    def test_malformed_junit_sets_failed(self) -> None:
+        router = _happy_router({"cat /tmp/results": ok("<<<not xml")})
+        check = _run_check(router)
+
+        assert not check.passed
+        assert "no testcases parsed" in check.message
+
+    def test_cleanup_disabled(self) -> None:
+        router = _happy_router()
+        check = _run_check(router, {"cleanup_namespace": False})
+
+        assert check.passed
+        assert not any("delete namespace" in cmd for cmd in router.seen)
+        assert not any("delete clusterrolebinding" in cmd for cmd in router.seen)
+
+    def test_report_individual_tests(self) -> None:
+        check = _run_check(_happy_router())
+
+        names = [r["name"] for r in check._subtest_results]
+        assert "[sig-api-machinery] ConfigMap create" in names
+        assert "[sig-node] Pods basic" in names
+        assert "[sig-storage] Disruptive CSI" in names
+        skipped = [r for r in check._subtest_results if r["skipped"]]
+        assert len(skipped) == 1
+
+    def test_report_individual_tests_disabled(self) -> None:
+        check = _run_check(_happy_router(), {"report_individual_tests": False})
+
+        assert check.passed
+        assert check._subtest_results == []
+
+
+def _render(
+    namespace: str = "n",
+    pod_name: str = "p",
+    image: str = "img",
+    env_vars: dict[str, str] | None = None,
+    resources: dict[str, str] | None = None,
+) -> str:
+    check = K8sCncfConformanceCheck(runner=MagicMock(), config={})
+    return check._render_manifest(
+        namespace=namespace,
+        pod_name=pod_name,
+        image=image,
+        env_vars=env_vars if env_vars is not None else _DEFAULT_ENV_VARS,
+        resources=resources if resources is not None else K8sCncfConformanceCheck._DEFAULT_RESOURCES,
+    )
+
+
+class TestRenderManifest:
+    def test_contains_namespace_and_image(self) -> None:
+        manifest = _render(namespace="myns", pod_name="e2e-conformance", image="registry.k8s.io/conformance:v1.31.0")
+        docs = {d["kind"]: d for d in yaml.safe_load_all(manifest)}
+        assert docs["Namespace"]["metadata"]["name"] == "myns"
+        assert docs["Pod"]["spec"]["containers"][0]["image"] == "registry.k8s.io/conformance:v1.31.0"
+        assert docs["Pod"]["spec"]["serviceAccountName"] == "conformance"
+        crb = docs["ClusterRoleBinding"]
+        assert crb["metadata"]["name"] == "conformance-myns"
+        assert crb["roleRef"]["name"] == "cluster-admin"
+
+    def test_env_vars_parse_under_container(self) -> None:
+        """Regression: env list must nest under the container, not be sibling containers.
+
+        A previous rendering used 4-space indentation for env entries, which made
+        the YAML parser treat them as additional entries in the outer `containers`
+        list — causing kubectl to reject the Pod with
+        `unknown field "spec.containers[1].value"`.
+        """
+        docs = list(yaml.safe_load_all(_render()))
+        pod = next(d for d in docs if d.get("kind") == "Pod")
+        containers = pod["spec"]["containers"]
+        assert len(containers) == 1, f"Expected 1 container, got {len(containers)}: {containers}"
+        env = {e["name"]: e["value"] for e in containers[0]["env"]}
+        assert env["E2E_FOCUS"] == r"\[Conformance\]"
+        assert env["E2E_PROVIDER"] == "skeleton"
+
+    def test_wrapper_command_keeps_pod_alive_after_e2e(self) -> None:
+        """The image entrypoint exits when the suite finishes; the Pod would
+        then transition to Succeeded and kubectl exec could no longer retrieve
+        the JUnit. Verify the container command wraps run_e2e.sh so the done
+        marker is written and the container sleeps after completion.
+        """
+        docs = list(yaml.safe_load_all(_render()))
+        pod = next(d for d in docs if d.get("kind") == "Pod")
+        container = pod["spec"]["containers"][0]
+        assert container["command"] == ["/bin/sh", "-c"]
+        script = container["args"][0]
+        assert "/run_e2e.sh" in script
+        assert "/tmp/results/done" in script
+        assert "sleep infinity" in script
+
+    def test_pod_has_resource_requests_and_limits(self) -> None:
+        """A BestEffort pod (no requests) is the first kubelet evicts under
+        node pressure, which kills long conformance runs. Verify defaults
+        render a Burstable-QoS pod with ephemeral-storage accounting.
+        """
+        docs = list(yaml.safe_load_all(_render()))
+        pod = next(d for d in docs if d.get("kind") == "Pod")
+        resources = pod["spec"]["containers"][0]["resources"]
+        assert resources["requests"]["cpu"] == "500m"
+        assert resources["requests"]["memory"] == "1Gi"
+        assert resources["requests"]["ephemeral-storage"] == "2Gi"
+        assert resources["limits"]["memory"] == "4Gi"
+        assert resources["limits"]["ephemeral-storage"] == "10Gi"
+        # CPU limit intentionally absent — CFS throttling causes e2e test timeouts.
+        assert "cpu" not in resources["limits"]
+
+    def test_pod_tolerates_e2e_evict_taint(self) -> None:
+        """The k8s e2e suite applies ``kubernetes.io/e2e-evict-taint-key`` during
+        eviction/NodeLifecycle tests — without this toleration the conformance
+        pod itself can be evicted by the suite it's running. Matches sonobuoy.
+        """
+        docs = list(yaml.safe_load_all(_render()))
+        pod = next(d for d in docs if d.get("kind") == "Pod")
+        toleration_keys = {t["key"] for t in pod["spec"]["tolerations"]}
+        assert "kubernetes.io/e2e-evict-taint-key" in toleration_keys
+        assert "CriticalAddonsOnly" in toleration_keys
+        # Both the legacy `master` key and the post-1.24 `control-plane` key —
+        # running this against clusters spanning that rename must not pin the
+        # pod onto a control-plane node either way.
+        assert "node-role.kubernetes.io/control-plane" in toleration_keys
+        assert pod["spec"]["nodeSelector"] == {"kubernetes.io/os": "linux"}
+
+    def test_resources_are_configurable(self) -> None:
+        manifest = _render(
+            resources={
+                "cpu_request": "1",
+                "memory_request": "2Gi",
+                "memory_limit": "8Gi",
+                "ephemeral_storage_request": "4Gi",
+                "ephemeral_storage_limit": "20Gi",
+            },
+        )
+        docs = list(yaml.safe_load_all(manifest))
+        pod = next(d for d in docs if d.get("kind") == "Pod")
+        resources = pod["spec"]["containers"][0]["resources"]
+        assert resources["requests"]["cpu"] == "1"
+        assert resources["requests"]["memory"] == "2Gi"
+        assert resources["requests"]["ephemeral-storage"] == "4Gi"
+        assert resources["limits"]["memory"] == "8Gi"
+        assert resources["limits"]["ephemeral-storage"] == "20Gi"
+
+    def test_yaml_special_chars_in_env_values_round_trip(self) -> None:
+        # Focus/skip regexes contain backslashes, brackets, pipes, and quotes —
+        # all YAML-special. Verify the serializer quotes them such that parsing
+        # yields the original string verbatim.
+        tricky = {
+            "E2E_FOCUS": r"\[Conformance\]",
+            "E2E_SKIP": r'\[Disruptive\]|\[Serial\]|has "quotes"',
+            "E2E_PROVIDER": "skeleton",
+        }
+        docs = list(yaml.safe_load_all(_render(env_vars=tricky)))
+        pod = next(d for d in docs if d.get("kind") == "Pod")
+        env = {e["name"]: e["value"] for e in pod["spec"]["containers"][0]["env"]}
+        assert env == tricky
+
+
+class TestParseJunit:
+    def _check(self) -> K8sCncfConformanceCheck:
+        return K8sCncfConformanceCheck(runner=MagicMock(), config={})
+
+    def test_single_testsuite_passing(self) -> None:
+        summary = self._check()._parse_junit(PASSING_JUNIT)
+        assert summary.total == 3
+        assert summary.passed == 2
+        assert summary.failed == 0
+        assert summary.skipped == 1
+        assert summary.cases[0].duration == 1.2
+
+    def test_single_testsuite_with_failure(self) -> None:
+        summary = self._check()._parse_junit(FAILING_JUNIT)
+        assert summary.failed == 1
+        assert summary.passed == 1
+        assert summary.cases[1].message == "expected 200 got 500"
+
+    def test_testsuites_wrapper(self) -> None:
+        summary = self._check()._parse_junit(WRAPPED_JUNIT)
+        assert summary.total == 2
+        assert summary.passed == 1
+        assert summary.skipped == 1
+
+    def test_error_element_treated_as_failure(self) -> None:
+        xml = """<testsuite>
+          <testcase name="x"><error message="boom"/></testcase>
+        </testsuite>"""
+        summary = self._check()._parse_junit(xml)
+        assert summary.failed == 1
+        assert summary.cases[0].message == "boom"
+
+    def test_malformed_returns_empty_summary(self) -> None:
+        summary = self._check()._parse_junit("<<<")
+        assert summary.total == 0
+        assert summary.cases == []
+
+    def test_unnamed_testcase(self) -> None:
+        xml = "<testsuite><testcase/></testsuite>"
+        summary = self._check()._parse_junit(xml)
+        assert summary.cases[0].name == "(unnamed)"
+
+
+class TestParseDuration:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("1.5", 1.5),
+            ("0", 0.0),
+            ("", None),
+            (None, None),
+            ("not-a-number", None),
+        ],
+    )
+    def test_parses_expected_values(self, value: str | None, expected: float | None) -> None:
+        assert _parse_duration(value) == expected


### PR DESCRIPTION
## Summary

- Add `K8sCncfConformanceCheck` (`isvtest/src/isvtest/validations/k8s_conformance.py`) — runs the upstream `registry.k8s.io/conformance:<server-version>` image directly as a Pod (the same binary Sonobuoy's e2e plugin invokes) and retrieves the JUnit report without depending on a host-side `sonobuoy` CLI
- Register the check in `isvtest/src/isvtest/validations/__init__.py` and add a `k8s_conformance` group to `isvctl/configs/suites/k8s.yaml`
- Add unit tests (`isvtest/tests/test_k8s_conformance.py`) covering guard paths, version auto-detection, the full run lifecycle (apply → startup wait → completion poll → JUnit retrieval → cleanup), and JUnit parsing across single/wrapped testsuites and failure/error/skipped nodes
- Extract reusable kubectl helpers into `isvtest/src/isvtest/core/k8s.py` (extend `get_kubectl_base_shell`, add `parse_pod_state` / `parse_server_version` / `TERMINAL_WAITING_REASONS` / `TRANSIENT_WAITING_REASONS`) and expand `isvtest/tests/test_k8s.py` accordingly, so other validations can fast-fail on image-pull / config errors without re-implementing the protocol knowledge

## Details

Auto-detects the server version via `kubectl version -o json` and pins the conformance image accordingly, renders a single Namespace/ServiceAccount/ClusterRoleBinding/Pod manifest, polls `/tmp/results/done` to detect completion (written by the image's `run_e2e.sh`, which then sleeps indefinitely), reads the JUnit XML via `kubectl exec -- cat` (no tar dependency), and reports each testcase as a subtest.

### Config knobs
`mode` (`certified-conformance` | `non-disruptive-conformance` | `quick`), `kubernetes_version` override, `timeout`, `startup_timeout`, `cleanup_namespace`, `report_individual_tests`, plus raw `E2E_FOCUS` / `E2E_SKIP` / `E2E_PARALLEL` / `E2E_PROVIDER` overrides.

### Refactor (post-review)
Reviewer feedback prompted moving shared logic out of the validation into `core/k8s.py`:
- Pure parsers `parse_pod_state` / `parse_server_version` plus waiting-reason frozensets, usable across validations
- `get_kubectl_base_shell` now accepts positional args and shell-quotes them inline (backwards compatible)
- `K8sCncfConformanceCheck` drops its private `_kubectl` helper and inline JSON/regex parsing, and merges `_get_pod_phase` + `_get_container_waiting` (and `_done_marker_exists` + `_exec_cat`) into single kubectl calls to halve per-iteration traffic
- Trim dead YAML content (`resources:`, `env: []`) always overwritten by the Python renderer

### Issue addressed
- Closes #233

## Test plan

- [x] `uv run pytest isvtest/tests/test_k8s_conformance.py isvtest/tests/test_k8s.py` — unit tests pass
- [x] Live run against a real K8s cluster (AWS EKS)
- [x] Pre-commit hooks pass (ruff, SPDX, yamlfmt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes conformance validation capability with support for three selectable modes: `quick`, `certified-conformance`, and `non-disruptive-conformance`.

* **Documentation**
  * Added comprehensive guide section on Kubernetes Conformance Modes, detailing configuration options and the scope of conformance tests for each mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->