### PR TITLE
fix: skip teardown steps when required {{steps.X.Y}} refs are undefined

### DIFF
--- a/isvctl/src/isvctl/orchestrator/step_executor.py
+++ b/isvctl/src/isvctl/orchestrator/step_executor.py
@@ -44,6 +44,7 @@ Example config:
 import json
 import logging
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -57,6 +58,47 @@ from isvctl.orchestrator.context import Context, _create_jinja_env
 from isvctl.redaction import mask_sensitive_args
 
 logger = logging.getLogger(__name__)
+
+
+_STEP_PATH_RE = re.compile(r"steps\.([\w.]+)")
+
+
+class MissingStepRefError(Exception):
+    """Raised when a step arg template references an undefined step output.
+
+    This happens when a {{steps.X.Y}} path cannot be resolved in the context
+    and the template has no `| default(...)` fallback — typically because an
+    upstream step failed or was skipped. The caller should treat this as a
+    signal to skip the step rather than passing a malformed empty argument
+    to the underlying command.
+    """
+
+    def __init__(self, arg: str, path: str) -> None:
+        self.arg = arg
+        self.missing_path = path
+        super().__init__(
+            f"template arg {arg!r} references undefined step output 'steps.{path}' with no `| default(...)` fallback"
+        )
+
+
+def _find_missing_step_path(arg: str, steps_data: dict[str, Any]) -> str | None:
+    """Return the first ``steps.X.Y`` path in ``arg`` that is unresolved.
+
+    A path is unresolved when any segment is missing from ``steps_data`` or
+    a non-leaf segment is not a dict. Returns None when every ``steps.*``
+    reference in the arg resolves to a value.
+    """
+    for match in _STEP_PATH_RE.finditer(arg):
+        path = match.group(1)
+        node: Any = steps_data
+        for part in path.split("."):
+            if isinstance(node, dict) and part in node:
+                node = node[part]
+            else:
+                return path
+        if node in (None, ""):
+            return path
+    return None
 
 
 @dataclass
@@ -285,7 +327,20 @@ class StepExecutor:
             StepResult with command outcome
         """
         # Render args with accumulated context
-        rendered_args = self._render_args(step.args, context)
+        try:
+            rendered_args = self._render_args(step.args, context)
+        except MissingStepRefError as e:
+            logger.warning(
+                f"Skipping step '{step.name}': {e}. This typically means an upstream step failed or was skipped."
+            )
+            return StepResult(
+                name=step.name,
+                success=False,
+                exit_code=-1,
+                stdout="",
+                stderr="",
+                error=f"Skipped: missing step reference steps.{e.missing_path}",
+            )
 
         # Normalize command - replace python/python3 with current interpreter
         # Also handle "uv run python3" pattern by stripping it
@@ -404,11 +459,20 @@ class StepExecutor:
             context: Context with step outputs for rendering
 
         Returns:
-            List of rendered argument strings (empty strings are filtered out)
+            List of rendered argument strings (empty strings are filtered out
+            only when the template used an explicit ``| default(...)`` fallback)
+
+        Raises:
+            MissingStepRefError: when an arg references ``{{steps.X.Y}}`` that
+                is unresolved in the current context and has no ``default()``
+                filter. This prevents silently producing malformed commands
+                (e.g., ``teardown.py --vpc-id`` with no value) when upstream
+                steps failed or were skipped.
         """
         env = _create_jinja_env()
         # Get full context including step outputs
         ctx_data = context.get_accumulated_context()
+        steps_data = ctx_data.get("steps", {})
         rendered = []
 
         for arg in args:
@@ -416,12 +480,24 @@ class StepExecutor:
                 try:
                     template = env.from_string(arg)
                     result = template.render(**ctx_data)
-                    # Filter out empty strings (from conditional templates)
-                    if result.strip():
-                        rendered.append(result)
                 except Exception as e:
                     logger.warning(f"Failed to render arg '{arg}': {e}")
                     rendered.append(arg)
+                    continue
+
+                if result.strip():
+                    rendered.append(result)
+                    continue
+
+                # Empty result: distinguish "explicit default(''/None)" from
+                # "silently-missing step output". The latter is an error —
+                # surface it so the caller can skip the step cleanly instead
+                # of invoking the command with a stripped-out required arg.
+                if "default(" in arg:
+                    continue
+                missing = _find_missing_step_path(arg, steps_data)
+                if missing:
+                    raise MissingStepRefError(arg, missing)
             else:
                 rendered.append(arg)
 

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -485,20 +485,24 @@ class TestMissingStepRefDetection:
     """Tests for detecting undefined {{steps.X.Y}} references in step args."""
 
     def test_find_missing_step_path_returns_none_when_resolved(self) -> None:
+        """Fully-resolved {{steps.X.Y}} refs return None (no missing path)."""
         steps_data = {"create_network": {"network_id": "vpc-abc123"}}
         arg = "{{steps.create_network.network_id}}"
         assert _find_missing_step_path(arg, steps_data) is None
 
     def test_find_missing_step_path_detects_missing_step(self) -> None:
+        """Return the full path when the top-level step name is absent."""
         arg = "{{steps.create_network.network_id}}"
         assert _find_missing_step_path(arg, {}) == "create_network.network_id"
 
     def test_find_missing_step_path_detects_missing_field(self) -> None:
+        """Return the full path when a leaf field is missing from step output."""
         steps_data = {"create_network": {"other_field": "x"}}
         arg = "{{steps.create_network.network_id}}"
         assert _find_missing_step_path(arg, steps_data) == "create_network.network_id"
 
     def test_find_missing_step_path_detects_empty_leaf(self) -> None:
+        """Treat an empty-string leaf as missing (would render to '')."""
         steps_data = {"create_network": {"network_id": ""}}
         arg = "{{steps.create_network.network_id}}"
         assert _find_missing_step_path(arg, steps_data) == "create_network.network_id"

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -17,7 +17,11 @@ from unittest.mock import patch
 from isvctl.config.schema import PlatformCommands, RunConfig, StepConfig, ValidationConfig
 from isvctl.orchestrator.context import Context
 from isvctl.orchestrator.loop import Orchestrator, Phase
-from isvctl.orchestrator.step_executor import StepExecutor
+from isvctl.orchestrator.step_executor import (
+    MissingStepRefError,
+    StepExecutor,
+    _find_missing_step_path,
+)
 
 
 class TestOrchestrator:
@@ -475,3 +479,88 @@ class TestStepExecutorBestEffort:
 
         executed = [s.name for s in results.steps]
         assert executed == ["fail_step", "ok_step"]
+
+
+class TestMissingStepRefDetection:
+    """Tests for detecting undefined {{steps.X.Y}} references in step args."""
+
+    def test_find_missing_step_path_returns_none_when_resolved(self) -> None:
+        steps_data = {"create_network": {"network_id": "vpc-abc123"}}
+        arg = "{{steps.create_network.network_id}}"
+        assert _find_missing_step_path(arg, steps_data) is None
+
+    def test_find_missing_step_path_detects_missing_step(self) -> None:
+        arg = "{{steps.create_network.network_id}}"
+        assert _find_missing_step_path(arg, {}) == "create_network.network_id"
+
+    def test_find_missing_step_path_detects_missing_field(self) -> None:
+        steps_data = {"create_network": {"other_field": "x"}}
+        arg = "{{steps.create_network.network_id}}"
+        assert _find_missing_step_path(arg, steps_data) == "create_network.network_id"
+
+    def test_find_missing_step_path_detects_empty_leaf(self) -> None:
+        steps_data = {"create_network": {"network_id": ""}}
+        arg = "{{steps.create_network.network_id}}"
+        assert _find_missing_step_path(arg, steps_data) == "create_network.network_id"
+
+    def test_teardown_step_skipped_when_setup_step_missing(self) -> None:
+        """Teardown with empty {{steps.create_network.network_id}} is skipped,
+        not invoked with a stripped-out required arg."""
+        executor = StepExecutor()
+        context = Context(RunConfig())
+        # No "create_network" step output — simulates a failed setup step.
+        steps = [
+            StepConfig(
+                name="teardown_network",
+                command="echo",
+                args=["--vpc-id", "{{steps.create_network.network_id}}"],
+                phase="teardown",
+            ),
+            StepConfig(
+                name="cleanup",
+                command="echo",
+                args=["done"],
+                phase="teardown",
+            ),
+        ]
+
+        results = executor.execute_steps(steps, context, best_effort=True)
+
+        assert not results.steps[0].success
+        assert "missing step reference" in (results.steps[0].error or "").lower()
+        assert results.steps[0].exit_code == -1
+        # Remaining teardown steps still run under best_effort.
+        assert [s.name for s in results.steps] == ["teardown_network", "cleanup"]
+        assert results.steps[1].success
+
+    def test_default_filter_suppresses_missing_ref_error(self) -> None:
+        """Args with `| default(...)` are allowed to render empty silently."""
+        executor = StepExecutor()
+        context = Context(RunConfig())
+        steps = [
+            StepConfig(
+                name="optional_flag",
+                command="echo",
+                args=["--region", "{{steps.create_network.region | default('')}}"],
+                phase="teardown",
+            ),
+        ]
+
+        results = executor.execute_steps(steps, context, best_effort=True)
+
+        # The empty arg is filtered out; the step runs successfully with just
+        # "--region" stripped (matching previous behavior for explicit defaults).
+        assert results.steps[0].success
+
+    def test_missing_ref_raised_from_render_args_directly(self) -> None:
+        """_render_args raises MissingStepRefError for bare references."""
+        import pytest
+
+        executor = StepExecutor()
+        context = Context(RunConfig())
+        args = ["--vpc-id", "{{steps.create_network.network_id}}"]
+
+        with pytest.raises(MissingStepRefError) as exc_info:
+            executor._render_args(args, context)
+
+        assert exc_info.value.missing_path == "create_network.network_id"


### PR DESCRIPTION
## Summary

- When `create_network` (or any upstream setup step) fails before producing JSON output, a downstream teardown step whose args reference that output — e.g. `--vpc-id {{steps.create_network.network_id}}` — silently renders to empty, `_render_args` strips the empty value, and `teardown.py` is invoked with `--vpc-id` missing its argument. The underlying script crashes with `argument --vpc-id: expected one argument`.
- This path was rare until #193 decoupled teardown from setup success. Now teardown always runs after a failed `create_network`, so every failed network setup trips the crash.
- The `ChainableUndefined` warning added in 0ff4698 only covers **validation** rendering (`Context.render_dict`/`render_string`), not step argument rendering in `step_executor._render_args`, so missing step refs in teardown args stay silent.

## Fix

`_render_args` now detects the case: a template that rendered to empty, references `{{steps.X.Y}}`, and has no `| default(...)` fallback — raise the new `MissingStepRefError`. `_execute_step` catches it and returns a clearly-labeled skipped `StepResult`:

> `Skipped: missing step reference steps.create_network.network_id`

Under `best_effort=True` (teardown) subsequent cleanup steps still run; under strict mode (setup/test) the error fails the step hard, which is the correct behavior. Templates with `default()` preserve today's behavior (empty-arg filtered silently).

## Context

Reported by Orga Shih while working with GCP.. Made visible by #193; this PR closes the regression window it opened.

## Test plan

- [x] New unit tests cover: resolved refs, missing step, missing field, empty leaf, teardown-skipped flow under best_effort, `default()` suppresses the error, direct `_render_args` raise path.
- [x] Full `isvctl/tests/test_orchestrator_loop.py` suite passes (26 tests).
- [x] Reviewer verifies the skipped-step log message is clear enough for an operator who sees it in the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved detection of unresolved step-output references in workflow arguments, surfacing clear missing-reference notices.

* **Bug Fixes**
  * Steps that reference missing or empty outputs now fail gracefully with exit code -1 and a descriptive error, instead of silently continuing.
  * Teardown steps continue to run under best-effort even when prior steps fail due to missing references.
  * Default/fallback filters suppress missing-reference errors so steps can proceed.

* **Tests**
  * Added tests covering missing-reference detection, error conversion, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->