### PR TITLE
feat: add auto_assign_ip_mode to VpcIpConfigCheck for non-AWS NCPs

### DIFF
--- a/isvtest/src/isvtest/validations/network.py
+++ b/isvtest/src/isvtest/validations/network.py
@@ -543,11 +543,19 @@ class VpcIpConfigCheck(BaseValidation):
     Checks that:
     1. DHCP options set is configured with DNS servers
     2. Subnet CIDRs are valid, non-overlapping, and within VPC range
-    3. At least one subnet has auto-assign public IP enabled
+    3. Public IP assignment is configured per the provider's model
 
     Config:
         step_output: VPC creation output with dhcp_options, subnets, cidr
         min_ips_per_subnet: Minimum IPs per subnet (default: 16)
+        auto_assign_ip_mode: How the NCP exposes external IPs (default: "subnet"):
+            - "subnet": at least one subnet must have ``auto_assign_public_ip``
+              truthy (AWS model — MapPublicIpOnLaunch)
+            - "instance": external IPs are attached per instance at launch time
+              (GCP model — accessConfig), so subnet-level flags don't apply;
+              the subtest reports PASS with informational status
+            - "disabled": no public IPs expected for this deployment; the
+              subtest reports PASS with informational status
 
     Step output:
         cidr: VPC CIDR block (e.g. "10.0.0.0/16")
@@ -687,7 +695,34 @@ class VpcIpConfigCheck(BaseValidation):
             )
 
     def _check_auto_assign_ip(self, step_output: dict) -> None:
-        """Check that at least one subnet has auto-assign public IP enabled."""
+        """Check public IP assignment per the NCP's configured model."""
+        mode = self.config.get("auto_assign_ip_mode", "subnet")
+        valid_modes = ("subnet", "instance", "disabled")
+        if mode not in valid_modes:
+            self.report_subtest(
+                "auto_assign_ip_enabled",
+                False,
+                f"Invalid auto_assign_ip_mode={mode!r} (expected one of {valid_modes})",
+            )
+            return
+
+        if mode == "instance":
+            self.report_subtest(
+                "auto_assign_ip_enabled",
+                True,
+                "NCP assigns external IPs per-instance (no subnet-level flag)",
+            )
+            return
+
+        if mode == "disabled":
+            self.report_subtest(
+                "auto_assign_ip_enabled",
+                True,
+                "Public IP assignment disabled for this deployment",
+            )
+            return
+
+        # mode == "subnet": AWS-style, at least one subnet must opt in.
         subnets = step_output.get("subnets", [])
 
         if not subnets:

--- a/isvtest/tests/test_network.py
+++ b/isvtest/tests/test_network.py
@@ -412,3 +412,71 @@ class TestVpcIpConfigCheck:
         result = v.execute()
         assert result["passed"] is False
         assert "auto_assign_ip_enabled" in result["error"]
+
+    def test_auto_assign_mode_instance_passes_without_subnet_flag(self) -> None:
+        """GCP-style: external IPs are per-instance, no subnet flag expected."""
+        cfg = _vpc_config(
+            {
+                "subnets": [
+                    {
+                        "subnet_id": "subnet-a",
+                        "cidr": "10.0.1.0/24",
+                        "auto_assign_public_ip": False,
+                        "available_ips": 251,
+                    },
+                ],
+            }
+        )
+        cfg["auto_assign_ip_mode"] = "instance"
+        v = VpcIpConfigCheck(config=cfg)
+        result = v.execute()
+        assert result["passed"] is True
+
+    def test_auto_assign_mode_disabled_passes(self) -> None:
+        """Deployments that don't expose public IPs pass the subtest."""
+        cfg = _vpc_config(
+            {
+                "subnets": [
+                    {
+                        "subnet_id": "subnet-a",
+                        "cidr": "10.0.1.0/24",
+                        "auto_assign_public_ip": False,
+                        "available_ips": 251,
+                    },
+                ],
+            }
+        )
+        cfg["auto_assign_ip_mode"] = "disabled"
+        v = VpcIpConfigCheck(config=cfg)
+        result = v.execute()
+        assert result["passed"] is True
+
+    def test_auto_assign_mode_invalid_fails(self) -> None:
+        """Unknown mode values are a config error."""
+        cfg = _vpc_config()
+        cfg["auto_assign_ip_mode"] = "something-else"
+        v = VpcIpConfigCheck(config=cfg)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "auto_assign_ip_enabled" in result["error"]
+
+    def test_auto_assign_mode_subnet_is_default(self) -> None:
+        """Omitting mode keeps the current AWS-compatible behavior."""
+        cfg = _vpc_config(
+            {
+                "subnets": [
+                    {
+                        "subnet_id": "subnet-a",
+                        "cidr": "10.0.1.0/24",
+                        "auto_assign_public_ip": False,
+                        "available_ips": 251,
+                    },
+                ],
+            }
+        )
+        # No auto_assign_ip_mode set → default "subnet" → must fail since
+        # no subnet has auto_assign_public_ip=True.
+        v = VpcIpConfigCheck(config=cfg)
+        result = v.execute()
+        assert result["passed"] is False
+        assert "auto_assign_ip_enabled" in result["error"]


### PR DESCRIPTION
## Summary

- `VpcIpConfigCheck.auto_assign_ip_enabled` hard-requires at least one subnet with `auto_assign_public_ip` truthy. This encodes the AWS subnet-level model (MapPublicIpOnLaunch) and has no escape hatch for NCPs with a different public-IP model.
- GCP attaches external IPs per-instance via `accessConfig` — there is no subnet-level equivalent. Today the only way for a GCP stub to pass the subtest is to report `auto_assign_public_ip: true`, which is factually wrong and hides real configuration problems.
- Add `auto_assign_ip_mode` config on `VpcIpConfigCheck` with three values:
  - `subnet` (default, preserves current AWS behavior)
  - `instance` — NCP assigns external IPs per-instance; subtest PASSes with an informational status
  - `disabled` — no public IPs expected for this deployment; subtest PASSes with an informational status
- An invalid mode value is a hard config error so typos fail loudly.

## Migration

Default is unchanged, so existing AWS configs need no update. Non-AWS providers set `auto_assign_ip_mode: instance` (or `disabled`) in their validation config instead of either (a) lying in the stub output or (b) excluding the whole check and losing coverage of the DHCP/CIDR subtests.

Example GCP override:

```yaml
tests:
  validations:
    network:
      checks:
        VpcIpConfigCheck:
          step: vpc_ip_config
          auto_assign_ip_mode: instance
```

## Context

Reported by Orga Shih while working with GCP.

## Test plan

- [x] New unit tests cover all three modes, invalid mode, and unchanged default behavior.
- [x] Full `isvtest/tests/test_network.py::TestVpcIpConfigCheck` suite passes (11 tests).
- [x] Reviewer confirms naming (`subnet`/`instance`/`disabled`) reads sensibly on future NCPs (Azure accelerator networking, on-prem, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * VPC IP configuration validation is now model-driven via the new `auto_assign_ip_mode` configuration option. Three modes are supported: `"subnet"` (default, preserves prior behavior), `"instance"`, and `"disabled"`. The validation logic dynamically adjusts based on the selected mode, enabling flexible control over how public IP assignment is validated across different infrastructure deployment models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->