### PR TITLE
fix: DriverCheck falls back to /usr/local/cuda/bin/nvcc

### DIFF
--- a/isvtest/src/isvtest/validations/host.py
+++ b/isvtest/src/isvtest/validations/host.py
@@ -1002,8 +1002,14 @@ class DriverCheck(BaseValidation):
             else:
                 self.report_subtest("nvidia_driver", False, "NVIDIA driver not found")
 
-            # Check CUDA toolkit
-            exit_code, stdout, _ = run_ssh_command(ssh, "nvcc --version 2>/dev/null | grep release || echo 'not_found'")
+            # Check CUDA toolkit — try PATH first (AWS DL AMI), then fall back to
+            # NVIDIA's canonical install location (/usr/local/cuda/bin/nvcc).
+            # Required for NCPs like GCP DL VM where CUDA is installed but not
+            # exported on the login PATH.
+            exit_code, stdout, _ = run_ssh_command(
+                ssh,
+                "(nvcc --version || /usr/local/cuda/bin/nvcc --version) 2>/dev/null | grep release || echo 'not_found'",
+            )
             cuda_found = "not_found" not in stdout and "release" in stdout
             self.report_subtest("cuda_toolkit", cuda_found, stdout.strip() if cuda_found else "CUDA toolkit not found")
 


### PR DESCRIPTION
## Summary

- `DriverCheck.cuda_toolkit` probes `nvcc --version` via the login PATH. On the GCP Deep Learning VM image, CUDA is installed at `/usr/local/cuda/bin/nvcc` but the login PATH doesn't include it, so `nvidia-smi` reports a CUDA runtime yet `nvcc --version` is "not found" and the subtest fails.
- This is not an NCP compliance gap — `/usr/local/cuda` is NVIDIA's canonical install location and what the official installer produces. The AWS Deep Learning AMI happens to also export it on PATH.
- Extend the probe to try PATH first, then fall back to the canonical path:
  ```sh
  (nvcc --version || /usr/local/cuda/bin/nvcc --version) 2>/dev/null | grep release || echo 'not_found'
  ```
  AWS hits the PATH branch and is unaffected; GCP (and any NCP that doesn't export CUDA on login PATH) now passes.

## Context

Reported by Orga Shih while working with GCP.

## Test plan

- [ ] Reviewer verifies fallback path is acceptable for NVIDIA's canonical install layout.
- [ ] Run against a GCP DL VM (cuda installed at `/usr/local/cuda/bin/nvcc`, not on PATH) — expect PASS.
- [ ] Run against an AWS DL AMI — expect PASS (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced CUDA toolkit detection in host validation to check both the system PATH and the standard installation directory, improving reliability of CUDA identification across various system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->