### PR TITLE
refactor: align vm.yaml with bare_metal.yaml and fix lifecycle-check ordering

### DIFF
--- a/isvctl/configs/providers/aws/vm.yaml
+++ b/isvctl/configs/providers/aws/vm.yaml
@@ -14,14 +14,18 @@
 # This file only provides AWS-specific commands (boto3 stubs) and settings.
 #
 # Steps:
-#   1. launch_instance - boto3: Provisions EC2, outputs IP/key (setup)
-#   2. list_instances - boto3: Lists instances in VPC (test)
-#   3. stop_instance - boto3: Stops EC2, verifies stopped state (test)
-#   4. start_instance - boto3: Starts stopped EC2, verifies recovery (test)
-#   5. reboot_instance - boto3: Reboots EC2, validates recovery (test)
-#   6. deploy_nim - paramiko: Deploys NIM container via SSH (test)
-#   5. teardown_nim - paramiko: Stops NIM container via SSH (teardown)
-#   6. teardown - boto3: Terminates EC2 (teardown)
+#   1. launch_instance    - boto3: Provisions EC2, outputs IP/key (setup)
+#   2. list_instances     - boto3: Lists instances in VPC (test)
+#   3. verify_tags        - boto3: Verifies user-defined tags (test)
+#   4. serial_console     - boto3: Retrieves serial console output (test)
+#   5. stop_instance      - boto3: Stops EC2, verifies stopped state (test)
+#   6. start_instance     - boto3: Starts stopped EC2, verifies recovery (test)
+#   7. reboot_instance    - boto3: Reboots EC2, validates recovery (test)
+#   8. describe_instance  - boto3: Describes current state, passes SSH info (test)
+#                           (runs after reboot so IP is current; validation anchor)
+#   9. deploy_nim         - paramiko: Deploys NIM container via SSH (test)
+#  10. teardown_nim       - paramiko: Stops NIM container via SSH (teardown)
+#  11. teardown           - boto3: Terminates EC2 (teardown)
 #
 # Usage:
 #   uv run isvctl test run -f isvctl/configs/providers/aws/vm.yaml
@@ -72,6 +76,18 @@ commands:
           - "{{region}}"
         timeout: 60
 
+      # AWS-specific: Serial console output (boto3)
+      # Read-only - run before lifecycle ops
+      - name: serial_console
+        phase: test
+        command: "python3 ../../stubs/aws/vm/serial_console.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 60
+
       # AWS-specific: Stop instance and verify stopped state (boto3)
       - name: stop_instance
         phase: test
@@ -110,19 +126,23 @@ commands:
           - "--key-file"
           - "{{steps.launch_instance.key_file}}"
           - "--public-ip"
-          - "{{steps.launch_instance.public_ip}}"
+          - "{{steps.start_instance.public_ip}}"
         timeout: 600
 
-      # AWS-specific: Serial console output (boto3)
-      - name: serial_console
+      # AWS-specific: Describe instance state - SSH/GPU validation anchor (boto3)
+      # Runs after reboot so the IP is current (stop/start may reassign it).
+      # Host-level checks bind to this step so they validate the post-reboot host.
+      - name: describe_instance
         phase: test
-        command: "python3 ../../stubs/aws/vm/serial_console.py"
+        command: "python3 ../../stubs/aws/vm/describe_instance.py"
         args:
           - "--instance-id"
           - "{{steps.launch_instance.instance_id}}"
           - "--region"
           - "{{region}}"
-        timeout: 60
+          - "--key-file"
+          - "{{steps.launch_instance.key_file}}"
+        timeout: 120
 
       # Shared: Deploy NIM container via SSH (paramiko)
       # Uses post-reboot IP/key since reboot may reassign the public IP

--- a/isvctl/configs/stubs/aws/vm/describe_instance.py
+++ b/isvctl/configs/stubs/aws/vm/describe_instance.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Describe a running AWS EC2 VM instance.
+
+Lightweight test-phase step that fetches current instance state and
+passes through SSH connection info. Validations (SSH, GPU, host OS)
+bind to this step so they run in the test phase rather than setup,
+ensuring teardown always runs even if tests fail.
+
+Additionally, running these checks against the post-reboot state proves
+the host survived the full stop/start/reboot lifecycle (driver, docker,
+pinning, etc.), which a launch-time anchor cannot prove.
+
+Usage:
+    python describe_instance.py --instance-id i-xxx --region us-west-2 \
+        --key-file /tmp/key.pem
+
+Output JSON:
+{
+    "success": true,
+    "platform": "vm",
+    "instance_id": "i-xxx",
+    "instance_type": "g5.xlarge",
+    "state": "running",
+    "public_ip": "54.x.x.x",
+    "private_ip": "10.0.1.5",
+    "key_file": "/tmp/key.pem",
+    "ssh_user": "ubuntu"
+}
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+def main() -> int:
+    """Describe a VM EC2 instance and return its current state.
+
+    Returns:
+        0 on success, 1 on failure
+    """
+    parser = argparse.ArgumentParser(description="Describe VM EC2 instance")
+    parser.add_argument("--instance-id", required=True, help="EC2 instance ID")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--key-file", required=True, help="Path to SSH private key")
+    parser.add_argument("--ssh-user", default="ubuntu", help="SSH username")
+    args = parser.parse_args()
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "vm",
+        "instance_id": args.instance_id,
+        "region": args.region,
+        "key_file": args.key_file,
+        "ssh_user": args.ssh_user,
+    }
+
+    try:
+        instances = ec2.describe_instances(InstanceIds=[args.instance_id])
+        instance = instances["Reservations"][0]["Instances"][0]
+
+        result["state"] = instance["State"]["Name"]
+        result["instance_type"] = instance.get("InstanceType")
+        result["public_ip"] = instance.get("PublicIpAddress")
+        result["private_ip"] = instance.get("PrivateIpAddress")
+        result["vpc_id"] = instance.get("VpcId")
+        result["subnet_id"] = instance.get("SubnetId")
+        result["availability_zone"] = instance.get("Placement", {}).get("AvailabilityZone")
+        result["launch_time"] = instance.get("LaunchTime", "").isoformat() if instance.get("LaunchTime") else None
+        result["success"] = True
+
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "InvalidInstanceID.NotFound":
+            result["error"] = f"Instance {args.instance_id} not found"
+        else:
+            result["error"] = str(e)
+    except Exception as e:
+        result["error"] = str(e)
+
+    print(json.dumps(result, indent=2, default=str))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/stubs/vm/describe_instance.py
+++ b/isvctl/configs/stubs/vm/describe_instance.py
@@ -42,6 +42,7 @@ Reference implementation: ../aws/vm/describe_instance.py
 import argparse
 import json
 import sys
+from typing import Any
 
 
 def main() -> int:
@@ -52,7 +53,7 @@ def main() -> int:
     parser.add_argument("--key-file", required=True, help="Path to SSH private key")
     args = parser.parse_args()
 
-    result: dict = {
+    result: dict[str, Any] = {
         "success": False,
         "platform": "vm",
         "instance_id": args.instance_id,

--- a/isvctl/configs/stubs/vm/describe_instance.py
+++ b/isvctl/configs/stubs/vm/describe_instance.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Describe VM instance - TEMPLATE (replace with your platform implementation).
+
+This script is called during the "test" phase. It must:
+  1. Query your platform for the current instance state
+  2. Return network info (public IP) and pass through the SSH key file
+  3. Print a JSON object to stdout
+
+This is a lightweight step that validations bind to. SSH, GPU, and host-OS
+checks run against this step's output, ensuring they execute in the test
+phase (so teardown always runs, even if tests fail) AND prove the host
+survived the full stop/start/reboot lifecycle.
+
+Required JSON output fields:
+  {
+    "success": true,             # boolean - did the query succeed?
+    "platform": "vm",            # string  - always "vm"
+    "instance_id": "...",        # string  - instance identifier
+    "state": "running",          # string  - current state
+    "public_ip": "54.x.x.x",     # string  - public IP for SSH access
+    "key_file": "/tmp/key.pem"   # string  - path to SSH private key
+  }
+
+On failure, set "success": false and include an "error" field.
+
+Usage:
+    python describe_instance.py --instance-id <id> --region <region> --key-file /tmp/key.pem
+
+Reference implementation: ../aws/vm/describe_instance.py
+"""
+
+import argparse
+import json
+import sys
+
+
+def main() -> int:
+    """Describe a VM instance (template)."""
+    parser = argparse.ArgumentParser(description="Describe VM instance (template)")
+    parser.add_argument("--instance-id", required=True, help="Instance identifier")
+    parser.add_argument("--region", required=True, help="Cloud region")
+    parser.add_argument("--key-file", required=True, help="Path to SSH private key")
+    args = parser.parse_args()
+
+    result: dict = {
+        "success": False,
+        "platform": "vm",
+        "instance_id": args.instance_id,
+        "state": "",
+        "public_ip": "",
+        "key_file": args.key_file,
+    }
+
+    # ╔══════════════════════════════════════════════════════════════════╗
+    # ║  TODO: Replace this block with your platform's describe logic    ║
+    # ║                                                                  ║
+    # ║  Example (pseudocode):                                           ║
+    # ║    client = MyCloudClient(region=args.region)                    ║
+    # ║    info = client.describe_instance(args.instance_id)             ║
+    # ║                                                                  ║
+    # ║    result["state"] = info.state                # "running"       ║
+    # ║    result["public_ip"] = info.public_ip        # for SSH         ║
+    # ║    result["success"] = True                                      ║
+    # ╚══════════════════════════════════════════════════════════════════╝
+
+    result["error"] = "Not implemented - replace with your platform's instance describe logic"
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/tests/bare_metal.yaml
+++ b/isvctl/configs/tests/bare_metal.yaml
@@ -443,6 +443,9 @@ tests:
     host_os:
       step: describe_instance
       checks:
+        VcpuPinningCheck: {}
+        PciBusCheck:
+          expected_gpus: 8
         HostSoftwareCheck: {}
 
     # GPU stress test - PyTorch matrix multiplications on all GPUs

--- a/isvctl/configs/tests/vm.yaml
+++ b/isvctl/configs/tests/vm.yaml
@@ -23,15 +23,19 @@
 #   fields, the validations pass regardless of which cloud you use.
 #
 # Steps:
-#   1. launch_instance  (setup)    - Provision GPU VM, output IP/key
-#   2. list_instances   (test)     - List instances, verify target exists
-#   3. verify_tags      (test)     - Verify user-defined tags on instance
-#   4. stop_instance    (test)     - Stop VM, verify stopped state
-#   5. start_instance   (test)     - Start stopped VM, verify recovery
-#   6. reboot_instance  (test)     - Reboot VM, validate recovery
-#   7. deploy_nim       (test)     - Deploy NIM container via SSH
-#   8. teardown_nim     (teardown) - Stop NIM container via SSH
-#   9. teardown         (teardown) - Terminate VM and cleanup
+#   1. launch_instance    (setup)    - Provision GPU VM, output IP/key
+#   2. list_instances     (test)     - List instances, verify target exists
+#   3. verify_tags        (test)     - Verify user-defined tags on instance
+#   4. serial_console     (test)     - Retrieve serial console output (read-only)
+#   5. stop_instance      (test)     - Stop VM, verify stopped state
+#   6. start_instance     (test)     - Start stopped VM, verify recovery
+#   7. reboot_instance    (test)     - Reboot VM, validate recovery
+#   8. describe_instance  (test)     - Describe current state + SSH info
+#                                      (runs after reboot; host-level validations
+#                                       anchor here to prove lifecycle survival)
+#   9. deploy_nim         (test)     - Deploy NIM container via SSH
+#  10. teardown_nim       (teardown) - Stop NIM container via SSH
+#  11. teardown           (teardown) - Terminate VM and cleanup
 #
 # Quick start (new provider):
 #   1. Create your provider folder: mkdir -p isvctl/configs/providers/my-isv/
@@ -58,7 +62,7 @@ commands:
       #     "public_ip": "<ip-address>",
       #     "key_file": "<path-to-ssh-key>",
       #     "vpc_id": "<network-id>",
-      #     "instance_state": "running",
+      #     "state": "running",
       #     "security_group_id": "<sg-id>",
       #     "key_name": "<key-pair-name>"
       #   }
@@ -113,7 +117,28 @@ commands:
           - "{{region}}"
         timeout: 60
 
-      # ─── Step 4: Stop Instance ────────────────────────────────────
+      # ─── Step 4: Serial Console Access ──────────────────────────────
+      # Read-only; doesn't depend on lifecycle ops, so runs before them.
+      # YOUR SCRIPT must output JSON with at minimum:
+      #   {
+      #     "success": true,
+      #     "platform": "vm",
+      #     "instance_id": "<id>",
+      #     "console_available": true,
+      #     "serial_access_enabled": true,
+      #     "output_length": 4096
+      #   }
+      - name: serial_console
+        phase: test
+        command: "python3 ../stubs/vm/serial_console.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 60
+
+      # ─── Step 5: Stop Instance ────────────────────────────────────
       # YOUR SCRIPT must output JSON with at minimum:
       #   {
       #     "success": true,
@@ -132,7 +157,7 @@ commands:
           - "{{region}}"
         timeout: 600
 
-      # ─── Step 5: Start Instance ───────────────────────────────────
+      # ─── Step 6: Start Instance ───────────────────────────────────
       # YOUR SCRIPT must output JSON with at minimum:
       #   {
       #     "success": true,
@@ -158,13 +183,13 @@ commands:
           - "{{steps.launch_instance.public_ip}}"
         timeout: 300
 
-      # ─── Step 6: Reboot Instance ──────────────────────────────────
+      # ─── Step 7: Reboot Instance ──────────────────────────────────
       # YOUR SCRIPT must output JSON with at minimum:
       #   {
       #     "success": true,
       #     "platform": "vm",
       #     "instance_id": "...",
-      #     "instance_state": "running",
+      #     "state": "running",
       #     "public_ip": "...",
       #     "key_file": "...",
       #     "uptime_seconds": <int>,
@@ -181,31 +206,36 @@ commands:
           - "--key-file"
           - "{{steps.launch_instance.key_file}}"
           - "--public-ip"
-          - "{{steps.launch_instance.public_ip}}"
+          - "{{steps.start_instance.public_ip}}"
         timeout: 600
 
-      # ─── Step 7: Serial Console Access ──────────────────────────────
+      # ─── Step 8: Describe Instance ─────────────────────────────────
+      # Runs AFTER reboot so the IP is current (stop/start may reassign).
+      # This step is the SSH/GPU/host validation anchor: host-level checks
+      # bind to describe_instance so they prove the host survived the full
+      # stop/start/reboot lifecycle (driver, Docker, pinning, etc.).
       # YOUR SCRIPT must output JSON with at minimum:
       #   {
       #     "success": true,
       #     "platform": "vm",
-      #     "instance_id": "<id>",
-      #     "console_available": true,
-      #     "serial_access_enabled": true,
-      #     "output_length": 4096
+      #     "instance_id": "...",
+      #     "state": "running",
+      #     "public_ip": "...",
+      #     "key_file": "..."
       #   }
-      - name: serial_console
+      - name: describe_instance
         phase: test
-        command: "python3 ../stubs/vm/serial_console.py"
+        command: "python3 ../stubs/vm/describe_instance.py"
         args:
           - "--instance-id"
-          # instance_id is stable across reboots; no need to use post-reboot step output
           - "{{steps.launch_instance.instance_id}}"
           - "--region"
           - "{{region}}"
-        timeout: 60
+          - "--key-file"
+          - "{{steps.launch_instance.key_file}}"
+        timeout: 120
 
-      # ─── Step 8: Deploy NIM Container ─────────────────────────────
+      # ─── Step 9: Deploy NIM Container ─────────────────────────────
       # Uses post-reboot IP/key since reboot may reassign the public IP.
       # See stubs/common/deploy_nim.py for the JSON contract.
       - name: deploy_nim
@@ -218,7 +248,7 @@ commands:
           - "{{steps.reboot_instance.key_file}}"
         timeout: 1800
 
-      # ─── Step 9: Teardown NIM ─────────────────────────────────────
+      # ─── Step 10: Teardown NIM ────────────────────────────────────
       # Uses post-reboot IP/key to match what deploy_nim used.
       - name: teardown_nim
         phase: teardown
@@ -230,7 +260,7 @@ commands:
           - "{{steps.reboot_instance.key_file}}"
         timeout: 120
 
-      # ─── Step 10: Teardown Instance ───────────────────────────────
+      # ─── Step 11: Teardown Instance ───────────────────────────────
       # YOUR SCRIPT must output JSON with at minimum:
       #   {
       #     "success": true,
@@ -264,6 +294,12 @@ tests:
 
   # ─── Validations ─────────────────────────────────────────────────
   # These are PROVIDER-AGNOSTIC. They only check JSON field names/values.
+  #
+  # Layout mirrors bare_metal.yaml:
+  #   launch checks -> list -> tags -> serial_console -> cloud_init
+  #   -> describe_instance (SSH / GPU / host anchor, post-reboot)
+  #   -> lifecycle (stop / start / reboot)
+  #   -> NIM -> teardown
   validations:
     setup_checks:
       step: launch_instance
@@ -282,38 +318,68 @@ tests:
         InstanceListCheck:
           min_count: 1
 
-    ssh:
-      step: launch_instance
-      checks:
-        ConnectivityCheck: {}
-        OsCheck:
-          expected_os: "ubuntu"
-
-    gpu:
-      step: launch_instance
-      checks:
-        GpuCheck:
-          expected_gpus: 1
-
-    host_os:
-      step: launch_instance
-      checks:
-        VcpuPinningCheck: {}
-        PciBusCheck:
-          expected_gpus: 1
-        HostSoftwareCheck: {}
-
-    tags:
+    tag_checks:
       step: verify_tags
       checks:
         InstanceTagCheck:
           required_keys: ["Name", "CreatedBy"]
+
+    serial_console:
+      step: serial_console
+      checks:
+        SerialConsoleCheck: {}
 
     cloud_init:
       step: launch_instance
       checks:
         CloudInitCheck: {}
 
+    # ─── Host-level validations anchored to describe_instance ────────
+    # describe_instance runs AFTER reboot, so these checks prove the
+    # host and its software survived the full stop/start/reboot lifecycle.
+    instance_info:
+      step: describe_instance
+      checks:
+        InstanceStateCheck:
+          expected_state: "running"
+
+    ssh:
+      step: describe_instance
+      checks:
+        ConnectivityCheck: {}
+        OsCheck:
+          expected_os: "ubuntu"
+
+    gpu:
+      step: describe_instance
+      checks:
+        GpuCheck:
+          expected_gpus: 1
+
+    host_os:
+      step: describe_instance
+      checks:
+        VcpuPinningCheck: {}
+        PciBusCheck:
+          expected_gpus: 1
+        HostSoftwareCheck: {}
+
+    driver_info:
+      step: describe_instance
+      checks:
+        DriverCheck: {}
+
+    cpu_info:
+      step: describe_instance
+      checks:
+        CpuInfoCheck: {}
+
+    container_runtime:
+      step: describe_instance
+      checks:
+        ContainerRuntimeCheck: {}
+
+    # ─── Lifecycle validations ───────────────────────────────────────
     stop_checks:
       step: stop_instance
       checks:
@@ -366,19 +432,7 @@ tests:
         GpuCheck:
           expected_gpus: 1
 
-    reboot_host_os:
-      step: reboot_instance
-      checks:
-        VcpuPinningCheck: {}
-        PciBusCheck:
-          expected_gpus: 1
-        HostSoftwareCheck: {}
-
-    serial_console:
-      step: serial_console
-      checks:
-        SerialConsoleCheck: {}
-
+    # ─── NIM validations ─────────────────────────────────────────────
     nim_health:
       step: deploy_nim
       checks:
@@ -396,21 +450,7 @@ tests:
           prompt: "What is CUDA?"
           max_tokens: 50
 
-    driver_info:
-      step: launch_instance
-      checks:
-        DriverCheck: {}
-
-    cpu_info:
-      step: launch_instance
-      checks:
-        CpuInfoCheck: {}
-
-    container_runtime:
-      step: launch_instance
-      checks:
-        ContainerRuntimeCheck: {}
-
+    # ─── Teardown validations ────────────────────────────────────────
     nim_teardown:
       step: teardown_nim
       checks:


### PR DESCRIPTION
## Summary

The canonical `vm.yaml` and `bare_metal.yaml` test suites had drifted significantly, including a real ordering bug where `ContainerRuntimeCheck` (verifies Docker) ran AFTER `deploy_nim` (which depends on Docker), and several misleading documentation inconsistencies that would trip up anyone writing a new provider implementation. This PR realigns the two suites and eliminates the drift.

### The bug

VM host-level checks (`driver_info`, `cpu_info`, `container_runtime`, `host_os`, `ssh`, `gpu`) were anchored to `launch_instance`, meaning they validated only the fresh-launch state. If Docker was somehow unhealthy after the stop/start/reboot lifecycle, we'd never catch it — `deploy_nim` would just fail with a noisier error before `ContainerRuntimeCheck` ever ran.

`bare_metal.yaml` had already solved this correctly: it introduces a lightweight `describe_instance` step that runs post-power-cycle, and all host-level checks anchor to that step. This PR applies the same pattern to VM (post-reboot).

### Changes

**vm.yaml restructured to mirror bare_metal.yaml:**
- New `describe_instance` step (step 8, post-reboot) — lightweight SSH/GPU/host validation anchor.
- Host-level checks (`ssh`, `gpu`, `host_os`, `driver_info`, `cpu_info`, `container_runtime`) now anchor to `describe_instance` instead of `launch_instance`. They now prove the host and its software survived the full stop/start/reboot lifecycle.
- `serial_console` step moved from step 7 (post-reboot) to step 4 (pre-lifecycle). It's a read-only op with no lifecycle dependency.
- Validation blocks reordered to match bare_metal.yaml's logical flow: launch -> list -> tags -> serial_console -> cloud_init -> describe_instance anchor -> lifecycle -> NIM -> teardown.
- `reboot_host_os` validation removed (redundant now that `host_os` runs post-reboot on `describe_instance`).
- New `instance_info` validation (`InstanceStateCheck` on `describe_instance`), matching bare_metal.yaml.

**Latent bug fixed:**
- `reboot_instance` was referencing `{{steps.launch_instance.public_ip}}` for its `--public-ip` arg, but stop/start can reassign the public IP. Now references `{{steps.start_instance.public_ip}}`, matching bare_metal.yaml.

**Documentation bug fixed:**
- vm.yaml JSON contract docs for `launch_instance` and `reboot_instance` said `"instance_state": "running"`, but `InstanceStateCheck` reads `state` and every real stub outputs `state`. Corrected. (Same bug exists in `image-registry.yaml` and `tests/README.md`; intentionally out of scope for this PR.)

**Naming parity:**
- `tags` validation renamed to `tag_checks` (matches bare_metal.yaml).

**bare_metal.yaml parity:**
- `host_os` augmented with `VcpuPinningCheck` + `PciBusCheck` (with `expected_gpus: 8`) — these are generic host-introspection checks that apply to bare metal too.

**AWS provider config:**
- Step-header numbering comments corrected (previously had duplicate "5" and "6").
- `serial_console` step reordered, `describe_instance` override added, `reboot_instance` `--public-ip` ref updated.

**New files:**
- `isvctl/configs/stubs/vm/describe_instance.py` — provider-agnostic template.
- `isvctl/configs/stubs/aws/vm/describe_instance.py` — boto3 implementation.

### What's still intentionally asymmetric

Bare metal retains `power_cycle_instance`, `reinstall_instance`, `topology_placement`, `verify_teardown`, workload checks (`gpu_stress`, `nccl`, `training`), and interconnect checks (`nvlink`, `infiniband`, `ethernet`). These target 8-GPU metal with BMC access and aren't meaningful for a typical single-GPU VM.

## Test plan

- [x] `yaml.safe_load` on all four touched configs
- [x] `isvctl.config.merger.merge_yaml_files` on both AWS provider configs (11 steps, 26 validations for VM; BM `host_os` now carries 3 checks)
- [x] `uvx ruff check` + `ruff format --check` pass on new stubs
- [x] pre-commit hooks pass (ruff, ruff format, yamlfmt, SPDX headers)
- [x] Full end-to-end AWS VM run: `AWS_PROFILE=... uv run isvctl test run -f isvctl/configs/providers/aws/vm.yaml --lab-id 11` — 17 passed + 3 NGC-skipped, 49 subtests all green, clean teardown. Verified in logs that host-level checks SSH against the post-reboot IP (`52.32.21.194`, reassigned from launch-time `54.191.133.118`), proving describe_instance anchoring is working as intended.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added instance description and richer instance metadata reporting to support lifecycle validations.
  * Introduced a post-reboot instance validation anchor to improve host-level checks.

* **Tests**
  * Expanded test workflow with additional ordered validation steps around serial console and instance description.
  * Added host-level validations including vCPU pinning and PCI bus (GPU) verification; updated mappings so host checks use the post-reboot instance description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->