### PR TITLE
feat: add OIDC issuer endpoint validation (K8S18)

### DIFF
--- a/isvctl/configs/tests/k8s.yaml
+++ b/isvctl/configs/tests/k8s.yaml
@@ -92,6 +92,10 @@ tests:
             "nvidia.com/mig.capable": "true"
             "nvidia.com/mig.strategy": "single"
 
+    k8s_identity:
+      checks:
+        K8sOidcIssuerCheck: {}
+
     k8s_workloads:
       checks:
         K8sNcclWorkload:

--- a/isvtest/src/isvtest/validations/k8s_oidc.py
+++ b/isvtest/src/isvtest/validations/k8s_oidc.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+import json
+import shlex
+from collections.abc import Iterable
+from typing import ClassVar
+from urllib.parse import urlsplit
+
+from isvtest.core.k8s import get_kubectl_command
+from isvtest.core.validation import BaseValidation
+
+DEFAULT_REQUIRED_FIELDS = [
+    "issuer",
+    "jwks_uri",
+    "response_types_supported",
+    "subject_types_supported",
+    "id_token_signing_alg_values_supported",
+]
+
+
+class K8sOidcIssuerCheck(BaseValidation):
+    """Validate the cluster's OIDC discovery endpoint for workload identity federation."""
+
+    description: ClassVar[str] = (
+        "Verify the cluster exposes a valid OIDC Issuer endpoint for workload identity federation."
+    )
+    markers: ClassVar[list[str]] = ["kubernetes"]
+
+    def run(self) -> None:
+        """Fetch the OIDC discovery document and validate its shape and issuer URL."""
+        required_fields_config = self.config.get("required_fields", DEFAULT_REQUIRED_FIELDS)
+        if isinstance(required_fields_config, str):
+            required_fields = [required_fields_config]
+        elif isinstance(required_fields_config, Iterable):
+            required_fields = list(required_fields_config)
+            if any(not isinstance(field, str) or not field for field in required_fields):
+                self.set_failed("Invalid 'required_fields' config: expected a string or iterable of non-empty strings.")
+                return
+        else:
+            self.set_failed("Invalid 'required_fields' config: expected a string or iterable of non-empty strings.")
+            return
+
+        kubectl_parts = get_kubectl_command()
+        kubectl_base = " ".join(shlex.quote(part) for part in kubectl_parts)
+
+        cmd = f"{kubectl_base} get --raw /.well-known/openid-configuration"
+        result = self.run_command(cmd)
+
+        if result.exit_code != 0:
+            self.set_failed(f"Failed to query OIDC discovery endpoint: {result.stderr}")
+            return
+
+        try:
+            oidc_config = json.loads(result.stdout)
+        except json.JSONDecodeError as e:
+            self.set_failed(f"Failed to parse OIDC discovery response as JSON: {e}")
+            return
+
+        if not isinstance(oidc_config, dict):
+            self.set_failed("OIDC discovery response must be a JSON object.")
+            return
+
+        missing_fields = [f for f in required_fields if f not in oidc_config]
+        if missing_fields:
+            self.set_failed(f"OIDC discovery response missing required fields: {', '.join(missing_fields)}")
+            return
+
+        issuer = oidc_config.get("issuer")
+        if not isinstance(issuer, str):
+            self.set_failed(f"OIDC issuer is not a valid HTTPS URL: {issuer}")
+            return
+
+        parsed = urlsplit(issuer)
+        if parsed.scheme != "https" or not parsed.netloc:
+            self.set_failed(f"OIDC issuer is not a valid HTTPS URL: {issuer}")
+            return
+
+        self.log.info(f"OIDC issuer: {issuer}")
+        self.set_passed(f"OIDC discovery endpoint is valid with issuer: {issuer}")

--- a/isvtest/src/isvtest/validations/k8s_oidc.py
+++ b/isvtest/src/isvtest/validations/k8s_oidc.py
@@ -37,15 +37,27 @@ class K8sOidcIssuerCheck(BaseValidation):
     def run(self) -> None:
         """Fetch the OIDC discovery document and validate its shape and issuer URL."""
         required_fields_config = self.config.get("required_fields", DEFAULT_REQUIRED_FIELDS)
+        error_msg = "Invalid 'required_fields' config: expected a string or iterable of non-empty strings."
         if isinstance(required_fields_config, str):
-            required_fields = [required_fields_config]
-        elif isinstance(required_fields_config, Iterable):
-            required_fields = list(required_fields_config)
-            if any(not isinstance(field, str) or not field for field in required_fields):
-                self.set_failed("Invalid 'required_fields' config: expected a string or iterable of non-empty strings.")
+            field = required_fields_config.strip()
+            if not field:
+                self.set_failed(error_msg)
                 return
+            required_fields = [field]
+        elif isinstance(required_fields_config, Iterable):
+            required_fields = []
+            for field in required_fields_config:
+                if not isinstance(field, str):
+                    self.set_failed(error_msg)
+                    return
+
+                normalized_field = field.strip()
+                if not normalized_field:
+                    self.set_failed(error_msg)
+                    return
+                required_fields.append(normalized_field)
         else:
-            self.set_failed("Invalid 'required_fields' config: expected a string or iterable of non-empty strings.")
+            self.set_failed(error_msg)
             return
 
         kubectl_parts = get_kubectl_command()

--- a/isvtest/tests/test_k8s_oidc.py
+++ b/isvtest/tests/test_k8s_oidc.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+from isvtest.core.runners import CommandResult
+from isvtest.validations.k8s_oidc import K8sOidcIssuerCheck
+
+VALID_OIDC_RESPONSE = {
+    "issuer": "https://oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE",
+    "jwks_uri": "https://oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE/keys",
+    "response_types_supported": ["id_token"],
+    "subject_types_supported": ["public"],
+    "id_token_signing_alg_values_supported": ["RS256"],
+}
+
+
+def _make_check(
+    stdout: str = "",
+    stderr: str = "",
+    exit_code: int = 0,
+    config: dict[str, Any] | None = None,
+) -> K8sOidcIssuerCheck:
+    """Create a K8sOidcIssuerCheck instance with a mocked command runner."""
+    mock_runner = MagicMock()
+    mock_runner.run.return_value = CommandResult(
+        exit_code=exit_code,
+        stdout=stdout,
+        stderr=stderr,
+        duration=0.1,
+    )
+    return K8sOidcIssuerCheck(runner=mock_runner, config=config or {})
+
+
+class TestK8sOidcIssuerCheck:
+    """Unit tests for K8sOidcIssuerCheck."""
+
+    def test_success_with_all_required_fields(self) -> None:
+        check = _make_check(stdout=json.dumps(VALID_OIDC_RESPONSE))
+        result = check.execute()
+        assert result["passed"] is True
+        assert "OIDC discovery endpoint is valid" in result["output"]
+        assert VALID_OIDC_RESPONSE["issuer"] in result["output"]
+
+    def test_missing_required_fields(self) -> None:
+        incomplete = {"issuer": "https://example.com", "jwks_uri": "https://example.com/keys"}
+        check = _make_check(stdout=json.dumps(incomplete))
+        result = check.execute()
+        assert result["passed"] is False
+        assert "missing required fields" in result["error"]
+        assert "response_types_supported" in result["error"]
+
+    def test_invalid_json_response(self) -> None:
+        check = _make_check(stdout="not-json")
+        result = check.execute()
+        assert result["passed"] is False
+        assert "Failed to parse OIDC discovery response as JSON" in result["error"]
+
+    def test_non_object_json_response(self) -> None:
+        check = _make_check(stdout="[]")
+        result = check.execute()
+        assert result["passed"] is False
+        assert "must be a JSON object" in result["error"]
+
+    def test_kubectl_command_failure(self) -> None:
+        check = _make_check(exit_code=1, stderr="connection refused")
+        result = check.execute()
+        assert result["passed"] is False
+        assert "Failed to query OIDC discovery endpoint" in result["error"]
+        assert "connection refused" in result["error"]
+
+    def test_custom_required_fields(self) -> None:
+        response = {"issuer": "https://example.com", "custom_field": "value"}
+        check = _make_check(
+            stdout=json.dumps(response),
+            config={"required_fields": ["issuer", "custom_field"]},
+        )
+        result = check.execute()
+        assert result["passed"] is True
+
+    def test_required_fields_single_string_is_accepted(self) -> None:
+        response = {"issuer": "https://example.com"}
+        check = _make_check(
+            stdout=json.dumps(response),
+            config={"required_fields": "issuer"},
+        )
+        result = check.execute()
+        assert result["passed"] is True
+
+    def test_required_fields_none_is_rejected(self) -> None:
+        check = _make_check(
+            stdout=json.dumps(VALID_OIDC_RESPONSE),
+            config={"required_fields": None},
+        )
+        result = check.execute()
+        assert result["passed"] is False
+        assert "Invalid 'required_fields' config" in result["error"]
+
+    def test_required_fields_non_string_items_are_rejected(self) -> None:
+        check = _make_check(
+            stdout=json.dumps(VALID_OIDC_RESPONSE),
+            config={"required_fields": ["issuer", 1]},
+        )
+        result = check.execute()
+        assert result["passed"] is False
+        assert "Invalid 'required_fields' config" in result["error"]
+
+    def test_issuer_not_https(self) -> None:
+        response = dict(VALID_OIDC_RESPONSE, issuer="http://insecure.example.com")
+        check = _make_check(stdout=json.dumps(response))
+        result = check.execute()
+        assert result["passed"] is False
+        assert "not a valid HTTPS URL" in result["error"]
+
+    def test_issuer_empty_string(self) -> None:
+        response = dict(VALID_OIDC_RESPONSE, issuer="")
+        check = _make_check(stdout=json.dumps(response))
+        result = check.execute()
+        assert result["passed"] is False
+        assert "not a valid HTTPS URL" in result["error"]

--- a/isvtest/tests/test_k8s_oidc.py
+++ b/isvtest/tests/test_k8s_oidc.py
@@ -96,6 +96,24 @@ class TestK8sOidcIssuerCheck:
         result = check.execute()
         assert result["passed"] is True
 
+    def test_required_fields_single_string_with_whitespace_is_trimmed(self) -> None:
+        response = {"issuer": "https://example.com"}
+        check = _make_check(
+            stdout=json.dumps(response),
+            config={"required_fields": " issuer "},
+        )
+        result = check.execute()
+        assert result["passed"] is True
+
+    def test_required_fields_whitespace_string_is_rejected(self) -> None:
+        check = _make_check(
+            stdout=json.dumps(VALID_OIDC_RESPONSE),
+            config={"required_fields": "   "},
+        )
+        result = check.execute()
+        assert result["passed"] is False
+        assert "Invalid 'required_fields' config" in result["error"]
+
     def test_required_fields_none_is_rejected(self) -> None:
         check = _make_check(
             stdout=json.dumps(VALID_OIDC_RESPONSE),
@@ -109,6 +127,15 @@ class TestK8sOidcIssuerCheck:
         check = _make_check(
             stdout=json.dumps(VALID_OIDC_RESPONSE),
             config={"required_fields": ["issuer", 1]},
+        )
+        result = check.execute()
+        assert result["passed"] is False
+        assert "Invalid 'required_fields' config" in result["error"]
+
+    def test_required_fields_whitespace_items_are_rejected(self) -> None:
+        check = _make_check(
+            stdout=json.dumps(VALID_OIDC_RESPONSE),
+            config={"required_fields": ["issuer", "   "]},
         )
         result = check.execute()
         assert result["passed"] is False


### PR DESCRIPTION
## Summary
- Adds `K8sOidcIssuerCheck` validating that the cluster exposes a valid OIDC discovery endpoint (`/.well-known/openid-configuration`) for workload identity federation.
- Verifies the response parses as JSON, contains the required OIDC fields, and that `issuer` is an HTTPS URL.
- Wires the check into `isvctl/configs/tests/k8s.yaml` and adds unit tests.

## Linked issue
- Closes #226

## Test plan
- [x] `uv run pytest isvtest/tests/test_k8s_oidc.py`
- [x] Run `isvctl` against a K8s cluster and confirm the K8S18 step passes
- [x] Confirm the check fails cleanly when the discovery endpoint is unreachable / malformed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes OIDC issuer validation: queries the cluster discovery endpoint, verifies required discovery fields, and ensures the issuer is a valid HTTPS URL.
  * Added a configurable Kubernetes identity validation group to declare required discovery fields.

* **Tests**
  * Added unit tests covering success, missing fields, malformed/non-object responses, command failures, config validation, and issuer URL checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
