### PR TITLE
refactor: add get_kubectl_base_shell() helper and dedup call sites

### DIFF
--- a/isvtest/src/isvtest/core/k8s.py
+++ b/isvtest/src/isvtest/core/k8s.py
@@ -161,6 +161,16 @@ def get_kubectl_command() -> list[str]:
     return ["kubectl"]
 
 
+def get_kubectl_base_shell() -> str:
+    """Return the kubectl invocation as a shell-quoted string.
+
+    Use this when interpolating kubectl into a shell command string (e.g.
+    passing to ``run_command`` or composing pipes). For argv-style calls
+    (``subprocess.run``), use :func:`get_kubectl_command` instead.
+    """
+    return " ".join(shlex.quote(part) for part in get_kubectl_command())
+
+
 def run_kubectl(
     args: list[str],
     timeout: int = 30,

--- a/isvtest/src/isvtest/core/ngc.py
+++ b/isvtest/src/isvtest/core/ngc.py
@@ -17,7 +17,6 @@ This module provides shared functionality for:
 
 import json
 import os
-import shlex
 import subprocess
 import time
 import uuid
@@ -42,16 +41,6 @@ def get_ngc_api_key() -> str:
         The API key string, or empty string if neither variable is set.
     """
     return os.environ.get("NGC_API_KEY", "") or os.environ.get("NGC_NIM_API_KEY", "")
-
-
-def get_kubectl_base() -> str:
-    """Get the kubectl base command as a shell-safe string.
-
-    Returns:
-        Shell-escaped kubectl command string (e.g., "kubectl" or "microk8s kubectl").
-    """
-    kubectl_parts = get_kubectl_command()
-    return " ".join(shlex.quote(part) for part in kubectl_parts)
 
 
 def ensure_ngc_secrets(namespace: str, ngc_api_key: str | None = None) -> tuple[bool, str]:

--- a/isvtest/src/isvtest/core/workload.py
+++ b/isvtest/src/isvtest/core/workload.py
@@ -8,12 +8,11 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
-import shlex
 import subprocess
 import time
 from typing import Any, ClassVar
 
-from isvtest.core.k8s import get_kubectl_command
+from isvtest.core.k8s import get_kubectl_base_shell, get_kubectl_command
 from isvtest.core.runners import CommandResult, Runner
 from isvtest.core.validation import BaseValidation
 
@@ -45,7 +44,7 @@ class BaseWorkloadCheck(BaseValidation):
         4. Delete Job
         """
         kubectl_parts = get_kubectl_command()
-        kubectl_base = " ".join(shlex.quote(part) for part in kubectl_parts)
+        kubectl_base = get_kubectl_base_shell()
 
         # 1. Apply Job
         self.log.info(f"Deploying job {job_name} in namespace {namespace}...")

--- a/isvtest/src/isvtest/validations/k8s_cluster.py
+++ b/isvtest/src/isvtest/validations/k8s_cluster.py
@@ -8,10 +8,9 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
-import shlex
 from typing import ClassVar
 
-from isvtest.core.k8s import get_kubectl_command
+from isvtest.core.k8s import get_kubectl_base_shell
 from isvtest.core.validation import BaseValidation
 
 
@@ -23,8 +22,7 @@ class K8sPodHealthCheck(BaseValidation):
         # Configurable ignore phases
         ignore_phases = self.config.get("ignore_phases", [])
 
-        kubectl_parts = get_kubectl_command()
-        kubectl_base = " ".join(shlex.quote(part) for part in kubectl_parts)
+        kubectl_base = get_kubectl_base_shell()
 
         # We generally query for everything NOT running/succeeded
         cmd = f"{kubectl_base} get pods -A --no-headers --field-selector status.phase!=Running,status.phase!=Succeeded"
@@ -64,8 +62,7 @@ class K8sNoPendingPodsCheck(BaseValidation):
     markers: ClassVar[list[str]] = ["kubernetes"]
 
     def run(self) -> None:
-        kubectl_parts = get_kubectl_command()
-        kubectl_base = " ".join(shlex.quote(part) for part in kubectl_parts)
+        kubectl_base = get_kubectl_base_shell()
 
         cmd = f"{kubectl_base} get pods -A --field-selector status.phase=Pending --no-headers"
         result = self.run_command(cmd)
@@ -93,8 +90,7 @@ class K8sNoErrorPodsCheck(BaseValidation):
     markers: ClassVar[list[str]] = ["kubernetes"]
 
     def run(self) -> None:
-        kubectl_parts = get_kubectl_command()
-        kubectl_base = " ".join(shlex.quote(part) for part in kubectl_parts)
+        kubectl_base = get_kubectl_base_shell()
 
         # Configurable error states
         error_states = self.config.get(

--- a/isvtest/src/isvtest/validations/k8s_gpu.py
+++ b/isvtest/src/isvtest/validations/k8s_gpu.py
@@ -9,14 +9,13 @@
 # its affiliates is strictly prohibited.
 
 import json
-import shlex
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from typing import ClassVar
 
 from isvtest.config.settings import get_k8s_namespace
-from isvtest.core.k8s import get_kubectl_command
+from isvtest.core.k8s import get_kubectl_base_shell
 from isvtest.core.nvidia import count_gpus_from_full_output, parse_driver_version
 from isvtest.core.validation import BaseValidation
 
@@ -50,10 +49,7 @@ class K8sNvidiaSmiCheck(BaseValidation):
 
     def _run_ephemeral_pods(self, timeout: int = 60) -> dict[str, dict]:
         """Run ephemeral pods on all GPU nodes and return results."""
-        kubectl_parts = get_kubectl_command()
-        # Ensure we quote parts correctly, but spaces in parts (like "microk8s kubectl")
-        # need to be handled carefully if passed as a single string to run_command
-        kubectl_base = " ".join(shlex.quote(part) for part in kubectl_parts)
+        kubectl_base = get_kubectl_base_shell()
         namespace = get_k8s_namespace()
 
         # 1. Identify GPU nodes

--- a/isvtest/src/isvtest/validations/k8s_gpu_operator.py
+++ b/isvtest/src/isvtest/validations/k8s_gpu_operator.py
@@ -12,7 +12,7 @@ import shlex
 from typing import ClassVar
 
 from isvtest.config.settings import get_k8s_gpu_operator_namespace
-from isvtest.core.k8s import get_kubectl_command
+from isvtest.core.k8s import get_kubectl_base_shell
 from isvtest.core.validation import BaseValidation
 
 
@@ -24,8 +24,7 @@ class K8sGpuOperatorNamespaceCheck(BaseValidation):
         # Prefer config value, fall back to global setting
         namespace = self.config.get("namespace") or get_k8s_gpu_operator_namespace()
 
-        kubectl_parts = get_kubectl_command()
-        kubectl_base = " ".join(shlex.quote(part) for part in kubectl_parts)
+        kubectl_base = get_kubectl_base_shell()
 
         result = self.run_command(f"{kubectl_base} get namespace {shlex.quote(namespace)}")
 
@@ -44,8 +43,7 @@ class K8sGpuOperatorPodsCheck(BaseValidation):
         # Prefer config value, fall back to global setting
         namespace = self.config.get("namespace") or get_k8s_gpu_operator_namespace()
 
-        kubectl_parts = get_kubectl_command()
-        kubectl_base = " ".join(shlex.quote(part) for part in kubectl_parts)
+        kubectl_base = get_kubectl_base_shell()
 
         result = self.run_command(f"{kubectl_base} get pods -n {shlex.quote(namespace)}")
 

--- a/isvtest/src/isvtest/validations/k8s_mig.py
+++ b/isvtest/src/isvtest/validations/k8s_mig.py
@@ -9,12 +9,11 @@
 # its affiliates is strictly prohibited.
 
 import json
-import shlex
 from typing import ClassVar
 
 import pytest
 
-from isvtest.core.k8s import get_kubectl_command
+from isvtest.core.k8s import get_kubectl_base_shell
 from isvtest.core.validation import BaseValidation
 
 
@@ -26,8 +25,7 @@ class K8sMigConfigCheck(BaseValidation):
         require_mig = self.config.get("require_mig", False)
         expected_labels = self.config.get("expected_labels", {})
 
-        kubectl_parts = get_kubectl_command()
-        kubectl_base = " ".join(shlex.quote(part) for part in kubectl_parts)
+        kubectl_base = get_kubectl_base_shell()
 
         # Get all nodes JSON to check labels
         cmd = f"{kubectl_base} get nodes -o json"

--- a/isvtest/src/isvtest/validations/k8s_nodes.py
+++ b/isvtest/src/isvtest/validations/k8s_nodes.py
@@ -9,10 +9,9 @@
 # its affiliates is strictly prohibited.
 
 import json
-import shlex
 from typing import ClassVar
 
-from isvtest.core.k8s import get_kubectl_command
+from isvtest.core.k8s import get_kubectl_base_shell
 from isvtest.core.validation import BaseValidation
 
 
@@ -34,8 +33,7 @@ class K8sNodeCountCheck(BaseValidation):
             self.set_failed(f"Invalid expected count: {expected_count}")
             return
 
-        kubectl_parts = get_kubectl_command()
-        kubectl_base = " ".join(shlex.quote(part) for part in kubectl_parts)
+        kubectl_base = get_kubectl_base_shell()
         cmd = f"{kubectl_base} get nodes --no-headers | wc -l"
 
         result = self.run_command(cmd)
@@ -62,8 +60,7 @@ class K8sNodeReadyCheck(BaseValidation):
     markers: ClassVar[list[str]] = ["kubernetes"]
 
     def run(self) -> None:
-        kubectl_parts = get_kubectl_command()
-        kubectl_base = " ".join(shlex.quote(part) for part in kubectl_parts)
+        kubectl_base = get_kubectl_base_shell()
 
         # Use JSON output for safer parsing
         cmd = f"{kubectl_base} get nodes -o json"
@@ -128,8 +125,7 @@ class K8sExpectedNodesCheck(BaseValidation):
             return
 
         # Get actual nodes
-        kubectl_parts = get_kubectl_command()
-        kubectl_base = " ".join(shlex.quote(part) for part in kubectl_parts)
+        kubectl_base = get_kubectl_base_shell()
         cmd = f"{kubectl_base} get nodes -o jsonpath='{{.items[*].metadata.name}}'"
 
         result = self.run_command(cmd)

--- a/isvtest/src/isvtest/validations/k8s_scheduling.py
+++ b/isvtest/src/isvtest/validations/k8s_scheduling.py
@@ -11,7 +11,7 @@
 import shlex
 from typing import ClassVar
 
-from isvtest.core.k8s import get_kubectl_command
+from isvtest.core.k8s import get_kubectl_base_shell
 from isvtest.core.validation import BaseValidation
 
 
@@ -22,8 +22,7 @@ class K8sGpuLabelsCheck(BaseValidation):
     def run(self) -> None:
         label_selector = self.config.get("label_selector", "nvidia.com/gpu.present=true")
 
-        kubectl_parts = get_kubectl_command()
-        kubectl_base = " ".join(shlex.quote(part) for part in kubectl_parts)
+        kubectl_base = get_kubectl_base_shell()
 
         cmd = f"{kubectl_base} get nodes -l {shlex.quote(label_selector)} --no-headers"
         result = self.run_command(cmd)
@@ -76,8 +75,7 @@ class K8sGpuCapacityCheck(BaseValidation):
         # Need to escape dot for jsonpath if it exists (e.g. nvidia.com/gpu -> nvidia\.com/gpu)
         escaped_resource = resource_name.replace(".", "\\.")
 
-        kubectl_parts = get_kubectl_command()
-        kubectl_base = " ".join(shlex.quote(part) for part in kubectl_parts)
+        kubectl_base = get_kubectl_base_shell()
 
         # Check for resource in node capacity
         cmd = f'{kubectl_base} get nodes -o jsonpath=\'{{range .items[*]}}{{.metadata.name}}{{"\\t"}}{{.status.capacity.{escaped_resource}}}{{"\\n"}}{{end}}\''

--- a/isvtest/src/isvtest/workloads/k8s_nim.py
+++ b/isvtest/src/isvtest/workloads/k8s_nim.py
@@ -23,11 +23,12 @@ from isvtest.config.settings import get_k8s_namespace
 from isvtest.core.k8s import (
     get_gpu_nodes,
     get_job_pods,
+    get_kubectl_base_shell,
     get_kubectl_command,
     get_pod_logs,
     wait_for_job_completion,
 )
-from isvtest.core.ngc import ensure_ngc_secrets, get_kubectl_base
+from isvtest.core.ngc import ensure_ngc_secrets
 from isvtest.core.workload import BaseWorkloadCheck
 
 
@@ -82,7 +83,7 @@ class K8sNimInferenceWorkload(BaseWorkloadCheck):
         self.log.info("Steps: 1. Pull images, 2. Download model, 3. Load model (10-12m), 4. Run inference")
 
         kubectl_parts = get_kubectl_command()
-        kubectl_base = get_kubectl_base()
+        kubectl_base = get_kubectl_base_shell()
 
         try:
             result = subprocess.run(
@@ -144,7 +145,7 @@ class K8sNimInferenceWorkload(BaseWorkloadCheck):
             True if PVC exists or was created, False on error.
         """
         pvc_name = "nim-model-cache"
-        kubectl_base = get_kubectl_base()
+        kubectl_base = get_kubectl_base_shell()
 
         res = self.run_command(f"{kubectl_base} get pvc {pvc_name} -n {namespace}")
         if res.exit_code == 0:

--- a/isvtest/src/isvtest/workloads/k8s_nim_helm.py
+++ b/isvtest/src/isvtest/workloads/k8s_nim_helm.py
@@ -29,8 +29,8 @@ from typing import Any, ClassVar
 import pytest
 
 from isvtest.config.settings import get_k8s_namespace
-from isvtest.core.k8s import get_gpu_nodes, get_kubectl_command
-from isvtest.core.ngc import get_kubectl_base, get_ngc_api_key, validate_nim_inference
+from isvtest.core.k8s import get_gpu_nodes, get_kubectl_base_shell, get_kubectl_command
+from isvtest.core.ngc import get_ngc_api_key, validate_nim_inference
 from isvtest.core.workload import BaseWorkloadCheck
 
 
@@ -140,7 +140,7 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
             release_name = None  # No cleanup needed
 
             # Just verify the service exists
-            kubectl_base = get_kubectl_base()
+            kubectl_base = get_kubectl_base_shell()
             result = self.run_command(f"{kubectl_base} get svc {service_name} -n {namespace}")
             if result.exit_code != 0:
                 self.set_failed(f"Service {service_name} not found in namespace {namespace}")
@@ -267,7 +267,7 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
             pytest.skip("NGC_API_KEY not set - NGC credentials required")
 
         kubectl_parts = get_kubectl_command()
-        kubectl_base = get_kubectl_base()
+        kubectl_base = get_kubectl_base_shell()
 
         # Create namespace if it doesn't exist
         self.run_command(
@@ -457,7 +457,7 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
         """Wait for NIM deployment to be ready and serving."""
         self.log.info(f"Waiting for NIM service {service_name} to be ready...")
 
-        kubectl_base = get_kubectl_base()
+        kubectl_base = get_kubectl_base_shell()
         release_name = service_name.replace("-nim-llm", "")
 
         start_time = time.time()
@@ -559,7 +559,7 @@ class K8sNimHelmWorkload(BaseWorkloadCheck):
 
         job_name = f"genai-perf-{uuid.uuid4().hex[:8]}"
         kubectl_parts = get_kubectl_command()
-        kubectl_base = get_kubectl_base()
+        kubectl_base = get_kubectl_base_shell()
 
         # Create GenAI-Perf job manifest
         job_yaml = self._create_genai_perf_job_yaml(
@@ -800,7 +800,7 @@ spec:
         """Dump Helm release status for debugging."""
         self.log.error("Dumping Helm release status for debugging...")
 
-        kubectl_base = get_kubectl_base()
+        kubectl_base = get_kubectl_base_shell()
 
         self.run_command(f"helm status {release_name} -n {namespace}")
         self.run_command(f"{kubectl_base} describe pods -n {namespace} -l app.kubernetes.io/instance={release_name}")

--- a/isvtest/src/isvtest/workloads/k8s_stress.py
+++ b/isvtest/src/isvtest/workloads/k8s_stress.py
@@ -8,7 +8,6 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
-import shlex
 import subprocess
 import time
 import uuid
@@ -24,7 +23,7 @@ from isvtest.config.settings import (
     get_gpu_stress_timeout,
     get_k8s_namespace,
 )
-from isvtest.core.k8s import get_gpu_nodes, get_kubectl_command, get_node_gpu_count
+from isvtest.core.k8s import get_gpu_nodes, get_kubectl_base_shell, get_kubectl_command, get_node_gpu_count
 from isvtest.core.workload import BaseWorkloadCheck
 
 
@@ -114,8 +113,7 @@ class K8sGpuStressWorkload(BaseWorkloadCheck):
             pod_succeeded = False
             pod_logs = ""
 
-            # Build kubectl base command for this file's runner.run() calls
-            kubectl_base = " ".join(shlex.quote(part) for part in kubectl_parts)
+            kubectl_base = get_kubectl_base_shell()
 
             while time.time() < end_time:
                 time.sleep(5)

--- a/isvtest/tests/test_k8s.py
+++ b/isvtest/tests/test_k8s.py
@@ -15,8 +15,7 @@ from unittest.mock import patch
 
 import pytest
 
-from isvtest.core.k8s import get_k8s_provider, get_kubectl_command
-from isvtest.core.ngc import get_kubectl_base
+from isvtest.core.k8s import get_k8s_provider, get_kubectl_base_shell, get_kubectl_command
 
 
 class TestGetKubectlCommandOverride:
@@ -101,13 +100,13 @@ class TestGetKubectlCommandOverride:
             result = get_kubectl_command()
         assert result == ["kubectl"]
 
-    def test_get_kubectl_base_round_trip(self) -> None:
-        """get_kubectl_base() returns shell-safe string from KUBECTL override."""
+    def test_get_kubectl_base_shell_round_trip(self) -> None:
+        """get_kubectl_base_shell() returns shell-safe string from KUBECTL override."""
         with (
             patch.dict(os.environ, {"KUBECTL": "microk8s kubectl"}, clear=True),
             patch("isvtest.core.k8s.shutil.which", return_value="/snap/bin/microk8s"),
         ):
-            result = get_kubectl_base()
+            result = get_kubectl_base_shell()
         assert result == "microk8s kubectl"
 
     def test_binary_not_on_path_raises(self) -> None:


### PR DESCRIPTION
## Summary

- Add `get_kubectl_base_shell()` in `core/k8s.py` — a shared helper returning the kubectl invocation as a shell-quoted string, complementing the existing `get_kubectl_command()` (which returns argv).
- Migrate the repeated `" ".join(shlex.quote(p) for p in get_kubectl_command())` idiom in all k8s validations, NIM/GPU-stress workloads, and `core/workload.py` to the new helper.
- Remove the duplicate `get_kubectl_base()` helper from `core/ngc.py` — the helper belongs in `core/k8s.py`, and validations no longer need to reach into `core.ngc` for a k8s-domain concern.

Pure refactor, no behavior change. `get_kubectl_base_shell()` produces an identical shell-quoted string to the inline pattern it replaces.

## Test plan

- [x] `uv run pytest tests/test_k8s.py` — 11/11 pass (includes renamed `test_get_kubectl_base_shell_round_trip` covering the `KUBECTL=microk8s kubectl` round-trip)
- [x] All modified modules import cleanly
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated Kubernetes command construction logic by centralizing kubectl base command generation into a single reusable helper, eliminating duplicate shell-quoting code across validation and workload modules. This improves code maintainability and reduces redundancy while preserving all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->