### PR TITLE
feat: add K8sControlPlaneLogsCheck for control-plane log retrieval (K8S20)

### DIFF
--- a/isvctl/configs/providers/aws/eks.yaml
+++ b/isvctl/configs/providers/aws/eks.yaml
@@ -58,3 +58,7 @@ commands:
 
 tests:
   description: "AWS EKS GPU cluster validation"
+
+  exclude:
+    tests:
+      - K8sControlPlaneLogsCheck # TODO: need control plane logging

--- a/isvctl/configs/tests/k8s.yaml
+++ b/isvctl/configs/tests/k8s.yaml
@@ -91,33 +91,6 @@ tests:
           expected_labels:
             "nvidia.com/mig.capable": "true"
             "nvidia.com/mig.strategy": "single"
-        K8sControlPlaneLogsCheck:
-          # mode=auto resolves each component independently: kubectl when a
-          # control-plane pod exists in `namespace`, else `commands[component]`.
-          # This covers hybrid clusters (some components as static pods, others
-          # managed externally). Managed-provider examples:
-          #   commands:
-          #     kube-apiserver: >-
-          #       aws logs tail /aws/eks/my-cluster/cluster
-          #       --log-stream-name-prefix kube-apiserver- --since 5m
-          #     kube-scheduler: >-
-          #       gcloud logging read
-          #       'resource.type=k8s_cluster AND logName:kube-scheduler'
-          #       --limit 20 --freshness 5m
-          #     kube-controller-manager: >-
-          #       az monitor log-analytics query -w $LAW_ID --analytics-query
-          #       "KubeEvents | where ObjectKind == 'kube-controller-manager'
-          #       | take 20"
-          # `namespace` is only used by the kubectl path; `since` is forwarded
-          # to `kubectl logs --since` and ignored in command mode.
-          mode: auto
-          components:
-            - kube-apiserver
-            - kube-scheduler
-            - kube-controller-manager
-          min_log_lines: 1
-          namespace: "{{ steps.setup.kubernetes.control_plane_namespace | default('kube-system') }}"
-          tail: 20
 
     k8s_identity:
       checks:
@@ -158,6 +131,33 @@ tests:
     k8s_observability:
       checks:
         K8sApiServerMetricsCheck: {}
+        K8sControlPlaneLogsCheck:
+          # mode=auto resolves each component independently: kubectl when a
+          # control-plane pod exists in `namespace`, else `commands[component]`.
+          # This covers hybrid clusters (some components as static pods, others
+          # managed externally). Managed-provider examples:
+          #   commands:
+          #     kube-apiserver: >-
+          #       aws logs tail /aws/eks/my-cluster/cluster
+          #       --log-stream-name-prefix kube-apiserver- --since 5m
+          #     kube-scheduler: >-
+          #       gcloud logging read
+          #       'resource.type=k8s_cluster AND logName:kube-scheduler'
+          #       --limit 20 --freshness 5m
+          #     kube-controller-manager: >-
+          #       az monitor log-analytics query -w $LAW_ID --analytics-query
+          #       "KubeEvents | where ObjectKind == 'kube-controller-manager'
+          #       | take 20"
+          # `namespace` is only used by the kubectl path; `since` is forwarded
+          # to `kubectl logs --since` and ignored in command mode.
+          mode: auto
+          components:
+            - kube-apiserver
+            - kube-scheduler
+            - kube-controller-manager
+          min_log_lines: 1
+          namespace: "{{ steps.setup.kubernetes.control_plane_namespace | default('kube-system') }}"
+          tail: 20
 
   exclude:
     markers: []

--- a/isvctl/configs/tests/k8s.yaml
+++ b/isvctl/configs/tests/k8s.yaml
@@ -91,6 +91,33 @@ tests:
           expected_labels:
             "nvidia.com/mig.capable": "true"
             "nvidia.com/mig.strategy": "single"
+        K8sControlPlaneLogsCheck:
+          # mode=auto resolves each component independently: kubectl when a
+          # control-plane pod exists in `namespace`, else `commands[component]`.
+          # This covers hybrid clusters (some components as static pods, others
+          # managed externally). Managed-provider examples:
+          #   commands:
+          #     kube-apiserver: >-
+          #       aws logs tail /aws/eks/my-cluster/cluster
+          #       --log-stream-name-prefix kube-apiserver- --since 5m
+          #     kube-scheduler: >-
+          #       gcloud logging read
+          #       'resource.type=k8s_cluster AND logName:kube-scheduler'
+          #       --limit 20 --freshness 5m
+          #     kube-controller-manager: >-
+          #       az monitor log-analytics query -w $LAW_ID --analytics-query
+          #       "KubeEvents | where ObjectKind == 'kube-controller-manager'
+          #       | take 20"
+          # `namespace` is only used by the kubectl path; `since` is forwarded
+          # to `kubectl logs --since` and ignored in command mode.
+          mode: auto
+          components:
+            - kube-apiserver
+            - kube-scheduler
+            - kube-controller-manager
+          min_log_lines: 1
+          namespace: "{{ steps.setup.kubernetes.control_plane_namespace | default('kube-system') }}"
+          tail: 20
 
     k8s_identity:
       checks:

--- a/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
+++ b/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
@@ -11,7 +11,7 @@
 from __future__ import annotations
 
 import shlex
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from isvtest.core.k8s import get_kubectl_base_shell
 from isvtest.core.validation import BaseValidation
@@ -52,7 +52,7 @@ class K8sControlPlaneLogsCheck(BaseValidation):
             min_log_lines=cfg["min_log_lines"],
         )
 
-    def _parse_config(self) -> dict | None:
+    def _parse_config(self) -> dict[str, Any] | None:
         mode = str(self.config.get("mode", "auto")).lower()
         if mode not in _VALID_MODES:
             self.set_failed(f"Invalid mode: {mode!r} (expected one of {list(_VALID_MODES)})")

--- a/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
+++ b/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
@@ -124,6 +124,9 @@ class K8sControlPlaneLogsCheck(BaseValidation):
 
     def _parse_positive_int(self, key: str, *, default: int) -> int | None:
         raw = self.config.get(key, default)
+        if isinstance(raw, bool):
+            self.set_failed(f"`{key}` must be an integer, got bool: {raw!r}")
+            return None
         try:
             value = int(raw)
         except (TypeError, ValueError):

--- a/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
+++ b/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
@@ -1,0 +1,360 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+from __future__ import annotations
+
+import shlex
+from typing import ClassVar
+
+from isvtest.core.k8s import get_kubectl_base_shell
+from isvtest.core.validation import BaseValidation
+
+_VALID_MODES = ("auto", "kubectl", "command")
+_DEFAULT_COMPONENTS = (
+    "kube-apiserver",
+    "kube-scheduler",
+    "kube-controller-manager",
+)
+_CMD_SNIPPET_LEN = 80
+
+
+class K8sControlPlaneLogsCheck(BaseValidation):
+    description: ClassVar[str] = "Verify Kubernetes control-plane logs can be viewed or exported."
+    timeout: ClassVar[int] = 120
+    markers: ClassVar[list[str]] = ["kubernetes"]
+
+    def run(self) -> None:
+        cfg = self._parse_config()
+        if cfg is None:
+            return
+
+        plan = self._build_plan(
+            mode=cfg["mode"],
+            namespace=cfg["namespace"],
+            components=cfg["components"],
+            commands=cfg["commands"],
+        )
+        if plan is None:
+            return
+
+        self._execute_plan(
+            plan=plan,
+            namespace=cfg["namespace"],
+            tail=cfg["tail"],
+            since=cfg["since"],
+            min_log_lines=cfg["min_log_lines"],
+        )
+
+    def _parse_config(self) -> dict | None:
+        mode = str(self.config.get("mode", "auto")).lower()
+        if mode not in _VALID_MODES:
+            self.set_failed(f"Invalid mode: {mode!r} (expected one of {list(_VALID_MODES)})")
+            return None
+
+        raw_components = self.config.get("components")
+        if raw_components is None:
+            components = list(_DEFAULT_COMPONENTS)
+        elif not isinstance(raw_components, (list, tuple)):
+            # str falls through here too — `isinstance("foo", (list, tuple))` is False —
+            # which stops YAML scalars from being iterated character-by-character.
+            self.set_failed(
+                f"`components` must be a YAML list, got {type(raw_components).__name__}: "
+                f"{raw_components!r}. Example: `components: [kube-apiserver, kube-scheduler]`."
+            )
+            return None
+        else:
+            components = [str(c) for c in raw_components]
+            if not components:
+                self.set_failed("components list is empty")
+                return None
+
+        min_log_lines = self._parse_positive_int("min_log_lines", default=1)
+        if min_log_lines is None:
+            return None
+
+        tail = self._parse_positive_int("tail", default=20)
+        if tail is None:
+            return None
+
+        if mode != "command" and min_log_lines > tail:
+            self.set_failed(
+                f"`min_log_lines` ({min_log_lines}) cannot exceed `tail` ({tail}): "
+                f"kubectl returns at most `tail` lines, so the check would always fail. "
+                f"Raise `tail` or lower `min_log_lines`."
+            )
+            return None
+
+        namespace = str(self.config.get("namespace", "kube-system"))
+
+        since_raw = self.config.get("since")
+        since = str(since_raw) if since_raw else None
+
+        raw_commands = self.config.get("commands")
+        if raw_commands is None:
+            commands: dict[str, str] = {}
+        elif not isinstance(raw_commands, dict):
+            self.set_failed(
+                f"`commands` must be a mapping of component -> shell command, got "
+                f"{type(raw_commands).__name__}: {raw_commands!r}. Example: "
+                f"`commands: {{kube-apiserver: 'aws logs tail ...'}}`."
+            )
+            return None
+        else:
+            commands = {str(k): str(v) for k, v in raw_commands.items() if v}
+
+        if mode == "command" and since:
+            self.log.warning("`since` is only used by the kubectl path; ignoring in mode=command")
+
+        return {
+            "mode": mode,
+            "components": components,
+            "min_log_lines": min_log_lines,
+            "tail": tail,
+            "namespace": namespace,
+            "since": since,
+            "commands": commands,
+        }
+
+    def _parse_positive_int(self, key: str, *, default: int) -> int | None:
+        raw = self.config.get(key, default)
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            self.set_failed(f"`{key}` must be an integer, got {type(raw).__name__}: {raw!r}")
+            return None
+        if value < 1:
+            self.set_failed(f"{key} must be >= 1 (got {value})")
+            return None
+        return value
+
+    def _build_plan(
+        self,
+        mode: str,
+        namespace: str,
+        components: list[str],
+        commands: dict[str, str],
+    ) -> list[tuple[str, str, str]] | None:
+        """Resolve each component to a ``(component, path, target)`` triple.
+
+        In ``auto`` mode we try kubectl first per-component and fall through
+        to ``commands[component]`` when the pod isn't present — this covers
+        hybrid clusters where some components are static pods and others are
+        managed externally.
+        """
+        pods_by_component: dict[str, str] = {}
+        probe_error: str | None = None
+        if mode in ("auto", "kubectl"):
+            pods_by_component, probe_error = self._find_component_pods(namespace, components)
+
+        plan: list[tuple[str, str, str]] = []
+        unresolved: list[str] = []
+        for component in components:
+            pod = pods_by_component.get(component) if mode in ("kubectl", "auto") else None
+            cmd = commands.get(component) if mode in ("command", "auto") else None
+            if pod:
+                plan.append((component, "kubectl", pod))
+            elif cmd:
+                plan.append((component, "command", cmd))
+            else:
+                unresolved.append(component)
+
+        if unresolved:
+            self._fail_unresolved(
+                mode=mode,
+                namespace=namespace,
+                unresolved=unresolved,
+                pods_by_component=pods_by_component,
+                probe_error=probe_error,
+            )
+            return None
+        return plan
+
+    def _fail_unresolved(
+        self,
+        mode: str,
+        namespace: str,
+        unresolved: list[str],
+        pods_by_component: dict[str, str],
+        probe_error: str | None,
+    ) -> None:
+        if mode == "kubectl":
+            if probe_error and not pods_by_component:
+                self.set_failed(
+                    f"Unable to list pods in namespace {namespace!r} (kubectl "
+                    f"error: {probe_error}). Fix cluster access, or switch to "
+                    f"`mode: command` with a `commands` mapping."
+                )
+            else:
+                self.set_failed(f"No control-plane pod found for component(s) {unresolved} in namespace {namespace!r}")
+            return
+
+        if mode == "command":
+            self.set_failed(
+                f"Mode 'command' but no command configured for component(s): {unresolved}. "
+                f"Populate `commands` in the check config with one shell command per component "
+                f"that prints log lines."
+            )
+            return
+
+        # auto mode
+        if probe_error and not pods_by_component:
+            self.set_failed(
+                f"Unable to list pods in namespace {namespace!r} (kubectl "
+                f"error: {probe_error}). Cannot decide between kubectl and "
+                f"command paths — fix cluster access or set `mode: command` "
+                f"with a `commands` mapping."
+            )
+            return
+        if not pods_by_component:
+            self.set_failed(
+                f"No control-plane pods found in namespace {namespace!r} and no "
+                f"`commands` mapping configured. Supply `commands` for managed "
+                f"clusters (one shell command per component that prints log lines)."
+            )
+            return
+        self.set_failed(
+            f"Auto mode could not resolve component(s) {unresolved}: no matching pod "
+            f"in namespace {namespace!r} and no `commands[{unresolved[0]}]` configured. "
+            f"Either expose the component as a pod or add it to the `commands` mapping."
+        )
+
+    def _execute_plan(
+        self,
+        plan: list[tuple[str, str, str]],
+        namespace: str,
+        tail: int,
+        since: str | None,
+        min_log_lines: int,
+    ) -> None:
+        failures: list[str] = []
+        summaries: list[str] = []
+        kubectl_base = get_kubectl_base_shell()
+        paths_used: set[str] = set()
+
+        for component, path, target in plan:
+            paths_used.add(path)
+            if path == "kubectl":
+                pod = target
+                parts = [
+                    kubectl_base,
+                    "logs",
+                    shlex.quote(pod),
+                    "-n",
+                    shlex.quote(namespace),
+                    f"--tail={tail}",
+                ]
+                if since:
+                    parts.append(f"--since={shlex.quote(since)}")
+                cmd = " ".join(parts)
+                label = f"{component} (pod {pod})"
+            else:
+                cmd = target
+                label = component
+
+            result = self.run_command(cmd)
+            if result.exit_code != 0:
+                detail = result.stderr.strip() or result.stdout.strip() or f"exit code {result.exit_code}"
+                if path == "kubectl":
+                    failures.append(f"{label}: kubectl logs failed: {detail}")
+                else:
+                    snippet = cmd if len(cmd) <= _CMD_SNIPPET_LEN else cmd[: _CMD_SNIPPET_LEN - 3] + "..."
+                    failures.append(f"{label}: command exited {result.exit_code}: {detail} (cmd: {snippet})")
+                continue
+
+            line_count = _count_nonempty_lines(result.stdout)
+            if line_count < min_log_lines:
+                failures.append(f"{label}: retrieved {line_count} lines (required >= {min_log_lines})")
+                continue
+            summaries.append(f"{component}={line_count} lines")
+
+        via = _format_via(paths_used)
+        if failures:
+            self.set_failed(
+                f"{len(failures)} component(s) failed control-plane log retrieval via {via}: {'; '.join(failures)}"
+            )
+            return
+        self.set_passed(f"Control-plane logs retrieved via {via}: {', '.join(summaries)}")
+
+    def _find_component_pods(self, namespace: str, components: list[str]) -> tuple[dict[str, str], str | None]:
+        """Return ``({component: pod_name}, probe_error)`` for the namespace.
+
+        Resolution runs from a single ``kubectl get pods`` call that emits
+        ``<pod_name>\\t<component_label>`` per line — label matching and
+        the name-prefix fallback are both resolved client-side from that
+        one response, so the cost is one round-trip regardless of how
+        many components are requested.
+
+        ``probe_error`` carries the stderr when the call fails, so auto-
+        mode can distinguish "cluster reachable but control plane is
+        hidden" from "kubectl itself is broken".
+        """
+        kubectl_base = get_kubectl_base_shell()
+        jsonpath = r"""{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.component}{"\n"}{end}"""
+        cmd = f"{kubectl_base} get pods -n {shlex.quote(namespace)} -o jsonpath={shlex.quote(jsonpath)}"
+        result = self.run_command(cmd)
+        if result.exit_code != 0:
+            probe_error = result.stderr.strip() or result.stdout.strip() or f"exit code {result.exit_code}"
+            return {}, probe_error
+
+        pods: list[tuple[str, str]] = []
+        for line in result.stdout.splitlines():
+            if not line.strip():
+                continue
+            pod_name, _, label = line.partition("\t")
+            pod_name = pod_name.strip()
+            if pod_name:
+                pods.append((pod_name, label.strip()))
+
+        found: dict[str, str] = {}
+        claimed: set[str] = set()
+
+        # Pass 1: exact ``component`` label match. On HA control planes a
+        # component may have multiple replicas (e.g. 3 kube-apiservers);
+        # we intentionally pick the first pod kubectl returns — one log
+        # sample is enough for this check, and probing every replica
+        # would multiply round-trips without changing pass/fail.
+        for component in components:
+            for pod_name, label in pods:
+                if pod_name in claimed:
+                    continue
+                if label == component:
+                    found[component] = pod_name
+                    claimed.add(pod_name)
+                    break
+
+        # Pass 2: name-prefix fallback for components still missing
+        # (distributions that do not set the ``component`` label). Match
+        # longest component name first so e.g. ``kube-scheduler-extender``
+        # claims its pod before ``kube-scheduler`` greedily picks it up.
+        missing = [c for c in components if c not in found]
+        for component in sorted(missing, key=len, reverse=True):
+            for pod_name, _label in pods:
+                if pod_name in claimed:
+                    continue
+                if pod_name == component or pod_name.startswith(f"{component}-"):
+                    found[component] = pod_name
+                    claimed.add(pod_name)
+                    break
+
+        return found, None
+
+
+def _count_nonempty_lines(text: str) -> int:
+    if not text:
+        return 0
+    return sum(1 for line in text.splitlines() if line.strip())
+
+
+def _format_via(paths: set[str]) -> str:
+    if paths == {"kubectl"}:
+        return "kubectl"
+    if paths == {"command"}:
+        return "command"
+    return "kubectl+command"

--- a/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
+++ b/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
@@ -202,6 +202,20 @@ class K8sControlPlaneLogsCheck(BaseValidation):
                 probe_error=probe_error,
             )
             return None
+
+        # Auto mode: a probe_error means kubectl itself failed (kubeconfig,
+        # RBAC, or context), not "no matching pods". Don't mask that by
+        # falling through to commands for every component — the operator
+        # needs to see the access failure and explicitly choose `mode: command`.
+        if mode == "auto" and probe_error is not None:
+            self.set_failed(
+                f"Unable to list pods in namespace {namespace!r} (kubectl error: "
+                f"{probe_error}). Auto mode cannot verify which components should "
+                f"use kubectl vs. commands — fix cluster access or set "
+                f"`mode: command` to use the `commands` mapping explicitly."
+            )
+            return None
+
         return plan
 
     def _fail_unresolved(

--- a/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
+++ b/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
@@ -26,11 +26,25 @@ _CMD_SNIPPET_LEN = 80
 
 
 class K8sControlPlaneLogsCheck(BaseValidation):
+    """Verify Kubernetes control-plane logs can be viewed or exported.
+
+    Supports ``kubectl`` (in-cluster static pods), ``command`` (managed
+    distributions that expose logs via an out-of-cluster tool such as
+    ``aws logs tail``), and ``auto`` (per-component fallback from kubectl
+    to the configured command).
+    """
+
     description: ClassVar[str] = "Verify Kubernetes control-plane logs can be viewed or exported."
     timeout: ClassVar[int] = 120
     markers: ClassVar[list[str]] = ["kubernetes"]
 
     def run(self) -> None:
+        """Parse the check config, resolve each component, and retrieve its logs.
+
+        On any validation failure (bad config, unresolved component, empty
+        output, non-zero exit), marks the check failed via ``set_failed``
+        and returns; on success marks it passed via ``set_passed``.
+        """
         cfg = self._parse_config()
         if cfg is None:
             return
@@ -53,6 +67,12 @@ class K8sControlPlaneLogsCheck(BaseValidation):
         )
 
     def _parse_config(self) -> dict[str, Any] | None:
+        """Validate and normalize ``self.config`` into a plan-ready mapping.
+
+        Returns a dict with ``mode``, ``components``, ``min_log_lines``,
+        ``tail``, ``namespace``, ``since``, and ``commands`` on success.
+        On any invalid input calls ``set_failed`` and returns ``None``.
+        """
         mode = str(self.config.get("mode", "auto")).lower()
         if mode not in _VALID_MODES:
             self.set_failed(f"Invalid mode: {mode!r} (expected one of {list(_VALID_MODES)})")
@@ -123,6 +143,11 @@ class K8sControlPlaneLogsCheck(BaseValidation):
         }
 
     def _parse_positive_int(self, key: str, *, default: int) -> int | None:
+        """Read ``self.config[key]`` as an ``int >= 1`` (rejecting ``bool``).
+
+        Returns the parsed integer, or ``None`` after ``set_failed`` when
+        the value is a bool, non-numeric, or less than 1.
+        """
         raw = self.config.get(key, default)
         if isinstance(raw, bool):
             self.set_failed(f"`{key}` must be an integer, got bool: {raw!r}")
@@ -187,6 +212,11 @@ class K8sControlPlaneLogsCheck(BaseValidation):
         pods_by_component: dict[str, str],
         probe_error: str | None,
     ) -> None:
+        """Emit a mode-specific ``set_failed`` message for unresolved components.
+
+        Distinguishes between kubectl probe failure, absent pods, and missing
+        ``commands`` entries so the operator sees actionable remediation.
+        """
         if mode == "kubectl":
             if probe_error and not pods_by_component:
                 self.set_failed(
@@ -236,6 +266,13 @@ class K8sControlPlaneLogsCheck(BaseValidation):
         since: str | None,
         min_log_lines: int,
     ) -> None:
+        """Run each ``(component, path, target)`` entry and aggregate results.
+
+        For ``path == "kubectl"`` builds a ``kubectl logs`` invocation with
+        ``--tail`` and optional ``--since``; otherwise runs ``target`` as a
+        shell command. Each component must emit at least ``min_log_lines``
+        non-empty lines. Concludes with ``set_passed`` or ``set_failed``.
+        """
         failures: list[str] = []
         summaries: list[str] = []
         kubectl_base = get_kubectl_base_shell()
@@ -350,12 +387,14 @@ class K8sControlPlaneLogsCheck(BaseValidation):
 
 
 def _count_nonempty_lines(text: str) -> int:
+    """Return the number of lines in ``text`` that contain non-whitespace."""
     if not text:
         return 0
     return sum(1 for line in text.splitlines() if line.strip())
 
 
 def _format_via(paths: set[str]) -> str:
+    """Render the retrieval-path set as a human-readable ``via`` label."""
     if paths == {"kubectl"}:
         return "kubectl"
     if paths == {"command"}:

--- a/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
+++ b/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
@@ -260,10 +260,12 @@ class K8sControlPlaneLogsCheck(BaseValidation):
             )
             return
         if not pods_by_component:
+            missing = sorted(unresolved)
             self.set_failed(
                 f"No control-plane pods found in namespace {namespace!r} and no "
-                f"`commands` mapping configured. Supply `commands` for managed "
-                f"clusters (one shell command per component that prints log lines)."
+                f"`commands` entries configured for component(s): {missing}. "
+                f"Supply `commands` for managed clusters (one shell command per "
+                f"component that prints log lines)."
             )
             return
         self.set_failed(

--- a/isvtest/tests/test_k8s_control_plane_logs.py
+++ b/isvtest/tests/test_k8s_control_plane_logs.py
@@ -1,0 +1,515 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Unit tests for ``isvtest.validations.k8s_control_plane_logs``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from isvtest.core.runners import CommandResult
+from isvtest.validations.k8s_control_plane_logs import (
+    K8sControlPlaneLogsCheck,
+    _count_nonempty_lines,
+)
+
+
+def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _fail(stdout: str = "", stderr: str = "", exit_code: int = 1) -> CommandResult:
+    return CommandResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _pod_list(*pairs: tuple[str, str]) -> str:
+    """Simulate ``kubectl get pods -o jsonpath='...'`` output: one
+    ``<pod_name>\\t<component_label>`` line per pod."""
+    return "".join(f"{pod}\t{label}\n" for pod, label in pairs)
+
+
+class TestCountNonemptyLines:
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("", 0),
+            ("\n", 0),
+            ("   \n   ", 0),
+            ("one", 1),
+            ("one\ntwo", 2),
+            ("one\n\nthree\n", 2),
+            ("  one  \n\n  two  ", 2),
+        ],
+    )
+    def test_counts(self, text: str, expected: int) -> None:
+        assert _count_nonempty_lines(text) == expected
+
+
+class TestInputValidation:
+    def test_invalid_mode_fails(self) -> None:
+        check = K8sControlPlaneLogsCheck(config={"mode": "bogus"})
+        check.run()
+        assert not check.passed
+        assert "Invalid mode" in check.message
+
+    def test_empty_components_fails(self) -> None:
+        check = K8sControlPlaneLogsCheck(config={"components": []})
+        check.run()
+        assert not check.passed
+        assert "components list is empty" in check.message
+
+    def test_scalar_components_rejected_with_friendly_error(self) -> None:
+        """A YAML scalar (e.g. `components: kube-apiserver`) must not be
+        silently iterated character-by-character."""
+        check = K8sControlPlaneLogsCheck(config={"components": "kube-apiserver"})
+        check.run()
+        assert not check.passed
+        assert "`components` must be a YAML list" in check.message
+
+    def test_non_dict_commands_rejected_with_friendly_error(self) -> None:
+        """`commands` as a scalar must be rejected up front rather than
+        crashing downstream on `.get()`."""
+        check = K8sControlPlaneLogsCheck(
+            config={"mode": "command", "components": ["kube-apiserver"], "commands": "echo hi"}
+        )
+        check.run()
+        assert not check.passed
+        assert "`commands` must be a mapping" in check.message
+
+    def test_non_integer_tail_rejected_with_friendly_error(self) -> None:
+        check = K8sControlPlaneLogsCheck(config={"tail": "twenty"})
+        check.run()
+        assert not check.passed
+        assert "`tail` must be an integer" in check.message
+
+    def test_non_integer_min_log_lines_rejected_with_friendly_error(self) -> None:
+        check = K8sControlPlaneLogsCheck(config={"min_log_lines": "one"})
+        check.run()
+        assert not check.passed
+        assert "`min_log_lines` must be an integer" in check.message
+
+    def test_min_log_lines_over_tail_rejected_for_kubectl_modes(self) -> None:
+        """Structurally unsatisfiable kubectl config must fail up front."""
+        check = K8sControlPlaneLogsCheck(config={"mode": "kubectl", "tail": 5, "min_log_lines": 10})
+        check.run()
+        assert not check.passed
+        assert "cannot exceed `tail`" in check.message
+
+    def test_min_log_lines_over_tail_allowed_for_command_mode(self) -> None:
+        """`tail` is kubectl-only; command mode must not enforce the bound."""
+        check = K8sControlPlaneLogsCheck(
+            config={
+                "mode": "command",
+                "components": ["kube-apiserver"],
+                "commands": {"kube-apiserver": "echo hi"},
+                "tail": 5,
+                "min_log_lines": 100,
+            }
+        )
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            return _ok(stdout="\n".join(f"line{i}" for i in range(200)) + "\n")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert check.passed, check.message
+
+
+class TestAutoDispatch:
+    def test_auto_hard_fails_when_no_pods_and_no_commands(self) -> None:
+        check = K8sControlPlaneLogsCheck(config={"mode": "auto", "components": ["kube-apiserver"]})
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            if "get pods" in cmd:
+                return _ok(stdout="")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert not check.passed
+        assert "no `commands` mapping configured" in check.message
+
+    def test_auto_surfaces_kubectl_error_when_probe_fails(self) -> None:
+        """When ``kubectl get pods`` itself errors, the failure must blame
+        cluster access rather than a missing ``commands`` mapping."""
+        check = K8sControlPlaneLogsCheck(config={"mode": "auto", "components": ["kube-apiserver"]})
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            if "get pods" in cmd:
+                return _fail(stderr="Unable to connect to the server: dial tcp: i/o timeout")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert not check.passed
+        assert "Unable to list pods" in check.message
+        assert "i/o timeout" in check.message
+        assert "no `commands` mapping configured" not in check.message
+
+    def test_auto_picks_kubectl_when_pods_present(self) -> None:
+        check = K8sControlPlaneLogsCheck(config={"mode": "auto", "components": ["kube-apiserver"]})
+        run_commands: list[str] = []
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            run_commands.append(cmd)
+            if "get pods" in cmd:
+                return _ok(stdout=_pod_list(("kube-apiserver-node1", "kube-apiserver")))
+            if "logs " in cmd:
+                return _ok(stdout="apiserver started\nserving HTTPS\nready\n")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert check.passed, check.message
+        assert any("logs " in c for c in run_commands)
+        # Pod discovery must be a single kubectl round-trip, and auto
+        # dispatch must not re-run it after picking kubectl.
+        assert sum(1 for c in run_commands if "get pods" in c) == 1
+
+    def test_auto_falls_through_to_command_when_no_pods(self) -> None:
+        check = K8sControlPlaneLogsCheck(
+            config={
+                "mode": "auto",
+                "components": ["kube-apiserver"],
+                "commands": {"kube-apiserver": "echo 'one\\ntwo\\nthree'"},
+            }
+        )
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            if "get pods" in cmd:
+                return _ok(stdout="")
+            if cmd.startswith("echo"):
+                return _ok(stdout="line1\nline2\nline3\n")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert check.passed, check.message
+        assert "command" in check.message
+
+    def test_auto_resolves_each_component_independently(self) -> None:
+        """Hybrid cluster: kube-apiserver is a static pod (kubectl), but
+        kube-scheduler is externally managed (command). Auto must route
+        each component separately instead of forcing one path for all."""
+        check = K8sControlPlaneLogsCheck(
+            config={
+                "mode": "auto",
+                "components": ["kube-apiserver", "kube-scheduler"],
+                "commands": {"kube-scheduler": "echo scheduler-log"},
+            }
+        )
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            if "get pods" in cmd:
+                # Only the apiserver is visible via kubectl.
+                return _ok(stdout=_pod_list(("kube-apiserver-node1", "kube-apiserver")))
+            if "logs kube-apiserver-node1" in cmd:
+                return _ok(stdout="apiserver-line\n")
+            if cmd == "echo scheduler-log":
+                return _ok(stdout="scheduler-line\n")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert check.passed, check.message
+        assert "kubectl+command" in check.message
+        assert "kube-apiserver=1 lines" in check.message
+        assert "kube-scheduler=1 lines" in check.message
+
+    def test_auto_partial_unresolved_component_fails_with_guidance(self) -> None:
+        """When only some components resolve and no command is configured
+        for the rest, the failure names the missing component(s) and tells
+        the user how to fix it."""
+        check = K8sControlPlaneLogsCheck(
+            config={
+                "mode": "auto",
+                "components": ["kube-apiserver", "kube-scheduler"],
+            }
+        )
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            if "get pods" in cmd:
+                return _ok(stdout=_pod_list(("kube-apiserver-node1", "kube-apiserver")))
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert not check.passed
+        assert "kube-scheduler" in check.message
+        assert "commands[kube-scheduler]" in check.message
+
+
+class TestKubectlPath:
+    def test_kubectl_path_passes_when_each_component_returns_logs(self) -> None:
+        check = K8sControlPlaneLogsCheck(
+            config={
+                "mode": "kubectl",
+                "components": ["kube-apiserver", "kube-scheduler"],
+                "tail": 5,
+            }
+        )
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            if "get pods" in cmd:
+                return _ok(
+                    stdout=_pod_list(
+                        ("kube-apiserver-node1", "kube-apiserver"),
+                        ("kube-scheduler-node1", "kube-scheduler"),
+                    )
+                )
+            if "logs kube-apiserver-node1" in cmd:
+                return _ok(stdout="line1\nline2\n")
+            if "logs kube-scheduler-node1" in cmd:
+                return _ok(stdout="entryA\nentryB\nentryC\n")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert check.passed, check.message
+        assert "kube-apiserver=2 lines" in check.message
+        assert "kube-scheduler=3 lines" in check.message
+
+    def test_kubectl_path_fails_when_component_pod_missing(self) -> None:
+        check = K8sControlPlaneLogsCheck(config={"mode": "kubectl", "components": ["kube-apiserver", "kube-scheduler"]})
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            if "get pods" in cmd:
+                # Apiserver resolvable by label; nothing that can match scheduler.
+                return _ok(
+                    stdout=_pod_list(
+                        ("kube-apiserver-node1", "kube-apiserver"),
+                        ("coredns-abc", "coredns"),
+                    )
+                )
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert not check.passed
+        assert "kube-scheduler" in check.message
+
+    def test_kubectl_path_fallback_matches_by_name_prefix(self) -> None:
+        """When no pod carries the ``component`` label, fall back to
+        matching by pod-name prefix."""
+        check = K8sControlPlaneLogsCheck(config={"mode": "kubectl", "components": ["kube-apiserver"]})
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            if "get pods" in cmd:
+                # No component labels set — fallback must kick in.
+                return _ok(stdout=_pod_list(("kube-apiserver-node1", ""), ("coredns-abc", "")))
+            if "logs kube-apiserver-node1" in cmd:
+                return _ok(stdout="logged\n")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert check.passed, check.message
+
+    def test_kubectl_path_forwards_tail_to_logs_command(self) -> None:
+        check = K8sControlPlaneLogsCheck(config={"mode": "kubectl", "components": ["kube-apiserver"], "tail": 42})
+        run_commands: list[str] = []
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            run_commands.append(cmd)
+            if "get pods" in cmd:
+                return _ok(stdout=_pod_list(("kube-apiserver-node1", "kube-apiserver")))
+            if "logs " in cmd:
+                return _ok(stdout="line1\n")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert check.passed, check.message
+        logs_cmds = [c for c in run_commands if "logs " in c]
+        assert len(logs_cmds) == 1
+        assert "--tail=42" in logs_cmds[0]
+
+    def test_kubectl_path_forwards_since_to_logs_command(self) -> None:
+        """`since` must be shell-quoted and appended as `--since=<value>`."""
+        check = K8sControlPlaneLogsCheck(config={"mode": "kubectl", "components": ["kube-apiserver"], "since": "5m"})
+        run_commands: list[str] = []
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            run_commands.append(cmd)
+            if "get pods" in cmd:
+                return _ok(stdout=_pod_list(("kube-apiserver-node1", "kube-apiserver")))
+            if "logs " in cmd:
+                return _ok(stdout="line1\n")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert check.passed, check.message
+        logs_cmd = next(c for c in run_commands if "logs " in c)
+        assert "--since=5m" in logs_cmd
+
+    def test_kubectl_path_fallback_prefers_longest_component_name(self) -> None:
+        """``kube-scheduler-extender`` must claim its pod before ``kube-scheduler``
+        greedily picks it up via the ``startswith`` fallback."""
+        check = K8sControlPlaneLogsCheck(
+            config={
+                "mode": "kubectl",
+                "components": ["kube-scheduler", "kube-scheduler-extender"],
+            }
+        )
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            if "get pods" in cmd:
+                # No component labels — forces pure name-prefix fallback.
+                return _ok(
+                    stdout=_pod_list(
+                        ("kube-scheduler-extender-abc", ""),
+                        ("kube-scheduler-node1", ""),
+                    )
+                )
+            if "logs kube-scheduler-extender-abc" in cmd:
+                return _ok(stdout="extender-log\n")
+            if "logs kube-scheduler-node1" in cmd:
+                return _ok(stdout="scheduler-log\n")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert check.passed, check.message
+
+    def test_kubectl_path_fails_when_logs_return_too_few_lines(self) -> None:
+        check = K8sControlPlaneLogsCheck(
+            config={"mode": "kubectl", "components": ["kube-apiserver"], "min_log_lines": 3}
+        )
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            if "get pods" in cmd:
+                return _ok(stdout=_pod_list(("kube-apiserver-node1", "kube-apiserver")))
+            if "logs " in cmd:
+                return _ok(stdout="just-one-line\n")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert not check.passed
+        assert "retrieved 1 lines" in check.message
+
+    def test_kubectl_path_fails_when_logs_command_errors(self) -> None:
+        check = K8sControlPlaneLogsCheck(config={"mode": "kubectl", "components": ["kube-apiserver"]})
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            if "get pods" in cmd:
+                return _ok(stdout=_pod_list(("kube-apiserver-node1", "kube-apiserver")))
+            if "logs " in cmd:
+                return _fail(stderr="Error from server (Forbidden)")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert not check.passed
+        assert "Forbidden" in check.message
+
+
+class TestCommandPath:
+    def test_command_path_passes_when_each_command_returns_logs(self) -> None:
+        check = K8sControlPlaneLogsCheck(
+            config={
+                "mode": "command",
+                "components": ["kube-apiserver", "kube-scheduler"],
+                "commands": {
+                    "kube-apiserver": "echo apiserver-line",
+                    "kube-scheduler": "echo scheduler-line",
+                },
+            }
+        )
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            if cmd == "echo apiserver-line":
+                return _ok(stdout="apiserver-line\n")
+            if cmd == "echo scheduler-line":
+                return _ok(stdout="scheduler-line\n")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert check.passed, check.message
+        assert "kube-apiserver=1 lines" in check.message
+        assert "kube-scheduler=1 lines" in check.message
+
+    def test_command_path_fails_when_command_missing_for_component(self) -> None:
+        check = K8sControlPlaneLogsCheck(
+            config={
+                "mode": "command",
+                "components": ["kube-apiserver", "kube-scheduler"],
+                "commands": {"kube-apiserver": "echo a"},
+            }
+        )
+        check.run()
+        assert not check.passed
+        assert "kube-scheduler" in check.message
+
+    def test_command_path_fails_when_commands_config_absent(self) -> None:
+        check = K8sControlPlaneLogsCheck(config={"mode": "command", "components": ["kube-apiserver", "kube-scheduler"]})
+        check.run()
+        assert not check.passed
+        assert "kube-apiserver" in check.message
+        assert "kube-scheduler" in check.message
+        assert "no command configured" in check.message
+
+    def test_command_path_fails_when_command_returns_no_lines(self) -> None:
+        check = K8sControlPlaneLogsCheck(
+            config={
+                "mode": "command",
+                "components": ["kube-apiserver"],
+                "commands": {"kube-apiserver": "true"},
+            }
+        )
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            return _ok(stdout="")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert not check.passed
+        assert "0 lines" in check.message
+
+    def test_command_path_fails_when_command_exits_nonzero(self) -> None:
+        check = K8sControlPlaneLogsCheck(
+            config={
+                "mode": "command",
+                "components": ["kube-apiserver"],
+                "commands": {"kube-apiserver": "false"},
+            }
+        )
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            return _fail(stderr="denied")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert not check.passed
+        assert "exited" in check.message
+
+    def test_command_path_failure_includes_command_snippet(self) -> None:
+        """On failure, users need to see *which* command blew up so they
+        can distinguish credentials errors from syntax typos without
+        having to grep the logger output."""
+        check = K8sControlPlaneLogsCheck(
+            config={
+                "mode": "command",
+                "components": ["kube-apiserver"],
+                "commands": {"kube-apiserver": "aws logs tail /aws/eks/demo --since 5m"},
+            }
+        )
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            return _fail(stderr="AccessDeniedException")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert not check.passed
+        assert "aws logs tail" in check.message

--- a/isvtest/tests/test_k8s_control_plane_logs.py
+++ b/isvtest/tests/test_k8s_control_plane_logs.py
@@ -144,7 +144,8 @@ class TestAutoDispatch:
         check.run_command = fake  # type: ignore[assignment]
         check.run()
         assert not check.passed
-        assert "no `commands` mapping configured" in check.message
+        assert "no `commands` entries configured for component(s)" in check.message
+        assert "kube-apiserver" in check.message
 
     def test_auto_surfaces_kubectl_error_when_probe_fails(self) -> None:
         """When ``kubectl get pods`` itself errors, the failure must blame
@@ -161,7 +162,7 @@ class TestAutoDispatch:
         assert not check.passed
         assert "Unable to list pods" in check.message
         assert "i/o timeout" in check.message
-        assert "no `commands` mapping configured" not in check.message
+        assert "no `commands` entries configured" not in check.message
 
     def test_auto_surfaces_kubectl_error_even_when_commands_cover_all_components(self) -> None:
         """A probe failure (kubeconfig/RBAC/context broken) must not be

--- a/isvtest/tests/test_k8s_control_plane_logs.py
+++ b/isvtest/tests/test_k8s_control_plane_logs.py
@@ -24,10 +24,12 @@ from isvtest.validations.k8s_control_plane_logs import (
 
 
 def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    """Return a successful ``CommandResult`` (exit code 0) with the given output streams."""
     return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.0)
 
 
 def _fail(stdout: str = "", stderr: str = "", exit_code: int = 1) -> CommandResult:
+    """Return a failing ``CommandResult`` with the given non-zero exit code and output streams."""
     return CommandResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration=0.0)
 
 
@@ -38,6 +40,8 @@ def _pod_list(*pairs: tuple[str, str]) -> str:
 
 
 class TestCountNonemptyLines:
+    """Unit tests for the ``_count_nonempty_lines`` helper."""
+
     @pytest.mark.parametrize(
         ("text", "expected"),
         [
@@ -55,6 +59,8 @@ class TestCountNonemptyLines:
 
 
 class TestInputValidation:
+    """Config-level input validation: reject malformed ``mode``, ``components``, ``commands``, ``tail`` and ``min_log_lines`` up front with clear errors."""
+
     def test_invalid_mode_fails(self) -> None:
         check = K8sControlPlaneLogsCheck(config={"mode": "bogus"})
         check.run()
@@ -125,6 +131,8 @@ class TestInputValidation:
 
 
 class TestAutoDispatch:
+    """``mode: auto`` dispatch: route each component to kubectl or command based on pod discovery, and surface actionable errors when neither path can serve it."""
+
     def test_auto_hard_fails_when_no_pods_and_no_commands(self) -> None:
         check = K8sControlPlaneLogsCheck(config={"mode": "auto", "components": ["kube-apiserver"]})
 
@@ -249,6 +257,8 @@ class TestAutoDispatch:
 
 
 class TestKubectlPath:
+    """``mode: kubectl`` path: pod discovery (label then name-prefix fallback), ``--tail``/``--since`` forwarding, and failure handling when logs are missing, too short, or error out."""
+
     def test_kubectl_path_passes_when_each_component_returns_logs(self) -> None:
         check = K8sControlPlaneLogsCheck(
             config={
@@ -415,6 +425,8 @@ class TestKubectlPath:
 
 
 class TestCommandPath:
+    """``mode: command`` path: run the per-component command, enforce line-count thresholds, and report which command failed and why."""
+
     def test_command_path_passes_when_each_command_returns_logs(self) -> None:
         check = K8sControlPlaneLogsCheck(
             config={

--- a/isvtest/tests/test_k8s_control_plane_logs.py
+++ b/isvtest/tests/test_k8s_control_plane_logs.py
@@ -163,6 +163,29 @@ class TestAutoDispatch:
         assert "i/o timeout" in check.message
         assert "no `commands` mapping configured" not in check.message
 
+    def test_auto_surfaces_kubectl_error_even_when_commands_cover_all_components(self) -> None:
+        """A probe failure (kubeconfig/RBAC/context broken) must not be
+        masked by falling through to commands for every component — the
+        operator needs to know cluster access is broken."""
+        check = K8sControlPlaneLogsCheck(
+            config={
+                "mode": "auto",
+                "components": ["kube-apiserver"],
+                "commands": {"kube-apiserver": "echo hi"},
+            }
+        )
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            if "get pods" in cmd:
+                return _fail(stderr="Unable to connect to the server: dial tcp: i/o timeout")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert not check.passed
+        assert "Unable to list pods" in check.message
+        assert "i/o timeout" in check.message
+
     def test_auto_picks_kubectl_when_pods_present(self) -> None:
         check = K8sControlPlaneLogsCheck(config={"mode": "auto", "components": ["kube-apiserver"]})
         run_commands: list[str] = []


### PR DESCRIPTION
## Summary
- Adds `K8sControlPlaneLogsCheck` (K8S20), a provider-agnostic check that actively pulls Kubernetes control-plane log lines to prove they are retrievable — not just configured.
- Supports three modes: `kubectl` (finds a pod per component via label, with a longest-first name-prefix fallback so `kube-scheduler-extender` wins over `kube-scheduler`, then runs `kubectl logs --tail=<N>`), `command` (runs a configured shell command per component for managed clusters where control-plane pods are not visible), and `auto` (default: kubectl when control-plane pods exist, otherwise falls through to `commands`). Surfaces kubectl errors from the probe so a broken cluster doesn't masquerade as a missing `commands` mapping, and hard-fails when neither path is viable so managed providers cannot silently skip the check.
- `min_log_lines` and `tail` are bounded to sensible values to reject nonsensical configs early.
- Wires the check into the k8s observability block in `isvctl/configs/tests/k8s.yaml` with a self-managed default and an inline `commands:` example; managed providers supply their own `commands` mapping in follow-up work.

## Linked issue
- Refs #227

## Test plan
- [x] `uv run pytest isvtest/tests/test_k8s_control_plane_logs.py`
- [x] Run `isvctl` against a self-managed K8s cluster and confirm the K8S20 step passes in `auto`/`kubectl` mode
- [ ] Run against a managed cluster with a `commands:` mapping and confirm `command` mode succeeds
- [x] Confirm the check fails cleanly when control-plane pods are absent and no `commands` are configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Kubernetes control-plane logs validation with automatic, kubectl, or custom-command retrieval; configurable components, namespace, tail/since, and minimum log-line thresholds; reports per-component results and which retrieval method(s) were used.

* **Tests**
  * Added comprehensive tests for configuration validation, mode selection and fallbacks, pod-resolution behavior, log retrieval limits, success/failure conditions, and line-counting.

* **Chores**
  * Added default configuration and excluded the check for an EKS provider where control-plane logging is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->