### PR TITLE
feat: add dual-stack node and NetworkPolicy enforcement checks (K8S22)

### DIFF
--- a/isvctl/configs/providers/aws/config/eks.yaml
+++ b/isvctl/configs/providers/aws/config/eks.yaml
@@ -62,3 +62,4 @@ tests:
   exclude:
     tests:
       - K8sControlPlaneLogsCheck # TODO: need control plane logging
+      - K8sNetworkPolicyCheck # TODO: enable ENABLE_NETWORK_POLICY on the VPC CNI addon (or install an enforcing CNI) so NetworkPolicy is enforced on the data plane

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -92,7 +92,14 @@ tests:
             "nvidia.com/mig.capable": "true"
             "nvidia.com/mig.strategy": "single"
         K8sDualStackNodeCheck:
-          require_dual_stack: "auto"   # true | false | "auto"
+          require_dual_stack: "auto" # true | false | "auto"
+        K8sNetworkPolicyCheck:
+          image: "registry.k8s.io/e2e-test-images/agnhost:2.47"
+          probe_port: 8080
+          probe_timeout_s: 10
+          settle_timeout_s: 30
+          namespace_prefix: "isvtest-netpol"
+          test_egress: true
 
     k8s_identity:
       checks:

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -91,6 +91,8 @@ tests:
           expected_labels:
             "nvidia.com/mig.capable": "true"
             "nvidia.com/mig.strategy": "single"
+        K8sDualStackNodeCheck:
+          require_dual_stack: "auto"   # true | false | "auto"
 
     k8s_identity:
       checks:

--- a/isvtest/src/isvtest/config/settings.py
+++ b/isvtest/src/isvtest/config/settings.py
@@ -58,6 +58,10 @@ class Settings:
         NIM_HELM_GPU_COUNT: Number of GPUs for NIM (default: 1)
         NIM_GENAI_PERF_REQUESTS: Number of GenAI-Perf test requests (default: 100)
         NIM_GENAI_PERF_CONCURRENCY: GenAI-Perf concurrent requests (default: 1)
+
+        Dual-Stack Node Validation Configuration (K8S22):
+        K8S_REQUIRE_DUAL_STACK: Whether the cluster must be dual-stack
+            ("true", "false", or "auto", default: "auto")
     """
 
     validation_timeout: int = int(os.getenv("VALIDATION_TIMEOUT", "300"))
@@ -304,6 +308,16 @@ def get_nim_genai_perf_concurrency() -> int:
         Concurrency level (default: 1)
     """
     return int(os.getenv("NIM_GENAI_PERF_CONCURRENCY", "1"))
+
+
+def get_k8s_require_dual_stack() -> str:
+    """Get the dual-stack requirement for :class:`K8sDualStackNodeCheck`.
+
+    Returns:
+        One of ``"true"``, ``"false"``, or ``"auto"`` (default: ``"auto"``).
+        The validation itself normalizes these to bool / ``"auto"``.
+    """
+    return os.getenv("K8S_REQUIRE_DUAL_STACK", "auto")
 
 
 settings = Settings()

--- a/isvtest/src/isvtest/config/settings.py
+++ b/isvtest/src/isvtest/config/settings.py
@@ -62,6 +62,10 @@ class Settings:
         Dual-Stack Node Validation Configuration (K8S22):
         K8S_REQUIRE_DUAL_STACK: Whether the cluster must be dual-stack
             ("true", "false", or "auto", default: "auto")
+
+        NetworkPolicy Validation Configuration (K8S22):
+        K8S_NETPOL_IMAGE: Container image for NetworkPolicy probe pods
+            (default: registry.k8s.io/e2e-test-images/agnhost:2.47)
     """
 
     validation_timeout: int = int(os.getenv("VALIDATION_TIMEOUT", "300"))
@@ -318,6 +322,18 @@ def get_k8s_require_dual_stack() -> str:
         The validation itself normalizes these to bool / ``"auto"``.
     """
     return os.getenv("K8S_REQUIRE_DUAL_STACK", "auto")
+
+
+def get_k8s_network_policy_image() -> str:
+    """Get container image for NetworkPolicy probe pods.
+
+    The image must provide the ``agnhost`` binary (supports both ``connect``
+    and ``netexec`` subcommands).
+
+    Returns:
+        Container image URL (default: registry.k8s.io/e2e-test-images/agnhost:2.47)
+    """
+    return os.getenv("K8S_NETPOL_IMAGE", "registry.k8s.io/e2e-test-images/agnhost:2.47")
 
 
 settings = Settings()

--- a/isvtest/src/isvtest/validations/k8s_network_policy.py
+++ b/isvtest/src/isvtest/validations/k8s_network_policy.py
@@ -8,23 +8,325 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
-"""Dual-stack node validation (K8S22).
+"""NetworkPolicy enforcement and dual-stack node validations (K8S22).
 
-This module provides :class:`K8sDualStackNodeCheck`, which inspects every
-node's ``InternalIP`` addresses (and ``spec.podCIDRs`` as a supplementary
-hint) and verifies that the cluster is dual-stack (IPv4 + IPv6) when
-configuration requires it.
+This module provides two independent ``BaseValidation`` subclasses:
+
+* :class:`K8sNetworkPolicyCheck` — applies a pair of NetworkPolicies in an
+  ephemeral namespace and verifies that ingress/egress are enforced as
+  expected against both IPv4 and (when available) IPv6 pod addresses.
+* :class:`K8sDualStackNodeCheck` — inspects every node's ``InternalIP``
+  addresses and verifies that the cluster is dual-stack (IPv4 + IPv6) when
+  configuration requires it.
+
+The classes are kept split so clusters that only support one stack can still
+exercise the NetworkPolicy validation.
 """
 
 from __future__ import annotations
 
 import ipaddress
 import json
+import shlex
+import subprocess
+import time
+import uuid
+from pathlib import Path
 from typing import Any, ClassVar
 
-from isvtest.config.settings import get_k8s_require_dual_stack
-from isvtest.core.k8s import get_kubectl_base_shell
+from isvtest.config.settings import (
+    get_k8s_network_policy_image,
+    get_k8s_require_dual_stack,
+)
+from isvtest.core.k8s import get_kubectl_base_shell, get_kubectl_command
 from isvtest.core.validation import BaseValidation
+
+_MANIFEST_DIR = Path(__file__).parent / "manifests" / "k8s"
+_PODS_MANIFEST = _MANIFEST_DIR / "network_policy_test_pods.yaml"
+_INGRESS_MANIFEST = _MANIFEST_DIR / "network_policy_ingress.yaml"
+_EGRESS_MANIFEST = _MANIFEST_DIR / "network_policy_egress.yaml"
+
+
+class K8sNetworkPolicyCheck(BaseValidation):
+    """Verify that Kubernetes NetworkPolicy enforces ingress and egress.
+
+    The validation stands up four agnhost pods in an ephemeral namespace and
+    probes TCP connectivity between them both before and after applying a pair
+    of NetworkPolicies. Each probe is reported as a subtest so that individual
+    ingress/egress failures are visible without masking the others.
+
+    Config keys (with defaults):
+        image: Agnhost image providing ``connect`` / ``netexec``
+            (default from :func:`get_k8s_network_policy_image`).
+        probe_port: TCP port exposed by the server pods (default: 8080).
+        probe_timeout_s: ``agnhost connect`` timeout per probe (default: 10).
+        settle_timeout_s: Max time to wait after applying the policies before
+            starting real probes (default: 30).
+        namespace_prefix: Prefix for the ephemeral namespace name
+            (default: ``isvtest-netpol``).
+        timeout: Overall class-level timeout for each ``run_command`` call
+            (default: 300).
+        test_egress: Whether to run the egress subtests (default: True).
+    """
+
+    description: ClassVar[str] = (
+        "Apply a NetworkPolicy and verify pod connectivity is restricted (ingress + egress) on IPv4 and IPv6."
+    )
+    timeout: ClassVar[int] = 300
+    markers: ClassVar[list[str]] = ["kubernetes"]
+
+    def run(self) -> None:
+        """Apply NetworkPolicy manifests and probe allowed/denied paths, recording subtests and a pass/fail outcome."""
+        self._kubectl_parts = get_kubectl_command()
+        self._kubectl_base = get_kubectl_base_shell()
+        self._image = self.config.get("image") or get_k8s_network_policy_image()
+        self._probe_port = int(self.config.get("probe_port", 8080))
+        self._probe_timeout = int(self.config.get("probe_timeout_s", 10))
+        settle_timeout = int(self.config.get("settle_timeout_s", 30))
+        namespace_prefix = self.config.get("namespace_prefix", "isvtest-netpol")
+        test_egress = bool(self.config.get("test_egress", True))
+        self._namespace = f"{namespace_prefix}-{uuid.uuid4().hex[:8]}"
+        ns_quoted = shlex.quote(self._namespace)
+
+        ns_created = False
+        try:
+            ns_result = self.run_command(f"{self._kubectl_base} create namespace {ns_quoted}")
+            if ns_result.exit_code != 0:
+                self.set_failed(f"Failed to create namespace {self._namespace}: {ns_result.stderr}")
+                return
+            ns_created = True
+
+            if not self._apply_manifest(_PODS_MANIFEST):
+                return
+
+            wait_cmd = (
+                f"{self._kubectl_base} wait --for=condition=Ready "
+                f"--timeout={self.timeout}s -n {ns_quoted} "
+                f"pod/server pod/other-server pod/allowed-client pod/denied-client"
+            )
+            wait_result = self.run_command(wait_cmd)
+            if wait_result.exit_code != 0:
+                self.set_failed(f"Probe pods did not become Ready: {wait_result.stderr or wait_result.stdout}")
+                return
+
+            server_ips = self._get_pod_ips("server")
+            other_ips = self._get_pod_ips("other-server")
+            if not server_ips:
+                self.set_failed("Failed to read server pod IPs")
+                return
+            if test_egress and not other_ips:
+                self.set_failed("Failed to read other-server pod IPs")
+                return
+
+            server_ipv4 = [ip for ip in server_ips if _is_ipv4(ip)]
+            server_ipv6 = [ip for ip in server_ips if _is_ipv6(ip)]
+            other_ipv4 = [ip for ip in other_ips if _is_ipv4(ip)]
+            other_ipv6 = [ip for ip in other_ips if _is_ipv6(ip)]
+
+            for client in ("allowed-client", "denied-client"):
+                for ip in server_ips:
+                    if not self._probe(client, ip):
+                        self.set_failed(
+                            f"Baseline connectivity broken — CNI issue? {client} could not reach server at {ip}"
+                        )
+                        return
+
+            # Baseline allowed-client -> other-server before egress policy lands,
+            # so a pre-existing CNI failure isn't misattributed to _EGRESS_MANIFEST.
+            if test_egress:
+                for ip in other_ips:
+                    if not self._probe("allowed-client", ip):
+                        self.set_failed(
+                            f"Baseline connectivity broken — CNI issue? allowed-client could not reach other-server at {ip}"
+                        )
+                        return
+
+            if not self._apply_manifest(_INGRESS_MANIFEST):
+                return
+            if test_egress and not self._apply_manifest(_EGRESS_MANIFEST):
+                return
+
+            # Poll every deny path that will later be asserted so IPv6 and
+            # egress policies don't get probed before enforcement has landed.
+            deny_probes: list[tuple[str, str, str]] = []
+            if server_ipv4:
+                deny_probes.append(("denied-client", "server", server_ipv4[0]))
+            if server_ipv6:
+                deny_probes.append(("denied-client", "server", server_ipv6[0]))
+            if test_egress:
+                if other_ipv4:
+                    deny_probes.append(("allowed-client", "other-server", other_ipv4[0]))
+                if other_ipv6:
+                    deny_probes.append(("allowed-client", "other-server", other_ipv6[0]))
+
+            for client, target_label, ip in deny_probes:
+                if not self._wait_for_policy_enforcement(client, ip, settle_timeout):
+                    self.set_failed(
+                        f"NetworkPolicy did not take effect within {settle_timeout}s "
+                        f"({client} still reaches {target_label} at {ip})"
+                    )
+                    return
+
+            # Families are driven by server presence alone so an IPv6-capable
+            # server still gets ingress coverage even if other-server lacks IPv6.
+            families: list[tuple[str, list[str], list[str]]] = []
+            if server_ipv4:
+                families.append(("IPv4", server_ipv4, other_ipv4))
+            if server_ipv6:
+                families.append(("IPv6", server_ipv6, other_ipv6))
+
+            any_failed = False
+            for family, server_family_ips, other_family_ips in families:
+                server_ip = server_family_ips[0]
+
+                # A single allow[family] subtest exercises both the server-side
+                # ingress rule and the client-side egress rule; they can't be
+                # attributed independently from this probe alone.
+                allow_ok = self._probe("allowed-client", server_ip)
+                if not self._report_probe(
+                    f"allow[{family}]", allow_ok, "allowed-client", "server", server_ip, expect_success=True
+                ):
+                    any_failed = True
+
+                denied_ok = self._probe("denied-client", server_ip)
+                if not self._report_probe(
+                    f"ingress-deny[{family}]", denied_ok, "denied-client", "server", server_ip, expect_success=False
+                ):
+                    any_failed = True
+
+                if test_egress:
+                    if other_family_ips:
+                        other_ip = other_family_ips[0]
+                        egress_ok = self._probe("allowed-client", other_ip)
+                        if not self._report_probe(
+                            f"egress-deny[{family}]",
+                            egress_ok,
+                            "allowed-client",
+                            "other-server",
+                            other_ip,
+                            expect_success=False,
+                        ):
+                            any_failed = True
+                    else:
+                        self.report_subtest(
+                            f"egress-deny[{family}]",
+                            passed=True,
+                            message=f"other-server has no {family} address; egress check skipped",
+                            skipped=True,
+                        )
+
+            if any_failed:
+                self.set_failed("One or more NetworkPolicy subtests failed; see subtest details")
+            else:
+                covered = [name for name, _, _ in families]
+                suffix = f" ({covered[0]} only)" if len(covered) == 1 else f" ({' + '.join(covered)})"
+                self.set_passed(f"NetworkPolicy enforcement verified{suffix}")
+        finally:
+            # Cleanup must never overwrite pass/fail outcome set above.
+            if ns_created:
+                cleanup = self.run_command(
+                    f"{self._kubectl_base} delete namespace {ns_quoted} --wait=false --ignore-not-found=true"
+                )
+                if cleanup.exit_code != 0:
+                    self.log.warning("Namespace cleanup failed for %s: %s", self._namespace, cleanup.stderr)
+
+    def _apply_manifest(self, manifest_path: Path) -> bool:
+        """Apply a manifest after substituting namespace/image/port placeholders.
+
+        Returns True on success; sets the validation to failed and returns
+        False on error.
+        """
+        if not manifest_path.exists():
+            self.set_failed(f"Manifest not found: {manifest_path}")
+            return False
+
+        content = (
+            manifest_path.read_text()
+            .replace("__NAMESPACE__", self._namespace)
+            .replace("__IMAGE__", self._image)
+            .replace("__PORT__", str(self._probe_port))
+        )
+
+        try:
+            proc = subprocess.run(
+                self._kubectl_parts + ["apply", "-f", "-"],
+                input=content,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+        except subprocess.TimeoutExpired:
+            self.set_failed(f"kubectl apply timed out for {manifest_path.name}")
+            return False
+        except Exception as exc:
+            self.set_failed(f"kubectl apply failed for {manifest_path.name}: {exc}")
+            return False
+
+        if proc.returncode != 0:
+            self.set_failed(
+                f"kubectl apply failed for {manifest_path.name}: {proc.stderr.strip() or proc.stdout.strip()}"
+            )
+            return False
+        return True
+
+    def _get_pod_ips(self, pod: str) -> list[str]:
+        """Return every IP assigned to ``pod`` via ``status.podIPs``."""
+        cmd = (
+            f"{self._kubectl_base} get pod {shlex.quote(pod)} -n {shlex.quote(self._namespace)} "
+            f"-o jsonpath='{{.status.podIPs[*].ip}}'"
+        )
+        result = self.run_command(cmd)
+        if result.exit_code != 0:
+            self.log.error("Failed to read pod IPs for %s: %s", pod, result.stderr)
+            return []
+        return [ip for ip in result.stdout.strip().split() if ip]
+
+    def _probe(self, client: str, host: str) -> bool:
+        """Run an ``agnhost connect`` probe from ``client`` to ``host:port``.
+
+        IPv6 literals are wrapped in brackets. Returns True iff the probe
+        succeeded (exit code 0).
+        """
+        host_literal = f"[{host}]" if _is_ipv6(host) else host
+        target = f"{host_literal}:{self._probe_port}"
+        cmd = (
+            f"{self._kubectl_base} exec -n {shlex.quote(self._namespace)} {shlex.quote(client)} "
+            f"-- /agnhost connect {shlex.quote(target)} --timeout={self._probe_timeout}s"
+        )
+        # Slack over the probe timeout so a real network timeout surfaces as
+        # probe failure rather than the exec itself being killed.
+        result = self.run_command(cmd, timeout=max(self._probe_timeout + 10, 30))
+        return result.exit_code == 0
+
+    def _report_probe(
+        self,
+        name: str,
+        probe_succeeded: bool,
+        client: str,
+        target_label: str,
+        host: str,
+        *,
+        expect_success: bool,
+    ) -> bool:
+        """Report a probe outcome as a subtest. Returns True iff outcome matched expectation."""
+        matched = probe_succeeded == expect_success
+        expected = "success" if expect_success else "timeout"
+        actual = "success" if probe_succeeded else "timeout"
+        self.report_subtest(
+            name,
+            passed=matched,
+            message=f"{client} -> {target_label}@{host}:{self._probe_port} (expected {expected}, got {actual})",
+        )
+        return matched
+
+    def _wait_for_policy_enforcement(self, client: str, host: str, settle_timeout: int) -> bool:
+        """Poll ``client``'s probe to ``host`` until it starts timing out (deny enforced)."""
+        deadline = time.time() + settle_timeout
+        while time.time() < deadline:
+            if not self._probe(client, host):
+                return True
+            time.sleep(1.0)
+        return False
 
 
 class K8sDualStackNodeCheck(BaseValidation):
@@ -49,6 +351,7 @@ class K8sDualStackNodeCheck(BaseValidation):
     markers: ClassVar[list[str]] = ["kubernetes"]
 
     def run(self) -> None:
+        """List cluster nodes and apply the ``require_dual_stack`` decision matrix, setting the validation pass/fail state."""
         require_dual_stack = self.config.get("require_dual_stack", get_k8s_require_dual_stack())
         try:
             normalized = _normalize_require_dual_stack(require_dual_stack)
@@ -75,14 +378,19 @@ class K8sDualStackNodeCheck(BaseValidation):
             return
 
         node_families: list[tuple[str, bool, bool]] = []
+        cluster_has_dual_stack_hint = False
         for node in nodes:
             name = node.get("metadata", {}).get("name", "unknown")
             has_v4, has_v6 = _classify_node(node)
             node_families.append((name, has_v4, has_v6))
+            # Cluster-level hint combines InternalIP and podCIDR evidence so
+            # auto mode still detects a dual-stack cluster when a node carries
+            # only one InternalIP family but advertises both pod CIDR families.
+            cidr_v4, cidr_v6 = _node_podcidr_families(node)
+            if (has_v4 or cidr_v4) and (has_v6 or cidr_v6):
+                cluster_has_dual_stack_hint = True
 
-        cluster_has_dual_stack_node = any(v4 and v6 for _, v4, v6 in node_families)
-
-        if normalized == "auto" and not cluster_has_dual_stack_node:
+        if normalized == "auto" and not cluster_has_dual_stack_hint:
             # Still emit per-node subtests for visibility, then skip.
             for name, has_v4, has_v6 in node_families:
                 self.report_subtest(
@@ -94,7 +402,7 @@ class K8sDualStackNodeCheck(BaseValidation):
             self.set_passed("Skipped: cluster is single-stack (auto mode)")
             return
 
-        require_both = normalized is True or (normalized == "auto" and cluster_has_dual_stack_node)
+        require_both = normalized is True or (normalized == "auto" and cluster_has_dual_stack_hint)
         failures: list[str] = []
 
         for name, has_v4, has_v6 in node_families:
@@ -156,7 +464,12 @@ def _is_ipv6(addr: str) -> bool:
 
 
 def _classify_node(node: dict[str, Any]) -> tuple[bool, bool]:
-    """Return ``(has_ipv4, has_ipv6)`` for a node based on InternalIP and podCIDRs."""
+    """Return ``(has_ipv4, has_ipv6)`` based on the node's InternalIP addresses.
+
+    podCIDRs are deliberately ignored here — a node that advertises both pod CIDR
+    families but only one InternalIP family is not dual-stack at the node level.
+    Use :func:`_node_podcidr_families` for cluster-level auto-detection hints.
+    """
     has_v4 = False
     has_v6 = False
 
@@ -169,8 +482,13 @@ def _classify_node(node: dict[str, Any]) -> tuple[bool, bool]:
         elif _is_ipv6(ip_str):
             has_v6 = True
 
-    # Also inspect podCIDRs as a supplementary hint — helpful on clusters that
-    # assign only one InternalIP family but allocate both pod CIDR families.
+    return has_v4, has_v6
+
+
+def _node_podcidr_families(node: dict[str, Any]) -> tuple[bool, bool]:
+    """Return ``(has_ipv4, has_ipv6)`` for the node's ``spec.podCIDRs``."""
+    has_v4 = False
+    has_v6 = False
     for cidr in node.get("spec", {}).get("podCIDRs", []) or []:
         try:
             network = ipaddress.ip_network(cidr, strict=False)
@@ -180,7 +498,6 @@ def _classify_node(node: dict[str, Any]) -> tuple[bool, bool]:
             has_v4 = True
         elif isinstance(network, ipaddress.IPv6Network):
             has_v6 = True
-
     return has_v4, has_v6
 
 

--- a/isvtest/src/isvtest/validations/k8s_network_policy.py
+++ b/isvtest/src/isvtest/validations/k8s_network_policy.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Dual-stack node validation (K8S22).
+
+This module provides :class:`K8sDualStackNodeCheck`, which inspects every
+node's ``InternalIP`` addresses (and ``spec.podCIDRs`` as a supplementary
+hint) and verifies that the cluster is dual-stack (IPv4 + IPv6) when
+configuration requires it.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+from typing import Any, ClassVar
+
+from isvtest.config.settings import get_k8s_require_dual_stack
+from isvtest.core.k8s import get_kubectl_base_shell
+from isvtest.core.validation import BaseValidation
+
+
+class K8sDualStackNodeCheck(BaseValidation):
+    """Verify that cluster nodes have both IPv4 and IPv6 InternalIP addresses.
+
+    Config keys (with defaults):
+        require_dual_stack: One of ``True``, ``False``, or ``"auto"``. Defaults
+            to the value returned by
+            :func:`isvtest.config.settings.get_k8s_require_dual_stack`
+            (``"auto"`` unless ``K8S_REQUIRE_DUAL_STACK`` is set).
+
+    Decision matrix:
+        * ``True`` — any node missing either family fails the validation.
+        * ``False`` — always passes; per-node summary is still emitted.
+        * ``"auto"`` — if at least one node has both families the cluster is
+          treated as dual-stack and every node must be; if no node has both
+          the check skips.
+    """
+
+    description: ClassVar[str] = "Verify IPv4 and IPv6 addresses on dual-stack nodes."
+    timeout: ClassVar[int] = 60
+    markers: ClassVar[list[str]] = ["kubernetes"]
+
+    def run(self) -> None:
+        require_dual_stack = self.config.get("require_dual_stack", get_k8s_require_dual_stack())
+        try:
+            normalized = _normalize_require_dual_stack(require_dual_stack)
+        except ValueError:
+            self.set_failed(
+                f"Invalid require_dual_stack value: {require_dual_stack!r} (expected True, False, or 'auto')"
+            )
+            return
+
+        result = self.run_command(f"{get_kubectl_base_shell()} get nodes -o json")
+        if result.exit_code != 0:
+            self.set_failed(f"Failed to list nodes: {result.stderr}")
+            return
+
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            self.set_failed(f"Failed to parse kubectl JSON output: {exc}")
+            return
+
+        nodes = payload.get("items", [])
+        if not nodes:
+            self.set_passed("No nodes found in cluster")
+            return
+
+        node_families: list[tuple[str, bool, bool]] = []
+        for node in nodes:
+            name = node.get("metadata", {}).get("name", "unknown")
+            has_v4, has_v6 = _classify_node(node)
+            node_families.append((name, has_v4, has_v6))
+
+        cluster_has_dual_stack_node = any(v4 and v6 for _, v4, v6 in node_families)
+
+        if normalized == "auto" and not cluster_has_dual_stack_node:
+            # Still emit per-node subtests for visibility, then skip.
+            for name, has_v4, has_v6 in node_families:
+                self.report_subtest(
+                    f"node/{name}",
+                    passed=True,
+                    message=_family_summary(has_v4, has_v6),
+                    skipped=True,
+                )
+            self.set_passed("Skipped: cluster is single-stack (auto mode)")
+            return
+
+        require_both = normalized is True or (normalized == "auto" and cluster_has_dual_stack_node)
+        failures: list[str] = []
+
+        for name, has_v4, has_v6 in node_families:
+            summary = _family_summary(has_v4, has_v6)
+            if require_both:
+                node_ok = has_v4 and has_v6
+                self.report_subtest(f"node/{name}", passed=node_ok, message=summary)
+                if not node_ok:
+                    failures.append(f"{name} ({summary})")
+            else:
+                self.report_subtest(f"node/{name}", passed=True, message=summary)
+
+        if failures:
+            self.set_failed(f"{len(failures)} node(s) missing required address family: {', '.join(failures)}")
+            return
+
+        if require_both:
+            self.set_passed(f"All {len(node_families)} nodes have IPv4 and IPv6 InternalIPs")
+        else:
+            self.set_passed(
+                f"Informational: per-node IPv4/IPv6 summary recorded for "
+                f"{len(node_families)} node(s) (require_dual_stack=False)"
+            )
+
+
+def _normalize_require_dual_stack(value: object) -> bool | str:
+    """Normalize a ``require_dual_stack`` config value.
+
+    Returns ``True``, ``False``, or ``"auto"``. Raises ``ValueError`` for
+    anything else.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "yes", "1"}:
+            return True
+        if lowered in {"false", "no", "0"}:
+            return False
+        if lowered == "auto":
+            return "auto"
+    raise ValueError(f"unrecognized require_dual_stack value: {value!r}")
+
+
+def _is_ipv4(addr: str) -> bool:
+    """Return True iff ``addr`` parses as an IPv4 address."""
+    try:
+        return isinstance(ipaddress.ip_address(addr), ipaddress.IPv4Address)
+    except ValueError:
+        return False
+
+
+def _is_ipv6(addr: str) -> bool:
+    """Return True iff ``addr`` parses as an IPv6 address."""
+    try:
+        return isinstance(ipaddress.ip_address(addr), ipaddress.IPv6Address)
+    except ValueError:
+        return False
+
+
+def _classify_node(node: dict[str, Any]) -> tuple[bool, bool]:
+    """Return ``(has_ipv4, has_ipv6)`` for a node based on InternalIP and podCIDRs."""
+    has_v4 = False
+    has_v6 = False
+
+    for addr in node.get("status", {}).get("addresses", []) or []:
+        if addr.get("type") != "InternalIP":
+            continue
+        ip_str = addr.get("address", "")
+        if _is_ipv4(ip_str):
+            has_v4 = True
+        elif _is_ipv6(ip_str):
+            has_v6 = True
+
+    # Also inspect podCIDRs as a supplementary hint — helpful on clusters that
+    # assign only one InternalIP family but allocate both pod CIDR families.
+    for cidr in node.get("spec", {}).get("podCIDRs", []) or []:
+        try:
+            network = ipaddress.ip_network(cidr, strict=False)
+        except ValueError:
+            continue
+        if isinstance(network, ipaddress.IPv4Network):
+            has_v4 = True
+        elif isinstance(network, ipaddress.IPv6Network):
+            has_v6 = True
+
+    return has_v4, has_v6
+
+
+def _family_summary(has_v4: bool, has_v6: bool) -> str:
+    """Human-readable per-node family summary."""
+    families = []
+    if has_v4:
+        families.append("IPv4")
+    if has_v6:
+        families.append("IPv6")
+    return f"families=[{', '.join(families) or 'none'}]"

--- a/isvtest/src/isvtest/validations/manifests/k8s/network_policy_egress.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/network_policy_egress.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# Egress NetworkPolicy for K8sNetworkPolicyCheck.
+#
+# Applied to pods labeled role=allowed-client. Allows egress traffic only to
+# pods labeled role=server. All other egress (including to other-server) is
+# denied. DNS is intentionally NOT allowed — the validation probes by pod IP.
+#
+# Placeholders (replaced by K8sNetworkPolicyCheck at runtime):
+#   __NAMESPACE__ - ephemeral test namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: isvtest-netpol-egress
+  namespace: __NAMESPACE__
+spec:
+  podSelector:
+    matchLabels:
+      role: allowed-client
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              role: server

--- a/isvtest/src/isvtest/validations/manifests/k8s/network_policy_ingress.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/network_policy_ingress.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# Ingress NetworkPolicy for K8sNetworkPolicyCheck.
+#
+# Applied to pods labeled role=server. Allows ingress traffic only from pods
+# labeled role=allowed-client. All other ingress is denied.
+#
+# Placeholders (replaced by K8sNetworkPolicyCheck at runtime):
+#   __NAMESPACE__ - ephemeral test namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: isvtest-netpol-ingress
+  namespace: __NAMESPACE__
+spec:
+  podSelector:
+    matchLabels:
+      role: server
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              role: allowed-client

--- a/isvtest/src/isvtest/validations/manifests/k8s/network_policy_test_pods.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/network_policy_test_pods.yaml
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NetworkPolicy validation probe pods.
+#
+# Placeholders (replaced by K8sNetworkPolicyCheck at runtime):
+#   __NAMESPACE__ - ephemeral test namespace
+#   __IMAGE__     - agnhost image (supports `connect` and `netexec`)
+#   __PORT__      - TCP port exposed by agnhost netexec
+#
+# Each pod runs agnhost netexec so the server pods accept TCP probes and the
+# client pods can still issue `agnhost connect` via `kubectl exec`.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: server
+  namespace: __NAMESPACE__
+  labels:
+    app: isvtest-netpol
+    role: server
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: agnhost
+      image: __IMAGE__
+      imagePullPolicy: IfNotPresent
+      args:
+        - netexec
+        - --http-port=__PORT__
+      ports:
+        - containerPort: __PORT__
+          protocol: TCP
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: other-server
+  namespace: __NAMESPACE__
+  labels:
+    app: isvtest-netpol
+    role: other-server
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: agnhost
+      image: __IMAGE__
+      imagePullPolicy: IfNotPresent
+      args:
+        - netexec
+        - --http-port=__PORT__
+      ports:
+        - containerPort: __PORT__
+          protocol: TCP
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowed-client
+  namespace: __NAMESPACE__
+  labels:
+    app: isvtest-netpol
+    role: allowed-client
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: agnhost
+      image: __IMAGE__
+      imagePullPolicy: IfNotPresent
+      args:
+        - netexec
+        - --http-port=__PORT__
+      ports:
+        - containerPort: __PORT__
+          protocol: TCP
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: denied-client
+  namespace: __NAMESPACE__
+  labels:
+    app: isvtest-netpol
+    role: denied-client
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: agnhost
+      image: __IMAGE__
+      imagePullPolicy: IfNotPresent
+      args:
+        - netexec
+        - --http-port=__PORT__
+      ports:
+        - containerPort: __PORT__
+          protocol: TCP
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]

--- a/isvtest/tests/test_k8s_network_policy.py
+++ b/isvtest/tests/test_k8s_network_policy.py
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Unit tests for ``isvtest.validations.k8s_network_policy``."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from isvtest.core.runners import CommandResult
+from isvtest.validations.k8s_network_policy import (
+    K8sDualStackNodeCheck,
+    _classify_node,
+    _family_summary,
+    _is_ipv4,
+    _is_ipv6,
+    _normalize_require_dual_stack,
+)
+
+
+def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _fail(stdout: str = "", stderr: str = "", exit_code: int = 1) -> CommandResult:
+    return CommandResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+class TestNormalizeRequireDualStack:
+    """Tests for ``_normalize_require_dual_stack``."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (True, True),
+            (False, False),
+            ("true", True),
+            ("FALSE", False),
+            ("Auto", "auto"),
+            ("  auto  ", "auto"),
+            ("yes", True),
+            ("no", False),
+            ("1", True),
+            ("0", False),
+        ],
+    )
+    def test_valid_values(self, value: Any, expected: Any) -> None:
+        assert _normalize_require_dual_stack(value) == expected
+
+    @pytest.mark.parametrize("value", ["maybe", "", None, 42, object()])
+    def test_invalid_values(self, value: Any) -> None:
+        with pytest.raises(ValueError):
+            _normalize_require_dual_stack(value)
+
+
+class TestIpClassification:
+    """Tests for ``_is_ipv4`` / ``_is_ipv6``."""
+
+    def test_ipv4(self) -> None:
+        assert _is_ipv4("10.0.0.1")
+        assert not _is_ipv6("10.0.0.1")
+
+    def test_ipv6(self) -> None:
+        assert _is_ipv6("fd00::1")
+        assert not _is_ipv4("fd00::1")
+
+    def test_invalid(self) -> None:
+        assert not _is_ipv4("not-an-ip")
+        assert not _is_ipv6("not-an-ip")
+        assert not _is_ipv4("")
+
+
+class TestClassifyNode:
+    """Tests for ``_classify_node``."""
+
+    def test_dual_stack_node(self) -> None:
+        node = {
+            "metadata": {"name": "n1"},
+            "status": {
+                "addresses": [
+                    {"type": "InternalIP", "address": "10.0.0.1"},
+                    {"type": "InternalIP", "address": "fd00::1"},
+                    {"type": "ExternalIP", "address": "1.2.3.4"},
+                ]
+            },
+        }
+        assert _classify_node(node) == (True, True)
+
+    def test_ipv4_only(self) -> None:
+        node = {
+            "status": {"addresses": [{"type": "InternalIP", "address": "10.0.0.1"}]},
+        }
+        assert _classify_node(node) == (True, False)
+
+    def test_ipv6_only(self) -> None:
+        node = {
+            "status": {"addresses": [{"type": "InternalIP", "address": "fd00::1"}]},
+        }
+        assert _classify_node(node) == (False, True)
+
+    def test_pod_cidrs_supplement_internal_ips(self) -> None:
+        # Only IPv4 InternalIP but pod CIDRs expose IPv6 too.
+        node = {
+            "status": {"addresses": [{"type": "InternalIP", "address": "10.0.0.1"}]},
+            "spec": {"podCIDRs": ["10.244.0.0/24", "fd00::/64"]},
+        }
+        assert _classify_node(node) == (True, True)
+
+    def test_no_addresses(self) -> None:
+        assert _classify_node({}) == (False, False)
+
+
+class TestFamilySummary:
+    def test_both(self) -> None:
+        assert _family_summary(True, True) == "families=[IPv4, IPv6]"
+
+    def test_none(self) -> None:
+        assert _family_summary(False, False) == "families=[none]"
+
+
+def _nodes_json(node_addrs: list[list[tuple[str, str]]]) -> str:
+    """Build a ``kubectl get nodes -o json`` payload.
+
+    ``node_addrs`` is a list of per-node address lists, each element a
+    ``(type, address)`` tuple.
+    """
+    items = []
+    for i, addrs in enumerate(node_addrs):
+        items.append(
+            {
+                "metadata": {"name": f"node-{i}"},
+                "status": {"addresses": [{"type": t, "address": a} for t, a in addrs]},
+            }
+        )
+    return json.dumps({"items": items})
+
+
+class TestDualStackNodeCheck:
+    """Tests for ``K8sDualStackNodeCheck``."""
+
+    def _make(self, config: dict[str, Any] | None = None) -> K8sDualStackNodeCheck:
+        check = K8sDualStackNodeCheck(config=config or {})
+        return check
+
+    def test_invalid_require_dual_stack_fails(self) -> None:
+        check = self._make({"require_dual_stack": "maybe"})
+        with patch.object(check, "run_command") as mock_run:
+            check.run()
+        mock_run.assert_not_called()
+        assert not check.passed
+        assert "Invalid require_dual_stack" in check._error
+
+    def test_kubectl_failure_sets_failed(self) -> None:
+        check = self._make({"require_dual_stack": True})
+        with patch.object(check, "run_command", return_value=_fail(stderr="boom")):
+            check.run()
+        assert not check.passed
+        assert "Failed to list nodes" in check._error
+
+    def test_bad_json_sets_failed(self) -> None:
+        check = self._make({"require_dual_stack": True})
+        with patch.object(check, "run_command", return_value=_ok(stdout="not-json")):
+            check.run()
+        assert not check.passed
+        assert "parse kubectl JSON" in check._error
+
+    def test_no_nodes_passes(self) -> None:
+        check = self._make({"require_dual_stack": True})
+        with patch.object(check, "run_command", return_value=_ok(stdout=json.dumps({"items": []}))):
+            check.run()
+        assert check.passed
+        assert "No nodes" in check._output
+
+    def test_require_true_fails_on_single_stack_node(self) -> None:
+        payload = _nodes_json(
+            [
+                [("InternalIP", "10.0.0.1"), ("InternalIP", "fd00::1")],
+                [("InternalIP", "10.0.0.2")],  # IPv4 only
+            ]
+        )
+        check = self._make({"require_dual_stack": True})
+        with patch.object(check, "run_command", return_value=_ok(stdout=payload)):
+            check.run()
+        assert not check.passed
+        assert "node-1" in check._error
+
+    def test_require_true_passes_when_all_dual_stack(self) -> None:
+        payload = _nodes_json(
+            [
+                [("InternalIP", "10.0.0.1"), ("InternalIP", "fd00::1")],
+                [("InternalIP", "10.0.0.2"), ("InternalIP", "fd00::2")],
+            ]
+        )
+        check = self._make({"require_dual_stack": True})
+        with patch.object(check, "run_command", return_value=_ok(stdout=payload)):
+            check.run()
+        assert check.passed
+        assert "All 2 nodes" in check._output
+
+    def test_require_false_always_passes(self) -> None:
+        payload = _nodes_json([[("InternalIP", "10.0.0.1")]])
+        check = self._make({"require_dual_stack": False})
+        with patch.object(check, "run_command", return_value=_ok(stdout=payload)):
+            check.run()
+        assert check.passed
+        assert "Informational" in check._output
+
+    def test_auto_skips_when_no_node_dual_stack(self) -> None:
+        payload = _nodes_json(
+            [
+                [("InternalIP", "10.0.0.1")],
+                [("InternalIP", "10.0.0.2")],
+            ]
+        )
+        check = self._make({"require_dual_stack": "auto"})
+        with patch.object(check, "run_command", return_value=_ok(stdout=payload)):
+            check.run()
+        assert check.passed
+        assert "single-stack" in check._output
+
+    def test_auto_requires_all_when_any_node_dual_stack(self) -> None:
+        payload = _nodes_json(
+            [
+                [("InternalIP", "10.0.0.1"), ("InternalIP", "fd00::1")],
+                [("InternalIP", "10.0.0.2")],  # Missing IPv6
+            ]
+        )
+        check = self._make({"require_dual_stack": "auto"})
+        with patch.object(check, "run_command", return_value=_ok(stdout=payload)):
+            check.run()
+        assert not check.passed
+        assert "node-1" in check._error
+
+    def test_auto_passes_when_all_nodes_dual_stack(self) -> None:
+        payload = _nodes_json(
+            [
+                [("InternalIP", "10.0.0.1"), ("InternalIP", "fd00::1")],
+                [("InternalIP", "10.0.0.2"), ("InternalIP", "fd00::2")],
+            ]
+        )
+        check = self._make({"require_dual_stack": "auto"})
+        with patch.object(check, "run_command", return_value=_ok(stdout=payload)):
+            check.run()
+        assert check.passed
+        assert "All 2 nodes" in check._output

--- a/isvtest/tests/test_k8s_network_policy.py
+++ b/isvtest/tests/test_k8s_network_policy.py
@@ -12,7 +12,9 @@
 
 from __future__ import annotations
 
+import itertools
 import json
+import subprocess
 from typing import Any
 from unittest.mock import patch
 
@@ -21,19 +23,23 @@ import pytest
 from isvtest.core.runners import CommandResult
 from isvtest.validations.k8s_network_policy import (
     K8sDualStackNodeCheck,
+    K8sNetworkPolicyCheck,
     _classify_node,
     _family_summary,
     _is_ipv4,
     _is_ipv6,
+    _node_podcidr_families,
     _normalize_require_dual_stack,
 )
 
 
 def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    """Return a successful ``CommandResult`` with the given stdout/stderr."""
     return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.0)
 
 
 def _fail(stdout: str = "", stderr: str = "", exit_code: int = 1) -> CommandResult:
+    """Return a failing ``CommandResult`` with the given output and exit code."""
     return CommandResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration=0.0)
 
 
@@ -109,19 +115,41 @@ class TestClassifyNode:
         }
         assert _classify_node(node) == (False, True)
 
-    def test_pod_cidrs_supplement_internal_ips(self) -> None:
-        # Only IPv4 InternalIP but pod CIDRs expose IPv6 too.
+    def test_pod_cidrs_do_not_supplement_internal_ips(self) -> None:
+        # Per-node classification must ignore podCIDRs: a node whose control
+        # plane advertises only an IPv4 InternalIP is not dual-stack at the
+        # node level, even when its pod CIDRs span both families.
         node = {
             "status": {"addresses": [{"type": "InternalIP", "address": "10.0.0.1"}]},
             "spec": {"podCIDRs": ["10.244.0.0/24", "fd00::/64"]},
         }
-        assert _classify_node(node) == (True, True)
+        assert _classify_node(node) == (True, False)
 
     def test_no_addresses(self) -> None:
         assert _classify_node({}) == (False, False)
 
 
+class TestNodePodCidrFamilies:
+    """Tests for ``_node_podcidr_families``."""
+
+    def test_dual_family(self) -> None:
+        node = {"spec": {"podCIDRs": ["10.244.0.0/24", "fd00::/64"]}}
+        assert _node_podcidr_families(node) == (True, True)
+
+    def test_ipv4_only(self) -> None:
+        assert _node_podcidr_families({"spec": {"podCIDRs": ["10.244.0.0/24"]}}) == (True, False)
+
+    def test_ipv6_only(self) -> None:
+        assert _node_podcidr_families({"spec": {"podCIDRs": ["fd00::/64"]}}) == (False, True)
+
+    def test_missing_and_invalid(self) -> None:
+        assert _node_podcidr_families({}) == (False, False)
+        assert _node_podcidr_families({"spec": {"podCIDRs": ["not-a-cidr"]}}) == (False, False)
+
+
 class TestFamilySummary:
+    """Tests for ``_family_summary``, which formats detected IP families for display."""
+
     def test_both(self) -> None:
         assert _family_summary(True, True) == "families=[IPv4, IPv6]"
 
@@ -129,20 +157,25 @@ class TestFamilySummary:
         assert _family_summary(False, False) == "families=[none]"
 
 
-def _nodes_json(node_addrs: list[list[tuple[str, str]]]) -> str:
+def _nodes_json(
+    node_addrs: list[list[tuple[str, str]]],
+    pod_cidrs: list[list[str]] | None = None,
+) -> str:
     """Build a ``kubectl get nodes -o json`` payload.
 
     ``node_addrs`` is a list of per-node address lists, each element a
-    ``(type, address)`` tuple.
+    ``(type, address)`` tuple. ``pod_cidrs`` is an optional per-node list of
+    CIDR strings set as ``spec.podCIDRs``.
     """
     items = []
     for i, addrs in enumerate(node_addrs):
-        items.append(
-            {
-                "metadata": {"name": f"node-{i}"},
-                "status": {"addresses": [{"type": t, "address": a} for t, a in addrs]},
-            }
-        )
+        node: dict[str, Any] = {
+            "metadata": {"name": f"node-{i}"},
+            "status": {"addresses": [{"type": t, "address": a} for t, a in addrs]},
+        }
+        if pod_cidrs and i < len(pod_cidrs) and pod_cidrs[i]:
+            node["spec"] = {"podCIDRs": pod_cidrs[i]}
+        items.append(node)
     return json.dumps({"items": items})
 
 
@@ -254,3 +287,311 @@ class TestDualStackNodeCheck:
             check.run()
         assert check.passed
         assert "All 2 nodes" in check._output
+
+    def test_auto_pod_cidrs_hint_requires_internal_ip_per_node(self) -> None:
+        # No node has both InternalIP families, but podCIDRs span both: the
+        # cluster-level auto hint fires, and the per-node check then fails the
+        # node that is missing the IPv6 InternalIP.
+        payload = _nodes_json(
+            [[("InternalIP", "10.0.0.1")]],
+            pod_cidrs=[["10.244.0.0/24", "fd00::/64"]],
+        )
+        check = self._make({"require_dual_stack": "auto"})
+        with patch.object(check, "run_command", return_value=_ok(stdout=payload)):
+            check.run()
+        assert not check.passed
+        assert "node-0" in check._error
+
+
+def _primed_check(config: dict[str, Any] | None = None, *, probe_timeout: int = 5) -> K8sNetworkPolicyCheck:
+    """Return a check with the invariants ``run()`` would normally set."""
+    check = K8sNetworkPolicyCheck(config=config or {})
+    check._kubectl_base = "kubectl"
+    check._kubectl_parts = ["kubectl"]
+    check._namespace = "ns"
+    check._image = "test-image"
+    check._probe_port = 8080
+    check._probe_timeout = probe_timeout
+    return check
+
+
+class TestNetworkPolicyCheckBehavior:
+    """Unit tests for ``K8sNetworkPolicyCheck`` that don't need a cluster."""
+
+    def test_namespace_create_failure_sets_failed(self) -> None:
+        check = K8sNetworkPolicyCheck(config={})
+        with patch.object(check, "run_command", return_value=_fail(stderr="forbidden")):
+            check.run()
+        assert not check.passed
+        assert "Failed to create namespace" in check._error
+
+    def test_get_pod_ips_parses_multiple_families(self) -> None:
+        check = _primed_check()
+        with patch.object(check, "run_command", return_value=_ok(stdout="10.0.0.1 fd00::1")):
+            ips = check._get_pod_ips("server")
+        assert ips == ["10.0.0.1", "fd00::1"]
+
+    def test_get_pod_ips_returns_empty_on_error(self) -> None:
+        check = _primed_check()
+        with patch.object(check, "run_command", return_value=_fail(stderr="boom")):
+            ips = check._get_pod_ips("server")
+        assert ips == []
+
+    def test_probe_success(self) -> None:
+        check = _primed_check()
+        with patch.object(check, "run_command", return_value=_ok()) as mock_run:
+            ok = check._probe("allowed-client", "10.0.0.1")
+        assert ok
+        cmd_arg = mock_run.call_args[0][0]
+        assert "allowed-client" in cmd_arg
+        assert "10.0.0.1:8080" in cmd_arg
+        assert "--timeout=5s" in cmd_arg
+
+    def test_probe_failure(self) -> None:
+        check = _primed_check()
+        with patch.object(check, "run_command", return_value=_fail(exit_code=1)):
+            ok = check._probe("denied-client", "10.0.0.1")
+        assert not ok
+
+    def test_probe_brackets_ipv6_literal(self) -> None:
+        check = _primed_check()
+        with patch.object(check, "run_command", return_value=_ok()) as mock_run:
+            check._probe("allowed-client", "fd00::1")
+        cmd_arg = mock_run.call_args[0][0]
+        assert "[fd00::1]:8080" in cmd_arg
+
+    def test_wait_for_policy_enforcement_succeeds_when_probe_stops(self) -> None:
+        check = _primed_check()
+        # First probe succeeds (reachable), second times out (enforced).
+        calls = [_ok(), _fail(exit_code=1)]
+
+        def fake_run(cmd: str, timeout: int | None = None, display_cmd: str | None = None) -> CommandResult:
+            return calls.pop(0)
+
+        with (
+            patch.object(check, "run_command", side_effect=fake_run),
+            patch("isvtest.validations.k8s_network_policy.time.sleep"),
+        ):
+            ok = check._wait_for_policy_enforcement("denied-client", "10.0.0.1", settle_timeout=10)
+        assert ok
+
+    def test_wait_for_policy_enforcement_times_out(self) -> None:
+        check = _primed_check()
+        # Sequence: deadline init (0.0), loop check #1 (0.0), loop check #2 (11.0 >= deadline).
+        with (
+            patch.object(check, "run_command", return_value=_ok()),
+            patch("isvtest.validations.k8s_network_policy.time.sleep"),
+            patch(
+                "isvtest.validations.k8s_network_policy.time.time",
+                side_effect=[0.0, 0.0, 11.0, 11.0, 11.0],
+            ),
+        ):
+            ok = check._wait_for_policy_enforcement("denied-client", "10.0.0.1", settle_timeout=10)
+        assert not ok
+
+
+class _NetPolStub:
+    """Scripted stub for the full ``K8sNetworkPolicyCheck.run()`` flow.
+
+    Dispatches ``run_command`` calls by command content and tracks
+    ``subprocess.run`` calls for manifest applies. Probe outcomes depend on
+    whether any NetworkPolicy manifest has been applied yet (``_policy_applied``).
+    """
+
+    def __init__(
+        self,
+        *,
+        server_ips: tuple[str, ...] = ("10.0.0.1",),
+        other_ips: tuple[str, ...] = ("10.2.2.2",),
+        baseline_blocks: set[str] | None = None,
+        enforcement_probes_until: int | None = 1,
+        allow_after: bool = True,
+        egress_blocks_after: bool = True,
+    ) -> None:
+        self.server_ips = list(server_ips)
+        self.other_ips = list(other_ips)
+        self.baseline_blocks: set[str] = set(baseline_blocks or ())
+        self.enforcement_probes_until = enforcement_probes_until
+        self.allow_after = allow_after
+        self.egress_blocks_after = egress_blocks_after
+        self._policy_applied = False
+        self._denied_probe_count = 0
+        self.applied_manifests: list[str] = []
+        self.run_commands: list[str] = []
+
+    def run_command(self, cmd: str, timeout: int | None = None, display_cmd: str | None = None) -> CommandResult:
+        """Dispatch a scripted ``CommandResult`` based on the shape of ``cmd``.
+
+        Records ``cmd`` in ``self.run_commands`` and returns the canned
+        response for namespace ops, readiness waits, pod IP lookups, or probes.
+        Raises ``AssertionError`` if ``cmd`` is not a recognized shape.
+        """
+        self.run_commands.append(cmd)
+        if "create namespace" in cmd or "delete namespace" in cmd:
+            return _ok()
+        if "wait --for=condition=Ready" in cmd:
+            return _ok()
+        if "jsonpath" in cmd:
+            if "other-server" in cmd:
+                return _ok(stdout=" ".join(self.other_ips))
+            return _ok(stdout=" ".join(self.server_ips))
+        if "/agnhost connect" in cmd:
+            return self._probe(cmd)
+        raise AssertionError(f"No scripted response for command: {cmd}")
+
+    def _probe(self, cmd: str) -> CommandResult:
+        """Return a probe ``CommandResult`` modeling pre/post-policy behavior.
+
+        Before any policy is applied, returns success unless the client is in
+        ``baseline_blocks``. After policy application, outcomes depend on
+        client/target pair and the ``allow_after``/``egress_blocks_after``/
+        ``enforcement_probes_until`` knobs.
+        """
+        client = "allowed-client" if "allowed-client" in cmd else "denied-client"
+        is_server_target = any(ip in cmd for ip in self.server_ips)
+        is_other_target = any(ip in cmd for ip in self.other_ips)
+
+        if not self._policy_applied:
+            if client in self.baseline_blocks:
+                return _fail(exit_code=1)
+            return _ok()
+
+        if client == "denied-client" and is_server_target:
+            self._denied_probe_count += 1
+            if self.enforcement_probes_until is None:
+                return _ok()
+            if self._denied_probe_count >= self.enforcement_probes_until:
+                return _fail(exit_code=1)
+            return _ok()
+        if client == "allowed-client" and is_server_target:
+            return _ok() if self.allow_after else _fail(exit_code=1)
+        if client == "allowed-client" and is_other_target:
+            return _fail(exit_code=1) if self.egress_blocks_after else _ok()
+        raise AssertionError(f"unexpected probe combination: {cmd}")
+
+    def subprocess_run(self, *args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
+        """Record a manifest apply and flip ``_policy_applied`` when relevant.
+
+        Inspects the piped manifest from ``kwargs['input']``, appends a label
+        (``"pods"``, ``"ingress"``, ``"egress"``, or ``"netpol-other"``) to
+        ``applied_manifests``, and returns a successful ``CompletedProcess``.
+        """
+        content = kwargs.get("input", "")
+        if "kind: NetworkPolicy" in content:
+            self._policy_applied = True
+            if "isvtest-netpol-ingress" in content:
+                self.applied_manifests.append("ingress")
+            elif "isvtest-netpol-egress" in content:
+                self.applied_manifests.append("egress")
+            else:
+                self.applied_manifests.append("netpol-other")
+        else:
+            self.applied_manifests.append("pods")
+        return subprocess.CompletedProcess(args=args[0] if args else [], returncode=0, stdout="", stderr="")
+
+
+class TestNetworkPolicyCheckEndToEnd:
+    """Integration-style tests driving the full ``K8sNetworkPolicyCheck.run()`` path."""
+
+    def _make(self, config: dict[str, Any] | None = None) -> K8sNetworkPolicyCheck:
+        return K8sNetworkPolicyCheck(config=config or {})
+
+    def test_happy_path_ipv4_only(self) -> None:
+        check = self._make({"probe_timeout_s": 1, "settle_timeout_s": 5})
+        stub = _NetPolStub()
+        with (
+            patch.object(check, "run_command", side_effect=stub.run_command),
+            patch("isvtest.validations.k8s_network_policy.subprocess.run", side_effect=stub.subprocess_run),
+            patch("isvtest.validations.k8s_network_policy.time.sleep"),
+        ):
+            check.run()
+        assert check.passed, check._error
+        assert "IPv4 only" in check._output
+        assert stub.applied_manifests == ["pods", "ingress", "egress"]
+        assert any("delete namespace" in c for c in stub.run_commands)
+
+    def test_baseline_failure_sets_failed_and_cleans_up(self) -> None:
+        check = self._make({"probe_timeout_s": 1})
+        stub = _NetPolStub(baseline_blocks={"allowed-client"})
+        with (
+            patch.object(check, "run_command", side_effect=stub.run_command),
+            patch("isvtest.validations.k8s_network_policy.subprocess.run", side_effect=stub.subprocess_run),
+        ):
+            check.run()
+        assert not check.passed
+        assert "Baseline connectivity broken" in check._error
+        assert any("delete namespace" in c for c in stub.run_commands)
+        # Policy manifests must not have been applied after baseline failure.
+        assert "ingress" not in stub.applied_manifests
+        assert "egress" not in stub.applied_manifests
+
+    def test_policy_never_enforced_sets_failed(self) -> None:
+        check = self._make({"probe_timeout_s": 1, "settle_timeout_s": 2})
+        stub = _NetPolStub(enforcement_probes_until=None)
+        with (
+            patch.object(check, "run_command", side_effect=stub.run_command),
+            patch("isvtest.validations.k8s_network_policy.subprocess.run", side_effect=stub.subprocess_run),
+            patch("isvtest.validations.k8s_network_policy.time.sleep"),
+            # First call establishes deadline; subsequent calls always exceed it.
+            patch(
+                "isvtest.validations.k8s_network_policy.time.time",
+                side_effect=itertools.chain([0.0], itertools.repeat(1000.0)),
+            ),
+        ):
+            check.run()
+        assert not check.passed
+        assert "NetworkPolicy did not take effect" in check._error
+        # Namespace cleanup still runs.
+        assert any("delete namespace" in c for c in stub.run_commands)
+
+    def test_test_egress_false_skips_egress_manifest_and_probes(self) -> None:
+        check = self._make({"probe_timeout_s": 1, "settle_timeout_s": 5, "test_egress": False})
+        stub = _NetPolStub()
+        with (
+            patch.object(check, "run_command", side_effect=stub.run_command),
+            patch("isvtest.validations.k8s_network_policy.subprocess.run", side_effect=stub.subprocess_run),
+            patch("isvtest.validations.k8s_network_policy.time.sleep"),
+        ):
+            check.run()
+        assert check.passed, check._error
+        assert stub.applied_manifests == ["pods", "ingress"]
+        # allowed-client must never be probed against the other-server IP.
+        assert not any("10.2.2.2" in c and "allowed-client" in c for c in stub.run_commands)
+
+    def test_wait_for_ready_failure_cleans_up_namespace(self) -> None:
+        check = self._make({"probe_timeout_s": 1})
+        run_commands: list[str] = []
+
+        def run_command(cmd: str, timeout: int | None = None, display_cmd: str | None = None) -> CommandResult:
+            run_commands.append(cmd)
+            if "create namespace" in cmd or "delete namespace" in cmd:
+                return _ok()
+            if "wait --for=condition=Ready" in cmd:
+                return _fail(stderr="pods not ready")
+            raise AssertionError(f"unexpected: {cmd}")
+
+        def subproc_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
+            return subprocess.CompletedProcess(args=args[0] if args else [], returncode=0, stdout="", stderr="")
+
+        with (
+            patch.object(check, "run_command", side_effect=run_command),
+            patch("isvtest.validations.k8s_network_policy.subprocess.run", side_effect=subproc_run),
+        ):
+            check.run()
+        assert not check.passed
+        assert "did not become Ready" in check._error
+        assert any("delete namespace" in c for c in run_commands)
+
+    def test_single_subtest_per_allow_family(self) -> None:
+        """The allow probe should produce exactly one subtest per address family."""
+        check = self._make({"probe_timeout_s": 1, "settle_timeout_s": 5})
+        stub = _NetPolStub()
+        with (
+            patch.object(check, "run_command", side_effect=stub.run_command),
+            patch("isvtest.validations.k8s_network_policy.subprocess.run", side_effect=stub.subprocess_run),
+            patch("isvtest.validations.k8s_network_policy.time.sleep"),
+        ):
+            check.run()
+        allow_subtests = [r for r in check._subtest_results if r["name"].startswith("allow[")]
+        assert len(allow_subtests) == 1
+        assert allow_subtests[0]["name"] == "allow[IPv4]"


### PR DESCRIPTION
## Summary

Adds two K8S22 validations covering cluster-level network policy requirements:

- **`K8sDualStackNodeCheck`** (`isvtest/src/isvtest/validations/k8s_network_policy.py`) — inspects every node's `InternalIP` addresses (with `podCIDRs` as a supplementary hint) and reports whether the cluster is dual-stack. `require_dual_stack` accepts `true` / `false` / `"auto"`; `"auto"` auto-skips on single-stack clusters and hard-requires every node to be dual-stack as soon as any node is.
- **`K8sNetworkPolicyCheck`** — stands up four `agnhost` pods in an ephemeral namespace, applies an ingress policy on `role=server` and an egress policy on `role=allowed-client`, and probes allow/deny against both IPv4 and IPv6 pod IPs. Probes hit pod IPs directly to avoid needing a DNS-egress carve-out. Ingress-deny and egress-deny are reported as independent subtests; the `allowed-client -> server` probe exercises both policies at once and is reported as a single `allow[family]` subtest (a failure there can't be attributed to one policy alone). Cleanup is best-effort and never overrides pass/fail.
- Wires both checks into `isvctl/configs/tests/k8s.yaml` and adds the corresponding manifests under `isvtest/src/isvtest/validations/manifests/k8s/`.

## Linked issue
- Closes #219

## Test plan
- [x] `uv run pytest isvtest/tests/test_k8s_network_policy.py`
- [x] Run `isvctl` against a dual-stack K8s cluster and confirm both K8S22 steps pass (kind + calico)
- [x] Run against a single-stack cluster and confirm `K8sDualStackNodeCheck` auto-skips (with `"auto"`) and `K8sNetworkPolicyCheck` passes for IPv4 only (minikube + calico)
- [x] Confirm `K8sNetworkPolicyCheck` fails cleanly when the CNI does not enforce NetworkPolicies (minikube with default CNI - does not enforce NetworkPolicies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes NetworkPolicy validations for ingress and optional egress, plus a dual-stack node validation to assess IPv4/IPv6 presence.
  * Exposed two runtime environment settings to control dual-stack behavior and the network-policy test image.

* **Tests**
  * Added comprehensive unit and end-to-end tests covering validations, helpers, probe behavior, and enforcement flows.

* **Chores**
  * Added default validation entries to test suites and updated a provider config to exclude the NetworkPolicy check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->