### PR TITLE
fix: orchestration cleanup — dedup, output paths, inventory field

### DIFF
--- a/isvctl/configs/stubs/my-isv/k8s/_common.sh
+++ b/isvctl/configs/stubs/my-isv/k8s/_common.sh
@@ -85,6 +85,16 @@ for ns in gpu-operator gpu-operator-resources nvidia-gpu-operator; do
 done
 GPU_OPERATOR_NS="${GPU_OPERATOR_NS:-$DEFAULT_GPU_NS}"
 
+# --- Control-plane namespace (where apiserver/scheduler/controller-manager run) ---
+CONTROL_PLANE_NS=""
+for ns in kube-system openshift-kube-apiserver; do
+    if $KUBECTL get pods -n "$ns" -l component=kube-apiserver --no-headers 2>/dev/null | grep -q .; then
+        CONTROL_PLANE_NS="$ns"
+        break
+    fi
+done
+CONTROL_PLANE_NS="${CONTROL_PLANE_NS:-kube-system}"
+
 # --- Runtime class ---
 RUNTIME_CLASS=""
 if $KUBECTL get runtimeclass nvidia &> /dev/null; then
@@ -105,6 +115,7 @@ cat << EOF
     "gpu_per_node": ${GPU_PER_NODE},
     "total_gpus": ${TOTAL_GPUS},
     "gpu_operator_namespace": "${GPU_OPERATOR_NS}",
+    "control_plane_namespace": "${CONTROL_PLANE_NS}",
     "runtime_class": "${RUNTIME_CLASS}",
     "gpu_resource_name": "nvidia.com/gpu"
   }

--- a/isvctl/schemas/command_output.schema.json
+++ b/isvctl/schemas/command_output.schema.json
@@ -398,6 +398,12 @@
           "title": "Gpu Operator Namespace",
           "type": "string"
         },
+        "control_plane_namespace": {
+          "default": "kube-system",
+          "description": "Namespace where control-plane components run",
+          "title": "Control Plane Namespace",
+          "type": "string"
+        },
         "runtime_class": {
           "default": "nvidia",
           "description": "Kubernetes RuntimeClass for GPU pods",

--- a/isvctl/src/isvctl/cli/catalog.py
+++ b/isvctl/src/isvctl/cli/catalog.py
@@ -15,13 +15,13 @@ Manage the test catalog: build, save, and upload to ISV Lab Service.
 
 import json
 import logging
-from pathlib import Path
 from typing import Annotated
 
 import typer
 from isvtest.catalog import build_catalog, get_catalog_version
 
 from isvctl.cli import setup_logging
+from isvctl.cli.common import get_output_dir
 
 logger = logging.getLogger(__name__)
 
@@ -61,8 +61,7 @@ def push(
     catalog_version = get_catalog_version()
     typer.echo(f"  {len(catalog_entries)} tests (version: {catalog_version})")
 
-    output_dir = Path("_output")
-    output_dir.mkdir(parents=True, exist_ok=True)
+    output_dir = get_output_dir()
     catalog_path = output_dir / "test_catalog.json"
     catalog_path.write_text(json.dumps({"isvTestVersion": catalog_version, "entries": catalog_entries}, indent=2))
     typer.echo(f"  Saved to: {catalog_path}")

--- a/isvctl/src/isvctl/cli/common.py
+++ b/isvctl/src/isvctl/cli/common.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Shared constants and helpers for CLI subcommands."""
+
+from pathlib import Path
+
+OUTPUT_DIR_NAME = "_output"
+
+
+def get_output_dir(root: Path | None = None) -> Path:
+    """Return the output directory, creating it if needed.
+
+    Args:
+        root: Base directory. Defaults to cwd when None.
+
+    Returns:
+        Path to the output directory (already created on disk).
+    """
+    base = root or Path.cwd()
+    output_dir = base / OUTPUT_DIR_NAME
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir

--- a/isvctl/src/isvctl/cli/deploy.py
+++ b/isvctl/src/isvctl/cli/deploy.py
@@ -26,6 +26,7 @@ from isvreporter.config import get_endpoint, get_ssa_issuer
 from isvreporter.platform import get_platform_from_config
 
 from isvctl.cli import setup_logging
+from isvctl.cli.common import get_output_dir
 from isvctl.orchestrator.loop import Phase
 from isvctl.remote import SCPTransfer, SSHClient, TarArchive
 from isvctl.remote.archive import DEFAULT_EXCLUDES as DEFAULT_ARCHIVE_EXCLUDES
@@ -497,9 +498,7 @@ exit ${{TEST_RESULT:-1}}
         # Step 6: Download results (always download to working_dir)
         typer.echo(typer.style("==>", fg=typer.colors.GREEN) + " Copying test results from remote machine...")
 
-        # Download results to _output/
-        output_dir = working_dir / "_output"
-        output_dir.mkdir(exist_ok=True)
+        output_dir = get_output_dir(working_dir)
 
         local_log = output_dir / "pytest-output.log"
         if scp.download_optional(f"{effective_remote_dir}/pytest-output.log", local_log):

--- a/isvctl/src/isvctl/cli/test.py
+++ b/isvctl/src/isvctl/cli/test.py
@@ -25,6 +25,7 @@ import yaml
 from isvtest.catalog import build_catalog, get_catalog_version
 
 from isvctl.cli import setup_logging
+from isvctl.cli.common import OUTPUT_DIR_NAME, get_output_dir
 from isvctl.config.merger import merge_yaml_files
 from isvctl.config.schema import RunConfig
 from isvctl.orchestrator.loop import Orchestrator, Phase
@@ -124,7 +125,7 @@ def run(
             "--junitxml",
             help="Path to write JUnit XML test report",
         ),
-    ] = Path("junit-validation.xml"),
+    ] = Path(OUTPUT_DIR_NAME) / "junit-validation.xml",
     color: Annotated[
         str | None,
         typer.Option(
@@ -294,10 +295,9 @@ def run(
             )
             upload_results = False
 
-    # Run orchestration with log file capture (like deploy run uses `tee pytest-output.log`)
+    # Run orchestration with log file capture (tee to _output/pytest-output.log)
     orchestrator = Orchestrator(config, working_dir=effective_working_dir)
-    output_dir = effective_working_dir / "_output"
-    output_dir.mkdir(exist_ok=True)
+    output_dir = get_output_dir()
     log_file_path = output_dir / "pytest-output.log"
 
     # Build test catalog early so it runs inside the TeeWriter context
@@ -305,19 +305,19 @@ def run(
     catalog_entries: list[dict] | None = None
     catalog_version: str | None = None
 
-    if upload_results:
-        # Capture output to log file while still displaying (like `tee`)
-        with open(log_file_path, "w") as log_file:
-            original_stdout, original_stderr = sys.stdout, sys.stderr
-            sys.stdout = TeeWriter(terminal=original_stdout, file=log_file)  # type: ignore[assignment]
-            sys.stderr = TeeWriter(terminal=original_stderr, file=log_file)  # type: ignore[assignment]
-            try:
-                result = orchestrator.run(
-                    phases=phases,
-                    extra_pytest_args=extra_pytest_args,
-                    verbose=verbose,
-                    junitxml=str(junitxml),
-                )
+    # Always capture output to log file while still displaying (like `tee`)
+    with open(log_file_path, "w") as log_file:
+        original_stdout, original_stderr = sys.stdout, sys.stderr
+        sys.stdout = TeeWriter(terminal=original_stdout, file=log_file)  # type: ignore[assignment]
+        sys.stderr = TeeWriter(terminal=original_stderr, file=log_file)  # type: ignore[assignment]
+        try:
+            result = orchestrator.run(
+                phases=phases,
+                extra_pytest_args=extra_pytest_args,
+                verbose=verbose,
+                junitxml=str(junitxml),
+            )
+            if upload_results:
                 try:
                     catalog_entries = build_catalog()
                     catalog_version = get_catalog_version()
@@ -329,15 +329,8 @@ def run(
                     typer.echo(f"  Saved test catalog to: {catalog_path}")
                 except Exception as e:
                     logger.warning("Failed to build test catalog: %s", e)
-            finally:
-                sys.stdout, sys.stderr = original_stdout, original_stderr
-    else:
-        result = orchestrator.run(
-            phases=phases,
-            extra_pytest_args=extra_pytest_args,
-            verbose=verbose,
-            junitxml=str(junitxml),
-        )
+        finally:
+            sys.stdout, sys.stderr = original_stdout, original_stderr
 
     # Update test run after tests complete
     if upload_results and test_run_id and lab_id:

--- a/isvctl/src/isvctl/config/schema.py
+++ b/isvctl/src/isvctl/config/schema.py
@@ -164,6 +164,9 @@ class KubernetesOutput(BaseModel):
     control_plane_address: str | None = Field(default=None, description="Control plane IP/hostname")
     kubeconfig_path: str | None = Field(default=None, description="Path to kubeconfig file")
     gpu_operator_namespace: str = Field(default="nvidia-gpu-operator", description="GPU operator namespace")
+    control_plane_namespace: str = Field(
+        default="kube-system", description="Namespace where control-plane components run"
+    )
     runtime_class: str = Field(default="nvidia", description="Kubernetes RuntimeClass for GPU pods")
     gpu_resource_name: str = Field(default="nvidia.com/gpu", description="GPU resource name")
 

--- a/isvtest/src/isvtest/main.py
+++ b/isvtest/src/isvtest/main.py
@@ -300,13 +300,22 @@ def _transform_validations_for_pytest(
     # "-category" so downstream dict-keyed storage keeps every instance.
     # Uses the existing ClassName-variant convention that pytest_generate_tests
     # already supports via suffix matching.
+    # When the same class appears twice in the same category (e.g. legacy list
+    # format), append a counter: ClassName-category-2, ClassName-category-3, etc.
     name_counts: dict[str, int] = {}
     for class_name, _, _ in entries:
         name_counts[class_name] = name_counts.get(class_name, 0) + 1
 
+    pair_counts: dict[tuple[str, str], int] = {}
     result: list[dict[str, Any]] = []
     for class_name, category, resolved_params in entries:
-        key = f"{class_name}-{category}" if name_counts[class_name] > 1 else class_name
+        if name_counts[class_name] == 1:
+            key = class_name
+        else:
+            pair = (class_name, category)
+            pair_counts[pair] = pair_counts.get(pair, 0) + 1
+            suffix = category if pair_counts[pair] == 1 else f"{category}-{pair_counts[pair]}"
+            key = f"{class_name}-{suffix}"
         result.append({key: resolved_params})
 
     return result

--- a/isvtest/src/isvtest/main.py
+++ b/isvtest/src/isvtest/main.py
@@ -222,7 +222,12 @@ def _transform_validations_for_pytest(
     Returns:
         List of validation dicts in pytest-compatible format
     """
-    result = []
+    # Two-pass approach: collect entries first, then qualify duplicate class
+    # names with a "-category" suffix so each becomes a unique pytest param.
+    # Without this, get_validations_for_category collapses them into a dict
+    # and only the last occurrence survives (e.g. InstanceStateCheck on
+    # launch_instance vs describe_instance vs reboot_instance).
+    entries: list[tuple[str, str, dict[str, Any]]] = []  # (class_name, category, params)
 
     for category, category_config in validations.items():
         if category in ADAPTER_HANDLED_CATEGORIES:
@@ -289,7 +294,20 @@ def _transform_validations_for_pytest(
             # Add category for result reporting
             resolved_params["_category"] = category
 
-            result.append({name: resolved_params})
+            entries.append((name, category, resolved_params))
+
+    # Detect class names that appear more than once and qualify them with
+    # "-category" so downstream dict-keyed storage keeps every instance.
+    # Uses the existing ClassName-variant convention that pytest_generate_tests
+    # already supports via suffix matching.
+    name_counts: dict[str, int] = {}
+    for class_name, _, _ in entries:
+        name_counts[class_name] = name_counts.get(class_name, 0) + 1
+
+    result: list[dict[str, Any]] = []
+    for class_name, category, resolved_params in entries:
+        key = f"{class_name}-{category}" if name_counts[class_name] > 1 else class_name
+        result.append({key: resolved_params})
 
     return result
 

--- a/isvtest/tests/test_main.py
+++ b/isvtest/tests/test_main.py
@@ -196,3 +196,22 @@ class TestTransformValidationsForPytest:
         keys = self._keys(result)
         assert "StepSuccessCheck-cat_a" in keys
         assert "StepSuccessCheck-cat_b" in keys
+
+    def test_same_class_same_category_gets_counter(self) -> None:
+        """Same class repeated in one category gets a numeric disambiguator."""
+        step_outputs = {
+            "step_a": {"ok": True},
+            "step_b": {"ok": True},
+        }
+        step_phases = {"step_a": "test", "step_b": "test"}
+        validations: dict[str, Any] = {
+            "checks": [
+                {"StepSuccessCheck": {"step": "step_a"}},
+                {"StepSuccessCheck": {"step": "step_b"}},
+            ],
+        }
+        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
+        keys = self._keys(result)
+        assert "StepSuccessCheck-checks" in keys
+        assert "StepSuccessCheck-checks-2" in keys
+        assert len(keys) == 2

--- a/isvtest/tests/test_main.py
+++ b/isvtest/tests/test_main.py
@@ -40,6 +40,7 @@ class TestTransformValidationsForPytest:
 
     @pytest.fixture()
     def step_outputs(self) -> dict[str, dict[str, Any]]:
+        """Simulated step outputs keyed by step name."""
         return {
             "launch_instance": {"instance_id": "i-abc", "state": "running"},
             "describe_instance": {"instance_id": "i-abc", "state": "running"},
@@ -48,6 +49,7 @@ class TestTransformValidationsForPytest:
 
     @pytest.fixture()
     def step_phases(self) -> dict[str, str]:
+        """Mapping of step names to the phase they belong to."""
         return {
             "launch_instance": "setup",
             "describe_instance": "test",

--- a/isvtest/tests/test_main.py
+++ b/isvtest/tests/test_main.py
@@ -8,9 +8,14 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
-"""Dummy test to ensure pytest runs successfully."""
+"""Tests for isvtest.main module."""
+
+from typing import Any
+
+import pytest
 
 import isvtest.main
+from isvtest.main import _transform_validations_for_pytest
 
 
 def test_dummy() -> None:
@@ -21,3 +26,173 @@ def test_dummy() -> None:
 def test_main_module_exists() -> None:
     """Test that the main module can be imported."""
     assert isvtest.main is not None
+
+
+# ---------------------------------------------------------------------------
+# _transform_validations_for_pytest
+# ---------------------------------------------------------------------------
+
+
+class TestTransformValidationsForPytest:
+    """Tests for the validation transform that feeds pytest parametrization."""
+
+    # Shared fixtures ---------------------------------------------------------
+
+    @pytest.fixture()
+    def step_outputs(self) -> dict[str, dict[str, Any]]:
+        return {
+            "launch_instance": {"instance_id": "i-abc", "state": "running"},
+            "describe_instance": {"instance_id": "i-abc", "state": "running"},
+            "reboot_instance": {"instance_id": "i-abc", "state": "running"},
+        }
+
+    @pytest.fixture()
+    def step_phases(self) -> dict[str, str]:
+        return {
+            "launch_instance": "setup",
+            "describe_instance": "test",
+            "reboot_instance": "test",
+        }
+
+    # Helpers -----------------------------------------------------------------
+
+    @staticmethod
+    def _keys(result: list[dict[str, Any]]) -> list[str]:
+        """Extract the validation key from each entry."""
+        return [next(iter(d)) for d in result]
+
+    # Tests -------------------------------------------------------------------
+
+    def test_unique_checks_keep_bare_name(
+        self,
+        step_outputs: dict[str, dict[str, Any]],
+        step_phases: dict[str, str],
+    ) -> None:
+        """When each class name is unique, no suffix is added."""
+        validations: dict[str, Any] = {
+            "ssh": {
+                "step": "describe_instance",
+                "checks": {"ConnectivityCheck": {}, "OsCheck": {}},
+            },
+        }
+        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
+        keys = self._keys(result)
+        assert keys == ["ConnectivityCheck", "OsCheck"]
+
+    def test_duplicate_checks_get_category_suffix(
+        self,
+        step_outputs: dict[str, dict[str, Any]],
+        step_phases: dict[str, str],
+    ) -> None:
+        """Same class in multiple categories gets '-category' suffix."""
+        validations: dict[str, Any] = {
+            "instance_info": {
+                "step": "describe_instance",
+                "checks": {"InstanceStateCheck": {"expected_state": "running"}},
+            },
+            "reboot_state": {
+                "step": "reboot_instance",
+                "checks": {"InstanceStateCheck": {"expected_state": "running"}},
+            },
+        }
+        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
+        keys = self._keys(result)
+        assert "InstanceStateCheck-instance_info" in keys
+        assert "InstanceStateCheck-reboot_state" in keys
+        assert len(keys) == 2
+
+    def test_duplicate_checks_preserve_params(
+        self,
+        step_outputs: dict[str, dict[str, Any]],
+        step_phases: dict[str, str],
+    ) -> None:
+        """Qualified entries keep correct step_output and _category."""
+        validations: dict[str, Any] = {
+            "instance_info": {
+                "step": "describe_instance",
+                "checks": {"InstanceStateCheck": {"expected_state": "running"}},
+            },
+            "reboot_state": {
+                "step": "reboot_instance",
+                "checks": {"InstanceStateCheck": {"expected_state": "running"}},
+            },
+        }
+        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
+        by_key = {next(iter(d)): next(iter(d.values())) for d in result}
+
+        info = by_key["InstanceStateCheck-instance_info"]
+        assert info["_category"] == "instance_info"
+        assert info["step_output"] == step_outputs["describe_instance"]
+
+        reboot = by_key["InstanceStateCheck-reboot_state"]
+        assert reboot["_category"] == "reboot_state"
+        assert reboot["step_output"] == step_outputs["reboot_instance"]
+
+    def test_mixed_unique_and_duplicate(
+        self,
+        step_outputs: dict[str, dict[str, Any]],
+        step_phases: dict[str, str],
+    ) -> None:
+        """Unique checks stay bare; only duplicates get the suffix."""
+        validations: dict[str, Any] = {
+            "ssh": {
+                "step": "describe_instance",
+                "checks": {"ConnectivityCheck": {}, "GpuCheck": {}},
+            },
+            "reboot_ssh": {
+                "step": "reboot_instance",
+                "checks": {"ConnectivityCheck": {}, "DriverCheck": {}},
+            },
+        }
+        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
+        keys = self._keys(result)
+        assert "ConnectivityCheck-ssh" in keys
+        assert "ConnectivityCheck-reboot_ssh" in keys
+        assert "GpuCheck" in keys
+        assert "DriverCheck" in keys
+
+    def test_phase_filtering_excludes_other_phases(
+        self,
+        step_outputs: dict[str, dict[str, Any]],
+        step_phases: dict[str, str],
+    ) -> None:
+        """Checks in a different phase are not emitted."""
+        validations: dict[str, Any] = {
+            "setup_checks": {
+                "step": "launch_instance",
+                "checks": {"InstanceStateCheck": {"expected_state": "running"}},
+            },
+            "instance_info": {
+                "step": "describe_instance",
+                "checks": {"InstanceStateCheck": {"expected_state": "running"}},
+            },
+        }
+        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
+        keys = self._keys(result)
+        # Only the test-phase entry should appear, and since it's the only one
+        # for this phase, it keeps the bare class name.
+        assert keys == ["InstanceStateCheck"]
+
+    def test_empty_validations(self) -> None:
+        """Empty input returns empty list."""
+        assert _transform_validations_for_pytest({}, {}, {}, "test") == []
+
+    def test_list_format_dedup(self) -> None:
+        """Duplicate class names in legacy list format also get qualified."""
+        step_outputs = {
+            "step_a": {"ok": True},
+            "step_b": {"ok": True},
+        }
+        step_phases = {"step_a": "test", "step_b": "test"}
+        validations: dict[str, Any] = {
+            "cat_a": [
+                {"StepSuccessCheck": {"step": "step_a"}},
+            ],
+            "cat_b": [
+                {"StepSuccessCheck": {"step": "step_b"}},
+            ],
+        }
+        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
+        keys = self._keys(result)
+        assert "StepSuccessCheck-cat_a" in keys
+        assert "StepSuccessCheck-cat_b" in keys


### PR DESCRIPTION
## Summary

- **Emit `control_plane_namespace` from K8s inventory stub** — `k8s.yaml` references `steps.setup.kubernetes.control_plane_namespace` but `_common.sh` never included it, causing an orchestrator warning on every run. Detects the namespace via kube-apiserver pod labels, falls back to `kube-system`.

- **Deduplicate validation names in ORCHESTRATION RESULTS** — When the same validation class (e.g. `InstanceStateCheck`) appears in multiple categories with different steps, `get_validations_for_category` collapsed them into a dict and only the last survived. Now qualifies duplicate class names with a `-category` suffix (e.g. `InstanceStateCheck-reboot_state`), using the existing variant convention that `pytest_generate_tests` already supports.

- **Write all outputs to root `_output/` directory** — `_output` was created relative to the config file's parent (e.g. `isvctl/configs/providers/_output/`) instead of the project root. Centralized the path in `cli/common.py` (`OUTPUT_DIR_NAME` + `get_output_dir` helper), routed `junit-validation.xml` into `_output/` by default, and made the pytest log write unconditionally (not only when uploading).

## Test plan

- [x] `make demo-test` — all 6 my-isv configs pass end-to-end
- [x] `uv run pytest isvtest/tests/ -m unit` — 295 passed
- [x] `uv run pytest isvctl/tests/` — 378 passed
- [x] `isvctl test run -f isvctl/configs/providers/minikube.yaml` — `control_plane_namespace` warning gone, `_output/` at root with junit + log

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection of the Kubernetes control-plane namespace, now included in command output (defaults to kube-system).
  * CLI now uses a unified output directory for test artifacts, JUnit/pytest outputs, and consistent log capture.

* **Bug Fixes**
  * Prevented duplicate validation names by disambiguating repeated validations across categories.

* **Tests**
  * Added comprehensive tests covering validation transformation and deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->