### PR TITLE
feat: add node-pool CRUD lifecycle management check (K8S06 - M5 P0)

### DIFF
--- a/isvctl/configs/providers/aws/config/eks.yaml
+++ b/isvctl/configs/providers/aws/config/eks.yaml
@@ -49,6 +49,52 @@ commands:
           # Override with your IP for security
           TF_VAR_cluster_endpoint_public_access_cidrs: '["0.0.0.0/0"]'
 
+      # K8S06-01 — test the Terraform node-pool create path. Runs after the
+      # cluster is up; reads cluster state via terraform_remote_state in the
+      # node-pool module. See ../scripts/eks/terraform-node-pool/README.md.
+      - name: create_test_node_pool
+        phase: setup
+        command: "../scripts/eks/create_node_pool.sh"
+        output_schema: node_pool
+        timeout: 900 # 15 min — EKS node group join can take 5-8 min
+        env:
+          TF_AUTO_APPROVE: "true"
+          TF_VAR_test_pool_name: "isv-test-pool"
+          TF_VAR_test_pool_instance_types: '["m6i.large"]'
+          TF_VAR_test_pool_desired_size: "1"
+          TF_VAR_test_pool_labels_json: '{"isv.ncp.validation/workload":"data-ingest"}'
+          TF_VAR_test_pool_taints_json: '[{"key":"isv.ncp.validation/dedicated","value":"k8s06","effect":"NoSchedule"}]'
+          TF_VAR_test_pool_node_type: "cpu"
+
+      # K8S06-02 — scale the same pool to a new target count. Re-applies the
+      # terraform-node-pool module with a bumped desired_size; create_node_pool.sh
+      # is reused because `terraform apply` is idempotent. The emitted
+      # node_pool payload carries the new replica count, which the second
+      # K8sNodePoolCheck invocation in the suite asserts on.
+      - name: update_test_node_pool
+        phase: setup
+        command: "../scripts/eks/create_node_pool.sh"
+        output_schema: node_pool
+        timeout: 900
+        env:
+          NODE_POOL_ACTION: "Updating"
+          TF_AUTO_APPROVE: "true"
+          TF_VAR_test_pool_name: "isv-test-pool"
+          TF_VAR_test_pool_instance_types: '["m6i.large"]'
+          TF_VAR_test_pool_desired_size: "2"
+          TF_VAR_test_pool_labels_json: '{"isv.ncp.validation/workload":"data-ingest"}'
+          TF_VAR_test_pool_taints_json: '[{"key":"isv.ncp.validation/dedicated","value":"k8s06","effect":"NoSchedule"}]'
+          TF_VAR_test_pool_node_type: "cpu"
+
+      # Teardown order: destroy the test node pool before tearing down the
+      # cluster so its ENIs/instances are freed before the VPC comes down.
+      - name: destroy_test_node_pool
+        phase: teardown
+        command: "../scripts/eks/destroy_node_pool.sh"
+        timeout: 900
+        env:
+          TF_AUTO_APPROVE: "true"
+
       - name: teardown
         phase: teardown
         command: "../scripts/eks/teardown.sh"

--- a/isvctl/configs/providers/aws/config/eks.yaml
+++ b/isvctl/configs/providers/aws/config/eks.yaml
@@ -49,7 +49,7 @@ commands:
           # Override with your IP for security
           TF_VAR_cluster_endpoint_public_access_cidrs: '["0.0.0.0/0"]'
 
-      # K8S06-01 — test the Terraform node-pool create path. Runs after the
+      # Test the Terraform node-pool create path. Runs after the
       # cluster is up; reads cluster state via terraform_remote_state in the
       # node-pool module. See ../scripts/eks/terraform-node-pool/README.md.
       - name: create_test_node_pool
@@ -63,10 +63,10 @@ commands:
           TF_VAR_test_pool_instance_types: '["m6i.large"]'
           TF_VAR_test_pool_desired_size: "1"
           TF_VAR_test_pool_labels_json: '{"isv.ncp.validation/workload":"data-ingest"}'
-          TF_VAR_test_pool_taints_json: '[{"key":"isv.ncp.validation/dedicated","value":"k8s06","effect":"NoSchedule"}]'
+          TF_VAR_test_pool_taints_json: '[{"key":"isv.ncp.validation/dedicated","value":"test","effect":"NoSchedule"}]'
           TF_VAR_test_pool_node_type: "cpu"
 
-      # K8S06-02 — scale the same pool to a new target count. Re-applies the
+      # Scale the same pool to a new target count. Re-applies the
       # terraform-node-pool module with a bumped desired_size; create_node_pool.sh
       # is reused because `terraform apply` is idempotent. The emitted
       # node_pool payload carries the new replica count, which the second
@@ -83,7 +83,7 @@ commands:
           TF_VAR_test_pool_instance_types: '["m6i.large"]'
           TF_VAR_test_pool_desired_size: "2"
           TF_VAR_test_pool_labels_json: '{"isv.ncp.validation/workload":"data-ingest"}'
-          TF_VAR_test_pool_taints_json: '[{"key":"isv.ncp.validation/dedicated","value":"k8s06","effect":"NoSchedule"}]'
+          TF_VAR_test_pool_taints_json: '[{"key":"isv.ncp.validation/dedicated","value":"test","effect":"NoSchedule"}]'
           TF_VAR_test_pool_node_type: "cpu"
 
       # Teardown order: destroy the test node pool before tearing down the

--- a/isvctl/configs/providers/aws/scripts/eks/create_node_pool.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/create_node_pool.sh
@@ -9,7 +9,7 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
-# K8S06 — Apply the test node pool via Terraform on AWS EKS.
+# Apply the test node pool via Terraform on AWS EKS.
 #
 # Applies ./terraform-node-pool/ against the existing cluster state and emits
 # a JSON payload matching the `node_pool` output schema. Because terraform
@@ -80,7 +80,7 @@ echo "${TAINTS_JSON}" | jq -e 'type == "array"' > /dev/null \
 
 echo "" >&2
 echo "========================================" >&2
-echo "  K8S06 — ${ACTION} test node pool" >&2
+echo "  ${ACTION} test node pool" >&2
 echo "========================================" >&2
 echo "  pool name: ${NODE_POOL_NAME}" >&2
 echo "  instance types: ${INSTANCE_TYPES_JSON}" >&2

--- a/isvctl/configs/providers/aws/scripts/eks/create_node_pool.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/create_node_pool.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+# K8S06 — Apply the test node pool via Terraform on AWS EKS.
+#
+# Applies ./terraform-node-pool/ against the existing cluster state and emits
+# a JSON payload matching the `node_pool` output schema. Because terraform
+# apply is idempotent, this script is used for both the initial create and
+# subsequent updates (e.g. scale via a new TF_VAR_test_pool_desired_size);
+# NODE_POOL_ACTION controls only the log banner. The JSON is consumed by
+# K8sNodePoolCheck via {{steps.create_test_node_pool.*}} /
+# {{steps.update_test_node_pool.*}} in the suite config.
+#
+# Environment variables (all optional):
+#   NODE_POOL_ACTION                  - Banner verb: "Creating" | "Updating"
+#                                       (default "Creating")
+#   TF_AUTO_APPROVE                   - "true" to skip approval (default: false)
+#   TF_VAR_region                     - AWS region (default from cluster state)
+#   TF_VAR_test_pool_name             - Node pool name (default "isv-test-pool")
+#   TF_VAR_test_pool_instance_types   - JSON array of instance types
+#                                       (default '["m6i.large"]')
+#   TF_VAR_test_pool_desired_size     - Node count (default 1; bump on update
+#                                       to scale)
+#   TF_VAR_test_pool_ami_type         - EKS AMI type
+#                                       (default "AL2023_x86_64_STANDARD")
+#   TF_VAR_test_pool_capacity_type    - ON_DEMAND | SPOT (default ON_DEMAND)
+#   TF_VAR_test_pool_labels_json      - JSON object of extra labels (default "{}")
+#   TF_VAR_test_pool_taints_json      - JSON array of taints with Kubernetes
+#                                       effect spelling (NoSchedule, etc.)
+#   TF_VAR_test_pool_node_type        - Informational "cpu" | "gpu" (default "cpu")
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TF_DIR="${SCRIPT_DIR}/terraform-node-pool"
+CLUSTER_TF_DIR="${SCRIPT_DIR}/terraform"
+
+if ! command -v terraform &> /dev/null; then
+    echo "Error: terraform not found - install from https://terraform.io" >&2
+    exit 1
+fi
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq not found" >&2
+    exit 1
+fi
+if [ ! -f "${CLUSTER_TF_DIR}/terraform.tfstate" ]; then
+    echo "Error: cluster state not found at ${CLUSTER_TF_DIR}/terraform.tfstate" >&2
+    echo "Run the cluster setup step first (provisions the EKS cluster)." >&2
+    exit 1
+fi
+
+# Defaults for user-facing knobs. We accept JSON via env vars so callers can
+# pass labels/taints without building Terraform var files.
+NODE_POOL_NAME="${TF_VAR_test_pool_name:-isv-test-pool}"
+INSTANCE_TYPES_JSON="${TF_VAR_test_pool_instance_types:-[\"m6i.large\"]}"
+DESIRED_SIZE="${TF_VAR_test_pool_desired_size:-1}"
+AMI_TYPE="${TF_VAR_test_pool_ami_type:-AL2023_x86_64_STANDARD}"
+CAPACITY_TYPE="${TF_VAR_test_pool_capacity_type:-ON_DEMAND}"
+LABELS_JSON="${TF_VAR_test_pool_labels_json:-"{}"}"
+TAINTS_JSON="${TF_VAR_test_pool_taints_json:-[]}"
+NODE_TYPE="${TF_VAR_test_pool_node_type:-cpu}"
+ACTION="${NODE_POOL_ACTION:-Creating}"
+
+# Validate JSON inputs up front with clear error messages — TF's own errors
+# for malformed HCL vars are hard to read.
+echo "${INSTANCE_TYPES_JSON}" | jq -e 'type == "array"' > /dev/null \
+    || { echo "Error: TF_VAR_test_pool_instance_types must be a JSON array" >&2; exit 1; }
+echo "${LABELS_JSON}" | jq -e 'type == "object"' > /dev/null \
+    || { echo "Error: TF_VAR_test_pool_labels_json must be a JSON object" >&2; exit 1; }
+echo "${TAINTS_JSON}" | jq -e 'type == "array"' > /dev/null \
+    || { echo "Error: TF_VAR_test_pool_taints_json must be a JSON array" >&2; exit 1; }
+
+echo "" >&2
+echo "========================================" >&2
+echo "  K8S06 — ${ACTION} test node pool" >&2
+echo "========================================" >&2
+echo "  pool name: ${NODE_POOL_NAME}" >&2
+echo "  instance types: ${INSTANCE_TYPES_JSON}" >&2
+echo "  desired size: ${DESIRED_SIZE}" >&2
+echo "  ami type: ${AMI_TYPE}" >&2
+echo "  capacity: ${CAPACITY_TYPE}" >&2
+echo "  node type tag: ${NODE_TYPE}" >&2
+echo "" >&2
+
+cd "${TF_DIR}"
+
+echo "Initializing Terraform..." >&2
+terraform init >&2
+
+# Map the user-facing JSON env vars onto the module's variable names. Using
+# HCL-compatible JSON means we can forward directly with TF_VAR_*.
+export TF_VAR_node_pool_name="${NODE_POOL_NAME}"
+export TF_VAR_instance_types="${INSTANCE_TYPES_JSON}"
+export TF_VAR_desired_size="${DESIRED_SIZE}"
+export TF_VAR_ami_type="${AMI_TYPE}"
+export TF_VAR_capacity_type="${CAPACITY_TYPE}"
+export TF_VAR_labels="${LABELS_JSON}"
+export TF_VAR_taints="${TAINTS_JSON}"
+
+TF_AUTO_APPROVE="${TF_AUTO_APPROVE:-false}"
+if [ "${TF_AUTO_APPROVE}" = "true" ]; then
+    terraform apply -auto-approve >&2
+else
+    terraform apply >&2
+fi
+
+# Read what Terraform actually created. expected_taints comes back with
+# Kubernetes effect spelling — the validation compares directly against
+# kubectl, so no further translation is needed.
+TF_OUT_NODE_POOL_NAME=$(terraform output -raw node_pool_name)
+TF_OUT_LABEL_SELECTOR=$(terraform output -raw label_selector)
+TF_OUT_DESIRED_SIZE=$(terraform output -raw desired_size)
+TF_OUT_EXPECTED_LABELS=$(terraform output -json expected_labels)
+TF_OUT_EXPECTED_TAINTS=$(terraform output -json expected_taints)
+TF_OUT_EXPECTED_INSTANCE_TYPES=$(terraform output -json expected_instance_types)
+
+cd - > /dev/null
+
+# Jinja templating in the suite config renders step outputs as strings; to
+# preserve structure, we store labels/taints/instance-types as *JSON
+# strings* inside the payload. The validation accepts either native
+# collections or JSON strings.
+EXPECTED_LABELS_COMPACT=$(echo "${TF_OUT_EXPECTED_LABELS}" | jq -c .)
+EXPECTED_TAINTS_COMPACT=$(echo "${TF_OUT_EXPECTED_TAINTS}" | jq -c .)
+EXPECTED_INSTANCE_TYPES_COMPACT=$(echo "${TF_OUT_EXPECTED_INSTANCE_TYPES}" | jq -c .)
+
+jq -n \
+    --arg node_pool_name "${TF_OUT_NODE_POOL_NAME}" \
+    --arg label_selector "${TF_OUT_LABEL_SELECTOR}" \
+    --argjson expected_replicas "${TF_OUT_DESIRED_SIZE}" \
+    --arg expected_labels_json "${EXPECTED_LABELS_COMPACT}" \
+    --arg expected_taints_json "${EXPECTED_TAINTS_COMPACT}" \
+    --arg expected_instance_types_json "${EXPECTED_INSTANCE_TYPES_COMPACT}" \
+    --arg node_type "${NODE_TYPE}" \
+    '{
+      success: true,
+      platform: "kubernetes",
+      node_pool_name: $node_pool_name,
+      label_selector: $label_selector,
+      expected_replicas: $expected_replicas,
+      expected_labels_json: $expected_labels_json,
+      expected_taints_json: $expected_taints_json,
+      expected_instance_types_json: $expected_instance_types_json,
+      node_type: $node_type
+    }'

--- a/isvctl/configs/providers/aws/scripts/eks/create_node_pool.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/create_node_pool.sh
@@ -78,6 +78,15 @@ echo "${LABELS_JSON}" | jq -e 'type == "object"' > /dev/null \
 echo "${TAINTS_JSON}" | jq -e 'type == "array"' > /dev/null \
     || { echo "Error: TF_VAR_test_pool_taints_json must be a JSON array" >&2; exit 1; }
 
+NODE_TYPE="$(echo "${NODE_TYPE}" | tr '[:upper:]' '[:lower:]')"
+case "${NODE_TYPE}" in
+    cpu|gpu) ;;
+    *)
+        echo "Error: TF_VAR_test_pool_node_type must be one of: cpu, gpu" >&2
+        exit 1
+        ;;
+esac
+
 echo "" >&2
 echo "========================================" >&2
 echo "  ${ACTION} test node pool" >&2

--- a/isvctl/configs/providers/aws/scripts/eks/destroy_node_pool.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/destroy_node_pool.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+# K8S06 — Destroy the test node pool created by create_node_pool.sh.
+#
+# Runs `terraform destroy` on the isolated terraform-node-pool state. This
+# runs before the cluster teardown so the node group's ENIs and instances
+# are freed before the VPC comes down.
+#
+# Environment variables:
+#   TF_AUTO_APPROVE   - "true" to skip confirmation (default: false)
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TF_DIR="${SCRIPT_DIR}/terraform-node-pool"
+
+if ! command -v terraform &> /dev/null; then
+    echo "Error: terraform not found" >&2
+    exit 1
+fi
+
+# If the module was never applied (e.g. create step failed before
+# `terraform apply`), there is no state to destroy. Report success so the
+# overall teardown phase can proceed to the main cluster destroy.
+if [ ! -f "${TF_DIR}/terraform.tfstate" ]; then
+    echo "No node-pool state found at ${TF_DIR}/terraform.tfstate; nothing to destroy." >&2
+    cat << 'EOF'
+{
+  "success": true,
+  "platform": "kubernetes",
+  "message": "Node pool state absent — nothing to destroy",
+  "resources_deleted": []
+}
+EOF
+    exit 0
+fi
+
+cd "${TF_DIR}"
+
+echo "" >&2
+echo "========================================" >&2
+echo "  K8S06 — Destroying test node pool" >&2
+echo "========================================" >&2
+
+if [ ! -d ".terraform" ]; then
+    terraform init >&2
+fi
+
+TF_AUTO_APPROVE="${TF_AUTO_APPROVE:-false}"
+if [ "${TF_AUTO_APPROVE}" = "true" ]; then
+    terraform destroy -auto-approve >&2
+else
+    terraform destroy >&2
+fi
+
+cat << 'EOF'
+{
+  "success": true,
+  "platform": "kubernetes",
+  "message": "Test node pool destroyed",
+  "resources_deleted": ["aws_eks_node_group", "aws_iam_role"]
+}
+EOF

--- a/isvctl/configs/providers/aws/scripts/eks/destroy_node_pool.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/destroy_node_pool.sh
@@ -9,7 +9,7 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
-# K8S06 — Destroy the test node pool created by create_node_pool.sh.
+# Destroy the test node pool created by create_node_pool.sh.
 #
 # Runs `terraform destroy` on the isolated terraform-node-pool state. This
 # runs before the cluster teardown so the node group's ENIs and instances
@@ -48,7 +48,7 @@ cd "${TF_DIR}"
 
 echo "" >&2
 echo "========================================" >&2
-echo "  K8S06 — Destroying test node pool" >&2
+echo "  Destroying test node pool" >&2
 echo "========================================" >&2
 
 if [ ! -d ".terraform" ]; then

--- a/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/.gitignore
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/.gitignore
@@ -1,0 +1,30 @@
+# Terraform state files
+*.tfstate
+*.tfstate.backup
+*.tfstate.lock.info
+
+# Terraform cache
+.terraform/
+.terraform.lock.hcl
+
+# Crash logs
+crash.log
+crash.*.log
+
+# User-specific variables (may contain sensitive data)
+terraform.tfvars
+*.auto.tfvars
+
+# Override files
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# CLI configuration files
+.terraformrc
+terraform.rc
+
+# Plan files
+*.tfplan
+tfplan

--- a/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/README.md
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/README.md
@@ -1,0 +1,39 @@
+# K8S06 — Node Pool Terraform module
+
+This module attaches a managed node group to the cluster provisioned by
+`../terraform/`, exercising the create, update (scale), and delete legs of
+the K8S06 CRUD contract. It is driven by `../create_node_pool.sh` (setup —
+used for both initial create and subsequent updates, since `terraform apply`
+is idempotent) and `../destroy_node_pool.sh` (teardown); end users should
+not `terraform apply` it by hand.
+
+## State
+
+Local backend: `terraform.tfstate` in this directory. The main cluster state
+in `../terraform/terraform.tfstate` is read via `terraform_remote_state` but
+never written.
+
+## Inputs
+
+| Variable          | Default                     | Notes                                                        |
+|-------------------|-----------------------------|--------------------------------------------------------------|
+| `region`          | `us-west-2`                 | Must match the cluster's region.                             |
+| `environment`     | `dev`                       | Default tag.                                                 |
+| `node_pool_name`  | `isv-test-pool`             | EKS `nodegroup` name; visible as `eks.amazonaws.com/nodegroup=<name>`. |
+| `instance_types`  | `["m6i.large"]`             | CPU default; set to `["c5n.18xlarge"]` etc. for high-perf-net. |
+| `ami_type`        | `AL2023_x86_64_STANDARD`    | Use `AL2_x86_64_GPU` for legacy GPU pools.                   |
+| `capacity_type`   | `ON_DEMAND`                 | `ON_DEMAND` or `SPOT`.                                       |
+| `desired_size`    | `1`                         | `min`/`max`/`desired` are pinned to this value.              |
+| `labels`          | `{}`                        | Merged on top of stable `isv.ncp.validation/pool` markers.   |
+| `taints`          | `[]`                        | Kubernetes effect spelling (`NoSchedule`…); module translates to EKS enum. |
+
+## Outputs
+
+Used by `create_node_pool.sh` to shape the `node_pool` JSON payload:
+
+- `node_pool_name`
+- `label_selector` (`eks.amazonaws.com/nodegroup=<name>`)
+- `desired_size`
+- `expected_labels`
+- `expected_taints`
+- `expected_instance_types`

--- a/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/README.md
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/README.md
@@ -1,8 +1,8 @@
-# K8S06 — Node Pool Terraform module
+# Node Pool Terraform module
 
 This module attaches a managed node group to the cluster provisioned by
 `../terraform/`, exercising the create, update (scale), and delete legs of
-the K8S06 CRUD contract. It is driven by `../create_node_pool.sh` (setup —
+the node-pool CRUD contract. It is driven by `../create_node_pool.sh` (setup —
 used for both initial create and subsequent updates, since `terraform apply`
 is idempotent) and `../destroy_node_pool.sh` (teardown); end users should
 not `terraform apply` it by hand.

--- a/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/main.tf
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/main.tf
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+# K8S06-01 — Node Pool Create via Terraform (AWS EKS)
+#
+# This module attaches a new EKS-managed node group to the cluster already
+# provisioned by ../terraform, exercising the "create node pool via Terraform
+# provider" leg of the K8S06 CRUD requirement. It is run by create_node_pool.sh
+# as part of the EKS validation setup phase; destroy_node_pool.sh tears it down.
+#
+# The module has its own local state (backend "local" -> terraform.tfstate in
+# this directory) so the round-trip is isolated from the main cluster state.
+# Cluster wiring (name, subnets) is read from the main cluster's state via
+# terraform_remote_state.
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Environment = var.environment
+      Project     = "isv-lab-tools"
+      ManagedBy   = "terraform"
+      Component   = "k8s06-test-node-pool"
+    }
+  }
+}
+
+# Read cluster wiring from the main cluster module's state. The path is
+# relative to this directory.
+data "terraform_remote_state" "cluster" {
+  backend = "local"
+  config = {
+    path = "../terraform/terraform.tfstate"
+  }
+}
+
+data "aws_eks_cluster" "this" {
+  name = data.terraform_remote_state.cluster.outputs.cluster_name
+}
+
+locals {
+  cluster_name    = data.terraform_remote_state.cluster.outputs.cluster_name
+  private_subnets = data.terraform_remote_state.cluster.outputs.private_subnets
+
+  # Labels applied to the test pool. Callers override via TF_VAR_test_pool_labels_json,
+  # but every node is also tagged with a stable marker so kubectl probes can
+  # identify them even if the caller omits labels entirely.
+  effective_labels = merge(
+    {
+      "isv.ncp.validation/pool"      = "k8s06"
+      "isv.ncp.validation/pool-name" = var.node_pool_name
+    },
+    var.labels,
+  )
+
+  # Kubernetes uses "NoSchedule"; the EKS API expects "NO_SCHEDULE". The
+  # variable accepts the Kubernetes spelling so the same JSON payload can be
+  # shared with the validation; translate here on the way to the resource.
+  effect_to_eks = {
+    NoSchedule       = "NO_SCHEDULE"
+    PreferNoSchedule = "PREFER_NO_SCHEDULE"
+    NoExecute        = "NO_EXECUTE"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# IAM role for the test node group
+# -----------------------------------------------------------------------------
+# The test pool gets its own role rather than reusing the cluster module's
+# role so this module can be applied/destroyed without mutating the main
+# cluster's IAM resources. The role matches the EKS worker-node baseline.
+
+resource "aws_iam_role" "node" {
+  name_prefix = "${local.cluster_name}-${var.node_pool_name}-"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "worker_node" {
+  role       = aws_iam_role.node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "cni" {
+  role       = aws_iam_role.node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role_policy_attachment" "ecr_read" {
+  role       = aws_iam_role.node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+# -----------------------------------------------------------------------------
+# The node group itself
+# -----------------------------------------------------------------------------
+
+resource "aws_eks_node_group" "this" {
+  cluster_name    = local.cluster_name
+  node_group_name = var.node_pool_name
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = local.private_subnets
+
+  instance_types = var.instance_types
+  ami_type       = var.ami_type
+  capacity_type  = var.capacity_type
+
+  scaling_config {
+    desired_size = var.desired_size
+    min_size     = var.desired_size
+    max_size     = var.desired_size
+  }
+
+  labels = local.effective_labels
+
+  dynamic "taint" {
+    for_each = var.taints
+    content {
+      key    = taint.value.key
+      value  = lookup(taint.value, "value", "")
+      effect = local.effect_to_eks[taint.value.effect]
+    }
+  }
+
+  # Policy attachments must exist before the node group comes up, else the
+  # kubelet on joining nodes won't be able to reach the API server or pull
+  # images.
+  depends_on = [
+    aws_iam_role_policy_attachment.worker_node,
+    aws_iam_role_policy_attachment.cni,
+    aws_iam_role_policy_attachment.ecr_read,
+  ]
+}

--- a/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/main.tf
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/main.tf
@@ -8,12 +8,13 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
-# K8S06-01 — Node Pool Create via Terraform (AWS EKS)
+# Node Pool Create via Terraform (AWS EKS)
 #
 # This module attaches a new EKS-managed node group to the cluster already
 # provisioned by ../terraform, exercising the "create node pool via Terraform
-# provider" leg of the K8S06 CRUD requirement. It is run by create_node_pool.sh
-# as part of the EKS validation setup phase; destroy_node_pool.sh tears it down.
+# provider" leg of the node-pool CRUD requirement. It is run by
+# create_node_pool.sh as part of the EKS validation setup phase;
+# destroy_node_pool.sh tears it down.
 #
 # The module has its own local state (backend "local" -> terraform.tfstate in
 # this directory) so the round-trip is isolated from the main cluster state.
@@ -43,7 +44,7 @@ provider "aws" {
       Environment = var.environment
       Project     = "isv-lab-tools"
       ManagedBy   = "terraform"
-      Component   = "k8s06-test-node-pool"
+      Component   = "test-node-pool"
     }
   }
 }
@@ -70,7 +71,7 @@ locals {
   # identify them even if the caller omits labels entirely.
   effective_labels = merge(
     {
-      "isv.ncp.validation/pool"      = "k8s06"
+      "isv.ncp.validation/pool"      = "test"
       "isv.ncp.validation/pool-name" = var.node_pool_name
     },
     var.labels,

--- a/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/outputs.tf
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/outputs.tf
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+# Outputs consumed by create_node_pool.sh to build the node_pool JSON payload
+# that the setup step emits; the validation reads these via
+# {{steps.create_test_node_pool.*}} in the suite config.
+
+output "node_pool_name" {
+  description = "Name of the created EKS managed node group."
+  value       = aws_eks_node_group.this.node_group_name
+}
+
+output "label_selector" {
+  description = <<-EOT
+    kubectl label selector identifying nodes in this pool. EKS always labels
+    managed-nodegroup nodes with eks.amazonaws.com/nodegroup=<name>, so that
+    is what the validation polls on.
+  EOT
+  value       = "eks.amazonaws.com/nodegroup=${aws_eks_node_group.this.node_group_name}"
+}
+
+output "desired_size" {
+  description = "Configured node count for the pool (min=max=desired)."
+  value       = aws_eks_node_group.this.scaling_config[0].desired_size
+}
+
+output "expected_labels" {
+  description = "Labels the validation should see on every node (stable markers + caller-supplied)."
+  value       = local.effective_labels
+}
+
+output "expected_taints" {
+  description = <<-EOT
+    Taints the validation should see on every node, using Kubernetes effect
+    spelling (NoSchedule/PreferNoSchedule/NoExecute). These mirror what
+    kubectl reports under `spec.taints`, not the EKS enum values.
+  EOT
+  value       = var.taints
+}
+
+output "expected_instance_types" {
+  description = "Instance types accepted for each node in the pool."
+  value       = var.instance_types
+}

--- a/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/variables.tf
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/variables.tf
@@ -71,8 +71,8 @@ variable "desired_size" {
   type        = number
   default     = 1
   validation {
-    condition     = var.desired_size >= 0 && var.desired_size <= 50
-    error_message = "desired_size must be in [0, 50]."
+    condition     = var.desired_size >= 0 && var.desired_size <= 50 && floor(var.desired_size) == var.desired_size
+    error_message = "desired_size must be an integer in [0, 50]."
   }
 }
 

--- a/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/variables.tf
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/variables.tf
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+variable "region" {
+  description = "AWS region. Must match the cluster's region."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "environment" {
+  description = "Deployment environment tag, used for default tags."
+  type        = string
+  default     = "dev"
+}
+
+variable "node_pool_name" {
+  description = "Name of the EKS managed node group created by this module."
+  type        = string
+  default     = "isv-test-pool"
+  validation {
+    condition     = length(var.node_pool_name) > 0 && length(var.node_pool_name) <= 63
+    error_message = "node_pool_name must be 1..63 characters."
+  }
+}
+
+variable "instance_types" {
+  description = <<-EOT
+    Instance types to use for the test node group. The first available type
+    in the cluster's AZs is chosen by EKS. Pass a single type (e.g.
+    ["m6i.large"]) for a predictable shape, or multiple for broader AZ
+    compatibility. For CPU-only high-performance-networking workloads use
+    network-optimized types (e.g. "c5n.18xlarge", "c6in.32xlarge").
+  EOT
+  type        = list(string)
+  default     = ["m6i.large"]
+  validation {
+    condition     = length(var.instance_types) > 0
+    error_message = "instance_types must not be empty."
+  }
+}
+
+variable "ami_type" {
+  description = <<-EOT
+    EKS AMI type. Use AL2023_x86_64_STANDARD or AL2023_ARM_64_STANDARD for
+    CPU nodes, AL2_x86_64_GPU for legacy GPU nodes. See
+    https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html
+  EOT
+  type        = string
+  default     = "AL2023_x86_64_STANDARD"
+}
+
+variable "capacity_type" {
+  description = "Node group capacity type: ON_DEMAND or SPOT."
+  type        = string
+  default     = "ON_DEMAND"
+  validation {
+    condition     = contains(["ON_DEMAND", "SPOT"], var.capacity_type)
+    error_message = "capacity_type must be ON_DEMAND or SPOT."
+  }
+}
+
+variable "desired_size" {
+  description = "Node count for the test pool. min/max are pinned to this value."
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.desired_size >= 0 && var.desired_size <= 50
+    error_message = "desired_size must be in [0, 50]."
+  }
+}
+
+variable "labels" {
+  description = <<-EOT
+    Additional Kubernetes labels to apply to nodes in this pool. Merged on
+    top of the stable markers (`isv.ncp.validation/pool` and `-pool-name`)
+    that this module always sets.
+  EOT
+  type        = map(string)
+  default     = {}
+}
+
+variable "taints" {
+  description = <<-EOT
+    Taints to apply to nodes in this pool. Each entry must provide `key` and
+    `effect`; `value` defaults to empty string. Effects use Kubernetes
+    spelling (``NoSchedule``, ``PreferNoSchedule``, ``NoExecute``) so the
+    same JSON payload can be forwarded directly to the validation, which
+    compares against ``kubectl get node -o json``. The module translates
+    to the EKS enum spelling internally.
+  EOT
+  type = list(object({
+    key    = string
+    value  = optional(string, "")
+    effect = string
+  }))
+  default = []
+  validation {
+    condition = alltrue([
+      for t in var.taints : contains(["NoSchedule", "PreferNoSchedule", "NoExecute"], t.effect)
+    ])
+    error_message = "Each taint effect must be one of NoSchedule, PreferNoSchedule, NoExecute (Kubernetes spelling)."
+  }
+}

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -148,7 +148,7 @@ tests:
           genai_perf_requests: 200
           genai_perf_concurrency: 8
 
-    # K8S06 — provider-agnostic node-pool CRUD outcome checks. Each
+    # Provider-agnostic node-pool CRUD outcome checks. Each
     # provisioning step (EKS: terraform; CAPI: kubectl apply) emits a
     # `node_pool` JSON payload that seeds the expected shape below; labels,
     # taints, and instance types come across as JSON strings so Jinja
@@ -157,7 +157,7 @@ tests:
     # so list form is required (dict form would collide on the class name).
     k8s_node_pools:
       - K8sNodePoolCheck:
-          # K8S06-01 — create: pool reaches desired replica count.
+          # Create: pool reaches desired replica count.
           label_selector: "{{ steps.create_test_node_pool.label_selector }}"
           expected_replicas: "{{ steps.create_test_node_pool.expected_replicas | default(1, true) }}"
           expected_labels: "{{ steps.create_test_node_pool.expected_labels_json | default('{}', true) }}"
@@ -167,7 +167,7 @@ tests:
           wait_timeout: 900
           poll_interval: 10
       - K8sNodePoolCheck:
-          # K8S06-02 — update (scale): same pool converges to the new count.
+          # Update (scale): same pool converges to the new count.
           label_selector: "{{ steps.update_test_node_pool.label_selector }}"
           expected_replicas: "{{ steps.update_test_node_pool.expected_replicas | default(2, true) }}"
           expected_labels: "{{ steps.update_test_node_pool.expected_labels_json | default('{}', true) }}"

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -148,6 +148,35 @@ tests:
           genai_perf_requests: 200
           genai_perf_concurrency: 8
 
+    # K8S06 — provider-agnostic node-pool CRUD outcome checks. Each
+    # provisioning step (EKS: terraform; CAPI: kubectl apply) emits a
+    # `node_pool` JSON payload that seeds the expected shape below; labels,
+    # taints, and instance types come across as JSON strings so Jinja
+    # string rendering doesn't mangle the structure, and K8sNodePoolCheck
+    # json-parses them. The check is listed twice — once per operation —
+    # so list form is required (dict form would collide on the class name).
+    k8s_node_pools:
+      - K8sNodePoolCheck:
+          # K8S06-01 — create: pool reaches desired replica count.
+          label_selector: "{{ steps.create_test_node_pool.label_selector }}"
+          expected_replicas: "{{ steps.create_test_node_pool.expected_replicas | default(1, true) }}"
+          expected_labels: "{{ steps.create_test_node_pool.expected_labels_json | default('{}', true) }}"
+          expected_taints: "{{ steps.create_test_node_pool.expected_taints_json | default('[]', true) }}"
+          expected_instance_types: "{{ steps.create_test_node_pool.expected_instance_types_json | default('[]', true) }}"
+          node_type: "{{ steps.create_test_node_pool.node_type | default('cpu') }}"
+          wait_timeout: 900
+          poll_interval: 10
+      - K8sNodePoolCheck:
+          # K8S06-02 — update (scale): same pool converges to the new count.
+          label_selector: "{{ steps.update_test_node_pool.label_selector }}"
+          expected_replicas: "{{ steps.update_test_node_pool.expected_replicas | default(2, true) }}"
+          expected_labels: "{{ steps.update_test_node_pool.expected_labels_json | default('{}', true) }}"
+          expected_taints: "{{ steps.update_test_node_pool.expected_taints_json | default('[]', true) }}"
+          expected_instance_types: "{{ steps.update_test_node_pool.expected_instance_types_json | default('[]', true) }}"
+          node_type: "{{ steps.update_test_node_pool.node_type | default('cpu') }}"
+          wait_timeout: 900
+          poll_interval: 10
+
     k8s_observability:
       checks:
         K8sApiServerMetricsCheck: {}

--- a/isvctl/src/isvctl/config/output_schemas.py
+++ b/isvctl/src/isvctl/config/output_schemas.py
@@ -125,7 +125,7 @@ STEP_SCHEMA_MAPPING: dict[str, str | None] = {
     "peering_validation": "vpc_peering",
     "sg_crud_test": "sg_crud",
     "sg_crud": "sg_crud",
-    # Node pool operations (K8S06)
+    # Node pool operations
     "create_test_node_pool": "node_pool",
     "create_node_pool": "node_pool",
     "update_test_node_pool": "node_pool",
@@ -818,7 +818,7 @@ OUTPUT_SCHEMAS: dict[str, dict[str, Any]] = {
         "description": "Generic schema for unrecognized step names",
     },
     # =========================================================================
-    # Node pool schemas (K8S06 — Terraform or Cluster API provisioned)
+    # Node pool schemas (Terraform or Cluster API provisioned)
     # =========================================================================
     # Labels / taints / instance_types are carried as JSON-encoded strings so
     # the downstream Jinja ``render_string`` can substitute them into check

--- a/isvctl/src/isvctl/config/output_schemas.py
+++ b/isvctl/src/isvctl/config/output_schemas.py
@@ -125,6 +125,13 @@ STEP_SCHEMA_MAPPING: dict[str, str | None] = {
     "peering_validation": "vpc_peering",
     "sg_crud_test": "sg_crud",
     "sg_crud": "sg_crud",
+    # Node pool operations (K8S06)
+    "create_test_node_pool": "node_pool",
+    "create_node_pool": "node_pool",
+    "update_test_node_pool": "node_pool",
+    "update_node_pool": "node_pool",
+    "destroy_test_node_pool": "teardown",
+    "destroy_node_pool": "teardown",
 }
 
 # Common fields present in all outputs
@@ -809,6 +816,55 @@ OUTPUT_SCHEMAS: dict[str, dict[str, Any]] = {
         "properties": COMMON_PROPERTIES,
         "additionalProperties": True,
         "description": "Generic schema for unrecognized step names",
+    },
+    # =========================================================================
+    # Node pool schemas (K8S06 — Terraform or Cluster API provisioned)
+    # =========================================================================
+    # Labels / taints / instance_types are carried as JSON-encoded strings so
+    # the downstream Jinja ``render_string`` can substitute them into check
+    # config without lossy str() conversion of a dict/list.
+    "node_pool": {
+        "type": "object",
+        "required": [
+            "success",
+            "platform",
+            "node_pool_name",
+            "label_selector",
+            "expected_replicas",
+        ],
+        "properties": {
+            **COMMON_PROPERTIES,
+            "node_pool_name": {"type": "string", "description": "Name of the created node pool"},
+            "label_selector": {
+                "type": "string",
+                "description": (
+                    "kubectl label selector that identifies the new nodes (e.g. eks.amazonaws.com/nodegroup=<name>)"
+                ),
+            },
+            "expected_replicas": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Node count that must reach Ready",
+            },
+            "expected_labels_json": {
+                "type": "string",
+                "description": "JSON-encoded mapping of labels each node must carry",
+            },
+            "expected_taints_json": {
+                "type": "string",
+                "description": "JSON-encoded list of {key,value,effect} each node must carry",
+            },
+            "expected_instance_types_json": {
+                "type": "string",
+                "description": "JSON-encoded list of allowed instance-type strings",
+            },
+            "node_type": {
+                "type": "string",
+                "enum": ["cpu", "gpu"],
+                "description": "Informational node pool flavor",
+            },
+        },
+        "additionalProperties": True,
     },
 }
 

--- a/isvtest/src/isvtest/validations/k8s_node_pool.py
+++ b/isvtest/src/isvtest/validations/k8s_node_pool.py
@@ -178,7 +178,7 @@ class K8sNodePoolCheck(BaseValidation):
 
 
 def _is_node_ready(node: dict[str, Any]) -> bool:
-    """Return True iff the node has a ``Ready=True`` condition."""
+    """Return True if the node has a ``Ready=True`` condition."""
     for cond in node.get("status", {}).get("conditions", []) or []:
         if cond.get("type") == "Ready":
             return cond.get("status") == "True"

--- a/isvtest/src/isvtest/validations/k8s_node_pool.py
+++ b/isvtest/src/isvtest/validations/k8s_node_pool.py
@@ -102,6 +102,7 @@ class K8sNodePoolCheck(BaseValidation):
             return  # set_failed already called
 
         failures: list[str] = []
+        failing_names: set[str] = set()
         for node in nodes:
             name = node.get("metadata", {}).get("name", "<unknown>")
             node_labels: dict[str, str] = node.get("metadata", {}).get("labels", {}) or {}
@@ -110,10 +111,12 @@ class K8sNodePoolCheck(BaseValidation):
             missing_labels = {k: v for k, v in expected_labels.items() if node_labels.get(k) != v}
             if missing_labels:
                 failures.append(f"{name}: missing/incorrect labels {sorted(missing_labels)}")
+                failing_names.add(name)
 
             missing_taints = _missing_taints(expected_taints, node_taints)
             if missing_taints:
                 failures.append(f"{name}: missing taints {missing_taints}")
+                failing_names.add(name)
 
             if expected_instance_types:
                 actual_type = node_labels.get("node.kubernetes.io/instance-type", "")
@@ -121,11 +124,12 @@ class K8sNodePoolCheck(BaseValidation):
                     failures.append(
                         f"{name}: instance-type {actual_type!r} not in allowlist {sorted(expected_instance_types)}"
                     )
+                    failing_names.add(name)
 
         if failures:
             self.set_failed(
                 "Node pool shape mismatched on {} of {} node(s):\n  - {}".format(
-                    len(failures), len(nodes), "\n  - ".join(failures)
+                    len(failing_names), len(nodes), "\n  - ".join(failures)
                 )
             )
             return

--- a/isvtest/src/isvtest/validations/k8s_node_pool.py
+++ b/isvtest/src/isvtest/validations/k8s_node_pool.py
@@ -1,0 +1,273 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Node pool state check (K8S06).
+
+This validation is **outcome-only**: it does not create, scale, or delete any
+node pool. Provisioning (create/update/scale) is delegated to provider-supplied
+setup steps (for AWS EKS, ``terraform apply`` on a small node-group module;
+for Cluster API-based providers, ``kubectl apply`` of a ``MachineDeployment``).
+Whichever mechanism is used, each step must emit a ``node_pool`` JSON payload
+so this check can verify the resulting state from ``kubectl``. Invoke it once
+per operation (e.g. after create, again after an update) pointing at that
+step's outputs.
+
+What is verified
+----------------
+* The expected number of nodes matching the provisioning step's
+  ``label_selector`` exist and are ``Ready`` within ``wait_timeout``.
+* Each node's ``metadata.labels`` is a superset of ``expected_labels``.
+* Each node's ``spec.taints`` is a superset of ``expected_taints``
+  (compared by ``(key, value, effect)``).
+* Each node's ``node.kubernetes.io/instance-type`` label is in
+  ``expected_instance_types``.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import time
+from typing import Any, ClassVar
+
+from isvtest.core.k8s import get_kubectl_base_shell
+from isvtest.core.validation import BaseValidation
+
+
+class K8sNodePoolCheck(BaseValidation):
+    """Verify a provider-managed node pool matches its expected state.
+
+    Config keys (populated from the provisioning step's JSON output):
+
+    * ``label_selector`` — kubectl label selector identifying the new nodes
+      (e.g. ``eks.amazonaws.com/nodegroup=isv-test-pool``). Required.
+    * ``expected_replicas`` — node count that must reach Ready. Required.
+    * ``expected_labels`` — mapping or JSON string; subset check per node.
+    * ``expected_taints`` — list of ``{key, value, effect}`` or JSON string;
+      subset check per node.
+    * ``expected_instance_types`` — list of instance type strings or JSON
+      string; each node's type must be in this set.
+    * ``node_type`` — informational ``"cpu"`` or ``"gpu"`` tag surfaced in
+      the result message.
+    * ``wait_timeout`` — seconds to wait for nodes to reach Ready (default 600).
+    * ``poll_interval`` — seconds between polls (default 5).
+
+    The label-check, taint-check, and instance-type-check are each skipped
+    when their corresponding ``expected_*`` config is empty, so callers can
+    exercise a strict subset of the assertions.
+    """
+
+    description: ClassVar[str] = "Verify a node pool matches its expected replicas, labels, taints, and instance type."
+    timeout: ClassVar[int] = 900
+    markers: ClassVar[list[str]] = ["kubernetes", "slow"]
+
+    def run(self) -> None:
+        """Poll until the node pool converges, then assert labels/taints/instance-type per node."""
+        try:
+            label_selector = str(self.config["label_selector"]).strip()
+            expected_replicas = int(self.config["expected_replicas"])
+        except (KeyError, TypeError, ValueError) as exc:
+            self.set_failed(f"Invalid config: {exc}")
+            return
+        if not label_selector:
+            self.set_failed("Invalid config: label_selector is empty")
+            return
+        if expected_replicas < 0:
+            self.set_failed(f"Invalid config: expected_replicas must be >= 0, got {expected_replicas}")
+            return
+
+        try:
+            expected_labels = _coerce_mapping(self.config.get("expected_labels"), "expected_labels")
+            expected_taints = _coerce_taints(self.config.get("expected_taints"))
+            expected_instance_types = _coerce_str_list(
+                self.config.get("expected_instance_types"), "expected_instance_types"
+            )
+        except ValueError as exc:
+            self.set_failed(f"Invalid config: {exc}")
+            return
+
+        wait_timeout = int(self.config.get("wait_timeout", 600))
+        poll_interval = max(1, int(self.config.get("poll_interval", 5)))
+        node_type = str(self.config.get("node_type") or "").strip().lower() or None
+
+        nodes = self._wait_for_ready_nodes(label_selector, expected_replicas, wait_timeout, poll_interval)
+        if nodes is None:
+            return  # set_failed already called
+
+        failures: list[str] = []
+        for node in nodes:
+            name = node.get("metadata", {}).get("name", "<unknown>")
+            node_labels: dict[str, str] = node.get("metadata", {}).get("labels", {}) or {}
+            node_taints: list[dict[str, Any]] = node.get("spec", {}).get("taints", []) or []
+
+            missing_labels = {k: v for k, v in expected_labels.items() if node_labels.get(k) != v}
+            if missing_labels:
+                failures.append(f"{name}: missing/incorrect labels {sorted(missing_labels)}")
+
+            missing_taints = _missing_taints(expected_taints, node_taints)
+            if missing_taints:
+                failures.append(f"{name}: missing taints {missing_taints}")
+
+            if expected_instance_types:
+                actual_type = node_labels.get("node.kubernetes.io/instance-type", "")
+                if actual_type not in expected_instance_types:
+                    failures.append(
+                        f"{name}: instance-type {actual_type!r} not in allowlist {sorted(expected_instance_types)}"
+                    )
+
+        if failures:
+            self.set_failed(
+                "Node pool shape mismatched on {} of {} node(s):\n  - {}".format(
+                    len(failures), len(nodes), "\n  - ".join(failures)
+                )
+            )
+            return
+
+        type_suffix = f" ({node_type})" if node_type else ""
+        self.set_passed(
+            f"Node pool{type_suffix} converged: {len(nodes)} node(s) Ready with expected labels, taints, "
+            f"and instance type (selector: {label_selector})"
+        )
+
+    def _wait_for_ready_nodes(
+        self,
+        label_selector: str,
+        expected_replicas: int,
+        wait_timeout: int,
+        poll_interval: int,
+    ) -> list[dict[str, Any]] | None:
+        """Poll until ``expected_replicas`` nodes match ``label_selector`` and are Ready.
+
+        Returns the list of node objects on success. On failure/timeout,
+        calls :meth:`set_failed` and returns ``None``.
+        """
+        cmd = f"{get_kubectl_base_shell()} get nodes -l {shlex.quote(label_selector)} -o json"
+        deadline = time.time() + wait_timeout
+        last_summary = "no nodes seen yet"
+
+        while True:
+            result = self.run_command(cmd, timeout=max(30, poll_interval * 4))
+            if result.exit_code != 0:
+                last_summary = f"kubectl failed: {result.stderr.strip() or result.stdout.strip()}"
+            else:
+                try:
+                    payload = json.loads(result.stdout or "{}")
+                except json.JSONDecodeError as exc:
+                    self.set_failed(f"Failed to parse kubectl JSON output: {exc}")
+                    return None
+                nodes = payload.get("items") or []
+                ready_nodes = [n for n in nodes if _is_node_ready(n)]
+                if expected_replicas == 0 and len(nodes) == 0:
+                    return []
+                if len(ready_nodes) == expected_replicas and len(nodes) == expected_replicas:
+                    return ready_nodes
+                last_summary = f"{len(ready_nodes)} Ready / {len(nodes)} total, want {expected_replicas}"
+
+            if time.time() >= deadline:
+                self.set_failed(f"Node pool did not converge within {wait_timeout}s ({last_summary})")
+                return None
+            self.log.info("Waiting for node pool (%s)", last_summary)
+            time.sleep(poll_interval)
+
+
+def _is_node_ready(node: dict[str, Any]) -> bool:
+    """Return True iff the node has a ``Ready=True`` condition."""
+    for cond in node.get("status", {}).get("conditions", []) or []:
+        if cond.get("type") == "Ready":
+            return cond.get("status") == "True"
+    return False
+
+
+def _coerce_mapping(value: Any, field: str) -> dict[str, str]:
+    """Coerce ``value`` to a ``{str: str}`` mapping.
+
+    Accepts ``None`` (returns empty), a native ``dict``, or a JSON string.
+    Raises ``ValueError`` for anything else or for non-string leaf values.
+    """
+    if value is None or value == "":
+        return {}
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{field} is not valid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{field} must be a mapping, got {type(value).__name__}")
+    out: dict[str, str] = {}
+    for k, v in value.items():
+        if not isinstance(k, str) or not isinstance(v, str):
+            raise ValueError(f"{field} entries must be str->str, got {k!r}: {v!r}")
+        out[k] = v
+    return out
+
+
+def _coerce_str_list(value: Any, field: str) -> list[str]:
+    """Coerce ``value`` to a ``list[str]``.
+
+    Accepts ``None`` (returns empty), a native ``list``, or a JSON string.
+    Raises ``ValueError`` for anything else or for non-string elements.
+    """
+    if value is None or value == "":
+        return []
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{field} is not valid JSON: {exc}") from exc
+    if not isinstance(value, list):
+        raise ValueError(f"{field} must be a list, got {type(value).__name__}")
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError(f"{field} entries must be strings, got {item!r}")
+    return list(value)
+
+
+def _coerce_taints(value: Any) -> list[tuple[str, str, str]]:
+    """Coerce ``value`` to a list of ``(key, value, effect)`` tuples.
+
+    Accepts ``None``, a JSON string, or a native list of
+    ``{"key": ..., "value": ..., "effect": ...}`` dicts. Missing ``value``
+    on a taint is normalized to empty string (matching kubectl's behavior
+    for ``key=:NoSchedule``-style taints).
+    """
+    if value is None or value == "":
+        return []
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"expected_taints is not valid JSON: {exc}") from exc
+    if not isinstance(value, list):
+        raise ValueError(f"expected_taints must be a list, got {type(value).__name__}")
+    out: list[tuple[str, str, str]] = []
+    for entry in value:
+        if not isinstance(entry, dict):
+            raise ValueError(f"expected_taints entries must be mappings, got {entry!r}")
+        key = entry.get("key")
+        effect = entry.get("effect")
+        taint_value = entry.get("value", "")
+        if not isinstance(key, str) or not key:
+            raise ValueError(f"expected_taints entry missing string 'key': {entry!r}")
+        if not isinstance(effect, str) or not effect:
+            raise ValueError(f"expected_taints entry missing string 'effect': {entry!r}")
+        if taint_value is None:
+            taint_value = ""
+        if not isinstance(taint_value, str):
+            raise ValueError(f"expected_taints entry 'value' must be a string, got {taint_value!r}")
+        out.append((key, taint_value, effect))
+    return out
+
+
+def _missing_taints(expected: list[tuple[str, str, str]], actual: list[dict[str, Any]]) -> list[tuple[str, str, str]]:
+    """Return expected taints that are not present on the node (by tuple equality)."""
+    if not expected:
+        return []
+    have = {(t.get("key", ""), t.get("value", "") or "", t.get("effect", "")) for t in actual}
+    return [t for t in expected if t not in have]

--- a/isvtest/src/isvtest/validations/k8s_node_pool.py
+++ b/isvtest/src/isvtest/validations/k8s_node_pool.py
@@ -8,7 +8,7 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
-"""Node pool state check (K8S06).
+"""Node pool state check.
 
 This validation is **outcome-only**: it does not create, scale, or delete any
 node pool. Provisioning (create/update/scale) is delegated to provider-supplied

--- a/isvtest/src/isvtest/validations/k8s_node_pool.py
+++ b/isvtest/src/isvtest/validations/k8s_node_pool.py
@@ -93,8 +93,15 @@ class K8sNodePoolCheck(BaseValidation):
             self.set_failed(f"Invalid config: {exc}")
             return
 
-        wait_timeout = int(self.config.get("wait_timeout", 600))
-        poll_interval = max(1, int(self.config.get("poll_interval", 5)))
+        try:
+            wait_timeout = int(self.config.get("wait_timeout", 600))
+            poll_interval = max(1, int(self.config.get("poll_interval", 5)))
+        except (TypeError, ValueError) as exc:
+            self.set_failed(f"Invalid config: {exc}")
+            return
+        if wait_timeout < 0:
+            self.set_failed(f"Invalid config: wait_timeout must be >= 0, got {wait_timeout}")
+            return
         node_type = str(self.config.get("node_type") or "").strip().lower() or None
 
         nodes = self._wait_for_ready_nodes(label_selector, expected_replicas, wait_timeout, poll_interval)
@@ -153,11 +160,19 @@ class K8sNodePoolCheck(BaseValidation):
         calls :meth:`set_failed` and returns ``None``.
         """
         cmd = f"{get_kubectl_base_shell()} get nodes -l {shlex.quote(label_selector)} -o json"
-        deadline = time.time() + wait_timeout
+        deadline = time.monotonic() + wait_timeout
         last_summary = "no nodes seen yet"
 
         while True:
-            result = self.run_command(cmd, timeout=max(30, poll_interval * 4))
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                self.set_failed(f"Node pool did not converge within {wait_timeout}s ({last_summary})")
+                return None
+
+            result = self.run_command(
+                cmd,
+                timeout=max(1, min(max(30, poll_interval * 4), int(remaining))),
+            )
             if result.exit_code != 0:
                 last_summary = f"kubectl failed: {result.stderr.strip() or result.stdout.strip()}"
             else:
@@ -174,11 +189,12 @@ class K8sNodePoolCheck(BaseValidation):
                     return ready_nodes
                 last_summary = f"{len(ready_nodes)} Ready / {len(nodes)} total, want {expected_replicas}"
 
-            if time.time() >= deadline:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
                 self.set_failed(f"Node pool did not converge within {wait_timeout}s ({last_summary})")
                 return None
             self.log.info("Waiting for node pool (%s)", last_summary)
-            time.sleep(poll_interval)
+            time.sleep(min(poll_interval, remaining))
 
 
 def _is_node_ready(node: dict[str, Any]) -> bool:

--- a/isvtest/tests/test_k8s_node_pool.py
+++ b/isvtest/tests/test_k8s_node_pool.py
@@ -30,10 +30,12 @@ from isvtest.validations.k8s_node_pool import (
 
 
 def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    """Build a successful ``CommandResult`` (exit_code=0) for mocked commands."""
     return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.0)
 
 
 def _fail(stdout: str = "", stderr: str = "", exit_code: int = 1) -> CommandResult:
+    """Build a failing ``CommandResult`` (non-zero exit) for mocked commands."""
     return CommandResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration=0.0)
 
 
@@ -61,6 +63,7 @@ def _node(
 
 
 def _nodes_payload(nodes: list[dict[str, Any]]) -> str:
+    """Serialize ``nodes`` into a ``kubectl get nodes -o json`` payload string."""
     return json.dumps({"items": nodes})
 
 
@@ -77,6 +80,8 @@ BASE_CONFIG: dict[str, Any] = {
 
 
 class TestCoerceMapping:
+    """Tests for ``_coerce_mapping`` (string/dict -> str->str dict)."""
+
     def test_none_is_empty(self) -> None:
         assert _coerce_mapping(None, "labels") == {}
 
@@ -103,6 +108,8 @@ class TestCoerceMapping:
 
 
 class TestCoerceStrList:
+    """Tests for ``_coerce_str_list`` (string/list -> list[str])."""
+
     def test_none_and_empty(self) -> None:
         assert _coerce_str_list(None, "x") == []
         assert _coerce_str_list("", "x") == []
@@ -123,6 +130,8 @@ class TestCoerceStrList:
 
 
 class TestCoerceTaints:
+    """Tests for ``_coerce_taints`` (string/list -> normalized taint dicts)."""
+
     def test_none(self) -> None:
         assert _coerce_taints(None) == []
 
@@ -156,6 +165,8 @@ class TestCoerceTaints:
 
 
 class TestMissingTaints:
+    """Tests for ``_missing_taints`` (expected vs. actual node taint diff)."""
+
     def test_empty_expected_skips(self) -> None:
         assert _missing_taints([], [{"key": "k", "value": "v", "effect": "NoSchedule"}]) == []
 
@@ -176,6 +187,8 @@ class TestMissingTaints:
 
 
 class TestIsNodeReady:
+    """Tests for ``_is_node_ready`` (Ready=True condition detection)."""
+
     def test_ready(self) -> None:
         assert _is_node_ready({"status": {"conditions": [{"type": "Ready", "status": "True"}]}})
 

--- a/isvtest/tests/test_k8s_node_pool.py
+++ b/isvtest/tests/test_k8s_node_pool.py
@@ -1,0 +1,528 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Unit tests for ``isvtest.validations.k8s_node_pool``."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from isvtest.core.runners import CommandResult
+from isvtest.validations.k8s_node_pool import (
+    K8sNodePoolCheck,
+    _coerce_mapping,
+    _coerce_str_list,
+    _coerce_taints,
+    _is_node_ready,
+    _missing_taints,
+)
+
+
+def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _fail(stdout: str = "", stderr: str = "", exit_code: int = 1) -> CommandResult:
+    return CommandResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _node(
+    name: str,
+    *,
+    ready: bool = True,
+    labels: dict[str, str] | None = None,
+    taints: list[dict[str, Any]] | None = None,
+    instance_type: str | None = "m6i.large",
+) -> dict[str, Any]:
+    """Build a minimal Node object matching ``kubectl get nodes -o json``."""
+    node_labels = dict(labels or {})
+    if instance_type is not None:
+        node_labels.setdefault("node.kubernetes.io/instance-type", instance_type)
+    return {
+        "metadata": {"name": name, "labels": node_labels},
+        "spec": {"taints": list(taints or [])},
+        "status": {
+            "conditions": [
+                {"type": "Ready", "status": "True" if ready else "False"},
+            ]
+        },
+    }
+
+
+def _nodes_payload(nodes: list[dict[str, Any]]) -> str:
+    return json.dumps({"items": nodes})
+
+
+BASE_CONFIG: dict[str, Any] = {
+    "label_selector": "eks.amazonaws.com/nodegroup=isv-test-pool",
+    "expected_replicas": 1,
+    "expected_labels": {"isv.test/pool": "k8s06"},
+    "expected_taints": [{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+    "expected_instance_types": ["m6i.large"],
+    "node_type": "cpu",
+    "wait_timeout": 1,
+    "poll_interval": 1,
+}
+
+
+class TestCoerceMapping:
+    def test_none_is_empty(self) -> None:
+        assert _coerce_mapping(None, "labels") == {}
+
+    def test_empty_string_is_empty(self) -> None:
+        assert _coerce_mapping("", "labels") == {}
+
+    def test_native_dict(self) -> None:
+        assert _coerce_mapping({"a": "1", "b": "2"}, "labels") == {"a": "1", "b": "2"}
+
+    def test_json_string(self) -> None:
+        assert _coerce_mapping('{"a":"1"}', "labels") == {"a": "1"}
+
+    def test_malformed_json(self) -> None:
+        with pytest.raises(ValueError, match="valid JSON"):
+            _coerce_mapping("{not json", "labels")
+
+    def test_wrong_shape(self) -> None:
+        with pytest.raises(ValueError, match="mapping"):
+            _coerce_mapping([1, 2], "labels")
+
+    def test_non_string_leaf(self) -> None:
+        with pytest.raises(ValueError, match="str->str"):
+            _coerce_mapping({"a": 1}, "labels")
+
+
+class TestCoerceStrList:
+    def test_none_and_empty(self) -> None:
+        assert _coerce_str_list(None, "x") == []
+        assert _coerce_str_list("", "x") == []
+
+    def test_native_list(self) -> None:
+        assert _coerce_str_list(["a", "b"], "x") == ["a", "b"]
+
+    def test_json_string(self) -> None:
+        assert _coerce_str_list('["a","b"]', "x") == ["a", "b"]
+
+    def test_wrong_shape(self) -> None:
+        with pytest.raises(ValueError, match="list"):
+            _coerce_str_list({"a": "b"}, "x")
+
+    def test_non_string_item(self) -> None:
+        with pytest.raises(ValueError, match="strings"):
+            _coerce_str_list([1, 2], "x")
+
+
+class TestCoerceTaints:
+    def test_none(self) -> None:
+        assert _coerce_taints(None) == []
+
+    def test_native(self) -> None:
+        v = [{"key": "k", "value": "v", "effect": "NoSchedule"}]
+        assert _coerce_taints(v) == [("k", "v", "NoSchedule")]
+
+    def test_missing_value_normalized_to_empty(self) -> None:
+        v = [{"key": "k", "effect": "NoSchedule"}]
+        assert _coerce_taints(v) == [("k", "", "NoSchedule")]
+
+    def test_null_value_normalized_to_empty(self) -> None:
+        v = [{"key": "k", "value": None, "effect": "NoSchedule"}]
+        assert _coerce_taints(v) == [("k", "", "NoSchedule")]
+
+    def test_missing_key(self) -> None:
+        with pytest.raises(ValueError, match="key"):
+            _coerce_taints([{"value": "v", "effect": "NoSchedule"}])
+
+    def test_missing_effect(self) -> None:
+        with pytest.raises(ValueError, match="effect"):
+            _coerce_taints([{"key": "k", "value": "v"}])
+
+    def test_non_string_value(self) -> None:
+        with pytest.raises(ValueError, match="value"):
+            _coerce_taints([{"key": "k", "value": 1, "effect": "NoSchedule"}])
+
+    def test_json_string(self) -> None:
+        s = '[{"key":"k","value":"v","effect":"NoSchedule"}]'
+        assert _coerce_taints(s) == [("k", "v", "NoSchedule")]
+
+
+class TestMissingTaints:
+    def test_empty_expected_skips(self) -> None:
+        assert _missing_taints([], [{"key": "k", "value": "v", "effect": "NoSchedule"}]) == []
+
+    def test_all_present(self) -> None:
+        expected = [("k", "v", "NoSchedule")]
+        actual = [{"key": "k", "value": "v", "effect": "NoSchedule"}]
+        assert _missing_taints(expected, actual) == []
+
+    def test_missing_one(self) -> None:
+        expected = [("k1", "v", "NoSchedule"), ("k2", "v", "NoSchedule")]
+        actual = [{"key": "k1", "value": "v", "effect": "NoSchedule"}]
+        assert _missing_taints(expected, actual) == [("k2", "v", "NoSchedule")]
+
+    def test_effect_differs(self) -> None:
+        expected = [("k", "v", "NoSchedule")]
+        actual = [{"key": "k", "value": "v", "effect": "PreferNoSchedule"}]
+        assert _missing_taints(expected, actual) == [("k", "v", "NoSchedule")]
+
+
+class TestIsNodeReady:
+    def test_ready(self) -> None:
+        assert _is_node_ready({"status": {"conditions": [{"type": "Ready", "status": "True"}]}})
+
+    def test_not_ready(self) -> None:
+        assert not _is_node_ready({"status": {"conditions": [{"type": "Ready", "status": "False"}]}})
+
+    def test_missing_condition(self) -> None:
+        assert not _is_node_ready({"status": {"conditions": []}})
+
+    def test_empty_status(self) -> None:
+        assert not _is_node_ready({})
+
+
+class TestNodePoolCreateHappyPath:
+    """Validation succeeds when kubectl shows the expected node pool shape."""
+
+    def _make(self, **overrides: Any) -> K8sNodePoolCheck:
+        cfg = {**BASE_CONFIG, **overrides}
+        return K8sNodePoolCheck(config=cfg)
+
+    def test_single_node_passes(self) -> None:
+        check = self._make()
+        node = _node(
+            "ip-10-0-0-1",
+            labels={"isv.test/pool": "k8s06"},
+            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+            instance_type="m6i.large",
+        )
+        with (
+            patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([node]))),
+            patch("isvtest.validations.k8s_node_pool.time.sleep"),
+        ):
+            check.run()
+        assert check.passed, check._error
+        assert "1 node(s) Ready" in check._output
+        assert "(cpu)" in check._output
+
+    def test_multiple_nodes_pass(self) -> None:
+        check = self._make(expected_replicas=3)
+        nodes = [
+            _node(
+                f"node-{i}",
+                labels={"isv.test/pool": "k8s06"},
+                taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+            )
+            for i in range(3)
+        ]
+        with (
+            patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload(nodes))),
+            patch("isvtest.validations.k8s_node_pool.time.sleep"),
+        ):
+            check.run()
+        assert check.passed
+        assert "3 node(s) Ready" in check._output
+
+    def test_extra_labels_still_pass_subset(self) -> None:
+        check = self._make()
+        node = _node(
+            "n",
+            labels={"isv.test/pool": "k8s06", "extra": "whatever"},
+            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+        )
+        with (
+            patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([node]))),
+            patch("isvtest.validations.k8s_node_pool.time.sleep"),
+        ):
+            check.run()
+        assert check.passed
+
+    def test_empty_expected_taints_skips_taint_check(self) -> None:
+        check = self._make(expected_taints=[])
+        # Node has taints not in the expected list; should still pass since check is skipped.
+        node = _node(
+            "n",
+            labels={"isv.test/pool": "k8s06"},
+            taints=[{"key": "unrelated", "value": "v", "effect": "NoSchedule"}],
+        )
+        with (
+            patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([node]))),
+            patch("isvtest.validations.k8s_node_pool.time.sleep"),
+        ):
+            check.run()
+        assert check.passed
+
+    def test_empty_instance_type_list_skips_type_check(self) -> None:
+        check = self._make(expected_instance_types=[])
+        node = _node(
+            "n",
+            labels={"isv.test/pool": "k8s06"},
+            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+            instance_type="whatever.xlarge",
+        )
+        with (
+            patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([node]))),
+            patch("isvtest.validations.k8s_node_pool.time.sleep"),
+        ):
+            check.run()
+        assert check.passed
+
+    def test_json_string_config_parsed(self) -> None:
+        # Step-output path: templated JSON strings instead of native lists/dicts.
+        cfg: dict[str, Any] = {
+            **BASE_CONFIG,
+            "expected_labels": '{"isv.test/pool":"k8s06"}',
+            "expected_taints": '[{"key":"isv.test/dedicated","value":"k8s06","effect":"NoSchedule"}]',
+            "expected_instance_types": '["m6i.large"]',
+        }
+        check = K8sNodePoolCheck(config=cfg)
+        node = _node(
+            "n",
+            labels={"isv.test/pool": "k8s06"},
+            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+        )
+        with (
+            patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([node]))),
+            patch("isvtest.validations.k8s_node_pool.time.sleep"),
+        ):
+            check.run()
+        assert check.passed
+
+    def test_expected_zero_replicas_passes_with_empty_list(self) -> None:
+        check = self._make(expected_replicas=0)
+        with (
+            patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([]))),
+            patch("isvtest.validations.k8s_node_pool.time.sleep"),
+        ):
+            check.run()
+        assert check.passed
+
+
+class TestNodePoolCreateConvergence:
+    """Polling behavior: eventual readiness vs. timeout."""
+
+    def _make(self, **overrides: Any) -> K8sNodePoolCheck:
+        cfg = {**BASE_CONFIG, **overrides}
+        return K8sNodePoolCheck(config=cfg)
+
+    def test_converges_after_initial_notready(self) -> None:
+        check = self._make(wait_timeout=30, poll_interval=1)
+        pending = _node(
+            "n",
+            ready=False,
+            labels={"isv.test/pool": "k8s06"},
+            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+        )
+        ready = _node(
+            "n",
+            ready=True,
+            labels={"isv.test/pool": "k8s06"},
+            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+        )
+        responses = iter(
+            [
+                _ok(stdout=_nodes_payload([])),
+                _ok(stdout=_nodes_payload([pending])),
+                _ok(stdout=_nodes_payload([ready])),
+            ]
+        )
+        with (
+            patch.object(check, "run_command", side_effect=lambda *a, **k: next(responses)),
+            patch("isvtest.validations.k8s_node_pool.time.sleep"),
+        ):
+            check.run()
+        assert check.passed
+
+    def test_timeout_when_never_ready(self) -> None:
+        check = self._make(wait_timeout=2, poll_interval=1)
+        pending = _node("n", ready=False, labels={"isv.test/pool": "k8s06"})
+        # Clock: 0.0 (start/deadline=2.0), 0.5 (first iter deadline check), 3.0 (second iter, past deadline).
+        clock = iter([0.0, 0.5, 3.0, 3.0, 3.0])
+        with (
+            patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([pending]))),
+            patch("isvtest.validations.k8s_node_pool.time.sleep"),
+            patch("isvtest.validations.k8s_node_pool.time.time", side_effect=lambda: next(clock, 999.0)),
+        ):
+            check.run()
+        assert not check.passed
+        assert "did not converge" in check._error
+        assert "0 Ready / 1 total" in check._error
+
+    def test_kubectl_error_propagates_in_timeout_message(self) -> None:
+        check = self._make(wait_timeout=1, poll_interval=1)
+        clock = iter([0.0, 0.5, 2.0, 2.0, 2.0])
+        with (
+            patch.object(check, "run_command", return_value=_fail(stderr="Unauthorized")),
+            patch("isvtest.validations.k8s_node_pool.time.sleep"),
+            patch("isvtest.validations.k8s_node_pool.time.time", side_effect=lambda: next(clock, 999.0)),
+        ):
+            check.run()
+        assert not check.passed
+        assert "Unauthorized" in check._error
+
+    def test_malformed_kubectl_json_fails_cleanly(self) -> None:
+        check = self._make()
+        with (
+            patch.object(check, "run_command", return_value=_ok(stdout="{not json")),
+            patch("isvtest.validations.k8s_node_pool.time.sleep"),
+        ):
+            check.run()
+        assert not check.passed
+        assert "parse kubectl JSON" in check._error
+
+
+class TestNodePoolCreateAssertionFailures:
+    """Once the pool converges, each per-node assertion fails independently."""
+
+    def _make(self, **overrides: Any) -> K8sNodePoolCheck:
+        cfg = {**BASE_CONFIG, **overrides}
+        return K8sNodePoolCheck(config=cfg)
+
+    def test_missing_label_fails(self) -> None:
+        check = self._make()
+        node = _node(
+            "bad-node",
+            labels={},  # missing isv.test/pool
+            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+        )
+        with (
+            patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([node]))),
+            patch("isvtest.validations.k8s_node_pool.time.sleep"),
+        ):
+            check.run()
+        assert not check.passed
+        assert "bad-node" in check._error
+        assert "missing/incorrect labels" in check._error
+
+    def test_wrong_label_value_fails(self) -> None:
+        check = self._make()
+        node = _node(
+            "n",
+            labels={"isv.test/pool": "wrong-value"},
+            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+        )
+        with (
+            patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([node]))),
+            patch("isvtest.validations.k8s_node_pool.time.sleep"),
+        ):
+            check.run()
+        assert not check.passed
+        assert "missing/incorrect labels" in check._error
+
+    def test_missing_taint_fails(self) -> None:
+        check = self._make()
+        node = _node(
+            "n",
+            labels={"isv.test/pool": "k8s06"},
+            taints=[],
+        )
+        with (
+            patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([node]))),
+            patch("isvtest.validations.k8s_node_pool.time.sleep"),
+        ):
+            check.run()
+        assert not check.passed
+        assert "missing taints" in check._error
+
+    def test_taint_effect_mismatch_fails(self) -> None:
+        check = self._make()
+        node = _node(
+            "n",
+            labels={"isv.test/pool": "k8s06"},
+            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "PreferNoSchedule"}],
+        )
+        with (
+            patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([node]))),
+            patch("isvtest.validations.k8s_node_pool.time.sleep"),
+        ):
+            check.run()
+        assert not check.passed
+        assert "missing taints" in check._error
+
+    def test_instance_type_mismatch_fails(self) -> None:
+        check = self._make()
+        node = _node(
+            "n",
+            labels={"isv.test/pool": "k8s06"},
+            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+            instance_type="c7g.large",  # not in expected list
+        )
+        with (
+            patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([node]))),
+            patch("isvtest.validations.k8s_node_pool.time.sleep"),
+        ):
+            check.run()
+        assert not check.passed
+        assert "c7g.large" in check._error
+        assert "allowlist" in check._error
+
+    def test_multiple_nodes_failure_counts_reflect_reality(self) -> None:
+        check = self._make(expected_replicas=2)
+        good = _node(
+            "good",
+            labels={"isv.test/pool": "k8s06"},
+            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+        )
+        bad = _node(
+            "bad",
+            labels={"isv.test/pool": "wrong"},
+            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+        )
+        with (
+            patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([good, bad]))),
+            patch("isvtest.validations.k8s_node_pool.time.sleep"),
+        ):
+            check.run()
+        assert not check.passed
+        assert "1 of 2 node(s)" in check._error
+        assert "bad" in check._error
+
+
+class TestNodePoolCreateBadConfig:
+    """Config validation failures should fail fast without polling kubectl."""
+
+    def test_missing_label_selector(self) -> None:
+        check = K8sNodePoolCheck(config={"expected_replicas": 1})
+        with patch.object(check, "run_command") as mock_run:
+            check.run()
+        assert not check.passed
+        assert "Invalid config" in check._error
+        mock_run.assert_not_called()
+
+    def test_empty_label_selector(self) -> None:
+        check = K8sNodePoolCheck(config={"label_selector": "  ", "expected_replicas": 1})
+        with patch.object(check, "run_command") as mock_run:
+            check.run()
+        assert not check.passed
+        assert "label_selector is empty" in check._error
+        mock_run.assert_not_called()
+
+    def test_negative_replicas(self) -> None:
+        check = K8sNodePoolCheck(config={"label_selector": "a=b", "expected_replicas": -1})
+        with patch.object(check, "run_command") as mock_run:
+            check.run()
+        assert not check.passed
+        assert ">= 0" in check._error
+        mock_run.assert_not_called()
+
+    def test_bad_labels_json_fails_fast(self) -> None:
+        check = K8sNodePoolCheck(
+            config={
+                "label_selector": "a=b",
+                "expected_replicas": 1,
+                "expected_labels": "{not json",
+            }
+        )
+        with patch.object(check, "run_command") as mock_run:
+            check.run()
+        assert not check.passed
+        assert "valid JSON" in check._error
+        mock_run.assert_not_called()

--- a/isvtest/tests/test_k8s_node_pool.py
+++ b/isvtest/tests/test_k8s_node_pool.py
@@ -67,8 +67,8 @@ def _nodes_payload(nodes: list[dict[str, Any]]) -> str:
 BASE_CONFIG: dict[str, Any] = {
     "label_selector": "eks.amazonaws.com/nodegroup=isv-test-pool",
     "expected_replicas": 1,
-    "expected_labels": {"isv.test/pool": "k8s06"},
-    "expected_taints": [{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+    "expected_labels": {"isv.test/pool": "test"},
+    "expected_taints": [{"key": "isv.test/dedicated", "value": "test", "effect": "NoSchedule"}],
     "expected_instance_types": ["m6i.large"],
     "node_type": "cpu",
     "wait_timeout": 1,
@@ -200,8 +200,8 @@ class TestNodePoolCreateHappyPath:
         check = self._make()
         node = _node(
             "ip-10-0-0-1",
-            labels={"isv.test/pool": "k8s06"},
-            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+            labels={"isv.test/pool": "test"},
+            taints=[{"key": "isv.test/dedicated", "value": "test", "effect": "NoSchedule"}],
             instance_type="m6i.large",
         )
         with (
@@ -218,8 +218,8 @@ class TestNodePoolCreateHappyPath:
         nodes = [
             _node(
                 f"node-{i}",
-                labels={"isv.test/pool": "k8s06"},
-                taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+                labels={"isv.test/pool": "test"},
+                taints=[{"key": "isv.test/dedicated", "value": "test", "effect": "NoSchedule"}],
             )
             for i in range(3)
         ]
@@ -235,8 +235,8 @@ class TestNodePoolCreateHappyPath:
         check = self._make()
         node = _node(
             "n",
-            labels={"isv.test/pool": "k8s06", "extra": "whatever"},
-            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+            labels={"isv.test/pool": "test", "extra": "whatever"},
+            taints=[{"key": "isv.test/dedicated", "value": "test", "effect": "NoSchedule"}],
         )
         with (
             patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([node]))),
@@ -250,7 +250,7 @@ class TestNodePoolCreateHappyPath:
         # Node has taints not in the expected list; should still pass since check is skipped.
         node = _node(
             "n",
-            labels={"isv.test/pool": "k8s06"},
+            labels={"isv.test/pool": "test"},
             taints=[{"key": "unrelated", "value": "v", "effect": "NoSchedule"}],
         )
         with (
@@ -264,8 +264,8 @@ class TestNodePoolCreateHappyPath:
         check = self._make(expected_instance_types=[])
         node = _node(
             "n",
-            labels={"isv.test/pool": "k8s06"},
-            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+            labels={"isv.test/pool": "test"},
+            taints=[{"key": "isv.test/dedicated", "value": "test", "effect": "NoSchedule"}],
             instance_type="whatever.xlarge",
         )
         with (
@@ -279,15 +279,15 @@ class TestNodePoolCreateHappyPath:
         # Step-output path: templated JSON strings instead of native lists/dicts.
         cfg: dict[str, Any] = {
             **BASE_CONFIG,
-            "expected_labels": '{"isv.test/pool":"k8s06"}',
-            "expected_taints": '[{"key":"isv.test/dedicated","value":"k8s06","effect":"NoSchedule"}]',
+            "expected_labels": '{"isv.test/pool":"test"}',
+            "expected_taints": '[{"key":"isv.test/dedicated","value":"test","effect":"NoSchedule"}]',
             "expected_instance_types": '["m6i.large"]',
         }
         check = K8sNodePoolCheck(config=cfg)
         node = _node(
             "n",
-            labels={"isv.test/pool": "k8s06"},
-            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+            labels={"isv.test/pool": "test"},
+            taints=[{"key": "isv.test/dedicated", "value": "test", "effect": "NoSchedule"}],
         )
         with (
             patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([node]))),
@@ -318,14 +318,14 @@ class TestNodePoolCreateConvergence:
         pending = _node(
             "n",
             ready=False,
-            labels={"isv.test/pool": "k8s06"},
-            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+            labels={"isv.test/pool": "test"},
+            taints=[{"key": "isv.test/dedicated", "value": "test", "effect": "NoSchedule"}],
         )
         ready = _node(
             "n",
             ready=True,
-            labels={"isv.test/pool": "k8s06"},
-            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+            labels={"isv.test/pool": "test"},
+            taints=[{"key": "isv.test/dedicated", "value": "test", "effect": "NoSchedule"}],
         )
         responses = iter(
             [
@@ -343,7 +343,7 @@ class TestNodePoolCreateConvergence:
 
     def test_timeout_when_never_ready(self) -> None:
         check = self._make(wait_timeout=2, poll_interval=1)
-        pending = _node("n", ready=False, labels={"isv.test/pool": "k8s06"})
+        pending = _node("n", ready=False, labels={"isv.test/pool": "test"})
         # Clock: 0.0 (start/deadline=2.0), 0.5 (first iter deadline check), 3.0 (second iter, past deadline).
         clock = iter([0.0, 0.5, 3.0, 3.0, 3.0])
         with (
@@ -391,7 +391,7 @@ class TestNodePoolCreateAssertionFailures:
         node = _node(
             "bad-node",
             labels={},  # missing isv.test/pool
-            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+            taints=[{"key": "isv.test/dedicated", "value": "test", "effect": "NoSchedule"}],
         )
         with (
             patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([node]))),
@@ -407,7 +407,7 @@ class TestNodePoolCreateAssertionFailures:
         node = _node(
             "n",
             labels={"isv.test/pool": "wrong-value"},
-            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+            taints=[{"key": "isv.test/dedicated", "value": "test", "effect": "NoSchedule"}],
         )
         with (
             patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([node]))),
@@ -421,7 +421,7 @@ class TestNodePoolCreateAssertionFailures:
         check = self._make()
         node = _node(
             "n",
-            labels={"isv.test/pool": "k8s06"},
+            labels={"isv.test/pool": "test"},
             taints=[],
         )
         with (
@@ -436,8 +436,8 @@ class TestNodePoolCreateAssertionFailures:
         check = self._make()
         node = _node(
             "n",
-            labels={"isv.test/pool": "k8s06"},
-            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "PreferNoSchedule"}],
+            labels={"isv.test/pool": "test"},
+            taints=[{"key": "isv.test/dedicated", "value": "test", "effect": "PreferNoSchedule"}],
         )
         with (
             patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([node]))),
@@ -451,8 +451,8 @@ class TestNodePoolCreateAssertionFailures:
         check = self._make()
         node = _node(
             "n",
-            labels={"isv.test/pool": "k8s06"},
-            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+            labels={"isv.test/pool": "test"},
+            taints=[{"key": "isv.test/dedicated", "value": "test", "effect": "NoSchedule"}],
             instance_type="c7g.large",  # not in expected list
         )
         with (
@@ -468,13 +468,13 @@ class TestNodePoolCreateAssertionFailures:
         check = self._make(expected_replicas=2)
         good = _node(
             "good",
-            labels={"isv.test/pool": "k8s06"},
-            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+            labels={"isv.test/pool": "test"},
+            taints=[{"key": "isv.test/dedicated", "value": "test", "effect": "NoSchedule"}],
         )
         bad = _node(
             "bad",
             labels={"isv.test/pool": "wrong"},
-            taints=[{"key": "isv.test/dedicated", "value": "k8s06", "effect": "NoSchedule"}],
+            taints=[{"key": "isv.test/dedicated", "value": "test", "effect": "NoSchedule"}],
         )
         with (
             patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([good, bad]))),

--- a/isvtest/tests/test_k8s_node_pool.py
+++ b/isvtest/tests/test_k8s_node_pool.py
@@ -362,7 +362,7 @@ class TestNodePoolCreateConvergence:
         with (
             patch.object(check, "run_command", return_value=_ok(stdout=_nodes_payload([pending]))),
             patch("isvtest.validations.k8s_node_pool.time.sleep"),
-            patch("isvtest.validations.k8s_node_pool.time.time", side_effect=lambda: next(clock, 999.0)),
+            patch("isvtest.validations.k8s_node_pool.time.monotonic", side_effect=lambda: next(clock, 999.0)),
         ):
             check.run()
         assert not check.passed
@@ -375,7 +375,7 @@ class TestNodePoolCreateConvergence:
         with (
             patch.object(check, "run_command", return_value=_fail(stderr="Unauthorized")),
             patch("isvtest.validations.k8s_node_pool.time.sleep"),
-            patch("isvtest.validations.k8s_node_pool.time.time", side_effect=lambda: next(clock, 999.0)),
+            patch("isvtest.validations.k8s_node_pool.time.monotonic", side_effect=lambda: next(clock, 999.0)),
         ):
             check.run()
         assert not check.passed


### PR DESCRIPTION
## Summary

Implements the K8S06 node-pool CRUD lifecycle management end-to-end: a provider-agnostic validation plus the AWS EKS reference provisioning, wired into the k8s suite so create → update → delete runs as one flow.

- **`K8sNodePoolCheck`** (`isvtest/src/isvtest/validations/k8s_node_pool.py`) — outcome-only: verifies replica count reaches Ready within a timeout and that labels / taints / instance-types are a superset on every node. Accepts JSON-string or native collections (Jinja step-output rendering goes through string interpolation). Driving the pool is left to provider setup/teardown steps; the check is invoked once per operation.
- **`node_pool` output schema** registered in `isvctl/src/isvctl/config/output_schemas.py`; `create_node_pool` / `update_node_pool` route to `node_pool`, `destroy_node_pool` routes to `teardown`, so provider configs can use either `create_test_node_pool` or `create_node_pool` spellings.
- **EKS Terraform module + wrappers** (`providers/aws/scripts/eks/terraform-node-pool/`, `create_node_pool.sh`, `destroy_node_pool.sh`) — attaches a managed node group to the existing cluster (cluster state read via `terraform_remote_state`, never written). `create_node_pool.sh` doubles as the update step — `terraform apply` is idempotent, so re-running with a bumped `TF_VAR_test_pool_desired_size` scales the same pool; `NODE_POOL_ACTION` only affects the log banner. `destroy_node_pool.sh` emits a success payload when no state exists so teardown can proceed if create failed early. Both wrappers validate JSON-shaped env inputs with `jq` up front for clearer errors than raw HCL parsing.
- **Suite + provider wiring** — `eks.yaml` adds `create_test_node_pool`, `update_test_node_pool` (same script, `NODE_POOL_ACTION=Updating`, `desired_size=2`), and `destroy_test_node_pool` (teardown, ordered before the cluster teardown so ENIs free first). `k8s.yaml` adds a `k8s_node_pools` validation group in list form — dict form is unusable here since the class name would collide across the two invocations (K8S06-01, K8S06-02).

## Related issues

- Closes #269 (K8S06-01: create a node pool via API/CLI specifying node type)
- Closes #270 (K8S06-02: update / scale a node pool to a target count)
- Closes #223 (K8S06: delete a node pool)
- Closes #222 (K8S06: scale a node pool to a target count)
- Closes #224 (K8S06: verify default node labels and taints via node pool)
- Refs #221 (K8S06: separate CPU and GPU node pools — contract supports it; multi-pool demo out of scope here)

## Test plan

- [x] `make test` — full unit suite (includes 528 lines of new `test_k8s_node_pool.py` cases)
- [x] `isvctl catalog push --no-upload` — `K8sNodePoolCheck` discovered
- [x] AWS live run: `isvctl test run -f isvctl/configs/providers/aws/config/eks.yaml` — create → update (scale to 2) → destroy all green, no leaked node groups
- [x] Teardown path when create fails early (destroy wrapper with no tfstate) — emits success payload, suite teardown continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end EKS node-pool lifecycle testing: automated create, scale (1→2), and destroy test node pools integrated into validation flow.
  * Node-pool outputs and schema support plus node_type (cpu/gpu) awareness for validations.

* **Documentation**
  * Added README documenting the node-pool module usage and state handling.

* **Tests**
  * Comprehensive unit tests for validation helpers, convergence, error cases, and multi-node scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
