### PR TITLE
feat: add CSI storage validation suite (K8S23 - M5 P0)

### DIFF
--- a/isvctl/configs/providers/aws/scripts/eks/setup.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/setup.sh
@@ -306,6 +306,24 @@ GPU_PRODUCT=$(kubectl get nodes -l nvidia.com/gpu.present=true -o jsonpath='{.it
 KUBECONFIG_PATH="${KUBECONFIG:-$HOME/.kube/config}"
 
 # -----------------------------------------------------------------------------
+# CSI StorageClasses (K8S23)
+# -----------------------------------------------------------------------------
+# Detect via kubectl so this works for both freshly-provisioned and
+# pre-existing clusters (the Terraform apply is skipped when the cluster
+# already exists, so we can't rely on Terraform outputs here).
+#
+# EFS satisfies both shared-filesystem (RWX) and NFS semantics — the AWS EFS
+# CSI driver mounts via NFSv4.1 — so when efs.csi.aws.com is installed we
+# surface the same StorageClass under both keys.
+
+BLOCK_SC=$(kubectl get sc -o json 2>/dev/null \
+    | jq -r '[.items[] | select(.provisioner == "ebs.csi.aws.com") | .metadata.name] | .[0] // ""' \
+    || echo "")
+EFS_SC=$(kubectl get sc -o json 2>/dev/null \
+    | jq -r '[.items[] | select(.provisioner == "efs.csi.aws.com") | .metadata.name] | .[0] // ""' \
+    || echo "")
+
+# -----------------------------------------------------------------------------
 # Output JSON Inventory
 # -----------------------------------------------------------------------------
 
@@ -332,6 +350,11 @@ cat << EOF
     "gpu_operator_namespace": "${GPU_OPERATOR_NS}",
     "runtime_class": "${RUNTIME_CLASS}",
     "gpu_resource_name": "nvidia.com/gpu"
+  },
+  "csi": {
+    "block_storage_class": "${BLOCK_SC}",
+    "shared_fs_storage_class": "${EFS_SC}",
+    "nfs_storage_class": "${EFS_SC}"
   },
   "aws": {
     "region": "${AWS_REGION}",

--- a/isvctl/configs/providers/aws/scripts/eks/setup.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/setup.sh
@@ -324,6 +324,62 @@ EFS_SC=$(kubectl get sc -o json 2>/dev/null \
     || echo "")
 
 # -----------------------------------------------------------------------------
+# Standalone EBS volume for static CSI provisioning (K8S23-05)
+# -----------------------------------------------------------------------------
+# K8sCsiProvisioningModesCheck needs a pre-provisioned backing volume that
+# the CSI driver does not own, so it can verify static provisioning via a
+# manually-created PV. We create a 1 GiB gp3 volume in a worker-node AZ and
+# tag it so teardown.sh can find and delete it before terraform destroy.
+# The volume is reused across runs: describe-volumes filters by our cluster
+# tag first and only creates a new one when none is found.
+
+STATIC_VOLUME_HANDLE=""
+STATIC_DRIVER_NAME=""
+if [ -n "$BLOCK_SC" ]; then
+    NODE_AZ=$(kubectl get nodes -l nvidia.com/gpu.present=true \
+        -o jsonpath='{.items[0].metadata.labels.topology\.kubernetes\.io/zone}' 2>/dev/null || echo "")
+    if [ -z "$NODE_AZ" ]; then
+        NODE_AZ=$(kubectl get nodes \
+            -o jsonpath='{.items[0].metadata.labels.topology\.kubernetes\.io/zone}' 2>/dev/null || echo "")
+    fi
+
+    if [ -n "$NODE_AZ" ]; then
+        STATIC_VOL_TAG="isv-ncp-static-csi-${EKS_CLUSTER_NAME}"
+        EXISTING_VOL=$(aws ec2 describe-volumes \
+            --filters "Name=tag:Name,Values=${STATIC_VOL_TAG}" "Name=status,Values=available,in-use,creating" \
+            --region "$AWS_REGION" --output json 2>/dev/null \
+            | jq -r '.Volumes[0].VolumeId // ""' 2>/dev/null || echo "")
+
+        if [ -n "$EXISTING_VOL" ] && [ "$EXISTING_VOL" != "null" ]; then
+            STATIC_VOLUME_HANDLE="$EXISTING_VOL"
+            echo "Reusing standalone EBS volume for static CSI validation: $STATIC_VOLUME_HANDLE" >&2
+        else
+            echo "Creating standalone EBS volume for static CSI validation in $NODE_AZ..." >&2
+            STATIC_VOLUME_HANDLE=$(aws ec2 create-volume \
+                --availability-zone "$NODE_AZ" \
+                --volume-type gp3 \
+                --size 1 \
+                --tag-specifications "ResourceType=volume,Tags=[{Key=Name,Value=${STATIC_VOL_TAG}},{Key=isv-ncp-validation-suite,Value=static-csi},{Key=cluster,Value=${EKS_CLUSTER_NAME}}]" \
+                --region "$AWS_REGION" \
+                --query 'VolumeId' --output text 2>/dev/null || echo "")
+            if [ -n "$STATIC_VOLUME_HANDLE" ] && [ "$STATIC_VOLUME_HANDLE" != "None" ]; then
+                echo "Created standalone EBS volume: $STATIC_VOLUME_HANDLE" >&2
+                aws ec2 wait volume-available --volume-ids "$STATIC_VOLUME_HANDLE" --region "$AWS_REGION" >&2 || true
+            else
+                STATIC_VOLUME_HANDLE=""
+                echo "Warning: failed to create standalone EBS volume; static CSI probe will skip" >&2
+            fi
+        fi
+
+        if [ -n "$STATIC_VOLUME_HANDLE" ]; then
+            STATIC_DRIVER_NAME="ebs.csi.aws.com"
+        fi
+    else
+        echo "Warning: could not determine worker-node AZ; skipping standalone EBS volume creation" >&2
+    fi
+fi
+
+# -----------------------------------------------------------------------------
 # Output JSON Inventory
 # -----------------------------------------------------------------------------
 
@@ -354,7 +410,9 @@ cat << EOF
   "csi": {
     "block_storage_class": "${BLOCK_SC}",
     "shared_fs_storage_class": "${EFS_SC}",
-    "nfs_storage_class": "${EFS_SC}"
+    "nfs_storage_class": "${EFS_SC}",
+    "static_volume_handle": "${STATIC_VOLUME_HANDLE}",
+    "static_driver_name": "${STATIC_DRIVER_NAME}"
   },
   "aws": {
     "region": "${AWS_REGION}",

--- a/isvctl/configs/providers/aws/scripts/eks/setup.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/setup.sh
@@ -306,7 +306,7 @@ GPU_PRODUCT=$(kubectl get nodes -l nvidia.com/gpu.present=true -o jsonpath='{.it
 KUBECONFIG_PATH="${KUBECONFIG:-$HOME/.kube/config}"
 
 # -----------------------------------------------------------------------------
-# CSI StorageClasses (K8S23)
+# CSI StorageClasses
 # -----------------------------------------------------------------------------
 # Detect via kubectl so this works for both freshly-provisioned and
 # pre-existing clusters (the Terraform apply is skipped when the cluster
@@ -324,7 +324,7 @@ EFS_SC=$(kubectl get sc -o json 2>/dev/null \
     || echo "")
 
 # -----------------------------------------------------------------------------
-# Standalone EBS volume for static CSI provisioning (K8S23-05)
+# Standalone EBS volume for static CSI provisioning
 # -----------------------------------------------------------------------------
 # K8sCsiProvisioningModesCheck needs a pre-provisioned backing volume that
 # the CSI driver does not own, so it can verify static provisioning via a

--- a/isvctl/configs/providers/aws/scripts/eks/teardown.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/teardown.sh
@@ -75,7 +75,7 @@ if [ ! -d ".terraform" ]; then
 fi
 
 # -----------------------------------------------------------------------------
-# Delete standalone EBS volume(s) created for K8S23-05 static CSI validation
+# Delete standalone EBS volume(s) created for static CSI validation
 # -----------------------------------------------------------------------------
 # These volumes are provisioned by setup.sh out-of-band (not via Terraform),
 # so terraform destroy would leave them orphaned. We look them up by the

--- a/isvctl/configs/providers/aws/scripts/eks/teardown.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/teardown.sh
@@ -84,21 +84,18 @@ fi
 # Terraform destroy pulls the cluster out from under them.
 
 if command -v aws &> /dev/null && command -v jq &> /dev/null; then
-    TF_CLUSTER_OUTPUT=$(terraform output -raw cluster_name 2>/dev/null || echo "")
-    if [ -n "$TF_CLUSTER_OUTPUT" ]; then
-        CLUSTER_NAME="$TF_CLUSTER_OUTPUT"
+    CLUSTER_NAME=$(terraform output -raw cluster_name 2>/dev/null || echo "")
+    if [ -z "$CLUSTER_NAME" ]; then
+        echo "Warning: could not resolve terraform output 'cluster_name'; skipping static CSI EBS cleanup." >&2
+        STATIC_VOLS=""
     else
-        TF_CLUSTER_PREFIX="${TF_VAR_cluster_name_prefix:-isv-gpu}"
-        TF_ENVIRONMENT="${TF_VAR_environment:-dev}"
-        CLUSTER_NAME="${TF_CLUSTER_PREFIX}-${TF_ENVIRONMENT}"
+        STATIC_VOLS=$(aws ec2 describe-volumes \
+            --filters \
+                "Name=tag:isv-ncp-validation-suite,Values=static-csi" \
+                "Name=tag:cluster,Values=${CLUSTER_NAME}" \
+            --region "$AWS_REGION" --output json 2>/dev/null \
+            | jq -r '.Volumes[].VolumeId' 2>/dev/null || echo "")
     fi
-
-    STATIC_VOLS=$(aws ec2 describe-volumes \
-        --filters \
-            "Name=tag:isv-ncp-validation-suite,Values=static-csi" \
-            "Name=tag:cluster,Values=${CLUSTER_NAME}" \
-        --region "$AWS_REGION" --output json 2>/dev/null \
-        | jq -r '.Volumes[].VolumeId' 2>/dev/null || echo "")
 
     if [ -n "$STATIC_VOLS" ]; then
         for vol in $STATIC_VOLS; do

--- a/isvctl/configs/providers/aws/scripts/eks/teardown.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/teardown.sh
@@ -74,6 +74,45 @@ if [ ! -d ".terraform" ]; then
     terraform init >&2
 fi
 
+# -----------------------------------------------------------------------------
+# Delete standalone EBS volume(s) created for K8S23-05 static CSI validation
+# -----------------------------------------------------------------------------
+# These volumes are provisioned by setup.sh out-of-band (not via Terraform),
+# so terraform destroy would leave them orphaned. We look them up by the
+# tags setup.sh writes, wait for them to detach (EBS CSI may still have
+# mounted them during a previous test run), and delete them before the
+# Terraform destroy pulls the cluster out from under them.
+
+if command -v aws &> /dev/null && command -v jq &> /dev/null; then
+    TF_CLUSTER_OUTPUT=$(terraform output -raw cluster_name 2>/dev/null || echo "")
+    if [ -n "$TF_CLUSTER_OUTPUT" ]; then
+        CLUSTER_NAME="$TF_CLUSTER_OUTPUT"
+    else
+        TF_CLUSTER_PREFIX="${TF_VAR_cluster_name_prefix:-isv-gpu}"
+        TF_ENVIRONMENT="${TF_VAR_environment:-dev}"
+        CLUSTER_NAME="${TF_CLUSTER_PREFIX}-${TF_ENVIRONMENT}"
+    fi
+
+    STATIC_VOLS=$(aws ec2 describe-volumes \
+        --filters \
+            "Name=tag:isv-ncp-validation-suite,Values=static-csi" \
+            "Name=tag:cluster,Values=${CLUSTER_NAME}" \
+        --region "$AWS_REGION" --output json 2>/dev/null \
+        | jq -r '.Volumes[].VolumeId' 2>/dev/null || echo "")
+
+    if [ -n "$STATIC_VOLS" ]; then
+        for vol in $STATIC_VOLS; do
+            echo "Releasing standalone static-CSI EBS volume $vol..." >&2
+            aws ec2 wait volume-available --volume-ids "$vol" --region "$AWS_REGION" >&2 2>&1 || true
+            if aws ec2 delete-volume --volume-id "$vol" --region "$AWS_REGION" >&2 2>&1; then
+                echo "  Deleted $vol" >&2
+            else
+                echo "  Warning: failed to delete $vol; manual cleanup may be required" >&2
+            fi
+        done
+    fi
+fi
+
 # Destroy
 TF_AUTO_APPROVE="${TF_AUTO_APPROVE:-false}"
 if [ "$TF_AUTO_APPROVE" = "true" ]; then

--- a/isvctl/configs/providers/my-isv/scripts/k8s/_common.sh
+++ b/isvctl/configs/providers/my-isv/scripts/k8s/_common.sh
@@ -114,7 +114,6 @@ if [ -z "$CSI_BLOCK_SC" ] || [ -z "$CSI_SHARED_FS_SC" ] || [ -z "$CSI_NFS_SC" ];
     CSI_DRIVERS=$($KUBECTL get csidrivers -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
     if [ -n "$CSI_DRIVERS" ]; then
         SC_LINES=$($KUBECTL get sc -o jsonpath='{range .items[*]}{.metadata.name}{"="}{.provisioner}{"\n"}{end}' 2>/dev/null || echo "")
-        FIRST_CSI_SC=""
         BLOCK_LIKE_SC=""
         SHARED_LIKE_SC=""
         NFS_LIKE_SC=""
@@ -126,7 +125,6 @@ if [ -z "$CSI_BLOCK_SC" ] || [ -z "$CSI_SHARED_FS_SC" ] || [ -z "$CSI_NFS_SC" ];
                 *" $sc_prov "*) ;;
                 *) continue ;;
             esac
-            [ -z "$FIRST_CSI_SC" ] && FIRST_CSI_SC="$sc_name"
             case "$sc_prov" in
                 *nfs*) [ -z "$NFS_LIKE_SC" ] && NFS_LIKE_SC="$sc_name" ;;
             esac
@@ -137,7 +135,7 @@ if [ -z "$CSI_BLOCK_SC" ] || [ -z "$CSI_SHARED_FS_SC" ] || [ -z "$CSI_NFS_SC" ];
                     [ -z "$BLOCK_LIKE_SC" ] && BLOCK_LIKE_SC="$sc_name" ;;
             esac
         done <<< "$SC_LINES"
-        [ -z "$CSI_BLOCK_SC" ] && CSI_BLOCK_SC="${BLOCK_LIKE_SC:-$FIRST_CSI_SC}"
+        [ -z "$CSI_BLOCK_SC" ] && CSI_BLOCK_SC="$BLOCK_LIKE_SC"
         [ -z "$CSI_SHARED_FS_SC" ] && CSI_SHARED_FS_SC="$SHARED_LIKE_SC"
         [ -z "$CSI_NFS_SC" ] && CSI_NFS_SC="$NFS_LIKE_SC"
     fi

--- a/isvctl/configs/providers/my-isv/scripts/k8s/_common.sh
+++ b/isvctl/configs/providers/my-isv/scripts/k8s/_common.sh
@@ -101,6 +101,48 @@ if $KUBECTL get runtimeclass nvidia &> /dev/null; then
     RUNTIME_CLASS="nvidia"
 fi
 
+# --- CSI StorageClasses ---
+# Env overrides take precedence; otherwise auto-detect from installed
+# CSIDrivers and the provisioners referenced by existing StorageClasses.
+# Shared-fs / NFS classification is a best-effort name match against common
+# provisioners; anything else is treated as block-capable.
+CSI_BLOCK_SC="${K8S_CSI_BLOCK_SC:-}"
+CSI_SHARED_FS_SC="${K8S_CSI_SHARED_FS_SC:-}"
+CSI_NFS_SC="${K8S_CSI_NFS_SC:-}"
+
+if [ -z "$CSI_BLOCK_SC" ] || [ -z "$CSI_SHARED_FS_SC" ] || [ -z "$CSI_NFS_SC" ]; then
+    CSI_DRIVERS=$($KUBECTL get csidrivers -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+    if [ -n "$CSI_DRIVERS" ]; then
+        SC_LINES=$($KUBECTL get sc -o jsonpath='{range .items[*]}{.metadata.name}{"="}{.provisioner}{"\n"}{end}' 2>/dev/null || echo "")
+        FIRST_CSI_SC=""
+        BLOCK_LIKE_SC=""
+        SHARED_LIKE_SC=""
+        NFS_LIKE_SC=""
+        while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            sc_name="${line%%=*}"
+            sc_prov="${line#*=}"
+            case " $CSI_DRIVERS " in
+                *" $sc_prov "*) ;;
+                *) continue ;;
+            esac
+            [ -z "$FIRST_CSI_SC" ] && FIRST_CSI_SC="$sc_name"
+            case "$sc_prov" in
+                *nfs*) [ -z "$NFS_LIKE_SC" ] && NFS_LIKE_SC="$sc_name" ;;
+            esac
+            case "$sc_prov" in
+                *nfs*|*efs*|*cephfs*|*filestore*|*azurefile*)
+                    [ -z "$SHARED_LIKE_SC" ] && SHARED_LIKE_SC="$sc_name" ;;
+                *)
+                    [ -z "$BLOCK_LIKE_SC" ] && BLOCK_LIKE_SC="$sc_name" ;;
+            esac
+        done <<< "$SC_LINES"
+        [ -z "$CSI_BLOCK_SC" ] && CSI_BLOCK_SC="${BLOCK_LIKE_SC:-$FIRST_CSI_SC}"
+        [ -z "$CSI_SHARED_FS_SC" ] && CSI_SHARED_FS_SC="$SHARED_LIKE_SC"
+        [ -z "$CSI_NFS_SC" ] && CSI_NFS_SC="$NFS_LIKE_SC"
+    fi
+fi
+
 # --- Output JSON ---
 cat << EOF
 {
@@ -118,6 +160,11 @@ cat << EOF
     "control_plane_namespace": "${CONTROL_PLANE_NS}",
     "runtime_class": "${RUNTIME_CLASS}",
     "gpu_resource_name": "nvidia.com/gpu"
+  },
+  "csi": {
+    "block_storage_class": "${CSI_BLOCK_SC}",
+    "shared_fs_storage_class": "${CSI_SHARED_FS_SC}",
+    "nfs_storage_class": "${CSI_NFS_SC}"
   }
 }
 EOF

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -101,6 +101,18 @@ tests:
           namespace_prefix: "isvtest-netpol"
           test_egress: true
 
+    k8s_storage:
+      checks:
+        K8sCsiStorageTypesCheck:
+          # StorageClass names by type; omit (or leave empty) to skip that type.
+          # Env overrides: K8S_CSI_BLOCK_SC, K8S_CSI_SHARED_FS_SC, K8S_CSI_NFS_SC.
+          block_storage_class: "{{ steps.setup.csi.block_storage_class | default('', true) }}"
+          shared_fs_storage_class: "{{ steps.setup.csi.shared_fs_storage_class | default('', true) }}"
+          nfs_storage_class: "{{ steps.setup.csi.nfs_storage_class | default('', true) }}"
+          pvc_size: "1Gi"
+          bind_timeout_s: 120
+          namespace_prefix: "isvtest-csi-types"
+
     k8s_identity:
       checks:
         K8sOidcIssuerCheck: {}

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -124,6 +124,16 @@ tests:
           bind_timeout_s: 120
           quota_settle_s: 30
           namespace_prefix: "isvtest-csi-quota"
+        K8sCsiTenantScopedCredentialsCheck:
+          # Pure read-only check: verifies CSI credentials are tenant-scoped
+          # by construction (Secret namespaces, labels/annotations, RBAC,
+          # and node-plugin volume topology). Skipped entirely when no
+          # CSIDriver objects exist.
+          csi_driver_namespaces:
+            - "kube-system"
+          allowed_workload_namespaces: []
+          forbidden_labels:
+            - "shared-across-clusters=true"
 
     k8s_identity:
       checks:

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -134,6 +134,22 @@ tests:
           allowed_workload_namespaces: []
           forbidden_labels:
             - "shared-across-clusters=true"
+        K8sCsiProvisioningModesCheck:
+          # Exercises dynamic and static CSI provisioning end-to-end with a
+          # BusyBox mount + canary-file write/read. Skipped entirely when
+          # dynamic_storage_class is unset. The static subtest is skipped
+          # (not failed) when static_pv.volume_handle / csi_driver are
+          # unset, so providers that don't pre-provision a volume can still
+          # run the dynamic probe.
+          dynamic_storage_class: "{{ steps.setup.csi.block_storage_class | default('', true) }}"
+          static_pv:
+            volume_handle: "{{ steps.setup.csi.static_volume_handle | default('', true) }}"
+            csi_driver: "{{ steps.setup.csi.static_driver_name | default('', true) }}"
+            fs_type: "ext4"
+            capacity: "1Gi"
+            access_mode: "ReadWriteOnce"
+          bind_timeout_s: 180
+          namespace_prefix: "isvtest-csi-prov"
 
     k8s_identity:
       checks:

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -112,6 +112,18 @@ tests:
           pvc_size: "1Gi"
           bind_timeout_s: 120
           namespace_prefix: "isvtest-csi-types"
+        K8sCsiStorageQuotaApiCheck:
+          # Uses the block StorageClass by default; skips entirely when unset.
+          # per_sc_quota must exceed pvc_request so the usage PVC fits, and
+          # over_quota_request must exceed per_sc_quota so admission rejects it.
+          storage_class: "{{ steps.setup.csi.block_storage_class | default('', true) }}"
+          total_quota: "10Gi"
+          per_sc_quota: "5Gi"
+          pvc_request: "1Gi"
+          over_quota_request: "100Gi"
+          bind_timeout_s: 120
+          quota_settle_s: 30
+          namespace_prefix: "isvtest-csi-quota"
 
     k8s_identity:
       checks:

--- a/isvtest/src/isvtest/config/settings.py
+++ b/isvtest/src/isvtest/config/settings.py
@@ -324,6 +324,33 @@ def get_k8s_require_dual_stack() -> str:
     return os.getenv("K8S_REQUIRE_DUAL_STACK", "auto")
 
 
+def get_k8s_csi_block_storage_class() -> str:
+    """Get StorageClass name for CSI block storage validation.
+
+    Returns:
+        StorageClass name (default: empty string — subtest will skip).
+    """
+    return os.getenv("K8S_CSI_BLOCK_SC", "")
+
+
+def get_k8s_csi_shared_fs_storage_class() -> str:
+    """Get StorageClass name for CSI shared filesystem (RWX) validation.
+
+    Returns:
+        StorageClass name (default: empty string — subtest will skip).
+    """
+    return os.getenv("K8S_CSI_SHARED_FS_SC", "")
+
+
+def get_k8s_csi_nfs_storage_class() -> str:
+    """Get StorageClass name for CSI NFS validation.
+
+    Returns:
+        StorageClass name (default: empty string — subtest will skip).
+    """
+    return os.getenv("K8S_CSI_NFS_SC", "")
+
+
 def get_k8s_network_policy_image() -> str:
     """Get container image for NetworkPolicy probe pods.
 

--- a/isvtest/src/isvtest/core/k8s.py
+++ b/isvtest/src/isvtest/core/k8s.py
@@ -18,7 +18,11 @@ import shlex
 import shutil
 import subprocess
 import time
+from collections.abc import Callable
+from pathlib import Path
 from typing import Any
+
+import yaml
 
 from isvtest.core.logger import setup_logger
 
@@ -192,6 +196,33 @@ def get_kubectl_base_shell(*args: str) -> str:
     that would otherwise re-implement the quoting inline.
     """
     return " ".join(shlex.quote(part) for part in (*get_kubectl_command(), *args))
+
+
+def render_k8s_manifest(
+    path: Path,
+    mutate: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+) -> str:
+    """Load a multi-doc YAML manifest, apply ``mutate`` to each doc, and serialize it back.
+
+    The manifest file must contain valid, parseable YAML with sensible default
+    values — callers mutate the parsed objects rather than templating strings.
+    This keeps manifests readable in isolation and avoids quoting / escaping
+    pitfalls of ``str.replace``-style substitution.
+
+    Args:
+        path: Path to a ``.yaml`` file with one or more documents.
+        mutate: Callable invoked once per non-empty document with the parsed
+            dict; must return the (possibly mutated) dict. ``None`` leaves each
+            document untouched.
+
+    Returns:
+        A YAML string suitable for ``kubectl apply -f -``.
+    """
+    raw = path.read_text()
+    docs = [doc for doc in yaml.safe_load_all(raw) if doc is not None]
+    if mutate is not None:
+        docs = [mutate(doc) for doc in docs]
+    return yaml.safe_dump_all(docs, sort_keys=False)
 
 
 def parse_pod_state(stdout: str, stderr: str) -> tuple[str, str, str]:

--- a/isvtest/src/isvtest/validations/k8s_storage.py
+++ b/isvtest/src/isvtest/validations/k8s_storage.py
@@ -17,6 +17,11 @@ Implements:
   a PVC binds against each configured class.
 * :class:`K8sCsiStorageQuotaApiCheck` (K8S23-07) — verify Kubernetes-native
   APIs expose storage quota and per-PVC/PV usage.
+* :class:`K8sCsiTenantScopedCredentialsCheck` (K8S23-06) — verify CSI
+  credentials are tenant-scoped "by construction" by inspecting in-cluster
+  observable state (Secret namespaces, labels, ServiceAccount RBAC, and
+  node-plugin volume topology). Does not prove cross-cluster isolation from
+  the outside.
 """
 
 from __future__ import annotations
@@ -801,3 +806,607 @@ def _set_resourcequota_fields(
         sc_quota_key: per_sc_quota,
     }
     return doc
+
+
+_CSI_CONTROLLER_IMAGE_TOKENS: tuple[str, ...] = (
+    "csi-provisioner",
+    "csi-attacher",
+    "csi-resizer",
+    "csi-snapshotter",
+    "external-provisioner",
+    "external-attacher",
+    "external-resizer",
+    "external-snapshotter",
+)
+
+_CSI_NODE_IMAGE_TOKENS: tuple[str, ...] = (
+    "csi-node-driver-registrar",
+    "node-driver-registrar",
+)
+
+_CSI_IMAGE_TOKENS: tuple[str, ...] = _CSI_CONTROLLER_IMAGE_TOKENS + _CSI_NODE_IMAGE_TOKENS
+
+_SECRET_VERBS: frozenset[str] = frozenset(
+    {"*", "get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"}
+)
+
+_NODE_PLUGIN_ALLOWED_VOLUME_KEYS: frozenset[str] = frozenset(
+    {
+        "hostPath",
+        "emptyDir",
+        "secret",
+        "configMap",
+        "projected",
+        "downwardAPI",
+        "serviceAccountToken",
+        "csi",
+    }
+)
+
+_SHARED_CLUSTER_ANNOTATIONS: tuple[str, ...] = (
+    "csi.nvidia.com/shared",
+    "csi.nvidia.com/shared-across-clusters",
+)
+
+
+class K8sCsiTenantScopedCredentialsCheck(BaseValidation):
+    """Verify CSI credentials are tenant-scoped by construction (K8S23-06).
+
+    This check inspects in-cluster observable state only; it does **not**
+    attempt any cross-cluster exfiltration, and so cannot prove isolation
+    between tenants from the outside — that is tracked separately.
+
+    Five subtests run (all must pass):
+
+    * ``csi-secrets-discovered`` — enumerate CSI drivers and discover the
+      Secrets they reference via ``PersistentVolume.spec.csi.*SecretRef``
+      and via CSI controller/node pod specs (``envFrom``, ``env.valueFrom``,
+      Secret volume mounts). Skipped when no ``CSIDriver`` objects exist.
+    * ``secrets-not-cross-namespace`` — every discovered Secret lives in
+      ``csi_driver_namespaces`` (or ``allowed_workload_namespaces``), never
+      in ``default`` or an unlisted workload namespace.
+    * ``no-shared-cluster-markers`` — no discovered Secret carries any of
+      ``forbidden_labels`` or an annotation like
+      ``csi.nvidia.com/shared=true``.
+    * ``serviceaccount-rbac-scoped`` — CSI controller ServiceAccounts hold
+      no ``ClusterRoleBinding`` that grants ``secrets`` verbs cluster-wide
+      without a ``resourceNames`` restriction. Namespace-scoped
+      ``RoleBinding`` grants are permitted.
+    * ``node-plugin-uses-hostpath-not-shared-mount`` — node-plugin pods
+      mount only local/pod-scoped volume types (hostPath, emptyDir, secret,
+      configMap, projected, downwardAPI, serviceAccountToken, csi). Any
+      ``nfs``/``iscsi``/``persistentVolumeClaim`` volume fails this subtest.
+
+    Config keys (with defaults):
+        csi_driver_namespaces: Namespaces where CSI controller/node pods
+            live (default: ``["kube-system"]``).
+        allowed_workload_namespaces: Extra namespaces where CSI Secrets are
+            permitted (default: ``[]``).
+        forbidden_labels: ``key=value`` label pairs whose presence on a CSI
+            Secret marks it as shared across clusters
+            (default: ``["shared-across-clusters=true"]``).
+        timeout: Overall class-level timeout for each ``run_command``
+            (default: 300).
+    """
+
+    description: ClassVar[str] = "Verify CSI credentials are tenant-scoped by construction (K8S23-06)."
+    timeout: ClassVar[int] = 300
+    markers: ClassVar[list[str]] = ["kubernetes"]
+
+    def run(self) -> None:
+        """Drive the five read-only subtests over CSI drivers, Secrets, RBAC, and pods."""
+        self._kubectl_base = get_kubectl_base_shell()
+
+        driver_namespaces = [str(ns) for ns in (self.config.get("csi_driver_namespaces") or ["kube-system"])]
+        allowed_workload_namespaces = [str(ns) for ns in (self.config.get("allowed_workload_namespaces") or [])]
+        forbidden_labels_raw = self.config.get("forbidden_labels") or ["shared-across-clusters=true"]
+        forbidden_labels = _parse_label_pairs(forbidden_labels_raw)
+
+        permitted_namespaces = set(driver_namespaces) | set(allowed_workload_namespaces)
+
+        # Discover CSIDriver objects up front. If none exist we have nothing
+        # to validate; the check is skipped so it is safe to enable on
+        # clusters without any CSI driver installed.
+        csi_drivers = self._list_csi_drivers()
+        if csi_drivers is None:
+            self.set_failed("Failed to list CSIDriver objects")
+            return
+        if not csi_drivers:
+            for name in (
+                "csi-secrets-discovered",
+                "secrets-not-cross-namespace",
+                "no-shared-cluster-markers",
+                "serviceaccount-rbac-scoped",
+                "node-plugin-uses-hostpath-not-shared-mount",
+            ):
+                self.report_subtest(name, passed=True, message="No CSIDriver objects present", skipped=True)
+            self.set_passed("Skipped: no CSIDriver objects found")
+            return
+
+        pods_by_ns: dict[str, list[dict[str, Any]]] = {}
+        for ns in driver_namespaces:
+            pods = self._list_pods(ns)
+            if pods is None:
+                self.set_failed(f"Failed to list pods in namespace {ns!r}")
+                return
+            pods_by_ns[ns] = pods
+
+        pvs = self._list_pvs()
+        if pvs is None:
+            self.set_failed("Failed to list PersistentVolumes")
+            return
+
+        pv_secret_refs = _collect_pv_secret_refs(pvs)
+        pod_secret_refs = _collect_pod_secret_refs(pods_by_ns)
+        discovered_secrets = sorted({(ns, name) for (ns, name) in (pv_secret_refs | pod_secret_refs)})
+
+        if not discovered_secrets:
+            self.report_subtest(
+                "csi-secrets-discovered",
+                passed=True,
+                message=(
+                    f"No CSI Secret references found across {len(csi_drivers)} driver(s); "
+                    "CSI likely uses IRSA / workload-identity or node-level IAM"
+                ),
+            )
+        else:
+            self.report_subtest(
+                "csi-secrets-discovered",
+                passed=True,
+                message=(
+                    f"Discovered {len(discovered_secrets)} CSI Secret reference(s): "
+                    f"{', '.join(f'{ns}/{name}' for ns, name in discovered_secrets[:10])}"
+                    + ("…" if len(discovered_secrets) > 10 else "")
+                ),
+            )
+
+        any_failed = False
+
+        cross_ns = [(ns, name) for (ns, name) in discovered_secrets if ns not in permitted_namespaces]
+        if cross_ns:
+            any_failed = True
+            self.report_subtest(
+                "secrets-not-cross-namespace",
+                passed=False,
+                message=(
+                    f"Discovered Secret(s) outside {sorted(permitted_namespaces)}: "
+                    f"{', '.join(f'{ns}/{name}' for ns, name in cross_ns)}"
+                ),
+            )
+        else:
+            self.report_subtest(
+                "secrets-not-cross-namespace",
+                passed=True,
+                message=(
+                    f"All {len(discovered_secrets)} discovered Secret(s) live in permitted namespaces "
+                    f"{sorted(permitted_namespaces)}"
+                ),
+            )
+
+        marker_failures: list[str] = []
+        missing_secrets: list[str] = []
+        for ns, name in discovered_secrets:
+            secret, status = self._get_secret(ns, name)
+            if status == "missing":
+                # Dangling Secret reference — the CSI pod declares it
+                # (e.g. `envFrom.secretRef`) but the Secret was never
+                # created, which is the EKS / IRSA default for EFS and
+                # EBS CSI drivers. Nothing to carry a marker, so this
+                # does not fail the check.
+                missing_secrets.append(f"{ns}/{name}")
+                continue
+            if secret is None:
+                # Reading the Secret failed for some other reason
+                # (typically Forbidden). We can't prove the marker is
+                # absent, so surface this as a failure for investigation.
+                marker_failures.append(f"{ns}/{name} (unreadable)")
+                continue
+            marker = _find_shared_cluster_marker(secret, forbidden_labels)
+            if marker:
+                marker_failures.append(f"{ns}/{name} ({marker})")
+
+        if marker_failures:
+            any_failed = True
+            self.report_subtest(
+                "no-shared-cluster-markers",
+                passed=False,
+                message=f"Secret(s) carry shared-cluster markers: {', '.join(marker_failures)}",
+            )
+        else:
+            if missing_secrets:
+                msg = (
+                    f"No shared-cluster labels/annotations on "
+                    f"{len(discovered_secrets) - len(missing_secrets)} discovered Secret(s); "
+                    f"{len(missing_secrets)} declared Secret ref(s) do not exist "
+                    f"(likely IRSA / workload-identity): "
+                    f"{', '.join(missing_secrets[:5])}"
+                    + ("…" if len(missing_secrets) > 5 else "")
+                )
+            else:
+                msg = f"No shared-cluster labels/annotations on {len(discovered_secrets)} discovered Secret(s)"
+            self.report_subtest("no-shared-cluster-markers", passed=True, message=msg)
+
+        controller_sa_refs = _collect_controller_service_accounts(pods_by_ns)
+        if not controller_sa_refs:
+            self.report_subtest(
+                "serviceaccount-rbac-scoped",
+                passed=True,
+                message="No CSI controller pods identified; RBAC check not applicable",
+                skipped=True,
+            )
+        else:
+            rbac_failures = self._check_controller_rbac(controller_sa_refs)
+            if rbac_failures is None:
+                any_failed = True
+                self.report_subtest(
+                    "serviceaccount-rbac-scoped",
+                    passed=False,
+                    message="Failed to enumerate ClusterRoleBindings / ClusterRoles",
+                )
+            elif rbac_failures:
+                any_failed = True
+                self.report_subtest(
+                    "serviceaccount-rbac-scoped",
+                    passed=False,
+                    message=(
+                        "CSI controller ServiceAccount(s) hold cluster-scoped Secret privileges: "
+                        + "; ".join(rbac_failures)
+                    ),
+                )
+            else:
+                self.report_subtest(
+                    "serviceaccount-rbac-scoped",
+                    passed=True,
+                    message=(
+                        f"No ClusterRoleBinding grants cluster-scoped Secret verbs to "
+                        f"{len(controller_sa_refs)} CSI controller ServiceAccount(s)"
+                    ),
+                )
+
+        node_volume_failures = _check_node_plugin_volumes(pods_by_ns)
+        if node_volume_failures == "no-node-pods":
+            self.report_subtest(
+                "node-plugin-uses-hostpath-not-shared-mount",
+                passed=True,
+                message="No CSI node-plugin pods identified; mount-topology check not applicable",
+                skipped=True,
+            )
+        elif node_volume_failures:
+            any_failed = True
+            self.report_subtest(
+                "node-plugin-uses-hostpath-not-shared-mount",
+                passed=False,
+                message=(
+                    "CSI node-plugin pod(s) mount cross-namespace / non-local volume types: "
+                    + "; ".join(node_volume_failures)
+                ),
+            )
+        else:
+            self.report_subtest(
+                "node-plugin-uses-hostpath-not-shared-mount",
+                passed=True,
+                message="CSI node-plugin pods mount only local/pod-scoped volume types",
+            )
+
+        if any_failed:
+            self.set_failed("One or more CSI tenant-scoping subtests failed; see subtest details")
+        else:
+            self.set_passed(
+                f"CSI credentials tenant-scoped by construction "
+                f"({len(csi_drivers)} driver(s), {len(discovered_secrets)} Secret ref(s))"
+            )
+
+    def _list_csi_drivers(self) -> list[dict[str, Any]] | None:
+        result = self.run_command(f"{self._kubectl_base} get csidriver -o json")
+        if result.exit_code != 0:
+            self.log.error("kubectl get csidriver failed: %s", result.stderr.strip())
+            return None
+        return _load_items(result.stdout)
+
+    def _list_pods(self, namespace: str) -> list[dict[str, Any]] | None:
+        result = self.run_command(f"{self._kubectl_base} get pods -n {shlex.quote(namespace)} -o json")
+        if result.exit_code != 0:
+            self.log.error("kubectl get pods -n %s failed: %s", namespace, result.stderr.strip())
+            return None
+        return _load_items(result.stdout)
+
+    def _list_pvs(self) -> list[dict[str, Any]] | None:
+        result = self.run_command(f"{self._kubectl_base} get pv -o json")
+        if result.exit_code != 0:
+            self.log.error("kubectl get pv failed: %s", result.stderr.strip())
+            return None
+        return _load_items(result.stdout)
+
+    def _get_secret(self, namespace: str, name: str) -> tuple[dict[str, Any] | None, str]:
+        """Fetch Secret ``namespace/name``; return ``(secret, status)``.
+
+        ``status`` is one of:
+          * ``"found"`` — Secret exists and parsed (``secret`` is the dict).
+          * ``"missing"`` — Secret does not exist (``--ignore-not-found``
+            returned empty stdout). Common when a CSI pod declares an
+            ``envFrom.secretRef`` but the Secret is never created — e.g.
+            EKS CSI drivers running under IRSA.
+          * ``"error"`` — kubectl failed (Forbidden, RBAC, transient, …)
+            or JSON parsing failed.
+        """
+        result = self.run_command(
+            f"{self._kubectl_base} get secret {shlex.quote(name)} -n {shlex.quote(namespace)} "
+            f"--ignore-not-found=true -o json"
+        )
+        if result.exit_code != 0:
+            self.log.warning("kubectl get secret %s/%s failed: %s", namespace, name, result.stderr.strip())
+            return None, "error"
+        stdout = result.stdout.strip()
+        if not stdout:
+            self.log.info(
+                "Secret %s/%s referenced by CSI pod but not present in cluster "
+                "(likely optional envFrom with driver using IRSA / workload identity)",
+                namespace,
+                name,
+            )
+            return None, "missing"
+        try:
+            return json.loads(stdout), "found"
+        except json.JSONDecodeError as exc:
+            self.log.warning("Failed to parse Secret %s/%s JSON: %s", namespace, name, exc)
+            return None, "error"
+
+    def _check_controller_rbac(self, service_accounts: set[tuple[str, str]]) -> list[str] | None:
+        """Return a list of violation descriptions (empty if none) or None on listing error."""
+        crb_result = self.run_command(f"{self._kubectl_base} get clusterrolebinding -o json")
+        if crb_result.exit_code != 0:
+            self.log.error("kubectl get clusterrolebinding failed: %s", crb_result.stderr.strip())
+            return None
+        cr_result = self.run_command(f"{self._kubectl_base} get clusterrole -o json")
+        if cr_result.exit_code != 0:
+            self.log.error("kubectl get clusterrole failed: %s", cr_result.stderr.strip())
+            return None
+
+        bindings = _load_items(crb_result.stdout)
+        roles = {(item.get("metadata") or {}).get("name", ""): item for item in _load_items(cr_result.stdout)}
+
+        return _find_cluster_secret_grants(bindings, roles, service_accounts)
+
+
+def _parse_label_pairs(raw: list[Any]) -> list[tuple[str, str]]:
+    """Parse ``['k=v', 'k2=v2']`` config entries into ``[(k, v), ...]``.
+
+    Entries without ``=`` are treated as ``(key, "")`` so callers can match
+    a key regardless of value when that is the intent.
+    """
+    pairs: list[tuple[str, str]] = []
+    for entry in raw:
+        text = str(entry)
+        if "=" in text:
+            key, _, value = text.partition("=")
+            pairs.append((key.strip(), value.strip()))
+        else:
+            pairs.append((text.strip(), ""))
+    return pairs
+
+
+def _load_items(stdout: str) -> list[dict[str, Any]]:
+    """Parse a ``kubectl get ... -o json`` list payload into its ``items`` list."""
+    if not stdout:
+        return []
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        return []
+    items = payload.get("items")
+    if isinstance(items, list):
+        return [item for item in items if isinstance(item, dict)]
+    return []
+
+
+def _collect_pv_secret_refs(pvs: list[dict[str, Any]]) -> set[tuple[str, str]]:
+    """Return ``{(namespace, name), ...}`` for Secret refs under every PV's ``spec.csi``."""
+    refs: set[tuple[str, str]] = set()
+    secret_ref_keys = (
+        "controllerPublishSecretRef",
+        "nodePublishSecretRef",
+        "nodeStageSecretRef",
+        "controllerExpandSecretRef",
+        "nodeExpandSecretRef",
+    )
+    for pv in pvs:
+        csi = ((pv.get("spec") or {}).get("csi")) or {}
+        for key in secret_ref_keys:
+            ref = csi.get(key) or {}
+            name = ref.get("name")
+            namespace = ref.get("namespace")
+            if name and namespace:
+                refs.add((str(namespace), str(name)))
+    return refs
+
+
+def _collect_pod_secret_refs(pods_by_ns: dict[str, list[dict[str, Any]]]) -> set[tuple[str, str]]:
+    """Return Secret refs mounted / projected by CSI pods in each driver namespace.
+
+    Pods whose containers do not carry a CSI-related image token are
+    ignored — this keeps noisy side-car / operator Secret references from
+    leaking into the check's scope.
+    """
+    refs: set[tuple[str, str]] = set()
+    for namespace, pods in pods_by_ns.items():
+        for pod in pods:
+            if not _pod_has_csi_image(pod):
+                continue
+            spec = pod.get("spec") or {}
+            for container in (spec.get("containers") or []) + (spec.get("initContainers") or []):
+                for env_from in container.get("envFrom") or []:
+                    secret_ref = (env_from.get("secretRef") or {}).get("name")
+                    if secret_ref:
+                        refs.add((namespace, str(secret_ref)))
+                for env in container.get("env") or []:
+                    secret_key_ref = ((env.get("valueFrom") or {}).get("secretKeyRef") or {}).get("name")
+                    if secret_key_ref:
+                        refs.add((namespace, str(secret_key_ref)))
+            for volume in spec.get("volumes") or []:
+                secret_volume = volume.get("secret") or {}
+                name = secret_volume.get("secretName")
+                if name:
+                    refs.add((namespace, str(name)))
+                for source in (volume.get("projected") or {}).get("sources") or []:
+                    name = (source.get("secret") or {}).get("name")
+                    if name:
+                        refs.add((namespace, str(name)))
+    return refs
+
+
+def _pod_has_csi_image(pod: dict[str, Any]) -> bool:
+    """Return True when any container in the pod uses a CSI sidecar/node-registrar image."""
+    spec = pod.get("spec") or {}
+    for container in (spec.get("containers") or []) + (spec.get("initContainers") or []):
+        image = str(container.get("image") or "")
+        if any(token in image for token in _CSI_IMAGE_TOKENS):
+            return True
+    return False
+
+
+def _pod_is_controller(pod: dict[str, Any]) -> bool:
+    """Return True when the pod looks like a CSI controller (has a provisioner/attacher sidecar)."""
+    spec = pod.get("spec") or {}
+    for container in (spec.get("containers") or []) + (spec.get("initContainers") or []):
+        image = str(container.get("image") or "")
+        if any(token in image for token in _CSI_CONTROLLER_IMAGE_TOKENS):
+            return True
+    return False
+
+
+def _pod_is_node_plugin(pod: dict[str, Any]) -> bool:
+    """Return True when the pod looks like a CSI node plugin (has node-driver-registrar)."""
+    spec = pod.get("spec") or {}
+    for container in (spec.get("containers") or []) + (spec.get("initContainers") or []):
+        image = str(container.get("image") or "")
+        if any(token in image for token in _CSI_NODE_IMAGE_TOKENS):
+            return True
+    return False
+
+
+def _find_shared_cluster_marker(
+    secret: dict[str, Any],
+    forbidden_labels: list[tuple[str, str]],
+) -> str:
+    """Return a short human description of the first shared-cluster marker found, or ``""``.
+
+    An empty string means no marker was found.
+    """
+    metadata = secret.get("metadata") or {}
+    labels = metadata.get("labels") or {}
+    annotations = metadata.get("annotations") or {}
+
+    for key, value in forbidden_labels:
+        actual = labels.get(key)
+        if actual is None:
+            continue
+        if not value or str(actual) == value:
+            return f"label {key}={actual}"
+
+    for annotation_key in _SHARED_CLUSTER_ANNOTATIONS:
+        annotation_value = annotations.get(annotation_key)
+        if annotation_value and str(annotation_value).lower() == "true":
+            return f"annotation {annotation_key}={annotation_value}"
+
+    return ""
+
+
+def _collect_controller_service_accounts(
+    pods_by_ns: dict[str, list[dict[str, Any]]],
+) -> set[tuple[str, str]]:
+    """Return ``{(namespace, serviceAccountName), ...}`` for CSI controller pods."""
+    refs: set[tuple[str, str]] = set()
+    for namespace, pods in pods_by_ns.items():
+        for pod in pods:
+            if not _pod_is_controller(pod):
+                continue
+            spec = pod.get("spec") or {}
+            sa = spec.get("serviceAccountName") or spec.get("serviceAccount") or "default"
+            refs.add((namespace, str(sa)))
+    return refs
+
+
+def _find_cluster_secret_grants(
+    bindings: list[dict[str, Any]],
+    roles: dict[str, dict[str, Any]],
+    service_accounts: set[tuple[str, str]],
+) -> list[str]:
+    """Return a list of violation descriptions for cluster-scoped Secret grants to CSI SAs.
+
+    A violation is any ``ClusterRoleBinding`` whose ``subjects`` include one
+    of ``service_accounts`` and whose referenced ``ClusterRole`` contains a
+    rule covering ``secrets`` without a ``resourceNames`` restriction.
+    """
+    violations: list[str] = []
+    for binding in bindings:
+        subjects = binding.get("subjects") or []
+        matched = [
+            (subj.get("namespace", ""), subj.get("name", ""))
+            for subj in subjects
+            if subj.get("kind") == "ServiceAccount"
+            and (subj.get("namespace", ""), subj.get("name", "")) in service_accounts
+        ]
+        if not matched:
+            continue
+        role_ref = binding.get("roleRef") or {}
+        if role_ref.get("kind") != "ClusterRole":
+            continue
+        role_name = role_ref.get("name", "")
+        role = roles.get(role_name)
+        if role is None:
+            continue
+        for rule in role.get("rules") or []:
+            if _rule_grants_unrestricted_secrets(rule):
+                subject_str = ", ".join(f"{ns}/{name}" for ns, name in sorted(matched))
+                binding_name = (binding.get("metadata") or {}).get("name", "")
+                violations.append(
+                    f"ClusterRoleBinding {binding_name!r} → ClusterRole {role_name!r} (subjects: {subject_str})"
+                )
+                break
+    return violations
+
+
+def _rule_grants_unrestricted_secrets(rule: dict[str, Any]) -> bool:
+    """Return True when an RBAC rule covers the ``secrets`` resource without resourceNames."""
+    resources = {str(r) for r in (rule.get("resources") or [])}
+    if "secrets" not in resources and "*" not in resources:
+        return False
+    api_groups = {str(g) for g in (rule.get("apiGroups") or [])}
+    if api_groups and not (api_groups & {"", "*"}):
+        return False
+    verbs = {str(v) for v in (rule.get("verbs") or [])}
+    if not (verbs & _SECRET_VERBS):
+        return False
+    resource_names = rule.get("resourceNames") or []
+    if resource_names:
+        return False
+    return True
+
+
+def _check_node_plugin_volumes(
+    pods_by_ns: dict[str, list[dict[str, Any]]],
+) -> list[str] | str:
+    """Return a list of node-plugin volume-topology violations.
+
+    Returns the sentinel ``"no-node-pods"`` when no node plugin pods are
+    found at all (so the caller can surface a skipped subtest rather than
+    a false pass).
+    """
+    violations: list[str] = []
+    node_pod_seen = False
+    for namespace, pods in pods_by_ns.items():
+        for pod in pods:
+            if not _pod_is_node_plugin(pod):
+                continue
+            node_pod_seen = True
+            spec = pod.get("spec") or {}
+            pod_name = (pod.get("metadata") or {}).get("name", "")
+            for volume in spec.get("volumes") or []:
+                volume_name = volume.get("name", "")
+                keys = {k for k in volume.keys() if k != "name"}
+                bad_keys = keys - _NODE_PLUGIN_ALLOWED_VOLUME_KEYS
+                if bad_keys:
+                    violations.append(f"{namespace}/{pod_name} volume {volume_name!r} uses {sorted(bad_keys)}")
+    if not node_pod_seen:
+        return "no-node-pods"
+    return violations

--- a/isvtest/src/isvtest/validations/k8s_storage.py
+++ b/isvtest/src/isvtest/validations/k8s_storage.py
@@ -22,6 +22,9 @@ Implements:
   observable state (Secret namespaces, labels, ServiceAccount RBAC, and
   node-plugin volume topology). Does not prove cross-cluster isolation from
   the outside.
+* :class:`K8sCsiProvisioningModesCheck` (K8S23-05) — verify CSI supports
+  both dynamic and static provisioning, driving each through a real mount
+  + canary-file write/read inside a BusyBox pod.
 """
 
 from __future__ import annotations
@@ -49,6 +52,8 @@ from isvtest.core.validation import BaseValidation
 _MANIFEST_DIR = Path(__file__).parent / "manifests" / "k8s"
 _PVC_MANIFEST = _MANIFEST_DIR / "storage_pvc.yaml"
 _RESOURCEQUOTA_MANIFEST = _MANIFEST_DIR / "storage_resourcequota.yaml"
+_PV_MANIFEST = _MANIFEST_DIR / "storage_pv.yaml"
+_MOUNT_POD_MANIFEST = _MANIFEST_DIR / "storage_mount_pod.yaml"
 
 _STORAGE_TYPES: tuple[tuple[str, str], ...] = (
     ("block", "ReadWriteOnce"),
@@ -1019,8 +1024,7 @@ class K8sCsiTenantScopedCredentialsCheck(BaseValidation):
                     f"{len(discovered_secrets) - len(missing_secrets)} discovered Secret(s); "
                     f"{len(missing_secrets)} declared Secret ref(s) do not exist "
                     f"(likely IRSA / workload-identity): "
-                    f"{', '.join(missing_secrets[:5])}"
-                    + ("…" if len(missing_secrets) > 5 else "")
+                    f"{', '.join(missing_secrets[:5])}" + ("…" if len(missing_secrets) > 5 else "")
                 )
             else:
                 msg = f"No shared-cluster labels/annotations on {len(discovered_secrets)} discovered Secret(s)"
@@ -1410,3 +1414,483 @@ def _check_node_plugin_volumes(
     if not node_pod_seen:
         return "no-node-pods"
     return violations
+
+
+class K8sCsiProvisioningModesCheck(BaseValidation):
+    """Verify CSI supports both dynamic and static provisioning (K8S23-05).
+
+    Two subtests run against a single ephemeral namespace:
+
+    * ``dynamic`` — a PVC against ``dynamic_storage_class`` reaches ``Bound``,
+      the backing PV exposes ``spec.csi.driver``, and a BusyBox pod mounts
+      the PVC and round-trips a canary file (write then read back).
+    * ``static`` — a PersistentVolume with the configured ``volume_handle``
+      + ``csi_driver`` is pre-created, a PVC with ``storageClassName: ""``
+      and a matching ``volumeName`` pre-binds to that PV, and a BusyBox pod
+      round-trips a canary file. Skipped when ``static_pv.volume_handle`` or
+      ``static_pv.csi_driver`` is unset, so the check is safe to enable on
+      providers that do not supply an out-of-band volume.
+
+    Pass requires ``dynamic`` to pass; ``static`` is reported as skipped
+    (not failed) when its inputs are unset. When ``dynamic_storage_class``
+    itself is unset the whole check is skipped.
+
+    Config keys (with defaults):
+        dynamic_storage_class: StorageClass for the dynamic probe; defaults
+            to :func:`get_k8s_csi_block_storage_class`. When unset the whole
+            check is skipped.
+        static_pv.volume_handle: CSI ``volumeHandle`` of the pre-provisioned
+            backing volume. Unset disables the static subtest.
+        static_pv.csi_driver: CSI driver name matching the backing volume
+            (e.g. ``ebs.csi.aws.com``). Unset disables the static subtest.
+        static_pv.fs_type: Filesystem type written to ``spec.csi.fsType``
+            (default: ``ext4``).
+        static_pv.capacity: PV ``spec.capacity.storage`` and the matching
+            PVC request size (default: ``1Gi``).
+        static_pv.access_mode: PV / PVC access mode (default: ``ReadWriteOnce``).
+        bind_timeout_s: Max wait for PVC Bind and mount-pod Ready
+            (default: 180).
+        namespace_prefix: Prefix for the ephemeral namespace
+            (default: ``isvtest-csi-prov``).
+        timeout: Overall class-level timeout for each ``run_command``
+            (default: 600).
+    """
+
+    description: ClassVar[str] = "Verify CSI supports dynamic and static provisioning (K8S23-05)."
+    timeout: ClassVar[int] = 600
+    markers: ClassVar[list[str]] = ["kubernetes"]
+
+    def run(self) -> None:
+        """Drive the dynamic + static provisioning subtests against an ephemeral namespace."""
+        self._kubectl_parts = get_kubectl_command()
+        self._kubectl_base = get_kubectl_base_shell()
+
+        dynamic_sc = str(self.config.get("dynamic_storage_class") or get_k8s_csi_block_storage_class() or "")
+        static_pv_cfg = dict(self.config.get("static_pv") or {})
+        bind_timeout = int(self.config.get("bind_timeout_s", 180))
+        ns_prefix = self.config.get("namespace_prefix", "isvtest-csi-prov")
+
+        if not dynamic_sc:
+            self.set_passed("Skipped: no dynamic_storage_class configured")
+            return
+
+        self._namespace = f"{ns_prefix}-{uuid.uuid4().hex[:8]}"
+        ns_quoted = shlex.quote(self._namespace)
+        ns_created = False
+        static_pv_name = ""
+        try:
+            ns_result = self.run_command(f"{self._kubectl_base} create namespace {ns_quoted}")
+            if ns_result.exit_code != 0:
+                self.set_failed(f"Failed to create namespace {self._namespace}: {ns_result.stderr}")
+                return
+            ns_created = True
+
+            any_failed = False
+            dyn_summary = self._run_dynamic(dynamic_sc, bind_timeout)
+            if dyn_summary is None:
+                any_failed = True
+
+            static_volume_handle = str(static_pv_cfg.get("volume_handle") or "")
+            static_driver = str(static_pv_cfg.get("csi_driver") or "")
+            if not static_volume_handle or not static_driver:
+                self.report_subtest(
+                    "static",
+                    passed=True,
+                    message="static_pv.volume_handle or static_pv.csi_driver unset; static probe skipped",
+                    skipped=True,
+                )
+            else:
+                static_pv_name = f"csi-prov-static-{uuid.uuid4().hex[:6]}"
+                static_ok = self._run_static(
+                    pv_name=static_pv_name,
+                    driver=static_driver,
+                    volume_handle=static_volume_handle,
+                    fs_type=str(static_pv_cfg.get("fs_type") or "ext4"),
+                    capacity=str(static_pv_cfg.get("capacity") or "1Gi"),
+                    access_mode=str(static_pv_cfg.get("access_mode") or "ReadWriteOnce"),
+                    bind_timeout=bind_timeout,
+                )
+                if not static_ok:
+                    any_failed = True
+
+            if any_failed:
+                self.set_failed("One or more CSI provisioning-mode subtests failed; see subtest details")
+            else:
+                self.set_passed(
+                    f"CSI dynamic provisioning verified against StorageClass {dynamic_sc!r}"
+                    + (
+                        f"; static provisioning verified against driver {static_driver!r}"
+                        if static_pv_name
+                        else "; static provisioning skipped"
+                    )
+                )
+        finally:
+            # Cluster-scoped PV must be cleaned up separately from the
+            # namespace: the PVC is gone with the namespace, but the PV
+            # keeps a Released status (reclaimPolicy=Retain) because the
+            # underlying volume is managed out-of-band by the provider.
+            if static_pv_name:
+                pv_cleanup = self.run_command(
+                    f"{self._kubectl_base} delete pv {shlex.quote(static_pv_name)} --wait=false --ignore-not-found=true"
+                )
+                if pv_cleanup.exit_code != 0:
+                    self.log.warning("PV cleanup failed for %s: %s", static_pv_name, pv_cleanup.stderr)
+            if ns_created:
+                cleanup = self.run_command(
+                    f"{self._kubectl_base} delete namespace {ns_quoted} --wait=false --ignore-not-found=true"
+                )
+                if cleanup.exit_code != 0:
+                    self.log.warning("Namespace cleanup failed for %s: %s", self._namespace, cleanup.stderr)
+
+    def _run_dynamic(self, storage_class: str, bind_timeout: int) -> str | None:
+        """Run the ``dynamic`` subtest: PVC + consumer pod → Ready → Bound → PV has csi.driver → canary.
+
+        The mount pod is applied before waiting for ``Bound`` so this works
+        under ``volumeBindingMode: WaitForFirstConsumer``, where the PVC
+        stays ``Pending`` until a consumer is scheduled. Returns a short
+        summary string on pass, or ``None`` on failure; the subtest itself
+        is always reported before returning.
+        """
+        pvc_name = f"csi-prov-dyn-{uuid.uuid4().hex[:6]}"
+        pod_name = f"csi-prov-dyn-{uuid.uuid4().hex[:6]}"
+
+        returncode, stderr = self._apply_pvc(pvc_name, storage_class, "ReadWriteOnce", "1Gi")
+        if returncode != 0:
+            self.report_subtest(
+                "dynamic",
+                passed=False,
+                message=f"kubectl apply failed for dynamic PVC {pvc_name!r}: {stderr.strip()}",
+            )
+            return None
+
+        pod_rc, pod_err = _apply_mount_pod_manifest(
+            self._kubectl_parts, self._namespace, pod_name, pvc_name, self.timeout
+        )
+        if pod_rc != 0:
+            self.report_subtest(
+                "dynamic",
+                passed=False,
+                message=f"kubectl apply failed for mount pod {pod_name!r}: {pod_err.strip()[:200]}",
+            )
+            return None
+
+        pod_ready, wait_err = _wait_pod_ready(
+            self.run_command, self._kubectl_base, self._namespace, pod_name, bind_timeout
+        )
+        if not pod_ready:
+            self.report_subtest(
+                "dynamic",
+                passed=False,
+                message=(
+                    f"Mount pod {pod_name!r} for PVC {pvc_name!r} did not become Ready "
+                    f"within {bind_timeout}s: {wait_err[:200]}"
+                ),
+            )
+            return None
+
+        if not self._wait_pvc_bound(pvc_name, 5):
+            self.report_subtest(
+                "dynamic",
+                passed=False,
+                message=f"Dynamic PVC {pvc_name!r} did not reach Bound even after consumer pod became Ready",
+            )
+            return None
+
+        pv_name, csi_driver, err = self._resolve_bound_pv_driver(pvc_name)
+        if err:
+            self.report_subtest("dynamic", passed=False, message=err)
+            return None
+        if not csi_driver:
+            self.report_subtest(
+                "dynamic",
+                passed=False,
+                message=f"Dynamic PV {pv_name!r} missing spec.csi.driver",
+            )
+            return None
+
+        if not self._canary_write_read(pod_name):
+            self.report_subtest(
+                "dynamic",
+                passed=False,
+                message=(
+                    f"Dynamic PVC {pvc_name!r} bound to PV {pv_name!r} (driver={csi_driver!r}) "
+                    "but canary write/read failed"
+                ),
+            )
+            return None
+
+        summary = f"Dynamic PVC {pvc_name!r} bound to PV {pv_name!r} (driver={csi_driver!r}); canary roundtrip OK"
+        self.report_subtest("dynamic", passed=True, message=summary)
+        return summary
+
+    def _run_static(
+        self,
+        *,
+        pv_name: str,
+        driver: str,
+        volume_handle: str,
+        fs_type: str,
+        capacity: str,
+        access_mode: str,
+        bind_timeout: int,
+    ) -> bool:
+        """Run the ``static`` subtest: pre-create PV + PVC → Bound → mount + canary."""
+        pvc_name = f"csi-prov-static-{uuid.uuid4().hex[:6]}"
+        pod_name = f"csi-prov-static-{uuid.uuid4().hex[:6]}"
+
+        returncode, stderr = self._apply_pv(
+            pv_name=pv_name,
+            driver=driver,
+            volume_handle=volume_handle,
+            fs_type=fs_type,
+            capacity=capacity,
+            access_mode=access_mode,
+            claim_name=pvc_name,
+        )
+        if returncode != 0:
+            self.report_subtest(
+                "static",
+                passed=False,
+                message=f"kubectl apply failed for PV {pv_name!r}: {stderr.strip()}",
+            )
+            return False
+
+        returncode, stderr = self._apply_static_pvc(pvc_name, pv_name, access_mode, capacity)
+        if returncode != 0:
+            self.report_subtest(
+                "static",
+                passed=False,
+                message=f"kubectl apply failed for static PVC {pvc_name!r}: {stderr.strip()}",
+            )
+            return False
+
+        if not self._wait_pvc_bound(pvc_name, bind_timeout):
+            self.report_subtest(
+                "static",
+                passed=False,
+                message=(
+                    f"Static PVC {pvc_name!r} did not bind to PV {pv_name!r} (volume_handle={volume_handle!r}) "
+                    f"within {bind_timeout}s"
+                ),
+            )
+            return False
+
+        if not self._canary_roundtrip(pvc_name, pod_name, bind_timeout):
+            self.report_subtest(
+                "static",
+                passed=False,
+                message=(
+                    f"Static PV {pv_name!r} (volume_handle={volume_handle!r}, driver={driver!r}) "
+                    "bound but mount + canary roundtrip failed"
+                ),
+            )
+            return False
+
+        self.report_subtest(
+            "static",
+            passed=True,
+            message=(
+                f"Static PV {pv_name!r} (driver={driver!r}, volume_handle={volume_handle!r}) "
+                f"bound via PVC {pvc_name!r}; canary roundtrip OK"
+            ),
+        )
+        return True
+
+    def _apply_pvc(self, name: str, storage_class: str, access_mode: str, size: str) -> tuple[int, str]:
+        """Render the PVC manifest for dynamic provisioning and apply it."""
+
+        def _mutate(doc: dict[str, Any]) -> dict[str, Any]:
+            return _set_pvc_fields(
+                doc, namespace=self._namespace, name=name, sc=storage_class, mode=access_mode, size=size
+            )
+
+        return self._run_kubectl_apply(render_k8s_manifest(_PVC_MANIFEST, _mutate))
+
+    def _apply_static_pvc(self, name: str, pv_name: str, access_mode: str, size: str) -> tuple[int, str]:
+        """Render a PVC that pre-binds to the given PV via ``volumeName`` + empty StorageClass."""
+
+        def _mutate(doc: dict[str, Any]) -> dict[str, Any]:
+            _set_pvc_fields(doc, namespace=self._namespace, name=name, sc="", mode=access_mode, size=size)
+            doc.setdefault("spec", {})["volumeName"] = pv_name
+            return doc
+
+        return self._run_kubectl_apply(render_k8s_manifest(_PVC_MANIFEST, _mutate))
+
+    def _apply_pv(
+        self,
+        *,
+        pv_name: str,
+        driver: str,
+        volume_handle: str,
+        fs_type: str,
+        capacity: str,
+        access_mode: str,
+        claim_name: str,
+    ) -> tuple[int, str]:
+        """Render the static PV manifest and apply it."""
+
+        def _mutate(doc: dict[str, Any]) -> dict[str, Any]:
+            return _set_pv_fields(
+                doc,
+                name=pv_name,
+                driver=driver,
+                volume_handle=volume_handle,
+                fs_type=fs_type,
+                capacity=capacity,
+                access_mode=access_mode,
+                claim_namespace=self._namespace,
+                claim_name=claim_name,
+            )
+
+        return self._run_kubectl_apply(render_k8s_manifest(_PV_MANIFEST, _mutate))
+
+    def _apply_mount_pod(self, pod_name: str, pvc_name: str) -> tuple[int, str]:
+        """Render the BusyBox mount pod and apply it."""
+
+        def _mutate(doc: dict[str, Any]) -> dict[str, Any]:
+            return _set_mount_pod_fields(doc, namespace=self._namespace, name=pod_name, pvc_name=pvc_name)
+
+        return self._run_kubectl_apply(render_k8s_manifest(_MOUNT_POD_MANIFEST, _mutate))
+
+    def _run_kubectl_apply(self, manifest: str) -> tuple[int, str]:
+        return _apply_manifest(self._kubectl_parts, manifest, self.timeout)
+
+    def _wait_pvc_bound(self, pvc_name: str, timeout_s: int) -> bool:
+        return _poll_pvc_bound(self.run_command, self._kubectl_base, self._namespace, pvc_name, timeout_s)
+
+    def _resolve_bound_pv_driver(self, pvc_name: str) -> tuple[str, str, str]:
+        """Return ``(pv_name, csi_driver, error)`` — ``error`` is empty on success."""
+        vol_cmd = (
+            f"{self._kubectl_base} get pvc {shlex.quote(pvc_name)} "
+            f"-n {shlex.quote(self._namespace)} -o jsonpath='{{.spec.volumeName}}'"
+        )
+        vol_result = self.run_command(vol_cmd)
+        if vol_result.exit_code != 0:
+            return "", "", f"Failed to resolve volumeName for PVC {pvc_name!r}: {vol_result.stderr.strip()}"
+        pv_name = vol_result.stdout.strip().strip("'")
+        if not pv_name:
+            return "", "", f"PVC {pvc_name!r} bound but spec.volumeName is empty"
+
+        pv_json = self.run_command(f"{self._kubectl_base} get pv {shlex.quote(pv_name)} -o json")
+        if pv_json.exit_code != 0:
+            return pv_name, "", f"kubectl get pv {pv_name!r} failed: {pv_json.stderr.strip()}"
+        try:
+            payload = json.loads(pv_json.stdout)
+        except json.JSONDecodeError as exc:
+            return pv_name, "", f"Failed to parse PV {pv_name!r} JSON: {exc}"
+        spec = payload.get("spec") or {}
+        driver = (spec.get("csi") or {}).get("driver")
+        return pv_name, str(driver) if driver else "", ""
+
+    def _canary_roundtrip(self, pvc_name: str, pod_name: str, timeout_s: int) -> bool:
+        """Apply a BusyBox mount pod for ``pvc_name``, wait for Ready, and run the canary round-trip."""
+        returncode, stderr = self._apply_mount_pod(pod_name, pvc_name)
+        if returncode != 0:
+            self.log.error("kubectl apply failed for mount pod %s: %s", pod_name, stderr.strip())
+            return False
+
+        ready, err = _wait_pod_ready(self.run_command, self._kubectl_base, self._namespace, pod_name, timeout_s)
+        if not ready:
+            self.log.error("Mount pod %s did not become Ready: %s", pod_name, err)
+            return False
+
+        return self._canary_write_read(pod_name)
+
+    def _canary_write_read(self, pod_name: str) -> bool:
+        """Write a canary file to ``/data`` inside ``pod_name`` and read it back verbatim."""
+        canary = f"csi-prov-{uuid.uuid4().hex[:16]}"
+        write_inner = f"echo {shlex.quote(canary)} > /data/canary.txt"
+        write_cmd = (
+            f"{self._kubectl_base} exec -n {shlex.quote(self._namespace)} "
+            f"{shlex.quote(pod_name)} -- sh -c {shlex.quote(write_inner)}"
+        )
+        write_result = self.run_command(write_cmd)
+        if write_result.exit_code != 0:
+            self.log.error(
+                "Canary write failed in pod %s: %s",
+                pod_name,
+                write_result.stderr.strip() or write_result.stdout.strip(),
+            )
+            return False
+
+        read_cmd = (
+            f"{self._kubectl_base} exec -n {shlex.quote(self._namespace)} "
+            f"{shlex.quote(pod_name)} -- sh -c {shlex.quote('cat /data/canary.txt')}"
+        )
+        read_result = self.run_command(read_cmd)
+        if read_result.exit_code != 0:
+            self.log.error(
+                "Canary read failed in pod %s: %s",
+                pod_name,
+                read_result.stderr.strip() or read_result.stdout.strip(),
+            )
+            return False
+        if read_result.stdout.strip() != canary:
+            self.log.error(
+                "Canary mismatch in pod %s: expected %r, got %r",
+                pod_name,
+                canary,
+                read_result.stdout.strip(),
+            )
+            return False
+        return True
+
+
+def _set_pv_fields(
+    doc: dict[str, Any],
+    *,
+    name: str,
+    driver: str,
+    volume_handle: str,
+    fs_type: str,
+    capacity: str,
+    access_mode: str,
+    claim_namespace: str,
+    claim_name: str,
+) -> dict[str, Any]:
+    """Mutate a parsed PersistentVolume manifest in place with the requested fields.
+
+    ``claimRef`` pre-reserves the PV for the matching PVC so the binding is
+    deterministic and cannot race against another claim landing in the same
+    cluster while the static probe runs.
+    """
+    metadata = doc.setdefault("metadata", {})
+    metadata["name"] = name
+
+    spec = doc.setdefault("spec", {})
+    spec["capacity"] = {"storage": capacity}
+    spec["accessModes"] = [access_mode]
+    spec["persistentVolumeReclaimPolicy"] = "Retain"
+    spec["storageClassName"] = ""
+    spec["csi"] = {
+        "driver": driver,
+        "volumeHandle": volume_handle,
+        "fsType": fs_type,
+    }
+    spec["claimRef"] = {
+        "namespace": claim_namespace,
+        "name": claim_name,
+    }
+    return doc
+
+
+def _set_mount_pod_fields(
+    doc: dict[str, Any],
+    *,
+    namespace: str,
+    name: str,
+    pvc_name: str,
+) -> dict[str, Any]:
+    """Mutate a parsed mount-pod manifest in place, binding its single PVC volume."""
+    metadata = doc.setdefault("metadata", {})
+    metadata["name"] = name
+    metadata["namespace"] = namespace
+
+    spec = doc.setdefault("spec", {})
+    volumes = spec.setdefault("volumes", [])
+    if not volumes:
+        volumes.append({"name": "data"})
+    volumes[0]["name"] = "data"
+    volumes[0].pop("emptyDir", None)
+    volumes[0]["persistentVolumeClaim"] = {"claimName": pvc_name}
+    return doc

--- a/isvtest/src/isvtest/validations/k8s_storage.py
+++ b/isvtest/src/isvtest/validations/k8s_storage.py
@@ -1,0 +1,326 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""CSI storage validations (K8S23).
+
+Currently implements :class:`K8sCsiStorageTypesCheck` (K8S23-04), which verifies
+that the cluster exposes a StorageClass for each of block / shared filesystem /
+NFS storage and that a PVC binds against each configured class.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+import time
+import uuid
+from pathlib import Path
+from typing import Any, ClassVar
+
+from isvtest.config.settings import (
+    get_k8s_csi_block_storage_class,
+    get_k8s_csi_nfs_storage_class,
+    get_k8s_csi_shared_fs_storage_class,
+)
+from isvtest.core.k8s import (
+    get_kubectl_base_shell,
+    get_kubectl_command,
+    render_k8s_manifest,
+)
+from isvtest.core.validation import BaseValidation
+
+_MANIFEST_DIR = Path(__file__).parent / "manifests" / "k8s"
+_PVC_MANIFEST = _MANIFEST_DIR / "storage_pvc.yaml"
+
+_STORAGE_TYPES: tuple[tuple[str, str], ...] = (
+    ("block", "ReadWriteOnce"),
+    ("shared-fs", "ReadWriteMany"),
+    ("nfs", "ReadWriteMany"),
+)
+
+
+def _poll_pvc_bound(run_command, kubectl_base: str, namespace: str, pvc_name: str, timeout_s: int) -> bool:
+    """Poll ``kubectl get pvc`` until ``status.phase == "Bound"`` or timeout."""
+    deadline = time.time() + timeout_s
+    cmd = f"{kubectl_base} get pvc {shlex.quote(pvc_name)} -n {shlex.quote(namespace)} -o jsonpath='{{.status.phase}}'"
+    while time.time() < deadline:
+        result = run_command(cmd)
+        if result.exit_code == 0 and result.stdout.strip().strip("'") == "Bound":
+            return True
+        time.sleep(2.0)
+    return False
+
+
+def _apply_mount_pod_manifest(
+    kubectl_parts: list[str],
+    namespace: str,
+    pod_name: str,
+    pvc_name: str,
+    timeout: float,
+) -> tuple[int, str]:
+    """Render the BusyBox mount-pod manifest for ``pvc_name`` and ``kubectl apply`` it.
+
+    Storage classes with ``volumeBindingMode: WaitForFirstConsumer`` (the
+    default for AWS EBS, GCE PD, Azure Disk, etc.) keep the PVC ``Pending``
+    until a pod referencing it is scheduled, so every check that needs the
+    PVC to reach ``Bound`` must land a consumer alongside it.
+    """
+
+    def _mutate(doc: dict[str, Any]) -> dict[str, Any]:
+        return _set_mount_pod_fields(doc, namespace=namespace, name=pod_name, pvc_name=pvc_name)
+
+    return _apply_manifest(kubectl_parts, render_k8s_manifest(_MOUNT_POD_MANIFEST, _mutate), timeout)
+
+
+def _wait_pod_ready(run_command, kubectl_base: str, namespace: str, pod_name: str, timeout_s: int) -> tuple[bool, str]:
+    """``kubectl wait --for=condition=Ready`` for ``pod_name``; return (ok, stderr_or_stdout)."""
+    cmd = (
+        f"{kubectl_base} wait --for=condition=Ready "
+        f"--timeout={timeout_s}s -n {shlex.quote(namespace)} pod/{shlex.quote(pod_name)}"
+    )
+    result = run_command(cmd)
+    if result.exit_code == 0:
+        return True, ""
+    return False, (result.stderr.strip() or result.stdout.strip())
+
+
+class K8sCsiStorageTypesCheck(BaseValidation):
+    """Verify CSI supports block, shared filesystem, and NFS storage (K8S23-04).
+
+    For each configured storage type, two subtests run:
+
+    * ``sc-exists[<type>]`` — the named StorageClass is visible to kubectl.
+    * ``pvc-binds[<type>]`` — a fresh PVC against that StorageClass reaches
+      ``Bound`` within ``bind_timeout_s``. A BusyBox consumer pod is
+      scheduled alongside the PVC so this also works for StorageClasses
+      with ``volumeBindingMode: WaitForFirstConsumer`` (the default for
+      most cloud block CSIs).
+
+    Types with no configured StorageClass are reported as skipped, so the
+    check is safe to enable on every provider; pass iff every configured type
+    passes both subtests.
+
+    Config keys (with defaults):
+        block_storage_class: StorageClass for block (RWO) storage
+            (default: from :func:`get_k8s_csi_block_storage_class`).
+        shared_fs_storage_class: StorageClass for shared filesystem (RWX)
+            (default: from :func:`get_k8s_csi_shared_fs_storage_class`).
+        nfs_storage_class: StorageClass for NFS (RWX)
+            (default: from :func:`get_k8s_csi_nfs_storage_class`).
+        pvc_size: Requested capacity for each probe PVC (default: ``1Gi``).
+        bind_timeout_s: Max wait for each PVC to reach ``Bound`` (default: 120).
+        namespace_prefix: Prefix for the ephemeral namespace
+            (default: ``isvtest-csi-types``).
+        timeout: Overall class-level timeout for each ``run_command`` call
+            (default: 300).
+    """
+
+    description: ClassVar[str] = "Verify CSI supports block, shared filesystem, and NFS storage classes (K8S23-04)."
+    timeout: ClassVar[int] = 300
+    markers: ClassVar[list[str]] = ["kubernetes"]
+
+    def run(self) -> None:
+        """Create an ephemeral namespace, probe each configured storage type, and record subtests."""
+        self._kubectl_parts = get_kubectl_command()
+        self._kubectl_base = get_kubectl_base_shell()
+        bind_timeout = int(self.config.get("bind_timeout_s", 120))
+        namespace_prefix = self.config.get("namespace_prefix", "isvtest-csi-types")
+        pvc_size = str(self.config.get("pvc_size", "1Gi"))
+
+        configured: dict[str, str] = {}
+        for type_name, _ in _STORAGE_TYPES:
+            sc_name = self.config.get(f"{type_name.replace('-', '_')}_storage_class") or _env_fallback(type_name)
+            if sc_name:
+                configured[type_name] = sc_name
+
+        if not configured:
+            self.set_passed("Skipped: no StorageClass configured for block/shared-fs/nfs")
+            return
+
+        self._namespace = f"{namespace_prefix}-{uuid.uuid4().hex[:8]}"
+        ns_quoted = shlex.quote(self._namespace)
+        ns_created = False
+        try:
+            ns_result = self.run_command(f"{self._kubectl_base} create namespace {ns_quoted}")
+            if ns_result.exit_code != 0:
+                self.set_failed(f"Failed to create namespace {self._namespace}: {ns_result.stderr}")
+                return
+            ns_created = True
+
+            any_failed = False
+            covered: list[str] = []
+
+            for type_name, access_mode in _STORAGE_TYPES:
+                sc_name = configured.get(type_name)
+                if not sc_name:
+                    self.report_subtest(
+                        f"sc-exists[{type_name}]",
+                        passed=True,
+                        message=f"{type_name} StorageClass not configured",
+                        skipped=True,
+                    )
+                    self.report_subtest(
+                        f"pvc-binds[{type_name}]",
+                        passed=True,
+                        message=f"{type_name} StorageClass not configured",
+                        skipped=True,
+                    )
+                    continue
+
+                sc_result = self.run_command(f"{self._kubectl_base} get storageclass {shlex.quote(sc_name)} -o name")
+                sc_ok = sc_result.exit_code == 0
+                self.report_subtest(
+                    f"sc-exists[{type_name}]",
+                    passed=sc_ok,
+                    message=(
+                        f"StorageClass {sc_name!r} found"
+                        if sc_ok
+                        else f"StorageClass {sc_name!r} missing: {sc_result.stderr.strip() or sc_result.stdout.strip()}"
+                    ),
+                )
+                if not sc_ok:
+                    any_failed = True
+                    # Skip the paired pvc-binds subtest so the overall ratio
+                    # still reflects one failure per broken storage type.
+                    self.report_subtest(
+                        f"pvc-binds[{type_name}]",
+                        passed=True,
+                        message=f"StorageClass {sc_name!r} missing; PVC probe skipped",
+                        skipped=True,
+                    )
+                    continue
+
+                pvc_name = f"csi-types-{type_name}-{uuid.uuid4().hex[:6]}"
+                pod_name = f"csi-types-{type_name}-{uuid.uuid4().hex[:6]}"
+                if not self._apply_pvc(pvc_name, sc_name, access_mode, pvc_size):
+                    any_failed = True
+                    self.report_subtest(
+                        f"pvc-binds[{type_name}]",
+                        passed=False,
+                        message=f"kubectl apply failed for PVC {pvc_name!r} ({sc_name}, {access_mode})",
+                    )
+                    continue
+
+                pod_rc, pod_err = _apply_mount_pod_manifest(
+                    self._kubectl_parts, self._namespace, pod_name, pvc_name, self.timeout
+                )
+                if pod_rc != 0:
+                    any_failed = True
+                    self.report_subtest(
+                        f"pvc-binds[{type_name}]",
+                        passed=False,
+                        message=(
+                            f"kubectl apply failed for consumer pod {pod_name!r} "
+                            f"({sc_name}, {access_mode}): {pod_err.strip()[:200]}"
+                        ),
+                    )
+                    continue
+
+                pod_ready, wait_err = _wait_pod_ready(
+                    self.run_command, self._kubectl_base, self._namespace, pod_name, bind_timeout
+                )
+                bound = pod_ready and self._wait_pvc_bound(pvc_name, 5)
+                self.report_subtest(
+                    f"pvc-binds[{type_name}]",
+                    passed=bound,
+                    message=(
+                        f"PVC {pvc_name!r} bound against {sc_name} ({access_mode}) via consumer pod {pod_name!r}"
+                        if bound
+                        else (
+                            f"PVC {pvc_name!r} did not reach Bound via consumer pod {pod_name!r} "
+                            f"within {bind_timeout}s ({sc_name}, {access_mode}): {wait_err[:200]}"
+                        )
+                    ),
+                )
+                if bound:
+                    covered.append(type_name)
+                else:
+                    any_failed = True
+
+            if any_failed:
+                self.set_failed("One or more CSI storage-type subtests failed; see subtest details")
+            else:
+                self.set_passed(f"CSI supports storage types: {', '.join(sorted(covered))}")
+        finally:
+            # Cleanup must never overwrite pass/fail outcome set above.
+            if ns_created:
+                cleanup = self.run_command(
+                    f"{self._kubectl_base} delete namespace {ns_quoted} --wait=false --ignore-not-found=true"
+                )
+                if cleanup.exit_code != 0:
+                    self.log.warning("Namespace cleanup failed for %s: %s", self._namespace, cleanup.stderr)
+
+    def _apply_pvc(self, name: str, sc_name: str, access_mode: str, size: str) -> bool:
+        """Render the PVC manifest and apply it; return True on success."""
+
+        def _mutate(doc: dict[str, Any]) -> dict[str, Any]:
+            return _set_pvc_fields(doc, namespace=self._namespace, name=name, sc=sc_name, mode=access_mode, size=size)
+
+        manifest = render_k8s_manifest(_PVC_MANIFEST, _mutate)
+        try:
+            proc = subprocess.run(
+                self._kubectl_parts + ["apply", "-f", "-"],
+                input=manifest,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+        except subprocess.TimeoutExpired:
+            self.log.error("kubectl apply timed out for PVC %s", name)
+            return False
+        except Exception as exc:
+            self.log.error("kubectl apply failed for PVC %s: %s", name, exc)
+            return False
+
+        if proc.returncode != 0:
+            self.log.error(
+                "kubectl apply failed for PVC %s: %s",
+                name,
+                proc.stderr.strip() or proc.stdout.strip(),
+            )
+            return False
+        return True
+
+    def _wait_pvc_bound(self, pvc_name: str, timeout_s: int) -> bool:
+        return _poll_pvc_bound(self.run_command, self._kubectl_base, self._namespace, pvc_name, timeout_s)
+
+
+def _set_pvc_fields(
+    doc: dict[str, Any],
+    *,
+    namespace: str,
+    name: str,
+    sc: str,
+    mode: str,
+    size: str,
+) -> dict[str, Any]:
+    """Mutate a parsed PVC manifest in place with the requested fields."""
+    metadata = doc.setdefault("metadata", {})
+    metadata["name"] = name
+    metadata["namespace"] = namespace
+
+    spec = doc.setdefault("spec", {})
+    spec["storageClassName"] = sc
+    spec["accessModes"] = [mode]
+    resources = spec.setdefault("resources", {})
+    requests = resources.setdefault("requests", {})
+    requests["storage"] = size
+    return doc
+
+
+def _env_fallback(type_name: str) -> str:
+    """Return the env-backed StorageClass default for a given storage type."""
+    if type_name == "block":
+        return get_k8s_csi_block_storage_class()
+    if type_name == "shared-fs":
+        return get_k8s_csi_shared_fs_storage_class()
+    if type_name == "nfs":
+        return get_k8s_csi_nfs_storage_class()
+    return ""

--- a/isvtest/src/isvtest/validations/k8s_storage.py
+++ b/isvtest/src/isvtest/validations/k8s_storage.py
@@ -143,7 +143,7 @@ class K8sCsiStorageTypesCheck(BaseValidation):
       most cloud block CSIs).
 
     Types with no configured StorageClass are reported as skipped, so the
-    check is safe to enable on every provider; pass iff every configured type
+    check is safe to enable on every provider; pass if every configured type
     passes both subtests.
 
     Config keys (with defaults):
@@ -630,7 +630,7 @@ class K8sCsiStorageQuotaApiCheck(BaseValidation):
         return True
 
     def _run_quota_enforcement(self, pvc_name: str, storage_class: str, request_size: str) -> bool:
-        """Attempt to apply an over-quota PVC; pass iff admission rejects with a quota message."""
+        """Attempt to apply an over-quota PVC; pass if admission rejects with a quota message."""
         returncode, stderr = self._apply_pvc(pvc_name, storage_class, "ReadWriteOnce", request_size)
         if returncode == 0:
             self.report_subtest(

--- a/isvtest/src/isvtest/validations/k8s_storage.py
+++ b/isvtest/src/isvtest/validations/k8s_storage.py
@@ -8,21 +8,21 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
-"""CSI storage validations (K8S23).
+"""CSI storage validations.
 
 Implements:
 
-* :class:`K8sCsiStorageTypesCheck` (K8S23-04) — verify the cluster exposes a
+* :class:`K8sCsiStorageTypesCheck` — verify the cluster exposes a
   StorageClass for each of block / shared filesystem / NFS storage and that
   a PVC binds against each configured class.
-* :class:`K8sCsiStorageQuotaApiCheck` (K8S23-07) — verify Kubernetes-native
+* :class:`K8sCsiStorageQuotaApiCheck` — verify Kubernetes-native
   APIs expose storage quota and per-PVC/PV usage.
-* :class:`K8sCsiTenantScopedCredentialsCheck` (K8S23-06) — verify CSI
+* :class:`K8sCsiTenantScopedCredentialsCheck` — verify CSI
   credentials are tenant-scoped "by construction" by inspecting in-cluster
   observable state (Secret namespaces, labels, ServiceAccount RBAC, and
   node-plugin volume topology). Does not prove cross-cluster isolation from
   the outside.
-* :class:`K8sCsiProvisioningModesCheck` (K8S23-05) — verify CSI supports
+* :class:`K8sCsiProvisioningModesCheck` — verify CSI supports
   both dynamic and static provisioning, driving each through a real mount
   + canary-file write/read inside a BusyBox pod.
 """
@@ -131,7 +131,7 @@ def _wait_pod_ready(run_command, kubectl_base: str, namespace: str, pod_name: st
 
 
 class K8sCsiStorageTypesCheck(BaseValidation):
-    """Verify CSI supports block, shared filesystem, and NFS storage (K8S23-04).
+    """Verify CSI supports block, shared filesystem, and NFS storage.
 
     For each configured storage type, two subtests run:
 
@@ -161,7 +161,7 @@ class K8sCsiStorageTypesCheck(BaseValidation):
             (default: 300).
     """
 
-    description: ClassVar[str] = "Verify CSI supports block, shared filesystem, and NFS storage classes (K8S23-04)."
+    description: ClassVar[str] = "Verify CSI supports block, shared filesystem, and NFS storage classes."
     timeout: ClassVar[int] = 300
     markers: ClassVar[list[str]] = ["kubernetes"]
 
@@ -366,7 +366,7 @@ def _env_fallback(type_name: str) -> str:
 
 
 class K8sCsiStorageQuotaApiCheck(BaseValidation):
-    """Verify Kubernetes-native APIs expose storage quota and per-PVC/PV usage (K8S23-07).
+    """Verify Kubernetes-native APIs expose storage quota and per-PVC/PV usage.
 
     Four subtests run against a single ephemeral namespace:
 
@@ -409,7 +409,7 @@ class K8sCsiStorageQuotaApiCheck(BaseValidation):
             (default: 300).
     """
 
-    description: ClassVar[str] = "Verify Kubernetes-native APIs expose storage quota and per-PVC/PV usage (K8S23-07)."
+    description: ClassVar[str] = "Verify Kubernetes-native APIs expose storage quota and per-PVC/PV usage."
     timeout: ClassVar[int] = 300
     markers: ClassVar[list[str]] = ["kubernetes"]
 
@@ -855,7 +855,7 @@ _SHARED_CLUSTER_ANNOTATIONS: tuple[str, ...] = (
 
 
 class K8sCsiTenantScopedCredentialsCheck(BaseValidation):
-    """Verify CSI credentials are tenant-scoped by construction (K8S23-06).
+    """Verify CSI credentials are tenant-scoped by construction.
 
     This check inspects in-cluster observable state only; it does **not**
     attempt any cross-cluster exfiltration, and so cannot prove isolation
@@ -894,7 +894,7 @@ class K8sCsiTenantScopedCredentialsCheck(BaseValidation):
             (default: 300).
     """
 
-    description: ClassVar[str] = "Verify CSI credentials are tenant-scoped by construction (K8S23-06)."
+    description: ClassVar[str] = "Verify CSI credentials are tenant-scoped by construction."
     timeout: ClassVar[int] = 300
     markers: ClassVar[list[str]] = ["kubernetes"]
 
@@ -1417,7 +1417,7 @@ def _check_node_plugin_volumes(
 
 
 class K8sCsiProvisioningModesCheck(BaseValidation):
-    """Verify CSI supports both dynamic and static provisioning (K8S23-05).
+    """Verify CSI supports both dynamic and static provisioning.
 
     Two subtests run against a single ephemeral namespace:
 
@@ -1456,7 +1456,7 @@ class K8sCsiProvisioningModesCheck(BaseValidation):
             (default: 600).
     """
 
-    description: ClassVar[str] = "Verify CSI supports dynamic and static provisioning (K8S23-05)."
+    description: ClassVar[str] = "Verify CSI supports dynamic and static provisioning."
     timeout: ClassVar[int] = 600
     markers: ClassVar[list[str]] = ["kubernetes"]
 

--- a/isvtest/src/isvtest/validations/k8s_storage.py
+++ b/isvtest/src/isvtest/validations/k8s_storage.py
@@ -10,13 +10,18 @@
 
 """CSI storage validations (K8S23).
 
-Currently implements :class:`K8sCsiStorageTypesCheck` (K8S23-04), which verifies
-that the cluster exposes a StorageClass for each of block / shared filesystem /
-NFS storage and that a PVC binds against each configured class.
+Implements:
+
+* :class:`K8sCsiStorageTypesCheck` (K8S23-04) — verify the cluster exposes a
+  StorageClass for each of block / shared filesystem / NFS storage and that
+  a PVC binds against each configured class.
+* :class:`K8sCsiStorageQuotaApiCheck` (K8S23-07) — verify Kubernetes-native
+  APIs expose storage quota and per-PVC/PV usage.
 """
 
 from __future__ import annotations
 
+import json
 import shlex
 import subprocess
 import time
@@ -38,12 +43,36 @@ from isvtest.core.validation import BaseValidation
 
 _MANIFEST_DIR = Path(__file__).parent / "manifests" / "k8s"
 _PVC_MANIFEST = _MANIFEST_DIR / "storage_pvc.yaml"
+_RESOURCEQUOTA_MANIFEST = _MANIFEST_DIR / "storage_resourcequota.yaml"
 
 _STORAGE_TYPES: tuple[tuple[str, str], ...] = (
     ("block", "ReadWriteOnce"),
     ("shared-fs", "ReadWriteMany"),
     ("nfs", "ReadWriteMany"),
 )
+
+_QUOTA_REJECTION_TOKENS: tuple[str, ...] = ("exceeded quota", "forbidden")
+
+
+def _apply_manifest(kubectl_parts: list[str], manifest: str, timeout: float) -> tuple[int, str]:
+    """Invoke ``kubectl apply -f -`` with ``manifest``; return ``(returncode, stderr-or-stdout)``.
+
+    Timeouts and unexpected exceptions are normalised to returncode ``-1`` so
+    callers can treat them uniformly as apply failures.
+    """
+    try:
+        proc = subprocess.run(
+            kubectl_parts + ["apply", "-f", "-"],
+            input=manifest,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return -1, "kubectl apply timed out"
+    except Exception as exc:
+        return -1, f"kubectl apply raised: {exc}"
+    return proc.returncode, proc.stderr or proc.stdout
 
 
 def _poll_pvc_bound(run_command, kubectl_base: str, namespace: str, pvc_name: str, timeout_s: int) -> bool:
@@ -324,3 +353,451 @@ def _env_fallback(type_name: str) -> str:
     if type_name == "nfs":
         return get_k8s_csi_nfs_storage_class()
     return ""
+
+
+class K8sCsiStorageQuotaApiCheck(BaseValidation):
+    """Verify Kubernetes-native APIs expose storage quota and per-PVC/PV usage (K8S23-07).
+
+    Four subtests run against a single ephemeral namespace:
+
+    * ``resourcequota-storage-api`` — a ResourceQuota carrying both
+      ``requests.storage`` and
+      ``<sc>.storageclass.storage.k8s.io/requests.storage`` lands and its
+      ``.status.hard`` publishes both keys.
+    * ``per-pvc-usage`` — a PVC against the configured StorageClass binds
+      (via a BusyBox consumer pod so this works under
+      ``WaitForFirstConsumer``), exposes ``.status.capacity.storage``, and
+      its usage is reflected in the ResourceQuota's ``.status.used``.
+    * ``quota-enforcement`` — an over-quota PVC is rejected at admission
+      with an ``exceeded quota`` / ``forbidden`` message.
+    * ``pv-usage-api`` — the bound PV exposes ``.spec.capacity.storage``,
+      ``.spec.claimRef.name`` matching the usage PVC, and
+      ``.spec.csi.driver``.
+
+    When ``resourcequota-storage-api`` fails, the three downstream subtests
+    are reported as skipped because they all require the quota to be in
+    place; the overall validation still fails.
+
+    Config keys (with defaults):
+        storage_class: StorageClass to use for the probe PVCs; defaults to
+            :func:`get_k8s_csi_block_storage_class`. When unset the whole
+            check is skipped so it is safe to enable everywhere.
+        total_quota: Namespace-wide ``requests.storage`` cap
+            (default: ``10Gi``).
+        per_sc_quota: Per-StorageClass cap (default: ``5Gi``). Must exceed
+            ``pvc_request`` so the usage PVC fits.
+        pvc_request: Size requested by the usage PVC (default: ``1Gi``).
+        over_quota_request: Size requested by the enforcement PVC; must
+            exceed ``per_sc_quota`` so admission rejects it
+            (default: ``100Gi``).
+        bind_timeout_s: Max wait for the usage PVC to Bind (default: 120).
+        quota_settle_s: Max wait for each ``ResourceQuota.status`` section
+            (``hard`` and ``used``) to populate (default: 30).
+        namespace_prefix: Prefix for the ephemeral namespace
+            (default: ``isvtest-csi-quota``).
+        timeout: Overall class-level timeout for each ``run_command``
+            (default: 300).
+    """
+
+    description: ClassVar[str] = "Verify Kubernetes-native APIs expose storage quota and per-PVC/PV usage (K8S23-07)."
+    timeout: ClassVar[int] = 300
+    markers: ClassVar[list[str]] = ["kubernetes"]
+
+    def run(self) -> None:
+        """Drive the four-subtest quota-API probe against a single ephemeral namespace."""
+        storage_class = self.config.get("storage_class") or get_k8s_csi_block_storage_class()
+        if not storage_class:
+            self.set_passed("Skipped: no storage_class configured")
+            return
+
+        total_quota = str(self.config.get("total_quota", "10Gi"))
+        per_sc_quota = str(self.config.get("per_sc_quota", "5Gi"))
+        pvc_request = str(self.config.get("pvc_request", "1Gi"))
+        over_quota_request = str(self.config.get("over_quota_request", "100Gi"))
+        bind_timeout = int(self.config.get("bind_timeout_s", 120))
+        quota_settle = int(self.config.get("quota_settle_s", 30))
+        ns_prefix = self.config.get("namespace_prefix", "isvtest-csi-quota")
+
+        self._kubectl_parts = get_kubectl_command()
+        self._kubectl_base = get_kubectl_base_shell()
+        self._namespace = f"{ns_prefix}-{uuid.uuid4().hex[:8]}"
+        ns_quoted = shlex.quote(self._namespace)
+
+        sc_quota_key = f"{storage_class}.storageclass.storage.k8s.io/requests.storage"
+        rq_name = f"storage-quota-{uuid.uuid4().hex[:6]}"
+        usage_pvc = f"quota-usage-{uuid.uuid4().hex[:6]}"
+        over_pvc = f"quota-over-{uuid.uuid4().hex[:6]}"
+
+        ns_created = False
+        try:
+            ns_result = self.run_command(f"{self._kubectl_base} create namespace {ns_quoted}")
+            if ns_result.exit_code != 0:
+                self.set_failed(f"Failed to create namespace {self._namespace}: {ns_result.stderr}")
+                return
+            ns_created = True
+
+            any_failed = False
+
+            quota_ok = self._apply_resourcequota(rq_name, total_quota, sc_quota_key, per_sc_quota)
+            hard: dict[str, Any] | None = None
+            if quota_ok:
+                hard = self._wait_quota_section(rq_name, "hard", [sc_quota_key, "requests.storage"], quota_settle)
+                quota_ok = hard is not None
+
+            if quota_ok:
+                self.report_subtest(
+                    "resourcequota-storage-api",
+                    passed=True,
+                    message=(
+                        f"ResourceQuota {rq_name!r} hard={{requests.storage: {hard.get('requests.storage')!r}, "
+                        f"{sc_quota_key}: {hard.get(sc_quota_key)!r}}}"
+                        if hard
+                        else f"ResourceQuota {rq_name!r} hard populated"
+                    ),
+                )
+            else:
+                self.report_subtest(
+                    "resourcequota-storage-api",
+                    passed=False,
+                    message=(
+                        f"ResourceQuota {rq_name!r} did not publish hard limits "
+                        f"(both {'requests.storage'!r} and {sc_quota_key!r}) within {quota_settle}s"
+                    ),
+                )
+                for dependent in ("per-pvc-usage", "quota-enforcement", "pv-usage-api"):
+                    self.report_subtest(
+                        dependent,
+                        passed=True,
+                        message="resourcequota-storage-api failed; dependent probe skipped",
+                        skipped=True,
+                    )
+                self.set_failed("ResourceQuota did not land; downstream quota probes skipped")
+                return
+
+            usage_ok = self._run_per_pvc_usage(
+                pvc_name=usage_pvc,
+                storage_class=storage_class,
+                pvc_request=pvc_request,
+                rq_name=rq_name,
+                sc_quota_key=sc_quota_key,
+                bind_timeout=bind_timeout,
+                quota_settle=quota_settle,
+            )
+            if not usage_ok:
+                any_failed = True
+
+            if not self._run_quota_enforcement(over_pvc, storage_class, over_quota_request):
+                any_failed = True
+
+            # pv-usage-api requires per-pvc-usage to have produced a Bound PVC.
+            if usage_ok:
+                if not self._run_pv_usage_api(usage_pvc):
+                    any_failed = True
+            else:
+                self.report_subtest(
+                    "pv-usage-api",
+                    passed=True,
+                    message="per-pvc-usage did not produce a bound PV; pv-usage-api skipped",
+                    skipped=True,
+                )
+
+            if any_failed:
+                self.set_failed("One or more storage quota API subtests failed; see subtest details")
+            else:
+                self.set_passed(f"Storage quota APIs verified against StorageClass {storage_class!r}")
+        finally:
+            # Cleanup must never overwrite pass/fail outcome set above.
+            if ns_created:
+                cleanup = self.run_command(
+                    f"{self._kubectl_base} delete namespace {ns_quoted} --wait=false --ignore-not-found=true"
+                )
+                if cleanup.exit_code != 0:
+                    self.log.warning("Namespace cleanup failed for %s: %s", self._namespace, cleanup.stderr)
+
+    def _apply_resourcequota(
+        self,
+        name: str,
+        total_quota: str,
+        sc_quota_key: str,
+        per_sc_quota: str,
+    ) -> bool:
+        """Render and apply the ResourceQuota manifest; return True on success."""
+
+        def _mutate(doc: dict[str, Any]) -> dict[str, Any]:
+            return _set_resourcequota_fields(
+                doc,
+                namespace=self._namespace,
+                name=name,
+                total_quota=total_quota,
+                sc_quota_key=sc_quota_key,
+                per_sc_quota=per_sc_quota,
+            )
+
+        manifest = render_k8s_manifest(_RESOURCEQUOTA_MANIFEST, _mutate)
+        returncode, stderr = self._run_kubectl_apply(manifest)
+        if returncode != 0:
+            self.log.error("kubectl apply failed for ResourceQuota %s: %s", name, stderr)
+            return False
+        return True
+
+    def _run_per_pvc_usage(
+        self,
+        *,
+        pvc_name: str,
+        storage_class: str,
+        pvc_request: str,
+        rq_name: str,
+        sc_quota_key: str,
+        bind_timeout: int,
+        quota_settle: int,
+    ) -> bool:
+        """Apply the usage PVC + consumer pod, wait for Bound, and assert per-PVC / quota-used visibility."""
+        returncode, stderr = self._apply_pvc(pvc_name, storage_class, "ReadWriteOnce", pvc_request)
+        if returncode != 0:
+            self.report_subtest(
+                "per-pvc-usage",
+                passed=False,
+                message=f"kubectl apply failed for PVC {pvc_name!r}: {stderr.strip()}",
+            )
+            return False
+
+        pod_name = f"quota-usage-{uuid.uuid4().hex[:6]}"
+        pod_rc, pod_err = _apply_mount_pod_manifest(
+            self._kubectl_parts, self._namespace, pod_name, pvc_name, self.timeout
+        )
+        if pod_rc != 0:
+            self.report_subtest(
+                "per-pvc-usage",
+                passed=False,
+                message=f"kubectl apply failed for consumer pod {pod_name!r}: {pod_err.strip()[:200]}",
+            )
+            return False
+
+        pod_ready, wait_err = _wait_pod_ready(
+            self.run_command, self._kubectl_base, self._namespace, pod_name, bind_timeout
+        )
+        if not pod_ready or not self._wait_pvc_bound(pvc_name, 5):
+            self.report_subtest(
+                "per-pvc-usage",
+                passed=False,
+                message=(
+                    f"PVC {pvc_name!r} did not reach Bound via consumer pod {pod_name!r} "
+                    f"within {bind_timeout}s: {wait_err[:200]}"
+                ),
+            )
+            return False
+
+        capacity = self._get_pvc_capacity(pvc_name)
+        if not capacity:
+            self.report_subtest(
+                "per-pvc-usage",
+                passed=False,
+                message=f"PVC {pvc_name!r} bound but status.capacity.storage is empty",
+            )
+            return False
+
+        used = self._wait_quota_section(rq_name, "used", [sc_quota_key, "requests.storage"], quota_settle)
+        if used is None:
+            self.report_subtest(
+                "per-pvc-usage",
+                passed=False,
+                message=(
+                    f"PVC {pvc_name!r} capacity={capacity!r} but ResourceQuota.status.used "
+                    f"did not reflect both keys within {quota_settle}s"
+                ),
+            )
+            return False
+
+        self.report_subtest(
+            "per-pvc-usage",
+            passed=True,
+            message=(
+                f"PVC {pvc_name!r} capacity={capacity!r}; quota.used["
+                f"requests.storage]={used.get('requests.storage')!r}, "
+                f"quota.used[{sc_quota_key}]={used.get(sc_quota_key)!r}"
+            ),
+        )
+        return True
+
+    def _run_quota_enforcement(self, pvc_name: str, storage_class: str, request_size: str) -> bool:
+        """Attempt to apply an over-quota PVC; pass iff admission rejects with a quota message."""
+        returncode, stderr = self._apply_pvc(pvc_name, storage_class, "ReadWriteOnce", request_size)
+        if returncode == 0:
+            self.report_subtest(
+                "quota-enforcement",
+                passed=False,
+                message=(
+                    f"Over-quota PVC {pvc_name!r} (request={request_size}) was admitted; "
+                    f"ResourceQuota did not enforce the per-StorageClass cap"
+                ),
+            )
+            return False
+
+        lowered = stderr.lower()
+        if any(token in lowered for token in _QUOTA_REJECTION_TOKENS):
+            self.report_subtest(
+                "quota-enforcement",
+                passed=True,
+                message=f"Over-quota PVC {pvc_name!r} rejected at admission: {stderr.strip()[:200]}",
+            )
+            return True
+
+        self.report_subtest(
+            "quota-enforcement",
+            passed=False,
+            message=(
+                f"Over-quota PVC {pvc_name!r} apply failed but stderr did not mention quota enforcement: "
+                f"{stderr.strip()[:200]}"
+            ),
+        )
+        return False
+
+    def _run_pv_usage_api(self, pvc_name: str) -> bool:
+        """Resolve the PVC's bound PV and assert ``spec.capacity/claimRef/csi.driver`` are populated."""
+        vol_name_result = self.run_command(
+            f"{self._kubectl_base} get pvc {shlex.quote(pvc_name)} "
+            f"-n {shlex.quote(self._namespace)} -o jsonpath='{{.spec.volumeName}}'"
+        )
+        pv_name = vol_name_result.stdout.strip().strip("'")
+        if vol_name_result.exit_code != 0 or not pv_name:
+            self.report_subtest(
+                "pv-usage-api",
+                passed=False,
+                message=f"Could not resolve volumeName for PVC {pvc_name!r}: {vol_name_result.stderr.strip()}",
+            )
+            return False
+
+        pv_json = self.run_command(f"{self._kubectl_base} get pv {shlex.quote(pv_name)} -o json")
+        if pv_json.exit_code != 0:
+            self.report_subtest(
+                "pv-usage-api",
+                passed=False,
+                message=f"kubectl get pv {pv_name!r} failed: {pv_json.stderr.strip()}",
+            )
+            return False
+
+        try:
+            payload = json.loads(pv_json.stdout)
+        except json.JSONDecodeError as exc:
+            self.report_subtest(
+                "pv-usage-api",
+                passed=False,
+                message=f"Failed to parse PV {pv_name!r} JSON: {exc}",
+            )
+            return False
+
+        spec = payload.get("spec") or {}
+        capacity = (spec.get("capacity") or {}).get("storage")
+        claim_ref_name = (spec.get("claimRef") or {}).get("name")
+        csi_driver = (spec.get("csi") or {}).get("driver")
+
+        missing: list[str] = []
+        if not capacity:
+            missing.append("spec.capacity.storage")
+        if claim_ref_name != pvc_name:
+            missing.append(f"spec.claimRef.name (expected {pvc_name!r}, got {claim_ref_name!r})")
+        if not csi_driver:
+            missing.append("spec.csi.driver")
+
+        if missing:
+            self.report_subtest(
+                "pv-usage-api",
+                passed=False,
+                message=f"PV {pv_name!r} missing required fields: {', '.join(missing)}",
+            )
+            return False
+
+        self.report_subtest(
+            "pv-usage-api",
+            passed=True,
+            message=(
+                f"PV {pv_name!r} spec.capacity.storage={capacity!r}, "
+                f"spec.claimRef.name={claim_ref_name!r}, spec.csi.driver={csi_driver!r}"
+            ),
+        )
+        return True
+
+    def _apply_pvc(self, name: str, storage_class: str, access_mode: str, size: str) -> tuple[int, str]:
+        """Render the PVC manifest and apply it; return (returncode, stderr)."""
+
+        def _mutate(doc: dict[str, Any]) -> dict[str, Any]:
+            return _set_pvc_fields(
+                doc, namespace=self._namespace, name=name, sc=storage_class, mode=access_mode, size=size
+            )
+
+        manifest = render_k8s_manifest(_PVC_MANIFEST, _mutate)
+        return self._run_kubectl_apply(manifest)
+
+    def _run_kubectl_apply(self, manifest: str) -> tuple[int, str]:
+        return _apply_manifest(self._kubectl_parts, manifest, self.timeout)
+
+    def _wait_pvc_bound(self, pvc_name: str, timeout_s: int) -> bool:
+        return _poll_pvc_bound(self.run_command, self._kubectl_base, self._namespace, pvc_name, timeout_s)
+
+    def _get_pvc_capacity(self, pvc_name: str) -> str:
+        """Return ``.status.capacity.storage`` for ``pvc_name`` (empty string if unset)."""
+        cmd = (
+            f"{self._kubectl_base} get pvc {shlex.quote(pvc_name)} "
+            f"-n {shlex.quote(self._namespace)} "
+            f"-o jsonpath='{{.status.capacity.storage}}'"
+        )
+        result = self.run_command(cmd)
+        if result.exit_code != 0:
+            return ""
+        return result.stdout.strip().strip("'")
+
+    def _wait_quota_section(
+        self,
+        rq_name: str,
+        section: str,
+        required_keys: list[str],
+        timeout_s: int,
+    ) -> dict[str, Any] | None:
+        """Poll ``ResourceQuota.status.<section>`` until every ``required_keys`` entry appears.
+
+        Returns the section dict once fully populated, or ``None`` on timeout
+        / parse failure. Keys are compared verbatim — the caller is
+        responsible for passing the concrete per-StorageClass key name.
+        """
+        deadline = time.time() + timeout_s
+        cmd = f"{self._kubectl_base} get resourcequota {shlex.quote(rq_name)} -n {shlex.quote(self._namespace)} -o json"
+        while time.time() < deadline:
+            result = self.run_command(cmd)
+            if result.exit_code == 0 and result.stdout:
+                try:
+                    payload = json.loads(result.stdout)
+                except json.JSONDecodeError:
+                    payload = None
+                if payload:
+                    section_dict = (payload.get("status") or {}).get(section) or {}
+                    if all(key in section_dict for key in required_keys):
+                        return section_dict
+            time.sleep(2.0)
+        return None
+
+
+def _set_resourcequota_fields(
+    doc: dict[str, Any],
+    *,
+    namespace: str,
+    name: str,
+    total_quota: str,
+    sc_quota_key: str,
+    per_sc_quota: str,
+) -> dict[str, Any]:
+    """Mutate a parsed ResourceQuota manifest in place with the requested fields.
+
+    ``spec.hard`` is rebuilt rather than merged so the per-StorageClass key
+    (whose name is only known at runtime) fully replaces any placeholder
+    value carried by the template.
+    """
+    metadata = doc.setdefault("metadata", {})
+    metadata["name"] = name
+    metadata["namespace"] = namespace
+
+    spec = doc.setdefault("spec", {})
+    spec["hard"] = {
+        "requests.storage": total_quota,
+        sc_quota_key: per_sc_quota,
+    }
+    return doc

--- a/isvtest/src/isvtest/validations/manifests/k8s/storage_mount_pod.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/storage_mount_pod.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# Parameterisable BusyBox mount pod for CSI provisioning validations.
+#
+# Loaded by isvtest.core.k8s.render_k8s_manifest and mutated in-memory at
+# runtime. The placeholder values below exist only to keep the file valid
+# YAML; metadata.{name,namespace} and the persistentVolumeClaim.claimName
+# are overridden by the caller before apply. The container sleeps so the
+# caller can kubectl exec into it to write and read back a canary file on
+# the mounted PVC.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: placeholder
+  namespace: placeholder
+spec:
+  restartPolicy: Never
+  containers:
+    - name: probe
+      image: busybox:1.36
+      command: ["sh", "-c", "sleep 3600"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: placeholder

--- a/isvtest/src/isvtest/validations/manifests/k8s/storage_mount_pod.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/storage_mount_pod.yaml
@@ -16,10 +16,21 @@ metadata:
   namespace: placeholder
 spec:
   restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
+    fsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: probe
       image: busybox:1.36
       command: ["sh", "-c", "sleep 3600"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
       volumeMounts:
         - name: data
           mountPath: /data

--- a/isvtest/src/isvtest/validations/manifests/k8s/storage_pv.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/storage_pv.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# Parameterisable PersistentVolume template for static CSI provisioning.
+#
+# Loaded by isvtest.core.k8s.render_k8s_manifest and mutated in-memory at
+# runtime. The placeholder values below exist only to keep the file valid
+# YAML; name, capacity, accessModes, spec.csi.{driver,volumeHandle,fsType},
+# and claimRef are overridden by the caller before apply. storageClassName
+# is intentionally an empty string so the PV binds only to a PVC that also
+# sets storageClassName="" (the static-provisioning convention).
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: placeholder
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  csi:
+    driver: placeholder
+    volumeHandle: placeholder
+    fsType: ext4

--- a/isvtest/src/isvtest/validations/manifests/k8s/storage_pvc.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/storage_pvc.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# Parameterisable PVC template for CSI storage validations.
+#
+# Loaded by isvtest.core.k8s.render_k8s_manifest and mutated in-memory at
+# runtime. The placeholder defaults below exist only to keep the file valid
+# YAML; every field shown is overridden by the caller before apply.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: placeholder
+  namespace: placeholder
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: placeholder

--- a/isvtest/src/isvtest/validations/manifests/k8s/storage_resourcequota.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/storage_resourcequota.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# Parameterisable ResourceQuota template for CSI storage-quota validations.
+#
+# Loaded by isvtest.core.k8s.render_k8s_manifest and mutated in-memory at
+# runtime. The placeholder values below exist only to keep the file valid
+# YAML; name, namespace, and the full `spec.hard` map are overridden by the
+# caller before apply. The per-StorageClass key (which has the form
+# `<sc>.storageclass.storage.k8s.io/requests.storage`) is injected by the
+# mutator because the StorageClass name is only known at runtime.
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: placeholder
+  namespace: placeholder
+spec:
+  hard:
+    requests.storage: 10Gi

--- a/isvtest/tests/test_k8s_storage.py
+++ b/isvtest/tests/test_k8s_storage.py
@@ -1,0 +1,386 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Unit tests for ``isvtest.validations.k8s_storage``."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from isvtest.core.runners import CommandResult
+from isvtest.validations.k8s_storage import (
+    K8sCsiStorageTypesCheck,
+    _set_pvc_fields,
+)
+
+
+def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    """Return a successful ``CommandResult`` with the given stdout/stderr."""
+    return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _fail(stdout: str = "", stderr: str = "", exit_code: int = 1) -> CommandResult:
+    """Return a failing ``CommandResult`` with the given output and exit code."""
+    return CommandResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+class _FakeProc:
+    """Minimal stand-in for ``subprocess.CompletedProcess`` used by ``kubectl apply``."""
+
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class TestSetPvcFields:
+    """Tests for ``_set_pvc_fields`` — the in-memory manifest mutator."""
+
+    def _base_doc(self) -> dict[str, Any]:
+        return {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {"name": "placeholder", "namespace": "placeholder"},
+            "spec": {
+                "accessModes": ["ReadWriteOnce"],
+                "resources": {"requests": {"storage": "1Gi"}},
+                "storageClassName": "placeholder",
+            },
+        }
+
+    def test_overrides_all_fields(self) -> None:
+        doc = self._base_doc()
+        out = _set_pvc_fields(doc, namespace="ns1", name="p1", sc="gp3", mode="ReadWriteMany", size="5Gi")
+        assert out["metadata"]["namespace"] == "ns1"
+        assert out["metadata"]["name"] == "p1"
+        assert out["spec"]["storageClassName"] == "gp3"
+        assert out["spec"]["accessModes"] == ["ReadWriteMany"]
+        assert out["spec"]["resources"]["requests"]["storage"] == "5Gi"
+
+    def test_mutation_is_in_place(self) -> None:
+        doc = self._base_doc()
+        out = _set_pvc_fields(doc, namespace="ns", name="p", sc="sc", mode="ReadWriteOnce", size="1Gi")
+        assert out is doc
+
+    def test_missing_sections_are_created(self) -> None:
+        out = _set_pvc_fields({}, namespace="ns", name="p", sc="sc", mode="ReadWriteOnce", size="1Gi")
+        assert out["metadata"]["namespace"] == "ns"
+        assert out["spec"]["storageClassName"] == "sc"
+        assert out["spec"]["resources"]["requests"]["storage"] == "1Gi"
+
+
+class TestK8sCsiStorageTypesCheck:
+    """Tests for ``K8sCsiStorageTypesCheck``."""
+
+    def _make(self, config: dict[str, Any] | None = None) -> K8sCsiStorageTypesCheck:
+        return K8sCsiStorageTypesCheck(config=config or {})
+
+    def _stub_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Isolate from developer env: never leak a StorageClass from the host.
+        for var in ("K8S_CSI_BLOCK_SC", "K8S_CSI_SHARED_FS_SC", "K8S_CSI_NFS_SC"):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_no_storage_classes_configured_skips_without_work(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make({})
+        with patch.object(check, "run_command") as mock_run:
+            check.run()
+        mock_run.assert_not_called()
+        assert check.passed
+        assert "Skipped" in check._output
+        assert "no StorageClass" in check._output
+
+    def test_all_configured_storage_classes_pass(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make(
+            {
+                "block_storage_class": "gp3",
+                "shared_fs_storage_class": "efs-sc",
+                "nfs_storage_class": "efs-sc",
+                "bind_timeout_s": 5,
+                "namespace_prefix": "ut",
+            }
+        )
+
+        def fake_run(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "create namespace" in cmd:
+                return _ok()
+            if "get storageclass" in cmd:
+                return _ok(stdout="storageclass.storage.k8s.io/x\n")
+            if "wait --for=condition=Ready" in cmd:
+                return _ok()
+            if "get pvc" in cmd:
+                return _ok(stdout="Bound")
+            if "delete namespace" in cmd:
+                return _ok()
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with (
+            patch.object(check, "run_command", side_effect=fake_run),
+            patch("isvtest.validations.k8s_storage.subprocess.run", return_value=_FakeProc(returncode=0)),
+            patch("isvtest.validations.k8s_storage.time.sleep"),
+        ):
+            check.run()
+
+        assert check.passed, check._error
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        for t in ("block", "shared-fs", "nfs"):
+            assert outcomes[f"sc-exists[{t}]"]["passed"]
+            assert outcomes[f"pvc-binds[{t}]"]["passed"]
+
+    def test_only_block_configured_skips_others(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make(
+            {
+                "block_storage_class": "gp3",
+                "bind_timeout_s": 5,
+                "namespace_prefix": "ut",
+            }
+        )
+
+        def fake_run(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "create namespace" in cmd:
+                return _ok()
+            if "get storageclass" in cmd:
+                return _ok(stdout="storageclass.storage.k8s.io/gp3\n")
+            if "wait --for=condition=Ready" in cmd:
+                return _ok()
+            if "get pvc" in cmd:
+                return _ok(stdout="Bound")
+            if "delete namespace" in cmd:
+                return _ok()
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with (
+            patch.object(check, "run_command", side_effect=fake_run),
+            patch("isvtest.validations.k8s_storage.subprocess.run", return_value=_FakeProc(returncode=0)),
+            patch("isvtest.validations.k8s_storage.time.sleep"),
+        ):
+            check.run()
+
+        assert check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert outcomes["sc-exists[block]"]["passed"] and not outcomes["sc-exists[block]"]["skipped"]
+        assert outcomes["pvc-binds[block]"]["passed"] and not outcomes["pvc-binds[block]"]["skipped"]
+        for t in ("shared-fs", "nfs"):
+            assert outcomes[f"sc-exists[{t}]"]["skipped"]
+            assert outcomes[f"pvc-binds[{t}]"]["skipped"]
+
+    def test_missing_storageclass_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make({"block_storage_class": "nope", "bind_timeout_s": 5, "namespace_prefix": "ut"})
+
+        def fake_run(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "create namespace" in cmd:
+                return _ok()
+            if "get storageclass" in cmd:
+                return _fail(stderr='Error from server (NotFound): storageclasses.storage.k8s.io "nope" not found')
+            if "delete namespace" in cmd:
+                return _ok()
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with (
+            patch.object(check, "run_command", side_effect=fake_run),
+            patch("isvtest.validations.k8s_storage.time.sleep"),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["sc-exists[block]"]["passed"]
+        # Paired PVC subtest must be marked skipped so the failure isn't double-counted.
+        assert outcomes["pvc-binds[block]"]["skipped"]
+
+    def test_pvc_never_binds_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make({"block_storage_class": "gp3", "bind_timeout_s": 1, "namespace_prefix": "ut"})
+
+        def fake_run(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "create namespace" in cmd:
+                return _ok()
+            if "get storageclass" in cmd:
+                return _ok(stdout="storageclass.storage.k8s.io/gp3\n")
+            # Consumer pod never reaches Ready because the PVC stays Pending
+            # under WaitForFirstConsumer with no provisioner available.
+            if "wait --for=condition=Ready" in cmd:
+                return _fail(stderr="timed out waiting for the condition")
+            if "get pvc" in cmd:
+                return _ok(stdout="Pending")
+            if "delete namespace" in cmd:
+                return _ok()
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with (
+            patch.object(check, "run_command", side_effect=fake_run),
+            patch("isvtest.validations.k8s_storage.subprocess.run", return_value=_FakeProc(returncode=0)),
+            patch("isvtest.validations.k8s_storage.time.sleep"),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert outcomes["sc-exists[block]"]["passed"]
+        assert not outcomes["pvc-binds[block]"]["passed"]
+        assert "did not reach Bound" in outcomes["pvc-binds[block]"]["message"]
+
+    def test_pvc_apply_failure_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make({"block_storage_class": "gp3", "bind_timeout_s": 5, "namespace_prefix": "ut"})
+
+        def fake_run(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "create namespace" in cmd:
+                return _ok()
+            if "get storageclass" in cmd:
+                return _ok(stdout="storageclass.storage.k8s.io/gp3\n")
+            if "delete namespace" in cmd:
+                return _ok()
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with (
+            patch.object(check, "run_command", side_effect=fake_run),
+            patch(
+                "isvtest.validations.k8s_storage.subprocess.run",
+                return_value=_FakeProc(returncode=1, stderr="admission denied"),
+            ),
+            patch("isvtest.validations.k8s_storage.time.sleep"),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["pvc-binds[block]"]["passed"]
+        assert "kubectl apply failed" in outcomes["pvc-binds[block]"]["message"]
+
+    def test_kubectl_apply_timeout_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make({"block_storage_class": "gp3", "bind_timeout_s": 5, "namespace_prefix": "ut"})
+
+        def fake_run(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "create namespace" in cmd:
+                return _ok()
+            if "get storageclass" in cmd:
+                return _ok(stdout="storageclass.storage.k8s.io/gp3\n")
+            if "delete namespace" in cmd:
+                return _ok()
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with (
+            patch.object(check, "run_command", side_effect=fake_run),
+            patch(
+                "isvtest.validations.k8s_storage.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="kubectl", timeout=1),
+            ),
+            patch("isvtest.validations.k8s_storage.time.sleep"),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["pvc-binds[block]"]["passed"]
+
+    def test_namespace_create_failure_sets_failed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make({"block_storage_class": "gp3"})
+
+        def fake_run(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "create namespace" in cmd:
+                return _fail(stderr="forbidden")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with patch.object(check, "run_command", side_effect=fake_run):
+            check.run()
+
+        assert not check.passed
+        assert "Failed to create namespace" in check._error
+
+    def test_env_fallback_is_honoured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        monkeypatch.setenv("K8S_CSI_BLOCK_SC", "gp3-from-env")
+        check = self._make({"bind_timeout_s": 5, "namespace_prefix": "ut"})
+
+        seen: list[str] = []
+
+        def fake_run(cmd: str, timeout: int | None = None) -> CommandResult:
+            seen.append(cmd)
+            if "create namespace" in cmd:
+                return _ok()
+            if "get storageclass" in cmd:
+                return _ok(stdout="storageclass.storage.k8s.io/gp3-from-env\n")
+            if "wait --for=condition=Ready" in cmd:
+                return _ok()
+            if "get pvc" in cmd:
+                return _ok(stdout="Bound")
+            if "delete namespace" in cmd:
+                return _ok()
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with (
+            patch.object(check, "run_command", side_effect=fake_run),
+            patch("isvtest.validations.k8s_storage.subprocess.run", return_value=_FakeProc(returncode=0)),
+            patch("isvtest.validations.k8s_storage.time.sleep"),
+        ):
+            check.run()
+
+        assert check.passed
+        assert any("gp3-from-env" in c for c in seen)
+
+    def test_rendered_manifest_is_valid_yaml_with_overrides(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """End-to-end check that the applied manifest parses and carries the expected fields."""
+        self._stub_env(monkeypatch)
+        check = self._make(
+            {
+                "shared_fs_storage_class": "efs-sc",
+                "pvc_size": "3Gi",
+                "bind_timeout_s": 5,
+                "namespace_prefix": "ut",
+            }
+        )
+
+        captured: list[str] = []
+
+        def fake_run(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "create namespace" in cmd:
+                return _ok()
+            if "get storageclass" in cmd:
+                return _ok(stdout="storageclass.storage.k8s.io/efs-sc\n")
+            if "wait --for=condition=Ready" in cmd:
+                return _ok()
+            if "get pvc" in cmd:
+                return _ok(stdout="Bound")
+            if "delete namespace" in cmd:
+                return _ok()
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        def capture_apply(cmd: list[str], **kwargs: Any) -> _FakeProc:
+            captured.append(kwargs.get("input", ""))
+            return _FakeProc(returncode=0)
+
+        with (
+            patch.object(check, "run_command", side_effect=fake_run),
+            patch("isvtest.validations.k8s_storage.subprocess.run", side_effect=capture_apply),
+            patch("isvtest.validations.k8s_storage.time.sleep"),
+        ):
+            check.run()
+
+        assert check.passed
+        # Two applies per storage type (PVC, mount pod); find the PVC doc.
+        all_docs = [d for rendered in captured for d in yaml.safe_load_all(rendered) if d]
+        pvcs = [d for d in all_docs if d.get("kind") == "PersistentVolumeClaim"]
+        assert len(pvcs) == 1, f"expected exactly one rendered PVC, got {len(pvcs)}"
+        pvc = pvcs[0]
+        assert pvc["spec"]["storageClassName"] == "efs-sc"
+        assert pvc["spec"]["accessModes"] == ["ReadWriteMany"]
+        assert pvc["spec"]["resources"]["requests"]["storage"] == "3Gi"
+        assert pvc["metadata"]["namespace"].startswith("ut-")

--- a/isvtest/tests/test_k8s_storage.py
+++ b/isvtest/tests/test_k8s_storage.py
@@ -25,6 +25,10 @@ from isvtest.core.runners import CommandResult
 from isvtest.validations.k8s_storage import (
     K8sCsiStorageQuotaApiCheck,
     K8sCsiStorageTypesCheck,
+    K8sCsiTenantScopedCredentialsCheck,
+    _find_cluster_secret_grants,
+    _find_shared_cluster_marker,
+    _rule_grants_unrestricted_secrets,
     _set_pvc_fields,
     _set_resourcequota_fields,
 )
@@ -1084,3 +1088,656 @@ class TestK8sCsiStorageQuotaApiCheck:
         assert rq["kind"] == "ResourceQuota"
         assert rq["metadata"]["namespace"].startswith("ut-")
         assert rq["spec"]["hard"] == {"requests.storage": "10Gi", sc_key: "5Gi"}
+
+
+def _items_json(items: list[dict[str, Any]]) -> str:
+    """Wrap a list of objects in a ``kubectl get -o json`` ``items`` envelope."""
+    return json.dumps({"items": items})
+
+
+def _pod(
+    *,
+    name: str,
+    namespace: str = "kube-system",
+    images: list[str] | None = None,
+    service_account: str = "default",
+    volumes: list[dict[str, Any]] | None = None,
+    env_from_secrets: list[str] | None = None,
+    env_secret_keys: list[str] | None = None,
+    projected_secrets: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal Pod object with just the fields the check inspects."""
+    containers: list[dict[str, Any]] = []
+    for idx, image in enumerate(images or ["unrelated:latest"]):
+        container: dict[str, Any] = {"name": f"c{idx}", "image": image}
+        if env_from_secrets and idx == 0:
+            container["envFrom"] = [{"secretRef": {"name": s}} for s in env_from_secrets]
+        if env_secret_keys and idx == 0:
+            container["env"] = [
+                {"name": f"K{i}", "valueFrom": {"secretKeyRef": {"name": s, "key": "k"}}}
+                for i, s in enumerate(env_secret_keys)
+            ]
+        containers.append(container)
+    spec: dict[str, Any] = {
+        "containers": containers,
+        "serviceAccountName": service_account,
+    }
+    rendered_volumes = list(volumes or [])
+    if projected_secrets:
+        rendered_volumes.append(
+            {
+                "name": "projected",
+                "projected": {"sources": [{"secret": {"name": s}} for s in projected_secrets]},
+            }
+        )
+    if rendered_volumes:
+        spec["volumes"] = rendered_volumes
+    return {
+        "kind": "Pod",
+        "metadata": {"name": name, "namespace": namespace},
+        "spec": spec,
+    }
+
+
+def _pv_with_csi_secrets(
+    *,
+    name: str = "pv-1",
+    driver: str = "ebs.csi.aws.com",
+    secret_namespace: str | None = None,
+    secret_name: str | None = None,
+) -> dict[str, Any]:
+    """Build a PV carrying a ``spec.csi.nodePublishSecretRef`` if name/namespace given."""
+    csi: dict[str, Any] = {"driver": driver, "volumeHandle": "vol-1"}
+    if secret_name and secret_namespace:
+        csi["nodePublishSecretRef"] = {"name": secret_name, "namespace": secret_namespace}
+    return {
+        "kind": "PersistentVolume",
+        "metadata": {"name": name},
+        "spec": {"csi": csi, "capacity": {"storage": "1Gi"}},
+    }
+
+
+def _secret(
+    *,
+    name: str,
+    namespace: str,
+    labels: dict[str, str] | None = None,
+    annotations: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {"name": name, "namespace": namespace}
+    if labels:
+        metadata["labels"] = labels
+    if annotations:
+        metadata["annotations"] = annotations
+    return {"kind": "Secret", "metadata": metadata, "type": "Opaque"}
+
+
+def _crb(
+    *,
+    name: str,
+    cluster_role: str,
+    subject_namespace: str,
+    subject_name: str,
+) -> dict[str, Any]:
+    return {
+        "kind": "ClusterRoleBinding",
+        "metadata": {"name": name},
+        "roleRef": {"kind": "ClusterRole", "name": cluster_role, "apiGroup": "rbac.authorization.k8s.io"},
+        "subjects": [{"kind": "ServiceAccount", "namespace": subject_namespace, "name": subject_name}],
+    }
+
+
+def _cluster_role_secrets(
+    *,
+    name: str,
+    verbs: list[str] | None = None,
+    resource_names: list[str] | None = None,
+    resources: list[str] | None = None,
+    api_groups: list[str] | None = None,
+) -> dict[str, Any]:
+    rule: dict[str, Any] = {
+        "apiGroups": api_groups if api_groups is not None else [""],
+        "resources": resources if resources is not None else ["secrets"],
+        "verbs": verbs if verbs is not None else ["get", "list"],
+    }
+    if resource_names is not None:
+        rule["resourceNames"] = resource_names
+    return {
+        "kind": "ClusterRole",
+        "metadata": {"name": name},
+        "rules": [rule],
+    }
+
+
+class TestRuleGrantsUnrestrictedSecrets:
+    """Direct tests for ``_rule_grants_unrestricted_secrets``."""
+
+    def test_unrestricted_secrets_grant_flagged(self) -> None:
+        rule = {"apiGroups": [""], "resources": ["secrets"], "verbs": ["get", "list"]}
+        assert _rule_grants_unrestricted_secrets(rule) is True
+
+    def test_wildcard_resource_and_verb_flagged(self) -> None:
+        rule = {"apiGroups": ["*"], "resources": ["*"], "verbs": ["*"]}
+        assert _rule_grants_unrestricted_secrets(rule) is True
+
+    def test_resourcenames_restriction_not_flagged(self) -> None:
+        rule = {
+            "apiGroups": [""],
+            "resources": ["secrets"],
+            "verbs": ["get"],
+            "resourceNames": ["csi-creds"],
+        }
+        assert _rule_grants_unrestricted_secrets(rule) is False
+
+    def test_non_core_api_group_not_flagged(self) -> None:
+        rule = {"apiGroups": ["custom.example.com"], "resources": ["secrets"], "verbs": ["get"]}
+        assert _rule_grants_unrestricted_secrets(rule) is False
+
+    def test_unrelated_resource_not_flagged(self) -> None:
+        rule = {"apiGroups": [""], "resources": ["configmaps"], "verbs": ["get"]}
+        assert _rule_grants_unrestricted_secrets(rule) is False
+
+    def test_non_secret_verbs_not_flagged(self) -> None:
+        rule = {"apiGroups": [""], "resources": ["secrets"], "verbs": ["impersonate"]}
+        assert _rule_grants_unrestricted_secrets(rule) is False
+
+
+class TestFindSharedClusterMarker:
+    """Direct tests for ``_find_shared_cluster_marker``."""
+
+    def test_matching_label_flagged(self) -> None:
+        secret = _secret(name="s", namespace="kube-system", labels={"shared-across-clusters": "true"})
+        marker = _find_shared_cluster_marker(secret, [("shared-across-clusters", "true")])
+        assert "shared-across-clusters=true" in marker
+
+    def test_label_with_empty_value_matches_any_value(self) -> None:
+        secret = _secret(name="s", namespace="kube-system", labels={"tenant": "shared-cluster-a"})
+        marker = _find_shared_cluster_marker(secret, [("tenant", "")])
+        assert "tenant" in marker
+
+    def test_shared_annotation_flagged(self) -> None:
+        secret = _secret(
+            name="s",
+            namespace="kube-system",
+            annotations={"csi.nvidia.com/shared": "true"},
+        )
+        assert "csi.nvidia.com/shared" in _find_shared_cluster_marker(secret, [])
+
+    def test_clean_secret_returns_empty(self) -> None:
+        secret = _secret(name="s", namespace="kube-system", labels={"app": "ebs-csi"})
+        assert _find_shared_cluster_marker(secret, [("shared-across-clusters", "true")]) == ""
+
+
+class TestFindClusterSecretGrants:
+    """Direct tests for ``_find_cluster_secret_grants``."""
+
+    def test_matching_cluster_role_flagged(self) -> None:
+        bindings = [_crb(name="crb-1", cluster_role="cr-1", subject_namespace="kube-system", subject_name="sa-1")]
+        roles = {"cr-1": _cluster_role_secrets(name="cr-1")}
+        viols = _find_cluster_secret_grants(bindings, roles, {("kube-system", "sa-1")})
+        assert len(viols) == 1
+        assert "crb-1" in viols[0]
+
+    def test_other_sa_not_flagged(self) -> None:
+        bindings = [_crb(name="crb-1", cluster_role="cr-1", subject_namespace="default", subject_name="other")]
+        roles = {"cr-1": _cluster_role_secrets(name="cr-1")}
+        assert _find_cluster_secret_grants(bindings, roles, {("kube-system", "sa-1")}) == []
+
+    def test_resourcenames_restriction_not_flagged(self) -> None:
+        bindings = [_crb(name="crb-1", cluster_role="cr-1", subject_namespace="kube-system", subject_name="sa-1")]
+        roles = {"cr-1": _cluster_role_secrets(name="cr-1", resource_names=["csi-creds"])}
+        assert _find_cluster_secret_grants(bindings, roles, {("kube-system", "sa-1")}) == []
+
+    def test_missing_role_is_ignored(self) -> None:
+        bindings = [_crb(name="crb-1", cluster_role="cr-missing", subject_namespace="kube-system", subject_name="sa-1")]
+        assert _find_cluster_secret_grants(bindings, {}, {("kube-system", "sa-1")}) == []
+
+
+class TestK8sCsiTenantScopedCredentialsCheck:
+    """Tests for ``K8sCsiTenantScopedCredentialsCheck``."""
+
+    def _make(self, config: dict[str, Any] | None = None) -> K8sCsiTenantScopedCredentialsCheck:
+        return K8sCsiTenantScopedCredentialsCheck(config=config or {})
+
+    def _router(
+        self,
+        *,
+        csi_drivers: list[dict[str, Any]],
+        pods_by_ns: dict[str, list[dict[str, Any]]],
+        pvs: list[dict[str, Any]],
+        secrets_by_ref: dict[tuple[str, str], dict[str, Any] | None] | None = None,
+        missing_secret_refs: set[tuple[str, str]] | None = None,
+        cluster_role_bindings: list[dict[str, Any]] | None = None,
+        cluster_roles: list[dict[str, Any]] | None = None,
+        fail_on: str | None = None,
+    ) -> Any:
+        """Build a ``run_command`` side_effect that answers every kubectl query the check issues.
+
+        ``fail_on`` forces a non-zero exit on the named command substring so
+        we can exercise top-level error paths (e.g. ``"get csidriver"``,
+        ``"get pv -o"``). ``secrets_by_ref`` maps (namespace, name) to a
+        Secret object; a value of ``None`` simulates a Forbidden fetch.
+        ``missing_secret_refs`` simulates a Secret that does not exist —
+        with ``--ignore-not-found=true`` kubectl returns rc=0 and empty
+        stdout, which maps to the check's ``"missing"`` status.
+        """
+        secrets_by_ref = secrets_by_ref or {}
+        missing_secret_refs = missing_secret_refs or set()
+        cluster_role_bindings = cluster_role_bindings or []
+        cluster_roles = cluster_roles or []
+
+        def _route(cmd: str, timeout: int | None = None) -> CommandResult:
+            if fail_on and fail_on in cmd:
+                return _fail(stderr="boom")
+            if "get csidriver -o json" in cmd:
+                return _ok(stdout=_items_json(csi_drivers))
+            if "get pods -n " in cmd and "-o json" in cmd:
+                # Extract the namespace from the quoted `-n '<ns>'` fragment.
+                # shlex.quote renders most identifiers without quoting, so
+                # fall back to a simple split on whitespace.
+                parts = cmd.split()
+                ns = ""
+                for i, part in enumerate(parts):
+                    if part == "-n" and i + 1 < len(parts):
+                        ns = parts[i + 1].strip("'\"")
+                        break
+                return _ok(stdout=_items_json(pods_by_ns.get(ns, [])))
+            if cmd.rstrip().endswith("get pv -o json"):
+                return _ok(stdout=_items_json(pvs))
+            if "get secret " in cmd and "-o json" in cmd:
+                # Parse out `secret <name> -n <ns>`.
+                parts = cmd.split()
+                name = ""
+                ns = ""
+                for i, part in enumerate(parts):
+                    if part == "secret" and i + 1 < len(parts):
+                        name = parts[i + 1].strip("'\"")
+                    if part == "-n" and i + 1 < len(parts):
+                        ns = parts[i + 1].strip("'\"")
+                if (ns, name) in missing_secret_refs:
+                    # `--ignore-not-found=true` returns rc=0 + empty stdout.
+                    return _ok(stdout="")
+                secret = secrets_by_ref.get((ns, name))
+                if secret is None and (ns, name) in secrets_by_ref:
+                    return _fail(stderr="forbidden")
+                if secret is None:
+                    # Unknown Secret: return a minimal clean object.
+                    return _ok(stdout=json.dumps(_secret(name=name, namespace=ns)))
+                return _ok(stdout=json.dumps(secret))
+            if "get clusterrolebinding -o json" in cmd:
+                return _ok(stdout=_items_json(cluster_role_bindings))
+            if "get clusterrole -o json" in cmd:
+                return _ok(stdout=_items_json(cluster_roles))
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        return _route
+
+    # ----- tests -----
+
+    def test_no_csi_drivers_skips_all_subtests(self) -> None:
+        check = self._make({})
+        with patch.object(check, "run_command", side_effect=self._router(csi_drivers=[], pods_by_ns={}, pvs=[])):
+            check.run()
+
+        assert check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        for name in (
+            "csi-secrets-discovered",
+            "secrets-not-cross-namespace",
+            "no-shared-cluster-markers",
+            "serviceaccount-rbac-scoped",
+            "node-plugin-uses-hostpath-not-shared-mount",
+        ):
+            assert outcomes[name]["skipped"], name
+
+    def test_happy_path_no_secret_refs(self) -> None:
+        """Clean cluster: one CSI driver, node-plugin + controller pods with no Secret refs."""
+        check = self._make({})
+        csi_drivers = [{"kind": "CSIDriver", "metadata": {"name": "ebs.csi.aws.com"}}]
+        pods = [
+            _pod(
+                name="ebs-csi-controller-abc",
+                namespace="kube-system",
+                images=["public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1", "csi-provisioner:v4"],
+                service_account="ebs-csi-controller-sa",
+            ),
+            _pod(
+                name="ebs-csi-node-xyz",
+                namespace="kube-system",
+                images=["public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1", "csi-node-driver-registrar:v2"],
+                service_account="ebs-csi-node-sa",
+                volumes=[
+                    {"name": "plugin-dir", "hostPath": {"path": "/var/lib/kubelet/plugins"}},
+                    {"name": "scratch", "emptyDir": {}},
+                ],
+            ),
+        ]
+        pvs = [_pv_with_csi_secrets()]  # No SecretRefs.
+        crbs = [
+            _crb(
+                name="ebs-csi-provisioner",
+                cluster_role="external-provisioner",
+                subject_namespace="kube-system",
+                subject_name="ebs-csi-controller-sa",
+            )
+        ]
+        # Provisioner role grants events, not unrestricted secrets.
+        croles = [
+            {
+                "kind": "ClusterRole",
+                "metadata": {"name": "external-provisioner"},
+                "rules": [
+                    {"apiGroups": [""], "resources": ["events"], "verbs": ["create", "patch"]},
+                    {
+                        "apiGroups": [""],
+                        "resources": ["secrets"],
+                        "verbs": ["get"],
+                        "resourceNames": ["ebs-csi-creds"],
+                    },
+                ],
+            }
+        ]
+
+        with patch.object(
+            check,
+            "run_command",
+            side_effect=self._router(
+                csi_drivers=csi_drivers,
+                pods_by_ns={"kube-system": pods},
+                pvs=pvs,
+                cluster_role_bindings=crbs,
+                cluster_roles=croles,
+            ),
+        ):
+            check.run()
+
+        assert check.passed, check._error
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        for name in (
+            "csi-secrets-discovered",
+            "secrets-not-cross-namespace",
+            "no-shared-cluster-markers",
+            "serviceaccount-rbac-scoped",
+            "node-plugin-uses-hostpath-not-shared-mount",
+        ):
+            assert outcomes[name]["passed"], f"{name}: {outcomes[name]['message']}"
+
+    def test_cross_namespace_secret_reference_fails(self) -> None:
+        check = self._make({})
+        csi_drivers = [{"kind": "CSIDriver", "metadata": {"name": "custom.csi.example.com"}}]
+        pods = [
+            _pod(
+                name="csi-node",
+                images=["csi-node-driver-registrar:v2"],
+                volumes=[{"name": "plugin-dir", "hostPath": {"path": "/var/lib/kubelet/plugins"}}],
+            )
+        ]
+        # PV references a Secret in the "default" namespace — a workload ns.
+        pvs = [_pv_with_csi_secrets(secret_namespace="default", secret_name="exposed-creds")]
+        with patch.object(
+            check,
+            "run_command",
+            side_effect=self._router(csi_drivers=csi_drivers, pods_by_ns={"kube-system": pods}, pvs=pvs),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["secrets-not-cross-namespace"]["passed"]
+        assert "default/exposed-creds" in outcomes["secrets-not-cross-namespace"]["message"]
+
+    def test_allowed_workload_namespace_accepts_secret(self) -> None:
+        check = self._make({"allowed_workload_namespaces": ["csi-tenant-a"]})
+        csi_drivers = [{"kind": "CSIDriver", "metadata": {"name": "x"}}]
+        pods = [_pod(name="csi-node", images=["csi-node-driver-registrar:v2"])]
+        pvs = [_pv_with_csi_secrets(secret_namespace="csi-tenant-a", secret_name="tenant-creds")]
+        with patch.object(
+            check,
+            "run_command",
+            side_effect=self._router(csi_drivers=csi_drivers, pods_by_ns={"kube-system": pods}, pvs=pvs),
+        ):
+            check.run()
+
+        assert check.passed, check._error
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert outcomes["secrets-not-cross-namespace"]["passed"]
+
+    def test_shared_cluster_label_on_secret_fails(self) -> None:
+        check = self._make({})
+        csi_drivers = [{"kind": "CSIDriver", "metadata": {"name": "x"}}]
+        pods = [
+            _pod(
+                name="csi-controller",
+                images=["csi-provisioner:v4"],
+                service_account="csi-controller-sa",
+                env_from_secrets=["csi-creds"],
+            ),
+            _pod(name="csi-node", images=["csi-node-driver-registrar:v2"]),
+        ]
+        pvs: list[dict[str, Any]] = []
+        secrets = {
+            ("kube-system", "csi-creds"): _secret(
+                name="csi-creds",
+                namespace="kube-system",
+                labels={"shared-across-clusters": "true"},
+            )
+        }
+        with patch.object(
+            check,
+            "run_command",
+            side_effect=self._router(
+                csi_drivers=csi_drivers,
+                pods_by_ns={"kube-system": pods},
+                pvs=pvs,
+                secrets_by_ref=secrets,
+            ),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["no-shared-cluster-markers"]["passed"]
+        assert "shared-across-clusters" in outcomes["no-shared-cluster-markers"]["message"]
+
+    def test_unrestricted_cluster_secret_grant_fails(self) -> None:
+        check = self._make({})
+        csi_drivers = [{"kind": "CSIDriver", "metadata": {"name": "x"}}]
+        pods = [
+            _pod(
+                name="csi-controller",
+                images=["csi-provisioner:v4"],
+                service_account="csi-controller-sa",
+            ),
+            _pod(name="csi-node", images=["csi-node-driver-registrar:v2"]),
+        ]
+        pvs: list[dict[str, Any]] = []
+        crbs = [
+            _crb(
+                name="csi-secret-reader",
+                cluster_role="cluster-wide-secrets",
+                subject_namespace="kube-system",
+                subject_name="csi-controller-sa",
+            )
+        ]
+        croles = [_cluster_role_secrets(name="cluster-wide-secrets", verbs=["get", "list", "watch"])]
+        with patch.object(
+            check,
+            "run_command",
+            side_effect=self._router(
+                csi_drivers=csi_drivers,
+                pods_by_ns={"kube-system": pods},
+                pvs=pvs,
+                cluster_role_bindings=crbs,
+                cluster_roles=croles,
+            ),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["serviceaccount-rbac-scoped"]["passed"]
+        assert "csi-secret-reader" in outcomes["serviceaccount-rbac-scoped"]["message"]
+
+    def test_node_plugin_with_persistent_volume_claim_fails(self) -> None:
+        check = self._make({})
+        csi_drivers = [{"kind": "CSIDriver", "metadata": {"name": "x"}}]
+        pods = [
+            _pod(
+                name="csi-node",
+                images=["csi-node-driver-registrar:v2"],
+                volumes=[
+                    {"name": "plugin-dir", "hostPath": {"path": "/var/lib/kubelet/plugins"}},
+                    {
+                        "name": "shared-state",
+                        "persistentVolumeClaim": {"claimName": "shared-pvc"},
+                    },
+                ],
+            )
+        ]
+        with patch.object(
+            check,
+            "run_command",
+            side_effect=self._router(csi_drivers=csi_drivers, pods_by_ns={"kube-system": pods}, pvs=[]),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["node-plugin-uses-hostpath-not-shared-mount"]["passed"]
+        assert "persistentVolumeClaim" in outcomes["node-plugin-uses-hostpath-not-shared-mount"]["message"]
+
+    def test_no_node_plugin_skips_mount_check(self) -> None:
+        check = self._make({})
+        csi_drivers = [{"kind": "CSIDriver", "metadata": {"name": "x"}}]
+        # Only a controller pod — no node-plugin.
+        pods = [
+            _pod(
+                name="csi-controller",
+                images=["csi-provisioner:v4"],
+                service_account="csi-controller-sa",
+            )
+        ]
+        with patch.object(
+            check,
+            "run_command",
+            side_effect=self._router(csi_drivers=csi_drivers, pods_by_ns={"kube-system": pods}, pvs=[]),
+        ):
+            check.run()
+
+        assert check.passed, check._error
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert outcomes["node-plugin-uses-hostpath-not-shared-mount"]["skipped"]
+
+    def test_csidriver_list_failure_sets_failed(self) -> None:
+        check = self._make({})
+        with patch.object(
+            check,
+            "run_command",
+            side_effect=self._router(csi_drivers=[], pods_by_ns={}, pvs=[], fail_on="get csidriver"),
+        ):
+            check.run()
+
+        assert not check.passed
+        assert "Failed to list CSIDriver" in check._error
+
+    def test_secret_fetch_forbidden_is_surfaced(self) -> None:
+        check = self._make({})
+        csi_drivers = [{"kind": "CSIDriver", "metadata": {"name": "x"}}]
+        pods = [
+            _pod(
+                name="csi-controller",
+                images=["csi-provisioner:v4"],
+                env_from_secrets=["csi-creds"],
+            ),
+            _pod(name="csi-node", images=["csi-node-driver-registrar:v2"]),
+        ]
+        # Record the ref as known but mark the fetch itself as forbidden.
+        secrets: dict[tuple[str, str], dict[str, Any] | None] = {("kube-system", "csi-creds"): None}
+        with patch.object(
+            check,
+            "run_command",
+            side_effect=self._router(
+                csi_drivers=csi_drivers,
+                pods_by_ns={"kube-system": pods},
+                pvs=[],
+                secrets_by_ref=secrets,
+            ),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["no-shared-cluster-markers"]["passed"]
+        assert "unreadable" in outcomes["no-shared-cluster-markers"]["message"]
+
+    def test_dangling_envfrom_secret_ref_does_not_fail(self) -> None:
+        """An envFrom Secret ref that does not exist (EKS with IRSA) must not fail the check.
+
+        The AWS EFS/EBS CSI drivers ship with an optional ``envFrom.secretRef: aws-secret``
+        on the controller pod; when the cluster uses IRSA / workload identity
+        the Secret is never created. ``kubectl get secret --ignore-not-found``
+        returns rc=0 and empty stdout, which maps to the ``"missing"`` status
+        and must be treated as non-failure.
+        """
+        check = self._make({})
+        csi_drivers = [{"kind": "CSIDriver", "metadata": {"name": "efs.csi.aws.com"}}]
+        # Realistic EKS EFS controller: the driver container sits alongside
+        # the csi-provisioner sidecar that makes this pod recognisable as a
+        # CSI controller. The aws-secret envFrom on the controller is
+        # optional — omitted on clusters using IRSA.
+        pods = [
+            _pod(
+                name="efs-csi-controller",
+                images=["aws-efs-csi-driver:v2", "csi-provisioner:v4"],
+                env_from_secrets=["aws-secret"],
+            ),
+            _pod(
+                name="efs-csi-node",
+                images=["csi-node-driver-registrar:v2"],
+                volumes=[{"name": "plugin", "hostPath": {"path": "/var/lib/kubelet/plugins"}}],
+            ),
+        ]
+        with patch.object(
+            check,
+            "run_command",
+            side_effect=self._router(
+                csi_drivers=csi_drivers,
+                pods_by_ns={"kube-system": pods},
+                pvs=[],
+                missing_secret_refs={("kube-system", "aws-secret")},
+            ),
+        ):
+            check.run()
+
+        assert check.passed, check._error
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert outcomes["no-shared-cluster-markers"]["passed"]
+        assert "kube-system/aws-secret" in outcomes["no-shared-cluster-markers"]["message"]
+        assert "do not exist" in outcomes["no-shared-cluster-markers"]["message"]
+
+    def test_projected_secret_volume_is_discovered(self) -> None:
+        check = self._make({})
+        csi_drivers = [{"kind": "CSIDriver", "metadata": {"name": "x"}}]
+        pods = [
+            _pod(
+                name="csi-controller",
+                images=["csi-provisioner:v4"],
+                service_account="csi-controller-sa",
+                projected_secrets=["proj-secret"],
+            ),
+            _pod(
+                name="csi-node",
+                images=["csi-node-driver-registrar:v2"],
+                volumes=[{"name": "plugin", "hostPath": {"path": "/var/lib/kubelet/plugins"}}],
+            ),
+        ]
+        with patch.object(
+            check,
+            "run_command",
+            side_effect=self._router(csi_drivers=csi_drivers, pods_by_ns={"kube-system": pods}, pvs=[]),
+        ):
+            check.run()
+
+        assert check.passed, check._error
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert "proj-secret" in outcomes["csi-secrets-discovered"]["message"]

--- a/isvtest/tests/test_k8s_storage.py
+++ b/isvtest/tests/test_k8s_storage.py
@@ -23,12 +23,15 @@ import yaml
 
 from isvtest.core.runners import CommandResult
 from isvtest.validations.k8s_storage import (
+    K8sCsiProvisioningModesCheck,
     K8sCsiStorageQuotaApiCheck,
     K8sCsiStorageTypesCheck,
     K8sCsiTenantScopedCredentialsCheck,
     _find_cluster_secret_grants,
     _find_shared_cluster_marker,
     _rule_grants_unrestricted_secrets,
+    _set_mount_pod_fields,
+    _set_pv_fields,
     _set_pvc_fields,
     _set_resourcequota_fields,
 )
@@ -1741,3 +1744,328 @@ class TestK8sCsiTenantScopedCredentialsCheck:
         assert check.passed, check._error
         outcomes = {r["name"]: r for r in check._subtest_results}
         assert "proj-secret" in outcomes["csi-secrets-discovered"]["message"]
+
+
+class TestSetPvFields:
+    """Tests for ``_set_pv_fields`` — the static PV mutator."""
+
+    def _base_doc(self) -> dict[str, Any]:
+        return {
+            "apiVersion": "v1",
+            "kind": "PersistentVolume",
+            "metadata": {"name": "placeholder"},
+            "spec": {
+                "capacity": {"storage": "1Gi"},
+                "accessModes": ["ReadWriteOnce"],
+                "persistentVolumeReclaimPolicy": "Retain",
+                "storageClassName": "",
+                "csi": {"driver": "placeholder", "volumeHandle": "placeholder", "fsType": "ext4"},
+            },
+        }
+
+    def test_overrides_all_fields(self) -> None:
+        doc = self._base_doc()
+        out = _set_pv_fields(
+            doc,
+            name="pv-x",
+            driver="ebs.csi.aws.com",
+            volume_handle="vol-abc",
+            fs_type="xfs",
+            capacity="5Gi",
+            access_mode="ReadWriteOnce",
+            claim_namespace="ns1",
+            claim_name="pvc-x",
+        )
+        assert out["metadata"]["name"] == "pv-x"
+        assert out["spec"]["capacity"] == {"storage": "5Gi"}
+        assert out["spec"]["accessModes"] == ["ReadWriteOnce"]
+        assert out["spec"]["persistentVolumeReclaimPolicy"] == "Retain"
+        assert out["spec"]["storageClassName"] == ""
+        assert out["spec"]["csi"] == {"driver": "ebs.csi.aws.com", "volumeHandle": "vol-abc", "fsType": "xfs"}
+        assert out["spec"]["claimRef"] == {"namespace": "ns1", "name": "pvc-x"}
+
+    def test_missing_sections_are_created(self) -> None:
+        out = _set_pv_fields(
+            {},
+            name="pv-y",
+            driver="d",
+            volume_handle="vh",
+            fs_type="ext4",
+            capacity="1Gi",
+            access_mode="ReadWriteOnce",
+            claim_namespace="ns",
+            claim_name="pvc",
+        )
+        assert out["metadata"]["name"] == "pv-y"
+        assert out["spec"]["csi"]["volumeHandle"] == "vh"
+        assert out["spec"]["claimRef"]["name"] == "pvc"
+
+
+class TestSetMountPodFields:
+    """Tests for ``_set_mount_pod_fields`` — the BusyBox mount-pod mutator."""
+
+    def _base_doc(self) -> dict[str, Any]:
+        return {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {"name": "placeholder", "namespace": "placeholder"},
+            "spec": {
+                "restartPolicy": "Never",
+                "containers": [
+                    {
+                        "name": "probe",
+                        "image": "busybox:1.36",
+                        "command": ["sh", "-c", "sleep 3600"],
+                        "volumeMounts": [{"name": "data", "mountPath": "/data"}],
+                    }
+                ],
+                "volumes": [{"name": "data", "persistentVolumeClaim": {"claimName": "placeholder"}}],
+            },
+        }
+
+    def test_sets_name_namespace_and_pvc(self) -> None:
+        out = _set_mount_pod_fields(self._base_doc(), namespace="ns1", name="probe-1", pvc_name="pvc-1")
+        assert out["metadata"]["name"] == "probe-1"
+        assert out["metadata"]["namespace"] == "ns1"
+        assert out["spec"]["volumes"][0]["persistentVolumeClaim"] == {"claimName": "pvc-1"}
+        # volumeMounts inside the container are template-defined; the mutator
+        # only touches volumes so the mount path stays /data as documented.
+        assert out["spec"]["containers"][0]["volumeMounts"][0]["mountPath"] == "/data"
+
+
+class TestK8sCsiProvisioningModesCheck:
+    """Tests for ``K8sCsiProvisioningModesCheck``."""
+
+    _CANARY_PATTERN = "csi-prov-"
+
+    def _make(self, config: dict[str, Any] | None = None) -> K8sCsiProvisioningModesCheck:
+        return K8sCsiProvisioningModesCheck(config=config or {})
+
+    def _stub_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in ("K8S_CSI_BLOCK_SC", "K8S_CSI_SHARED_FS_SC", "K8S_CSI_NFS_SC"):
+            monkeypatch.delenv(var, raising=False)
+
+    def _pv_payload(self, driver: str = "ebs.csi.aws.com") -> str:
+        return json.dumps({"spec": {"csi": {"driver": driver}, "capacity": {"storage": "1Gi"}}})
+
+    def _make_router(
+        self,
+        *,
+        phase: str = "Bound",
+        volume_name: str = "pv-dyn-xyz",
+        pv_payload: str | None = None,
+        wait_exit: int = 0,
+        write_exit: int = 0,
+        read_exit: int = 0,
+        read_stdout_transform=None,
+    ):
+        """Build a ``run_command`` side-effect router covering every kubectl call.
+
+        The router keeps the last canary value it saw on a write, so the
+        read-side can echo it back (simulating the pod having persisted the
+        file); override by passing ``read_stdout_transform``.
+        """
+        state = {"canary": ""}
+        pv_json = pv_payload if pv_payload is not None else self._pv_payload()
+
+        def router(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "create namespace" in cmd:
+                return _ok()
+            if "delete namespace" in cmd or "delete pv" in cmd:
+                return _ok()
+            if "get pvc" in cmd and ".status.phase" in cmd:
+                return _ok(stdout=phase)
+            if "get pvc" in cmd and ".spec.volumeName" in cmd:
+                return _ok(stdout=volume_name)
+            if "get pv" in cmd and "-o json" in cmd:
+                return _ok(stdout=pv_json)
+            if "wait --for=condition=Ready" in cmd:
+                return _ok() if wait_exit == 0 else _fail(exit_code=wait_exit, stderr="timeout")
+            if "exec" in cmd and "echo " in cmd:
+                # Parse out the canary value so the read-side can return it.
+                # Command form: ... -- sh -c 'echo csi-prov-<hex> > /data/canary.txt'
+                import re
+
+                m = re.search(r"echo (?:'|\")?(csi-prov-[0-9a-f]+)(?:'|\")? > /data/canary\.txt", cmd)
+                if m:
+                    state["canary"] = m.group(1)
+                return _ok() if write_exit == 0 else _fail(exit_code=write_exit, stderr="write failed")
+            if "exec" in cmd and "cat /data/canary.txt" in cmd:
+                if read_exit != 0:
+                    return _fail(exit_code=read_exit, stderr="read failed")
+                stdout = state["canary"] if read_stdout_transform is None else read_stdout_transform(state["canary"])
+                return _ok(stdout=stdout)
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        return router
+
+    def test_no_dynamic_sc_configured_skips_without_work(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make({})
+        with patch.object(check, "run_command") as mock_run:
+            check.run()
+        mock_run.assert_not_called()
+        assert check.passed
+        assert "Skipped" in check._output
+        assert "dynamic_storage_class" in check._output
+
+    def test_dynamic_happy_path_static_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make(
+            {
+                "dynamic_storage_class": "gp3",
+                "bind_timeout_s": 5,
+                "namespace_prefix": "ut",
+            }
+        )
+        with (
+            patch.object(check, "run_command", side_effect=self._make_router()),
+            patch("isvtest.validations.k8s_storage.subprocess.run", return_value=_FakeProc(returncode=0)),
+            _patched_clock(),
+        ):
+            check.run()
+
+        assert check.passed, check._error
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert outcomes["dynamic"]["passed"]
+        assert outcomes["static"].get("skipped")
+        assert "static_pv.volume_handle" in outcomes["static"]["message"]
+
+    def test_dynamic_pvc_never_binds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make({"dynamic_storage_class": "gp3", "bind_timeout_s": 5, "namespace_prefix": "ut"})
+        with (
+            patch.object(check, "run_command", side_effect=self._make_router(phase="Pending")),
+            patch("isvtest.validations.k8s_storage.subprocess.run", return_value=_FakeProc(returncode=0)),
+            _patched_clock(),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["dynamic"]["passed"]
+        assert "did not reach Bound" in outcomes["dynamic"]["message"]
+
+    def test_dynamic_pv_missing_csi_driver(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make({"dynamic_storage_class": "gp3", "bind_timeout_s": 5, "namespace_prefix": "ut"})
+        empty_pv = json.dumps({"spec": {"csi": {}, "capacity": {"storage": "1Gi"}}})
+        with (
+            patch.object(check, "run_command", side_effect=self._make_router(pv_payload=empty_pv)),
+            patch("isvtest.validations.k8s_storage.subprocess.run", return_value=_FakeProc(returncode=0)),
+            _patched_clock(),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["dynamic"]["passed"]
+        assert "spec.csi.driver" in outcomes["dynamic"]["message"]
+
+    def test_dynamic_canary_mismatch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make({"dynamic_storage_class": "gp3", "bind_timeout_s": 5, "namespace_prefix": "ut"})
+        router = self._make_router(read_stdout_transform=lambda _: "not-the-canary")
+        with (
+            patch.object(check, "run_command", side_effect=router),
+            patch("isvtest.validations.k8s_storage.subprocess.run", return_value=_FakeProc(returncode=0)),
+            _patched_clock(),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["dynamic"]["passed"]
+        assert "canary write/read failed" in outcomes["dynamic"]["message"]
+
+    def test_static_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make(
+            {
+                "dynamic_storage_class": "gp3",
+                "static_pv": {
+                    "volume_handle": "vol-0abc",
+                    "csi_driver": "ebs.csi.aws.com",
+                    "capacity": "1Gi",
+                    "access_mode": "ReadWriteOnce",
+                },
+                "bind_timeout_s": 5,
+                "namespace_prefix": "ut",
+            }
+        )
+        delete_pv_cmds: list[str] = []
+        router = self._make_router()
+
+        def spy(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "delete pv " in cmd:
+                delete_pv_cmds.append(cmd)
+            return router(cmd, timeout)
+
+        with (
+            patch.object(check, "run_command", side_effect=spy),
+            patch("isvtest.validations.k8s_storage.subprocess.run", return_value=_FakeProc(returncode=0)),
+            _patched_clock(),
+        ):
+            check.run()
+
+        assert check.passed, check._error
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert outcomes["dynamic"]["passed"]
+        assert outcomes["static"]["passed"]
+        assert "vol-0abc" in outcomes["static"]["message"]
+        # Cleanup must delete the cluster-scoped PV even on success so the
+        # next run can re-apply its own PV against the same volume handle.
+        assert any("delete pv" in c for c in delete_pv_cmds), "static PV was not cleaned up"
+
+    def test_static_subprocess_failure_on_pv_apply(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A non-zero exit from ``kubectl apply`` for the static PV fails the static subtest only."""
+        self._stub_env(monkeypatch)
+        check = self._make(
+            {
+                "dynamic_storage_class": "gp3",
+                "static_pv": {
+                    "volume_handle": "vol-0abc",
+                    "csi_driver": "ebs.csi.aws.com",
+                },
+                "bind_timeout_s": 5,
+                "namespace_prefix": "ut",
+            }
+        )
+
+        def fake_subprocess(*args, **kwargs):
+            # Dispatch off the manifest YAML so the failure is specific to
+            # the static PV apply (which is the only document containing
+            # ``persistentVolumeReclaimPolicy: Retain``).
+            manifest = kwargs.get("input") or ""
+            if "persistentVolumeReclaimPolicy: Retain" in manifest:
+                return _FakeProc(returncode=1, stderr="forbidden: PersistentVolumes already exist")
+            return _FakeProc(returncode=0)
+
+        with (
+            patch.object(check, "run_command", side_effect=self._make_router()),
+            patch("isvtest.validations.k8s_storage.subprocess.run", side_effect=fake_subprocess),
+            _patched_clock(),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert outcomes["dynamic"]["passed"]
+        assert not outcomes["static"]["passed"]
+        assert "kubectl apply failed for PV" in outcomes["static"]["message"]
+
+    def test_namespace_create_failure_fails_check_without_subtests(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make({"dynamic_storage_class": "gp3", "namespace_prefix": "ut"})
+
+        def fake_run(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "create namespace" in cmd:
+                return _fail(stderr="forbidden")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with patch.object(check, "run_command", side_effect=fake_run):
+            check.run()
+
+        assert not check.passed
+        assert "Failed to create namespace" in check._error
+        assert check._subtest_results == []

--- a/isvtest/tests/test_k8s_storage.py
+++ b/isvtest/tests/test_k8s_storage.py
@@ -12,7 +12,9 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
+from contextlib import contextmanager
 from typing import Any
 from unittest.mock import patch
 
@@ -21,8 +23,10 @@ import yaml
 
 from isvtest.core.runners import CommandResult
 from isvtest.validations.k8s_storage import (
+    K8sCsiStorageQuotaApiCheck,
     K8sCsiStorageTypesCheck,
     _set_pvc_fields,
+    _set_resourcequota_fields,
 )
 
 
@@ -43,6 +47,42 @@ class _FakeProc:
         self.returncode = returncode
         self.stdout = stdout
         self.stderr = stderr
+
+
+class _FakeClock:
+    """Tiny fake clock — advances on each ``sleep`` call.
+
+    Used to keep poll loops from burning real wall-clock time under mocked
+    ``run_command`` / ``subprocess.run``: without it, patching only ``time.sleep``
+    makes the deadline-based loops spin for ``timeout_s`` seconds of real time.
+    Patch both ``time.sleep`` and ``time.time`` onto this instance's methods.
+    """
+
+    def __init__(self, start: float = 0.0) -> None:
+        self._now = float(start)
+
+    def time(self) -> float:
+        return self._now
+
+    def sleep(self, seconds: float) -> None:
+        self._now += float(seconds)
+
+
+@contextmanager
+def _patched_clock() -> Any:
+    """Patch ``k8s_storage.time.sleep`` and ``k8s_storage.time.time`` with a ``_FakeClock``.
+
+    Without patching ``time.time`` as well, deadline-based poll loops would
+    spin for ``timeout_s`` seconds of real wall clock even when ``sleep`` is
+    a no-op. Using a single fake clock for both keeps the tests in-process
+    and deterministic.
+    """
+    clock = _FakeClock()
+    with (
+        patch("isvtest.validations.k8s_storage.time.sleep", side_effect=clock.sleep),
+        patch("isvtest.validations.k8s_storage.time.time", side_effect=clock.time),
+    ):
+        yield clock
 
 
 class TestSetPvcFields:
@@ -130,7 +170,7 @@ class TestK8sCsiStorageTypesCheck:
         with (
             patch.object(check, "run_command", side_effect=fake_run),
             patch("isvtest.validations.k8s_storage.subprocess.run", return_value=_FakeProc(returncode=0)),
-            patch("isvtest.validations.k8s_storage.time.sleep"),
+            _patched_clock(),
         ):
             check.run()
 
@@ -166,7 +206,7 @@ class TestK8sCsiStorageTypesCheck:
         with (
             patch.object(check, "run_command", side_effect=fake_run),
             patch("isvtest.validations.k8s_storage.subprocess.run", return_value=_FakeProc(returncode=0)),
-            patch("isvtest.validations.k8s_storage.time.sleep"),
+            _patched_clock(),
         ):
             check.run()
 
@@ -193,7 +233,7 @@ class TestK8sCsiStorageTypesCheck:
 
         with (
             patch.object(check, "run_command", side_effect=fake_run),
-            patch("isvtest.validations.k8s_storage.time.sleep"),
+            _patched_clock(),
         ):
             check.run()
 
@@ -225,7 +265,7 @@ class TestK8sCsiStorageTypesCheck:
         with (
             patch.object(check, "run_command", side_effect=fake_run),
             patch("isvtest.validations.k8s_storage.subprocess.run", return_value=_FakeProc(returncode=0)),
-            patch("isvtest.validations.k8s_storage.time.sleep"),
+            _patched_clock(),
         ):
             check.run()
 
@@ -254,7 +294,7 @@ class TestK8sCsiStorageTypesCheck:
                 "isvtest.validations.k8s_storage.subprocess.run",
                 return_value=_FakeProc(returncode=1, stderr="admission denied"),
             ),
-            patch("isvtest.validations.k8s_storage.time.sleep"),
+            _patched_clock(),
         ):
             check.run()
 
@@ -282,7 +322,7 @@ class TestK8sCsiStorageTypesCheck:
                 "isvtest.validations.k8s_storage.subprocess.run",
                 side_effect=subprocess.TimeoutExpired(cmd="kubectl", timeout=1),
             ),
-            patch("isvtest.validations.k8s_storage.time.sleep"),
+            _patched_clock(),
         ):
             check.run()
 
@@ -329,7 +369,7 @@ class TestK8sCsiStorageTypesCheck:
         with (
             patch.object(check, "run_command", side_effect=fake_run),
             patch("isvtest.validations.k8s_storage.subprocess.run", return_value=_FakeProc(returncode=0)),
-            patch("isvtest.validations.k8s_storage.time.sleep"),
+            _patched_clock(),
         ):
             check.run()
 
@@ -370,7 +410,7 @@ class TestK8sCsiStorageTypesCheck:
         with (
             patch.object(check, "run_command", side_effect=fake_run),
             patch("isvtest.validations.k8s_storage.subprocess.run", side_effect=capture_apply),
-            patch("isvtest.validations.k8s_storage.time.sleep"),
+            _patched_clock(),
         ):
             check.run()
 
@@ -384,3 +424,663 @@ class TestK8sCsiStorageTypesCheck:
         assert pvc["spec"]["accessModes"] == ["ReadWriteMany"]
         assert pvc["spec"]["resources"]["requests"]["storage"] == "3Gi"
         assert pvc["metadata"]["namespace"].startswith("ut-")
+
+
+class TestSetResourceQuotaFields:
+    """Tests for ``_set_resourcequota_fields`` — the in-memory manifest mutator."""
+
+    def _base_doc(self) -> dict[str, Any]:
+        return {
+            "apiVersion": "v1",
+            "kind": "ResourceQuota",
+            "metadata": {"name": "placeholder", "namespace": "placeholder"},
+            "spec": {"hard": {"requests.storage": "10Gi"}},
+        }
+
+    def test_overrides_all_fields(self) -> None:
+        doc = self._base_doc()
+        out = _set_resourcequota_fields(
+            doc,
+            namespace="ns1",
+            name="rq1",
+            total_quota="20Gi",
+            sc_quota_key="gp3.storageclass.storage.k8s.io/requests.storage",
+            per_sc_quota="5Gi",
+        )
+        assert out["metadata"]["namespace"] == "ns1"
+        assert out["metadata"]["name"] == "rq1"
+        assert out["spec"]["hard"] == {
+            "requests.storage": "20Gi",
+            "gp3.storageclass.storage.k8s.io/requests.storage": "5Gi",
+        }
+
+    def test_mutation_is_in_place(self) -> None:
+        doc = self._base_doc()
+        out = _set_resourcequota_fields(
+            doc,
+            namespace="ns",
+            name="rq",
+            total_quota="10Gi",
+            sc_quota_key="sc.storageclass.storage.k8s.io/requests.storage",
+            per_sc_quota="5Gi",
+        )
+        assert out is doc
+
+    def test_hard_replaces_placeholder(self) -> None:
+        """The mutator must *replace* spec.hard rather than merge so placeholder keys don't leak."""
+        doc = self._base_doc()
+        # Add a stale key that must be dropped.
+        doc["spec"]["hard"]["legacy.storageclass.storage.k8s.io/requests.storage"] = "1Gi"
+        out = _set_resourcequota_fields(
+            doc,
+            namespace="ns",
+            name="rq",
+            total_quota="10Gi",
+            sc_quota_key="gp3.storageclass.storage.k8s.io/requests.storage",
+            per_sc_quota="5Gi",
+        )
+        assert "legacy.storageclass.storage.k8s.io/requests.storage" not in out["spec"]["hard"]
+
+
+class TestK8sCsiStorageQuotaApiCheck:
+    """Tests for ``K8sCsiStorageQuotaApiCheck``."""
+
+    def _make(self, config: dict[str, Any] | None = None) -> K8sCsiStorageQuotaApiCheck:
+        return K8sCsiStorageQuotaApiCheck(config=config or {})
+
+    def _stub_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Isolate from developer env: never leak a StorageClass from the host.
+        for var in ("K8S_CSI_BLOCK_SC", "K8S_CSI_SHARED_FS_SC", "K8S_CSI_NFS_SC"):
+            monkeypatch.delenv(var, raising=False)
+
+    def _happy_config(self) -> dict[str, Any]:
+        return {
+            "storage_class": "gp3",
+            "total_quota": "10Gi",
+            "per_sc_quota": "5Gi",
+            "pvc_request": "1Gi",
+            "over_quota_request": "100Gi",
+            "bind_timeout_s": 5,
+            "quota_settle_s": 5,
+            "namespace_prefix": "ut",
+        }
+
+    def _quota_json(
+        self,
+        *,
+        sc_key: str,
+        hard: dict[str, str] | None,
+        used: dict[str, str] | None,
+    ) -> str:
+        """Build a ``kubectl get resourcequota -o json`` payload with the given status sections."""
+        status: dict[str, Any] = {}
+        if hard is not None:
+            status["hard"] = hard
+        if used is not None:
+            status["used"] = used
+        return json.dumps({"metadata": {"name": "rq"}, "status": status})
+
+    def _pv_json(
+        self,
+        *,
+        claim_ref_name: str = "usage-pvc",
+        capacity: str | None = "1Gi",
+        csi_driver: str | None = "ebs.csi.aws.com",
+    ) -> str:
+        """Build a ``kubectl get pv -o json`` payload with tunable fields."""
+        spec: dict[str, Any] = {}
+        if capacity is not None:
+            spec["capacity"] = {"storage": capacity}
+        spec["claimRef"] = {"name": claim_ref_name}
+        if csi_driver is not None:
+            spec["csi"] = {"driver": csi_driver}
+        return json.dumps({"kind": "PersistentVolume", "spec": spec})
+
+    @staticmethod
+    def _kind_from_input(manifest_yaml: str) -> str:
+        """Peek at the first non-empty doc of a manifest and return its ``kind``."""
+        for doc in yaml.safe_load_all(manifest_yaml):
+            if doc:
+                return str(doc.get("kind", ""))
+        return ""
+
+    def _apply_router(
+        self,
+        *,
+        rq_rc: int = 0,
+        rq_err: str = "",
+        usage_rc: int = 0,
+        usage_err: str = "",
+        over_rc: int = 1,
+        over_err: str = 'error: persistentvolumeclaims "foo" is forbidden: exceeded quota',
+    ) -> Any:
+        """Return a ``subprocess.run`` side_effect that routes by manifest kind/name.
+
+        The happy path returns success for ResourceQuota and usage-PVC apply and
+        a forbidden/exceeded-quota rejection for the over-quota PVC apply. Any
+        knob can be tweaked to simulate a specific failure.
+        """
+
+        def _route(cmd: list[str], **kwargs: Any) -> _FakeProc:
+            manifest = kwargs.get("input", "") or ""
+            kind = self._kind_from_input(manifest)
+            if kind == "ResourceQuota":
+                return _FakeProc(returncode=rq_rc, stderr=rq_err)
+            if kind == "Pod":
+                # Consumer pod applied alongside the usage PVC so Bound can
+                # happen under WaitForFirstConsumer. Success by default.
+                return _FakeProc(returncode=0)
+            if kind == "PersistentVolumeClaim":
+                # The usage PVC is applied before the over-quota PVC, so track order.
+                # We distinguish by name via the metadata. The over-quota PVC name
+                # starts with "quota-over-"; usage PVC name starts with "quota-usage-".
+                for doc in yaml.safe_load_all(manifest):
+                    if not doc:
+                        continue
+                    name = doc.get("metadata", {}).get("name", "")
+                    if name.startswith("quota-over-"):
+                        return _FakeProc(returncode=over_rc, stderr=over_err)
+                    return _FakeProc(returncode=usage_rc, stderr=usage_err)
+            raise AssertionError(f"unexpected manifest kind={kind!r}")
+
+        return _route
+
+    def _run_command_router(
+        self,
+        *,
+        quota_hard: dict[str, str] | None,
+        quota_used: dict[str, str] | None,
+        pvc_phase: str = "Bound",
+        pvc_capacity: str = "1Gi",
+        volume_name: str = "pv-123",
+        pv_payload: str | None = None,
+        sc_key: str = "gp3.storageclass.storage.k8s.io/requests.storage",
+    ) -> Any:
+        """Build a ``run_command`` side_effect that answers every query the check issues."""
+        pv_json = pv_payload if pv_payload is not None else self._pv_json()
+
+        def _route(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "create namespace" in cmd:
+                return _ok()
+            if "get resourcequota" in cmd and "-o json" in cmd:
+                return _ok(stdout=self._quota_json(sc_key=sc_key, hard=quota_hard, used=quota_used))
+            if "wait --for=condition=Ready" in cmd:
+                # Consumer pod reaches Ready whenever the PVC phase is Bound;
+                # when the PVC stays Pending, the wait fails so the check
+                # reports the timeout correctly.
+                return _ok() if pvc_phase == "Bound" else _fail(stderr="timed out waiting for the condition")
+            if "get pvc" in cmd and "jsonpath='{.status.phase}'" in cmd:
+                return _ok(stdout=pvc_phase)
+            if "get pvc" in cmd and "jsonpath='{.status.capacity.storage}'" in cmd:
+                return _ok(stdout=pvc_capacity)
+            if "get pvc" in cmd and "jsonpath='{.spec.volumeName}'" in cmd:
+                return _ok(stdout=volume_name)
+            if "get pv " in cmd and "-o json" in cmd:
+                return _ok(stdout=pv_json)
+            if "delete namespace" in cmd:
+                return _ok()
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        return _route
+
+    # ----- tests -----
+
+    def test_no_storage_class_configured_skips_without_work(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make({})
+        with patch.object(check, "run_command") as mock_run:
+            check.run()
+        mock_run.assert_not_called()
+        assert check.passed
+        assert "Skipped" in check._output
+
+    def test_happy_path_all_subtests_pass(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make(self._happy_config())
+        sc_key = "gp3.storageclass.storage.k8s.io/requests.storage"
+        run = self._run_command_router(
+            quota_hard={"requests.storage": "10Gi", sc_key: "5Gi"},
+            quota_used={"requests.storage": "1Gi", sc_key: "1Gi"},
+            pv_payload=self._pv_json(),
+        )
+
+        # run_command_router's _pv_json defaults claim_ref_name to "usage-pvc" but
+        # the real PVC name is generated with a UUID prefix. Patch accordingly.
+        def _run_with_dynamic_pvname(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "get pv " in cmd and "-o json" in cmd:
+                # Resolve the current usage PVC name so spec.claimRef.name matches.
+                return _ok(stdout=self._pv_json(claim_ref_name=getattr(check, "_usage_pvc_name", "usage-pvc")))
+            return run(cmd, timeout)
+
+        # Capture the usage PVC name during subprocess.run (ResourceQuota is applied
+        # first, then usage PVC, then consumer Pod, then over-quota PVC).
+        def _capture_apply(cmd: list[str], **kwargs: Any) -> _FakeProc:
+            manifest = kwargs.get("input", "") or ""
+            kind = self._kind_from_input(manifest)
+            if kind == "PersistentVolumeClaim":
+                for doc in yaml.safe_load_all(manifest):
+                    if not doc:
+                        continue
+                    name = doc.get("metadata", {}).get("name", "")
+                    if name.startswith("quota-usage-"):
+                        check._usage_pvc_name = name  # type: ignore[attr-defined]
+                        return _FakeProc(returncode=0)
+                    if name.startswith("quota-over-"):
+                        return _FakeProc(returncode=1, stderr="forbidden: exceeded quota")
+            if kind == "ResourceQuota":
+                return _FakeProc(returncode=0)
+            if kind == "Pod":
+                return _FakeProc(returncode=0)
+            raise AssertionError(f"unexpected manifest kind={kind!r}")
+
+        with (
+            patch.object(check, "run_command", side_effect=_run_with_dynamic_pvname),
+            patch("isvtest.validations.k8s_storage.subprocess.run", side_effect=_capture_apply),
+            _patched_clock(),
+        ):
+            check.run()
+
+        assert check.passed, check._error
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        for name in ("resourcequota-storage-api", "per-pvc-usage", "quota-enforcement", "pv-usage-api"):
+            assert outcomes[name]["passed"], f"{name}: {outcomes[name]['message']}"
+            assert not outcomes[name]["skipped"]
+
+    def test_resourcequota_apply_failure_skips_dependents(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make(self._happy_config())
+        run = self._run_command_router(quota_hard=None, quota_used=None)
+
+        with (
+            patch.object(check, "run_command", side_effect=run),
+            patch(
+                "isvtest.validations.k8s_storage.subprocess.run",
+                side_effect=self._apply_router(rq_rc=1, rq_err="admission denied"),
+            ),
+            _patched_clock(),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["resourcequota-storage-api"]["passed"]
+        for dependent in ("per-pvc-usage", "quota-enforcement", "pv-usage-api"):
+            assert outcomes[dependent]["skipped"]
+
+    def test_resourcequota_hard_never_populates_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make(self._happy_config())
+        # Apply succeeds, but .status.hard is never published.
+        run = self._run_command_router(quota_hard=None, quota_used=None)
+
+        with (
+            patch.object(check, "run_command", side_effect=run),
+            patch(
+                "isvtest.validations.k8s_storage.subprocess.run",
+                side_effect=self._apply_router(),
+            ),
+            _patched_clock(),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["resourcequota-storage-api"]["passed"]
+        assert outcomes["per-pvc-usage"]["skipped"]
+
+    def test_usage_pvc_apply_failure_fails_per_pvc_usage(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make(self._happy_config())
+        sc_key = "gp3.storageclass.storage.k8s.io/requests.storage"
+        run = self._run_command_router(
+            quota_hard={"requests.storage": "10Gi", sc_key: "5Gi"},
+            quota_used=None,
+        )
+
+        with (
+            patch.object(check, "run_command", side_effect=run),
+            patch(
+                "isvtest.validations.k8s_storage.subprocess.run",
+                side_effect=self._apply_router(usage_rc=1, usage_err="boom"),
+            ),
+            _patched_clock(),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert outcomes["resourcequota-storage-api"]["passed"]
+        assert not outcomes["per-pvc-usage"]["passed"]
+        # pv-usage-api depends on a bound usage PVC; should be skipped.
+        assert outcomes["pv-usage-api"]["skipped"]
+
+    def test_usage_pvc_never_binds_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make(self._happy_config())
+        sc_key = "gp3.storageclass.storage.k8s.io/requests.storage"
+        run = self._run_command_router(
+            quota_hard={"requests.storage": "10Gi", sc_key: "5Gi"},
+            quota_used=None,
+            pvc_phase="Pending",
+        )
+
+        with (
+            patch.object(check, "run_command", side_effect=run),
+            patch("isvtest.validations.k8s_storage.subprocess.run", side_effect=self._apply_router()),
+            _patched_clock(),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["per-pvc-usage"]["passed"]
+        assert "did not reach Bound" in outcomes["per-pvc-usage"]["message"]
+
+    def test_quota_used_never_reflects_usage_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make(self._happy_config())
+        sc_key = "gp3.storageclass.storage.k8s.io/requests.storage"
+        # hard is populated but used never includes the per-SC key.
+        run = self._run_command_router(
+            quota_hard={"requests.storage": "10Gi", sc_key: "5Gi"},
+            quota_used={"requests.storage": "1Gi"},  # missing per-SC entry
+        )
+
+        with (
+            patch.object(check, "run_command", side_effect=run),
+            patch("isvtest.validations.k8s_storage.subprocess.run", side_effect=self._apply_router()),
+            _patched_clock(),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert outcomes["resourcequota-storage-api"]["passed"]
+        assert not outcomes["per-pvc-usage"]["passed"]
+        assert "did not reflect" in outcomes["per-pvc-usage"]["message"]
+
+    def test_over_quota_pvc_admitted_fails_enforcement(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make(self._happy_config())
+        sc_key = "gp3.storageclass.storage.k8s.io/requests.storage"
+        run = self._run_command_router(
+            quota_hard={"requests.storage": "10Gi", sc_key: "5Gi"},
+            quota_used={"requests.storage": "1Gi", sc_key: "1Gi"},
+        )
+        # Over-quota PVC incorrectly succeeds (returncode 0).
+        with (
+            patch.object(check, "run_command", side_effect=run),
+            patch(
+                "isvtest.validations.k8s_storage.subprocess.run",
+                side_effect=self._apply_router(over_rc=0, over_err=""),
+            ),
+            _patched_clock(),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["quota-enforcement"]["passed"]
+        assert "admitted" in outcomes["quota-enforcement"]["message"]
+
+    def test_over_quota_pvc_rejected_without_quota_message_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make(self._happy_config())
+        sc_key = "gp3.storageclass.storage.k8s.io/requests.storage"
+        run = self._run_command_router(
+            quota_hard={"requests.storage": "10Gi", sc_key: "5Gi"},
+            quota_used={"requests.storage": "1Gi", sc_key: "1Gi"},
+        )
+        with (
+            patch.object(check, "run_command", side_effect=run),
+            patch(
+                "isvtest.validations.k8s_storage.subprocess.run",
+                side_effect=self._apply_router(over_rc=1, over_err="network error"),
+            ),
+            _patched_clock(),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["quota-enforcement"]["passed"]
+        assert "did not mention quota" in outcomes["quota-enforcement"]["message"]
+
+    @pytest.mark.parametrize(
+        ("mutator_kwargs", "expected_missing"),
+        [
+            ({"csi_driver": None}, "spec.csi.driver"),
+            ({"capacity": None}, "spec.capacity.storage"),
+            ({"claim_ref_name": "other-pvc"}, "spec.claimRef.name"),
+        ],
+    )
+    def test_pv_usage_api_detects_missing_fields(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mutator_kwargs: dict[str, Any],
+        expected_missing: str,
+    ) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make(self._happy_config())
+        sc_key = "gp3.storageclass.storage.k8s.io/requests.storage"
+
+        # We need the PV's claimRef.name to match the generated usage-PVC name on
+        # the "happy" cases. To keep the parametrisation simple we let the check
+        # record the usage name during apply, then rebuild the PV payload against
+        # it when responding to `get pv ... -o json`.
+        usage_name_holder: dict[str, str] = {}
+
+        def _apply_side_effect(cmd: list[str], **kwargs: Any) -> _FakeProc:
+            manifest = kwargs.get("input", "") or ""
+            kind = self._kind_from_input(manifest)
+            if kind == "ResourceQuota":
+                return _FakeProc(returncode=0)
+            if kind == "Pod":
+                return _FakeProc(returncode=0)
+            if kind == "PersistentVolumeClaim":
+                for doc in yaml.safe_load_all(manifest):
+                    if not doc:
+                        continue
+                    name = doc.get("metadata", {}).get("name", "")
+                    if name.startswith("quota-usage-"):
+                        usage_name_holder["name"] = name
+                        return _FakeProc(returncode=0)
+                    if name.startswith("quota-over-"):
+                        return _FakeProc(returncode=1, stderr="forbidden: exceeded quota")
+            raise AssertionError(f"unexpected kind={kind!r}")
+
+        def _run(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "create namespace" in cmd:
+                return _ok()
+            if "get resourcequota" in cmd:
+                return _ok(
+                    stdout=self._quota_json(
+                        sc_key=sc_key,
+                        hard={"requests.storage": "10Gi", sc_key: "5Gi"},
+                        used={"requests.storage": "1Gi", sc_key: "1Gi"},
+                    )
+                )
+            if "wait --for=condition=Ready" in cmd:
+                return _ok()
+            if "get pvc" in cmd and "status.phase" in cmd:
+                return _ok(stdout="Bound")
+            if "get pvc" in cmd and "status.capacity.storage" in cmd:
+                return _ok(stdout="1Gi")
+            if "get pvc" in cmd and "spec.volumeName" in cmd:
+                return _ok(stdout="pv-123")
+            if "get pv " in cmd and "-o json" in cmd:
+                # Build PV payload; default claim ref matches usage PVC unless
+                # overridden by mutator_kwargs.
+                claim_name = mutator_kwargs.get("claim_ref_name", usage_name_holder.get("name", "usage-pvc"))
+                capacity = mutator_kwargs.get("capacity", "1Gi") if "capacity" in mutator_kwargs else "1Gi"
+                csi_driver = (
+                    mutator_kwargs.get("csi_driver", "ebs.csi.aws.com")
+                    if "csi_driver" in mutator_kwargs
+                    else "ebs.csi.aws.com"
+                )
+                return _ok(
+                    stdout=self._pv_json(
+                        claim_ref_name=claim_name,
+                        capacity=capacity,
+                        csi_driver=csi_driver,
+                    )
+                )
+            if "delete namespace" in cmd:
+                return _ok()
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with (
+            patch.object(check, "run_command", side_effect=_run),
+            patch("isvtest.validations.k8s_storage.subprocess.run", side_effect=_apply_side_effect),
+            _patched_clock(),
+        ):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["pv-usage-api"]["passed"]
+        assert expected_missing in outcomes["pv-usage-api"]["message"]
+
+    def test_env_fallback_is_honoured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        monkeypatch.setenv("K8S_CSI_BLOCK_SC", "gp3-from-env")
+        sc_key = "gp3-from-env.storageclass.storage.k8s.io/requests.storage"
+        # Drop storage_class so env has to provide it.
+        cfg = self._happy_config()
+        cfg.pop("storage_class")
+        check = self._make(cfg)
+
+        usage_name_holder: dict[str, str] = {}
+
+        def _apply(cmd: list[str], **kwargs: Any) -> _FakeProc:
+            manifest = kwargs.get("input", "") or ""
+            kind = self._kind_from_input(manifest)
+            if kind == "ResourceQuota":
+                # Verify the per-SC key inside the ResourceQuota references the env SC.
+                for doc in yaml.safe_load_all(manifest):
+                    if not doc:
+                        continue
+                    assert sc_key in doc["spec"]["hard"]
+                return _FakeProc(returncode=0)
+            if kind == "Pod":
+                return _FakeProc(returncode=0)
+            if kind == "PersistentVolumeClaim":
+                for doc in yaml.safe_load_all(manifest):
+                    if not doc:
+                        continue
+                    name = doc.get("metadata", {}).get("name", "")
+                    if name.startswith("quota-usage-"):
+                        usage_name_holder["name"] = name
+                        assert doc["spec"]["storageClassName"] == "gp3-from-env"
+                        return _FakeProc(returncode=0)
+                    if name.startswith("quota-over-"):
+                        return _FakeProc(returncode=1, stderr="forbidden: exceeded quota")
+            raise AssertionError(f"unexpected kind={kind!r}")
+
+        def _run(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "create namespace" in cmd:
+                return _ok()
+            if "get resourcequota" in cmd:
+                return _ok(
+                    stdout=self._quota_json(
+                        sc_key=sc_key,
+                        hard={"requests.storage": "10Gi", sc_key: "5Gi"},
+                        used={"requests.storage": "1Gi", sc_key: "1Gi"},
+                    )
+                )
+            if "wait --for=condition=Ready" in cmd:
+                return _ok()
+            if "get pvc" in cmd and "status.phase" in cmd:
+                return _ok(stdout="Bound")
+            if "get pvc" in cmd and "status.capacity.storage" in cmd:
+                return _ok(stdout="1Gi")
+            if "get pvc" in cmd and "spec.volumeName" in cmd:
+                return _ok(stdout="pv-env")
+            if "get pv " in cmd:
+                return _ok(
+                    stdout=self._pv_json(
+                        claim_ref_name=usage_name_holder.get("name", "usage-pvc"),
+                    )
+                )
+            if "delete namespace" in cmd:
+                return _ok()
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with (
+            patch.object(check, "run_command", side_effect=_run),
+            patch("isvtest.validations.k8s_storage.subprocess.run", side_effect=_apply),
+            _patched_clock(),
+        ):
+            check.run()
+
+        assert check.passed, check._error
+
+    def test_namespace_create_failure_sets_failed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make({"storage_class": "gp3"})
+
+        def _run(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "create namespace" in cmd:
+                return _fail(stderr="forbidden")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with patch.object(check, "run_command", side_effect=_run):
+            check.run()
+
+        assert not check.passed
+        assert "Failed to create namespace" in check._error
+
+    def test_rendered_resourcequota_manifest_is_valid_yaml(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """End-to-end check that the applied ResourceQuota carries the expected keys."""
+        self._stub_env(monkeypatch)
+        check = self._make(self._happy_config())
+        sc_key = "gp3.storageclass.storage.k8s.io/requests.storage"
+
+        captured: dict[str, str] = {}
+        usage_name_holder: dict[str, str] = {}
+
+        def _apply(cmd: list[str], **kwargs: Any) -> _FakeProc:
+            manifest = kwargs.get("input", "") or ""
+            kind = self._kind_from_input(manifest)
+            if kind == "ResourceQuota":
+                captured["rq"] = manifest
+                return _FakeProc(returncode=0)
+            if kind == "Pod":
+                return _FakeProc(returncode=0)
+            if kind == "PersistentVolumeClaim":
+                for doc in yaml.safe_load_all(manifest):
+                    if not doc:
+                        continue
+                    name = doc.get("metadata", {}).get("name", "")
+                    if name.startswith("quota-usage-"):
+                        usage_name_holder["name"] = name
+                        return _FakeProc(returncode=0)
+                    if name.startswith("quota-over-"):
+                        return _FakeProc(returncode=1, stderr="forbidden: exceeded quota")
+            raise AssertionError(f"unexpected kind={kind!r}")
+
+        run = self._run_command_router(
+            quota_hard={"requests.storage": "10Gi", sc_key: "5Gi"},
+            quota_used={"requests.storage": "1Gi", sc_key: "1Gi"},
+        )
+
+        def _run_with_dynamic_pvname(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "get pv " in cmd and "-o json" in cmd:
+                return _ok(stdout=self._pv_json(claim_ref_name=usage_name_holder.get("name", "usage-pvc")))
+            return run(cmd, timeout)
+
+        with (
+            patch.object(check, "run_command", side_effect=_run_with_dynamic_pvname),
+            patch("isvtest.validations.k8s_storage.subprocess.run", side_effect=_apply),
+            _patched_clock(),
+        ):
+            check.run()
+
+        assert check.passed, check._error
+        rq_yaml = captured["rq"]
+        docs = [d for d in yaml.safe_load_all(rq_yaml) if d]
+        assert len(docs) == 1
+        rq = docs[0]
+        assert rq["kind"] == "ResourceQuota"
+        assert rq["metadata"]["namespace"].startswith("ut-")
+        assert rq["spec"]["hard"] == {"requests.storage": "10Gi", sc_key: "5Gi"}


### PR DESCRIPTION
## Summary

Adds a new `k8s_storage` validation group covering four CSI storage sub-issues from the K8S23 umbrella, plus the AWS EKS reference provisioning, wired into the k8s suite so the full group runs from a single invocation. Every check skips gracefully when its required setup-step outputs are empty, so the group is safe to enable on every provider.

- **`K8sCsiStorageTypesCheck`** (`isvtest/src/isvtest/validations/k8s_storage.py`) — one ephemeral namespace, two subtests per storage type: `sc-exists[<type>]` (StorageClass visible to kubectl) and `pvc-binds[<type>]` (fresh PVC reaches `Bound` within `bind_timeout_s`, RWO for block / RWX for shared-fs and NFS). Types without a configured StorageClass are reported as skipped so the same check runs unmodified on providers that only offer a subset.
- **`K8sCsiStorageQuotaApiCheck`** — four subtests against a single ephemeral namespace: `resourcequota-storage-api` (both `requests.storage` and `<sc>.storageclass.storage.k8s.io/requests.storage` in `.status.hard`), `per-pvc-usage` (PVC binds, exposes `.status.capacity.storage`, `.status.used` reflects both keys), `quota-enforcement` (over-quota PVC rejected at admission with `exceeded quota` / `forbidden`), `pv-usage-api` (bound PV exposes `.spec.capacity.storage` / `.spec.claimRef.name` / `.spec.csi.driver`). When the quota never lands the three downstream subtests are skipped rather than double-counted as failures.
- **`K8sCsiTenantScopedCredentialsCheck`** — pure read-only; the docstring and report wording make clear this is "tenant-scoped by construction" (inspects in-cluster state) not a cross-cluster isolation proof. Five subtests: `csi-secrets-discovered` (enumerate CSIDriver objects, follow `PV.spec.csi.*SecretRef` + controller / node pod `envFrom` / Secret mounts / projected-secret sources), `secrets-not-cross-namespace`, `no-shared-cluster-markers` (forbidden labels + well-known `csi.nvidia.com/shared*` annotations), `serviceaccount-rbac-scoped` (no `ClusterRoleBinding` grants cluster-wide `secrets` verbs to a CSI controller SA without a `resourceNames` restriction), `node-plugin-uses-hostpath-not-shared-mount` (volumes limited to local / pod-scoped types — hostPath, emptyDir, secret, configMap, projected, downwardAPI, serviceAccountToken, csi).
- **`K8sCsiProvisioningModesCheck`** — `dynamic` subtest creates a PVC, waits for Bound, verifies the backing PV exposes `spec.csi.driver`, then round-trips a canary file through a BusyBox mount pod (`kubectl exec` write + read) — end-to-end mount validation, not just binding. `static` subtest pre-creates a PV with `claimRef` against a matching PVC using `storageClassName: ""`, then runs the same canary roundtrip; skipped when `static_pv.volume_handle` is unset so providers that don't pre-provision a volume still run the dynamic probe. Pass requires `dynamic`; `static` inputs being absent skips the subtest rather than failing it.
- **Shared infrastructure** — `isvtest.core.k8s.render_k8s_manifest(path, mutate)` loads a multi-doc YAML and applies the mutator to each parsed dict (deliberately no YAML-as-string templating). Four manifest templates under `isvtest/src/isvtest/validations/manifests/k8s/`: `storage_pvc.yaml`, `storage_resourcequota.yaml`, `storage_pv.yaml`, `storage_mount_pod.yaml`. `test_k8s_storage.py` adds a `_FakeClock` / `_patched_clock` helper that patches `time.time` alongside `time.sleep` so deadline-based poll loops stay in-process under mocked `run_command`.
- **EKS provider wiring** — `providers/aws/scripts/eks/setup.sh` now emits a top-level `csi` block: `{block,shared_fs,nfs}_storage_class` discovered via `kubectl get sc` filtered by provisioner (EFS satisfies both shared-fs and NFS via NFSv4.1, so both resolve to the single `efs-sc`), plus `static_volume_handle` / `static_driver_name` for a tagged 1 GiB gp3 EBS volume created out-of-band in a worker-node AZ (reused across runs via the cluster-scoped tag so reruns don't leak). `teardown.sh` looks up the tagged volume, waits for it to detach, and deletes it before `terraform destroy` so the cluster teardown doesn't orphan the manually-provisioned volume.
- **Suite wiring** — `isvctl/configs/suites/k8s.yaml` adds a `k8s_storage` validation group with the four checks. Every config key reads from `{{ steps.setup.csi.* | default('', true) }}` so a provider that exposes none of the inputs silently skips the whole group.

## Related issues

- Closes #273 (K8S23-04: Verify CSI supports block, shared filesystem, and NFS storage)
- Closes #272 (K8S23-01: Verify dynamic volume provisioning via CSI — covered by `K8sCsiProvisioningModesCheck.dynamic`)
- Closes #274 (K8S23-05: Verify CSI supports both static and dynamic provisioning via PVs and PVCs)
- Closes #275 (K8S23-06: Verify CSI credentials are tenant cluster scoped, no cross-cluster access)
- Closes #276 (K8S23-07: Verify APIs to query storage usage against overall cluster quota with per-PVC/Volume breakdown)
- Refs #329 (HSS03-01: Verify K8s CSI integration for storage — cross-requirement umbrella partially covered here)

## Test plan

- [x] `make test` — full unit suite passes (adds 67 new cases in `test_k8s_storage.py`; 478 total)
- [x] `ruff format` / `ruff check` / `pre-commit run --files …` — clean
- [x] `isvctl catalog push --no-upload` — verify all four new checks are discovered
- [x] AWS live run: `isvctl test run -f isvctl/configs/providers/aws/config/eks.yaml` — all four K8S23 checks green on an EKS cluster with EBS + EFS CSI installed
- [x] Teardown path leaves no orphaned EBS volumes (confirm the tagged standalone volume from `setup.sh` is gone after `terraform destroy`)
- [x] Skip paths: no StorageClass → `K8sCsiStorageTypesCheck` / `K8sCsiStorageQuotaApiCheck` skip; no CSIDriver → `K8sCsiTenantScopedCredentialsCheck` skips; no `static_volume_handle` → `K8sCsiProvisioningModesCheck.static` skips while `dynamic` still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comprehensive CSI storage validations for Kubernetes: block, shared‑FS, NFS, quota enforcement, tenant‑scoped credentials, and dynamic/static provisioning canaries.
  * EKS workflow: automatic CSI StorageClass discovery, optional creation/reuse of a static EBS volume for tests, and optional AWS-side cleanup during teardown.
* **Chores**
  * Inventory output now includes a CSI section and new environment-driven CSI settings.
* **New Files / Manifests**
  * Reusable PV/PVC/mount-pod/ResourceQuota templates.
* **Tests**
  * Extensive unit and end-to-end tests covering validations and manifest rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->