### PR TITLE
feat: add K8sApiNetworkAclCheck for API endpoint network ACL verification (K8S15-01 - M5 P0)

### DIFF
--- a/isvctl/configs/providers/aws/config/eks.yaml
+++ b/isvctl/configs/providers/aws/config/eks.yaml
@@ -63,3 +63,4 @@ tests:
     tests:
       - K8sControlPlaneLogsCheck # TODO: need control plane logging
       - K8sNetworkPolicyCheck # TODO: enable ENABLE_NETWORK_POLICY on the VPC CNI addon (or install an enforcing CNI) so NetworkPolicy is enforced on the data plane
+      - K8sApiNetworkAclCheck # TODO: EKS is not CAPI-managed and requires an out-of-allow-list vantage point to probe from; skipped until a provider-specific harness exists

--- a/isvctl/configs/providers/k3s.yaml
+++ b/isvctl/configs/providers/k3s.yaml
@@ -75,6 +75,20 @@ tests:
             "nvidia.com/mig.capable": "false"
             "nvidia.com/mig.strategy": "single"
 
+    # k3s has no real network ACL on its API; this exercises the
+    # check's probe logic end-to-end. The unauthorized probe targets a
+    # non-routable RFC 5737 address and will time out — proving the
+    # check correctly interprets a failing probe as "ACL enforced".
+    # Not a substitute for a real provider harness.
+    k8s_network:
+      checks:
+        K8sApiNetworkAclCheck:
+          cluster_name: "{{ steps.setup.cluster_name | default('k3s', true) }}"
+          require_endpoint_info: false
+          authorized_probe_cmd: "kubectl get --raw /healthz"
+          unauthorized_probe_cmd: "curl --max-time 3 -fsS https://192.0.2.1:6443/healthz"
+          probe_timeout: 10
+
     # ReFrame checks (not in k8s.yaml)
     reframe:
       checks:

--- a/isvctl/configs/providers/microk8s.yaml
+++ b/isvctl/configs/providers/microk8s.yaml
@@ -75,6 +75,20 @@ tests:
             "nvidia.com/mig.capable": "false"
             "nvidia.com/mig.strategy": "single"
 
+    # MicroK8s has no real network ACL on its API; this exercises the
+    # check's probe logic end-to-end. The unauthorized probe targets a
+    # non-routable RFC 5737 address and will time out — proving the
+    # check correctly interprets a failing probe as "ACL enforced".
+    # Not a substitute for a real provider harness.
+    k8s_network:
+      checks:
+        K8sApiNetworkAclCheck:
+          cluster_name: "{{ steps.setup.cluster_name | default('microk8s', true) }}"
+          require_endpoint_info: false
+          authorized_probe_cmd: "kubectl get --raw /healthz"
+          unauthorized_probe_cmd: "curl --max-time 3 -fsS https://192.0.2.1:6443/healthz"
+          probe_timeout: 10
+
     # ReFrame checks (not in k8s.yaml)
     reframe:
       checks:

--- a/isvctl/configs/providers/minikube.yaml
+++ b/isvctl/configs/providers/minikube.yaml
@@ -75,6 +75,20 @@ tests:
             "nvidia.com/mig.capable": "false"
             "nvidia.com/mig.strategy": "single"
 
+    # Minikube has no real network ACL on its API; this exercises the
+    # check's probe logic end-to-end. The unauthorized probe targets a
+    # non-routable RFC 5737 address and will time out — proving the
+    # check correctly interprets a failing probe as "ACL enforced".
+    # Not a substitute for a real provider harness.
+    k8s_network:
+      checks:
+        K8sApiNetworkAclCheck:
+          cluster_name: "{{ steps.setup.cluster_name | default('minikube', true) }}"
+          require_endpoint_info: false
+          authorized_probe_cmd: "kubectl get --raw /healthz"
+          unauthorized_probe_cmd: "curl --max-time 3 -fsS https://192.0.2.1:6443/healthz"
+          probe_timeout: 10
+
     # ReFrame checks (not in k8s.yaml)
     reframe:
       checks:

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -179,5 +179,28 @@ tests:
           namespace: "{{ steps.setup.kubernetes.control_plane_namespace | default('kube-system') }}"
           tail: 20
 
+    k8s_network:
+      checks:
+        K8sApiNetworkAclCheck:
+          # Probe-based, provider-agnostic: verifies the API endpoint
+          # refuses connections from a source that should be blocked. The
+          # operator supplies two shell commands:
+          #   - authorized_probe_cmd: a command expected to SUCCEED (e.g.
+          #     a kubectl call from an allow-listed admin host). Serves as
+          #     a baseline — without it, a failing unauthorized probe is
+          #     ambiguous (ACL works vs. API is down).
+          #   - unauthorized_probe_cmd: a command expected to FAIL or time
+          #     out (e.g. curling the endpoint via SSH on an external host
+          #     that is not in the allow-list).
+          # The check reads `Cluster.spec.controlPlaneEndpoint` from the
+          # management cluster to surface endpoint metadata in the result;
+          # set `require_endpoint_info: false` to skip that read.
+          cluster_name: "{{ steps.setup.kubernetes.capi_cluster_name }}"
+          namespace: "{{ steps.setup.kubernetes.capi_cluster_namespace | default('default') }}"
+          authorized_probe_cmd: "{{ steps.setup.kubernetes.authorized_probe_cmd }}"
+          unauthorized_probe_cmd: "{{ steps.setup.kubernetes.unauthorized_probe_cmd }}"
+          probe_timeout: 10
+          require_endpoint_info: true
+
   exclude:
     markers: []

--- a/isvtest/src/isvtest/core/validation.py
+++ b/isvtest/src/isvtest/core/validation.py
@@ -112,6 +112,21 @@ class BaseValidation(ABC):
         if output:
             self._output = output
 
+    def _parse_positive_int(self, key: str, *, default: int) -> int | None:
+        raw = self.config.get(key, default)
+        if isinstance(raw, bool):
+            self.set_failed(f"`{key}` must be an integer, got bool: {raw!r}")
+            return None
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            self.set_failed(f"`{key}` must be an integer, got {type(raw).__name__}: {raw!r}")
+            return None
+        if value < 1:
+            self.set_failed(f"{key} must be >= 1 (got {value})")
+            return None
+        return value
+
     def report_subtest(
         self,
         name: str,

--- a/isvtest/src/isvtest/core/validation.py
+++ b/isvtest/src/isvtest/core/validation.py
@@ -113,6 +113,11 @@ class BaseValidation(ABC):
             self._output = output
 
     def _parse_positive_int(self, key: str, *, default: int) -> int | None:
+        """Read ``key`` from config and coerce to an integer >= 1.
+
+        Returns the value on success, or ``None`` after calling ``set_failed``
+        if the value is missing, not integer-coercible, or less than 1.
+        """
         raw = self.config.get(key, default)
         if isinstance(raw, bool):
             self.set_failed(f"`{key}` must be an integer, got bool: {raw!r}")

--- a/isvtest/src/isvtest/utils/checks.py
+++ b/isvtest/src/isvtest/utils/checks.py
@@ -37,3 +37,10 @@ def command_exists(command: str) -> bool:
         True if the command is available, False otherwise.
     """
     return shutil.which(command) is not None
+
+
+def truncate(text: str, *, limit: int = 80) -> str:
+    """Return ``text`` shortened to at most ``limit`` characters with an ellipsis marker."""
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3] + "..."

--- a/isvtest/src/isvtest/validations/k8s_api_network_acl.py
+++ b/isvtest/src/isvtest/validations/k8s_api_network_acl.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Verify the Kubernetes API endpoint is protected by network access controls."""
+
+from __future__ import annotations
+
+import shlex
+from typing import Any, ClassVar
+
+from isvtest.core.k8s import get_kubectl_base_shell
+from isvtest.core.validation import BaseValidation
+from isvtest.utils.checks import truncate
+
+_DEFAULT_NAMESPACE = "default"
+_DEFAULT_PROBE_TIMEOUT = 10
+
+
+class K8sApiNetworkAclCheck(BaseValidation):
+    """Verify a Cluster API control-plane endpoint enforces network ACLs via operator-supplied probes."""
+
+    description: ClassVar[str] = "Verify the Kubernetes API endpoint is protected by network access controls."
+    timeout: ClassVar[int] = 120
+    markers: ClassVar[list[str]] = ["kubernetes"]
+
+    def run(self) -> None:
+        cfg = self._parse_config()
+        if cfg is None:
+            return
+
+        endpoint_info: str | None = None
+        if cfg["require_endpoint_info"]:
+            endpoint_info = self._read_endpoint(cfg["cluster_name"], cfg["namespace"])
+            if endpoint_info is None:
+                return
+
+        if not self._run_authorized_probe(cfg["authorized_probe_cmd"], cfg["probe_timeout"]):
+            return
+
+        self._run_unauthorized_probe(
+            unauthorized_probe_cmd=cfg["unauthorized_probe_cmd"],
+            probe_timeout=cfg["probe_timeout"],
+            endpoint_info=endpoint_info,
+        )
+
+    def _parse_config(self) -> dict[str, Any] | None:
+        cluster_name = self.config.get("cluster_name")
+        if not cluster_name or not isinstance(cluster_name, str):
+            self.set_failed("`cluster_name` is required and must be a string (the CAPI Cluster resource name).")
+            return None
+
+        namespace = str(self.config.get("namespace", _DEFAULT_NAMESPACE))
+
+        authorized = self.config.get("authorized_probe_cmd")
+        if not authorized or not isinstance(authorized, str):
+            self.set_failed(
+                "`authorized_probe_cmd` is required and must be a string (a shell "
+                "command expected to successfully reach the API, e.g. "
+                "`kubectl --kubeconfig /path/to/kubeconfig get --raw /healthz`). "
+                "Without this baseline a failing unauthorized probe cannot be "
+                "distinguished from a dead cluster."
+            )
+            return None
+
+        unauthorized = self.config.get("unauthorized_probe_cmd")
+        if not unauthorized or not isinstance(unauthorized, str):
+            self.set_failed(
+                "`unauthorized_probe_cmd` is required and must be a string (a "
+                "shell command expected to FAIL or time out because the source "
+                "network is not allow-listed, e.g. "
+                "`ssh external-host curl --max-time 5 https://<endpoint>:6443/healthz`)."
+            )
+            return None
+
+        probe_timeout = self._parse_positive_int("probe_timeout", default=_DEFAULT_PROBE_TIMEOUT)
+        if probe_timeout is None:
+            return None
+
+        require_endpoint_info_raw = self.config.get("require_endpoint_info", True)
+        if not isinstance(require_endpoint_info_raw, bool):
+            self.set_failed(
+                f"`require_endpoint_info` must be a boolean, got "
+                f"{type(require_endpoint_info_raw).__name__}: {require_endpoint_info_raw!r}"
+            )
+            return None
+
+        return {
+            "cluster_name": cluster_name,
+            "namespace": namespace,
+            "authorized_probe_cmd": authorized,
+            "unauthorized_probe_cmd": unauthorized,
+            "probe_timeout": probe_timeout,
+            "require_endpoint_info": require_endpoint_info_raw,
+        }
+
+    def _read_endpoint(self, cluster_name: str, namespace: str) -> str | None:
+        kubectl_base = get_kubectl_base_shell()
+        jsonpath = "{.spec.controlPlaneEndpoint.host}:{.spec.controlPlaneEndpoint.port}"
+        cmd = (
+            f"{kubectl_base} get cluster {shlex.quote(cluster_name)} "
+            f"-n {shlex.quote(namespace)} -o jsonpath={shlex.quote(jsonpath)}"
+        )
+        result = self.run_command(cmd)
+        if result.exit_code != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or f"exit code {result.exit_code}"
+            self.set_failed(
+                f"Unable to read Cluster {cluster_name!r} in namespace "
+                f"{namespace!r}: {detail}. Verify the CAPI Cluster exists and "
+                f"the management cluster is reachable, or set "
+                f"`require_endpoint_info: false` to skip this read."
+            )
+            return None
+        raw = result.stdout.strip()
+        # jsonpath with two missing components renders as ":" — treat that as
+        # "endpoint not populated yet" rather than a valid host:port.
+        if not raw or raw == ":":
+            self.set_failed(
+                f"Cluster {cluster_name!r} in namespace {namespace!r} has no "
+                f"`spec.controlPlaneEndpoint` populated — the control plane "
+                f"has not yet been provisioned, or this infra provider does "
+                f"not surface the endpoint here. Set "
+                f"`require_endpoint_info: false` if this is expected."
+            )
+            return None
+        return raw
+
+    def _run_authorized_probe(self, authorized_probe_cmd: str, probe_timeout: int) -> bool:
+        result = self.run_command(authorized_probe_cmd, timeout=probe_timeout)
+        if result.exit_code != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or f"exit code {result.exit_code}"
+            snippet = truncate(authorized_probe_cmd)
+            self.set_failed(
+                f"Authorized probe failed (cmd: {snippet}): {detail}. A failing "
+                f"baseline makes the unauthorized-probe result unreliable (could "
+                f"mean 'ACL works' OR 'API is down'). Fix cluster access first, "
+                f"then re-run."
+            )
+            return False
+        return True
+
+    def _run_unauthorized_probe(
+        self,
+        unauthorized_probe_cmd: str,
+        probe_timeout: int,
+        endpoint_info: str | None,
+    ) -> None:
+        result = self.run_command(unauthorized_probe_cmd, timeout=probe_timeout)
+        snippet = truncate(unauthorized_probe_cmd)
+        endpoint_clause = f" (endpoint: {endpoint_info})" if endpoint_info else ""
+
+        if result.exit_code == 0:
+            preview = result.stdout.strip() or result.stderr.strip() or "(no output)"
+            preview = truncate(preview, limit=120)
+            self.set_failed(
+                f"Unauthorized probe unexpectedly succeeded{endpoint_clause}: "
+                f"the API endpoint is reachable from a source that should be "
+                f"blocked, so no network ACL is in place. Probe cmd: {snippet}. "
+                f"Probe output: {preview!r}."
+            )
+            return
+
+        self.set_passed(
+            f"API endpoint{endpoint_clause} blocked the unauthorized probe "
+            f"(exit={result.exit_code}) and served the authorized probe — network "
+            f"ACL verified."
+        )

--- a/isvtest/src/isvtest/validations/k8s_api_network_acl.py
+++ b/isvtest/src/isvtest/validations/k8s_api_network_acl.py
@@ -101,6 +101,11 @@ class K8sApiNetworkAclCheck(BaseValidation):
         }
 
     def _read_endpoint(self, cluster_name: str, namespace: str) -> str | None:
+        """Read ``spec.controlPlaneEndpoint`` from the CAPI Cluster resource.
+
+        Returns ``"host:port"`` on success, or ``None`` after calling
+        ``set_failed`` if the Cluster is unreachable or the endpoint is empty.
+        """
         kubectl_base = get_kubectl_base_shell()
         jsonpath = "{.spec.controlPlaneEndpoint.host}:{.spec.controlPlaneEndpoint.port}"
         cmd = (
@@ -132,6 +137,12 @@ class K8sApiNetworkAclCheck(BaseValidation):
         return raw
 
     def _run_authorized_probe(self, authorized_probe_cmd: str, probe_timeout: int) -> bool:
+        """Run the authorized baseline probe and report failure on non-zero exit.
+
+        Returns ``True`` if the probe succeeded, or ``False`` after calling
+        ``set_failed`` — a failing baseline makes the unauthorized-probe result
+        ambiguous, so the check must stop before interpreting it.
+        """
         result = self.run_command(authorized_probe_cmd, timeout=probe_timeout)
         if result.exit_code != 0:
             detail = result.stderr.strip() or result.stdout.strip() or f"exit code {result.exit_code}"
@@ -151,6 +162,12 @@ class K8sApiNetworkAclCheck(BaseValidation):
         probe_timeout: int,
         endpoint_info: str | None,
     ) -> None:
+        """Run the unauthorized probe and set the final pass/fail verdict.
+
+        A non-zero exit (connection blocked or timeout) means the ACL is
+        enforced; a zero exit means the endpoint is reachable from a source
+        that should be blocked and the check fails.
+        """
         result = self.run_command(unauthorized_probe_cmd, timeout=probe_timeout)
         snippet = truncate(unauthorized_probe_cmd)
         endpoint_clause = f" (endpoint: {endpoint_info})" if endpoint_info else ""

--- a/isvtest/src/isvtest/validations/k8s_api_network_acl.py
+++ b/isvtest/src/isvtest/validations/k8s_api_network_acl.py
@@ -31,6 +31,7 @@ class K8sApiNetworkAclCheck(BaseValidation):
     markers: ClassVar[list[str]] = ["kubernetes"]
 
     def run(self) -> None:
+        """Execute the endpoint read, authorized baseline probe, and unauthorized probe flow."""
         cfg = self._parse_config()
         if cfg is None:
             return
@@ -51,6 +52,7 @@ class K8sApiNetworkAclCheck(BaseValidation):
         )
 
     def _parse_config(self) -> dict[str, Any] | None:
+        """Validate and normalize check configuration, or ``None`` after calling ``set_failed``."""
         cluster_name = self.config.get("cluster_name")
         if not cluster_name or not isinstance(cluster_name, str):
             self.set_failed("`cluster_name` is required and must be a string (the CAPI Cluster resource name).")
@@ -171,6 +173,18 @@ class K8sApiNetworkAclCheck(BaseValidation):
         result = self.run_command(unauthorized_probe_cmd, timeout=probe_timeout)
         snippet = truncate(unauthorized_probe_cmd)
         endpoint_clause = f" (endpoint: {endpoint_info})" if endpoint_info else ""
+
+        # 126/127 are shell conventions for "not executable" / "command not
+        # found". Treating them as an ACL-enforced pass would hide a broken
+        # probe and yield false assurance.
+        if result.exit_code in (126, 127):
+            detail = result.stderr.strip() or result.stdout.strip() or f"exit code {result.exit_code}"
+            self.set_failed(
+                f"Unauthorized probe could not execute{endpoint_clause} "
+                f"(cmd: {snippet}): {detail}. Fix the probe tooling/command "
+                f"and re-run."
+            )
+            return
 
         if result.exit_code == 0:
             preview = result.stdout.strip() or result.stderr.strip() or "(no output)"

--- a/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
+++ b/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
@@ -15,6 +15,7 @@ from typing import Any, ClassVar
 
 from isvtest.core.k8s import get_kubectl_base_shell
 from isvtest.core.validation import BaseValidation
+from isvtest.utils.checks import truncate
 
 _VALID_MODES = ("auto", "kubectl", "command")
 _DEFAULT_COMPONENTS = (
@@ -22,7 +23,6 @@ _DEFAULT_COMPONENTS = (
     "kube-scheduler",
     "kube-controller-manager",
 )
-_CMD_SNIPPET_LEN = 80
 
 
 class K8sControlPlaneLogsCheck(BaseValidation):
@@ -141,26 +141,6 @@ class K8sControlPlaneLogsCheck(BaseValidation):
             "since": since,
             "commands": commands,
         }
-
-    def _parse_positive_int(self, key: str, *, default: int) -> int | None:
-        """Read ``self.config[key]`` as an ``int >= 1`` (rejecting ``bool``).
-
-        Returns the parsed integer, or ``None`` after ``set_failed`` when
-        the value is a bool, non-numeric, or less than 1.
-        """
-        raw = self.config.get(key, default)
-        if isinstance(raw, bool):
-            self.set_failed(f"`{key}` must be an integer, got bool: {raw!r}")
-            return None
-        try:
-            value = int(raw)
-        except (TypeError, ValueError):
-            self.set_failed(f"`{key}` must be an integer, got {type(raw).__name__}: {raw!r}")
-            return None
-        if value < 1:
-            self.set_failed(f"{key} must be >= 1 (got {value})")
-            return None
-        return value
 
     def _build_plan(
         self,
@@ -320,7 +300,7 @@ class K8sControlPlaneLogsCheck(BaseValidation):
                 if path == "kubectl":
                     failures.append(f"{label}: kubectl logs failed: {detail}")
                 else:
-                    snippet = cmd if len(cmd) <= _CMD_SNIPPET_LEN else cmd[: _CMD_SNIPPET_LEN - 3] + "..."
+                    snippet = truncate(cmd)
                     failures.append(f"{label}: command exited {result.exit_code}: {detail} (cmd: {snippet})")
                 continue
 

--- a/isvtest/tests/test_k8s_api_network_acl.py
+++ b/isvtest/tests/test_k8s_api_network_acl.py
@@ -285,6 +285,46 @@ class TestUnauthorizedProbe:
         assert "api.example.com:6443" in check.message
         assert "no network ACL is in place" in check.message
 
+    def test_fails_when_unauthorized_probe_command_not_found(self) -> None:
+        """Exit 127 (command not found) must not be mistaken for an enforced ACL —
+        a broken probe would otherwise produce a false pass."""
+        check = K8sApiNetworkAclCheck(config=_minimal_config())
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            kind = _classify(cmd)
+            if kind == "cluster_read":
+                return _ok(stdout="api.example.com:6443")
+            if kind == "authorized":
+                return _ok(stdout="ok")
+            if kind == "unauthorized":
+                return _fail(stderr="ssh: command not found", exit_code=127)
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert not check.passed
+        assert "could not execute" in check.message
+        assert "ssh: command not found" in check.message
+
+    def test_fails_when_unauthorized_probe_not_executable(self) -> None:
+        """Exit 126 (found but not executable) must fail loudly too."""
+        check = K8sApiNetworkAclCheck(config=_minimal_config())
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            kind = _classify(cmd)
+            if kind == "cluster_read":
+                return _ok(stdout="api.example.com:6443")
+            if kind == "authorized":
+                return _ok(stdout="ok")
+            if kind == "unauthorized":
+                return _fail(stderr="permission denied", exit_code=126)
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert not check.passed
+        assert "could not execute" in check.message
+
     def test_probe_timeout_forwarded_to_run_command(self) -> None:
         """The configured ``probe_timeout`` must reach the runner so a
         hung unauthorized probe cannot freeze the check indefinitely."""

--- a/isvtest/tests/test_k8s_api_network_acl.py
+++ b/isvtest/tests/test_k8s_api_network_acl.py
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Unit tests for ``isvtest.validations.k8s_api_network_acl``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from isvtest.core.runners import CommandResult
+from isvtest.utils.checks import truncate
+from isvtest.validations.k8s_api_network_acl import K8sApiNetworkAclCheck
+
+
+def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _fail(stdout: str = "", stderr: str = "", exit_code: int = 1) -> CommandResult:
+    return CommandResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _minimal_config(**overrides: Any) -> dict[str, Any]:
+    cfg: dict[str, Any] = {
+        "cluster_name": "isv-cluster",
+        "authorized_probe_cmd": "kubectl get --raw /healthz",
+        "unauthorized_probe_cmd": "ssh ext-host curl --max-time 5 https://api:6443/healthz",
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def _classify(cmd: str) -> str:
+    if "get cluster" in cmd:
+        return "cluster_read"
+    if cmd.startswith("kubectl get --raw"):
+        return "authorized"
+    if cmd.startswith("ssh ext-host"):
+        return "unauthorized"
+    return "unknown"
+
+
+class TestInputValidation:
+    def test_missing_cluster_name_fails(self) -> None:
+        check = K8sApiNetworkAclCheck(
+            config={
+                "authorized_probe_cmd": "a",
+                "unauthorized_probe_cmd": "u",
+            }
+        )
+        check.run()
+        assert not check.passed
+        assert "`cluster_name` is required" in check.message
+
+    def test_missing_authorized_probe_cmd_fails(self) -> None:
+        check = K8sApiNetworkAclCheck(
+            config={
+                "cluster_name": "c",
+                "unauthorized_probe_cmd": "u",
+            }
+        )
+        check.run()
+        assert not check.passed
+        assert "`authorized_probe_cmd` is required" in check.message
+
+    def test_missing_unauthorized_probe_cmd_fails(self) -> None:
+        check = K8sApiNetworkAclCheck(
+            config={
+                "cluster_name": "c",
+                "authorized_probe_cmd": "a",
+            }
+        )
+        check.run()
+        assert not check.passed
+        assert "`unauthorized_probe_cmd` is required" in check.message
+
+    def test_non_integer_probe_timeout_rejected(self) -> None:
+        check = K8sApiNetworkAclCheck(config=_minimal_config(probe_timeout="ten"))
+        check.run()
+        assert not check.passed
+        assert "`probe_timeout` must be an integer" in check.message
+
+    def test_bool_probe_timeout_rejected(self) -> None:
+        check = K8sApiNetworkAclCheck(config=_minimal_config(probe_timeout=True))
+        check.run()
+        assert not check.passed
+        assert "must be an integer, got bool" in check.message
+
+    def test_non_bool_require_endpoint_info_rejected(self) -> None:
+        check = K8sApiNetworkAclCheck(config=_minimal_config(require_endpoint_info="yes"))
+        check.run()
+        assert not check.passed
+        assert "`require_endpoint_info` must be a boolean" in check.message
+
+
+class TestEndpointRead:
+    def test_cluster_read_failure_fails_when_required(self) -> None:
+        check = K8sApiNetworkAclCheck(config=_minimal_config())
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            if _classify(cmd) == "cluster_read":
+                return _fail(stderr='clusters.cluster.x-k8s.io "isv-cluster" not found')
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert not check.passed
+        assert "Unable to read Cluster" in check.message
+        assert "not found" in check.message
+
+    def test_empty_endpoint_rejected(self) -> None:
+        """A resource with no ``controlPlaneEndpoint`` renders as ``:`` under
+        the jsonpath format string — the check must refuse rather than
+        treating it as a valid host:port."""
+        check = K8sApiNetworkAclCheck(config=_minimal_config())
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            if _classify(cmd) == "cluster_read":
+                return _ok(stdout=":")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert not check.passed
+        assert "no `spec.controlPlaneEndpoint`" in check.message
+
+    def test_cluster_read_skipped_when_require_endpoint_info_false(self) -> None:
+        """When the operator opts out, the cluster-read is skipped entirely
+        so probes are the only source of truth — needed for non-CAPI
+        providers where the Cluster CRD doesn't exist."""
+        check = K8sApiNetworkAclCheck(config=_minimal_config(require_endpoint_info=False))
+        observed: list[str] = []
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            observed.append(_classify(cmd))
+            kind = _classify(cmd)
+            if kind == "authorized":
+                return _ok(stdout="ok")
+            if kind == "unauthorized":
+                return _fail(stderr="connection timed out")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert check.passed, check.message
+        assert "cluster_read" not in observed, observed
+
+    def test_endpoint_surfaced_in_passed_message(self) -> None:
+        check = K8sApiNetworkAclCheck(config=_minimal_config())
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            kind = _classify(cmd)
+            if kind == "cluster_read":
+                return _ok(stdout="10.0.0.42:6443")
+            if kind == "authorized":
+                return _ok(stdout="ok")
+            if kind == "unauthorized":
+                return _fail(stderr="connection timed out")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert check.passed, check.message
+        assert "10.0.0.42:6443" in check.message
+
+
+class TestAuthorizedProbe:
+    def test_authorized_failure_aborts_with_baseline_message(self) -> None:
+        """A failing authorized probe means the API is unreachable even from
+        an allow-listed source. We can't then assert anything about ACLs —
+        a failing unauthorized probe could equally mean 'ACL works' or
+        'API dead'. The check must refuse to guess."""
+        check = K8sApiNetworkAclCheck(config=_minimal_config())
+        calls: list[str] = []
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            calls.append(cmd)
+            kind = _classify(cmd)
+            if kind == "cluster_read":
+                return _ok(stdout="api.example.com:6443")
+            if kind == "authorized":
+                return _fail(stderr="Unable to connect to the server")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert not check.passed
+        assert "Authorized probe failed" in check.message
+        assert "could" in check.message and "mean" in check.message
+        # Unauthorized probe must NOT have been executed.
+        assert not any(_classify(c) == "unauthorized" for c in calls)
+
+    def test_authorized_probe_runs_before_unauthorized(self) -> None:
+        """Ordering matters: the baseline check must run before the
+        unauthorized probe, otherwise a slow/long-timeout unauthorized
+        probe wastes time on a check that was already doomed."""
+        check = K8sApiNetworkAclCheck(config=_minimal_config())
+        order: list[str] = []
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            kind = _classify(cmd)
+            if kind == "cluster_read":
+                return _ok(stdout="api.example.com:6443")
+            if kind == "authorized":
+                order.append("auth")
+                return _ok(stdout="ok")
+            if kind == "unauthorized":
+                order.append("unauth")
+                return _fail(stderr="timed out")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert check.passed, check.message
+        assert order == ["auth", "unauth"]
+
+
+class TestUnauthorizedProbe:
+    def test_passes_when_unauthorized_probe_fails(self) -> None:
+        check = K8sApiNetworkAclCheck(config=_minimal_config())
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            kind = _classify(cmd)
+            if kind == "cluster_read":
+                return _ok(stdout="api.example.com:6443")
+            if kind == "authorized":
+                return _ok(stdout="ok")
+            if kind == "unauthorized":
+                return _fail(stderr="connection refused", exit_code=7)
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert check.passed, check.message
+        assert "network ACL verified" in check.message
+        assert "exit=7" in check.message
+
+    def test_passes_when_unauthorized_probe_times_out(self) -> None:
+        """A timeout surfaces as a non-zero exit from the runner — that must
+        count as a valid 'blocked' outcome identical to connection refused."""
+        check = K8sApiNetworkAclCheck(config=_minimal_config())
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            kind = _classify(cmd)
+            if kind == "cluster_read":
+                return _ok(stdout="api.example.com:6443")
+            if kind == "authorized":
+                return _ok(stdout="ok")
+            if kind == "unauthorized":
+                # GNU timeout exit code is 124.
+                return _fail(stderr="", exit_code=124)
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert check.passed, check.message
+
+    def test_fails_when_unauthorized_probe_succeeds(self) -> None:
+        """Success from the unauthorized source = no ACL in place. The
+        failure message must name the endpoint so the operator knows
+        *which* endpoint is exposed."""
+        check = K8sApiNetworkAclCheck(config=_minimal_config())
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            kind = _classify(cmd)
+            if kind == "cluster_read":
+                return _ok(stdout="api.example.com:6443")
+            if kind == "authorized":
+                return _ok(stdout="ok")
+            if kind == "unauthorized":
+                return _ok(stdout='{"healthy": true}')
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert not check.passed
+        assert "Unauthorized probe unexpectedly succeeded" in check.message
+        assert "api.example.com:6443" in check.message
+        assert "no network ACL is in place" in check.message
+
+    def test_probe_timeout_forwarded_to_run_command(self) -> None:
+        """The configured ``probe_timeout`` must reach the runner so a
+        hung unauthorized probe cannot freeze the check indefinitely."""
+        check = K8sApiNetworkAclCheck(config=_minimal_config(probe_timeout=3))
+        seen_timeouts: dict[str, int] = {}
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            timeout = kw.get("timeout") if "timeout" in kw else (a[0] if a else None)
+            if timeout is not None:
+                seen_timeouts[_classify(cmd)] = timeout
+            kind = _classify(cmd)
+            if kind == "cluster_read":
+                return _ok(stdout="api.example.com:6443")
+            if kind == "authorized":
+                return _ok(stdout="ok")
+            if kind == "unauthorized":
+                return _fail(stderr="timed out", exit_code=124)
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert check.passed, check.message
+        assert seen_timeouts.get("authorized") == 3
+        assert seen_timeouts.get("unauthorized") == 3
+
+
+class TestTruncate:
+    def test_short_text_returned_unchanged(self) -> None:
+        assert truncate("short") == "short"
+
+    def test_long_text_ellipsized_at_limit(self) -> None:
+        long = "a" * 120
+        out = truncate(long, limit=80)
+        assert len(out) == 80
+        assert out.endswith("...")


### PR DESCRIPTION
## Summary

Probe-based, provider-agnostic validation that the Kubernetes API endpoint enforces network access controls (firewall / private link / security group). The operator supplies two shell commands — one that must succeed (from an allow-listed source) and one that must fail or time out (from a source that should be blocked). The baseline authorized probe is load-bearing: without it, a failing unauthorized probe is ambiguous (ACL works vs. API is down), so the check aborts rather than silently passing a dead cluster.

- **`K8sApiNetworkAclCheck`** (`isvtest/src/isvtest/validations/k8s_api_network_acl.py`) — reads `Cluster.spec.controlPlaneEndpoint` from the management cluster for endpoint metadata in the result; can be disabled via `require_endpoint_info: false`, in which case the cluster read is skipped entirely. Config: `cluster_name`, `namespace` (default `default`), `authorized_probe_cmd`, `unauthorized_probe_cmd`, `probe_timeout` (default 10s), `require_endpoint_info` (default true).
- **Shared helper lift** — `_parse_positive_int` moved from `K8sControlPlaneLogsCheck` onto `BaseValidation` (`isvtest/src/isvtest/core/validation.py`), and `truncate()` extracted to `isvtest.utils.checks`. Both are now reused by the new check and by `K8sControlPlaneLogsCheck` instead of being duplicated.
- **Suite wiring** — `isvctl/configs/suites/k8s.yaml` adds a `k8s_network` group containing `K8sApiNetworkAclCheck`, keyed off `steps.setup.kubernetes.{capi_cluster_name,capi_cluster_namespace,authorized_probe_cmd,unauthorized_probe_cmd}`.
- **EKS excluded** — `isvctl/configs/providers/aws/config/eks.yaml` adds `K8sApiNetworkAclCheck` to the k8s_network excludes list with a TODO: EKS is not CAPI-managed and lacks an out-of-allow-list vantage point to probe from, so it's skipped until a provider-specific harness exists.
- **Minikube smoke harness** — `isvctl/configs/providers/minikube.yaml` overrides with literal probes (`kubectl get --raw /healthz` authorized; `curl` to RFC 5737 `192.0.2.1:6443` unauthorized). Minikube has no real ACL; this exercises the probe logic end-to-end and proves the check correctly interprets a timing-out probe as \"ACL enforced.\"

## Related issues

- Closes #271 (K8S15-01: Verify the K8s API endpoint has network access controls (firewall/private link))

## Test plan

- [x] \`make test\` — full unit suite passes (adds 322 lines of new \`test_k8s_api_network_acl.py\` cases covering config validation, endpoint read, authorized baseline, unauthorized success/failure, timeout propagation, and the \`require_endpoint_info: false\` path)
- [x] \`ruff format\` / \`ruff check\` / \`pre-commit run --files …\` — clean
- [x] \`isvctl catalog push --no-upload\` — \`K8sApiNetworkAclCheck\` discovered
- [x] minikube live run: authorized probe passes, unauthorized probe to \`192.0.2.1:6443\` times out → check reports ACL verified
- [x] EKS run: \`K8sApiNetworkAclCheck\` is skipped cleanly (not in its k8s_network include list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes API network ACL validation to verify control-plane endpoints are protected.

* **Tests**
  * Comprehensive test suite for the new validation covering configuration, endpoint discovery, probe execution, and timeout behavior.

* **Improvements**
  * Better validation of numeric timeouts and safer truncation of long command/output snippets in failure messages.

* **Chores**
  * Configured network ACL validation across EKS (excluded where probing is constrained), Minikube, k3s, and microk8s; updated k8s suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->