### PR TITLE
fix(orchestrator): eliminate false-positive template warnings + cosmetic cleanup

### DIFF
--- a/isvctl/configs/providers/aws/README.md
+++ b/isvctl/configs/providers/aws/README.md
@@ -13,7 +13,7 @@ Provider configs that wire the [provider-agnostic test suites](../../suites/READ
 | [`config/eks.yaml`](config/eks.yaml) | Kubernetes GPU cluster (nodes, GPU operator, workloads) | [AWS EKS Guide](scripts/eks/docs/aws-eks.md) |
 | [`config/control-plane.yaml`](config/control-plane.yaml) | API health, access keys, tenant lifecycle | [AWS Control Plane Guide](scripts/control-plane/docs/aws-control-plane.md) |
 | [`config/image-registry.yaml`](config/image-registry.yaml) | Image upload, CRUD, VM launch, install config | [AWS Image Registry Guide](scripts/image-registry/docs/aws-image-registry.md) |
-| [`config/security.yaml`](config/security.yaml) | BMC isolation, API endpoint isolation, SA credential auth | — |
+| [`config/security.yaml`](config/security.yaml) | BMC isolation, API endpoint isolation, SA credential auth | - |
 
 ## Quick Start
 

--- a/isvctl/configs/providers/aws/config/eks.yaml
+++ b/isvctl/configs/providers/aws/config/eks.yaml
@@ -14,16 +14,17 @@
 #
 # Usage:
 #   # Provision cluster and run tests
-#   TF_AUTO_APPROVE=true uv run isvctl test run -f isvctl/configs/providers/aws/config/eks.yaml
+#   uv run isvctl test run -f isvctl/configs/providers/aws/config/eks.yaml
 #
 #   # Run tests only (skip setup/teardown)
 #   uv run isvctl test run -f isvctl/configs/providers/aws/config/eks.yaml --phase test
 #
 #   # Skip teardown (preserve resources)
-#   AWS_SKIP_TEARDOWN=true TF_AUTO_APPROVE=true uv run isvctl test run -f isvctl/configs/providers/aws/config/eks.yaml
+#   AWS_SKIP_TEARDOWN=true uv run isvctl test run -f isvctl/configs/providers/aws/config/eks.yaml
 #
 # Environment Variables:
-#   - TF_AUTO_APPROVE: Set to "true" to skip Terraform approval prompts (default: false)
+#   - TF_AUTO_APPROVE: Hard-coded to "true" in this config's step env so Terraform never prompts.
+#     Shell setting is ignored; edit this file to re-enable prompts.
 #   - TF_VAR_*: Terraform variables (e.g., TF_VAR_region, TF_VAR_gpu_node_instance_types)
 #   - AWS_SKIP_TEARDOWN: Set to "true" to skip teardown and preserve resources (default: false)
 #   - NGC_API_KEY: NGC API key for NIM workloads

--- a/isvctl/configs/providers/aws/config/eks.yaml
+++ b/isvctl/configs/providers/aws/config/eks.yaml
@@ -56,7 +56,7 @@ commands:
         phase: setup
         command: "../scripts/eks/create_node_pool.sh"
         output_schema: node_pool
-        timeout: 900 # 15 min — EKS node group join can take 5-8 min
+        timeout: 900 # 15 min - EKS node group join can take 5-8 min
         env:
           TF_AUTO_APPROVE: "true"
           TF_VAR_test_pool_name: "isv-test-pool"

--- a/isvctl/configs/providers/aws/scripts/bare_metal/reboot_instance.py
+++ b/isvctl/configs/providers/aws/scripts/bare_metal/reboot_instance.py
@@ -164,7 +164,7 @@ def main() -> int:
         result["private_ip"] = instance.get("PrivateIpAddress")
 
         # Poll for the fresh public IP. Dropping `or args.public_ip`
-        # fallback — safe on AWS, stale on NCPs that release on stop.
+        # fallback - safe on AWS, stale on NCPs that release on stop.
         public_ip = instance.get("PublicIpAddress") or wait_for_public_ip(ec2, args.instance_id)
         if not public_ip:
             result["error"] = "Instance has no public IP after reboot (timed out polling)"
@@ -199,7 +199,7 @@ def main() -> int:
 
         # Compare the host's current boot time against when we issued the
         # reboot API call. If the boot timestamp is later, the kernel booted
-        # after our request — affirmative reboot proof that doesn't depend
+        # after our request - affirmative reboot proof that doesn't depend
         # on having a pre-reboot uptime sample.
         boot_started_at = time.time() - post_uptime
         if boot_started_at >= reboot_requested_at:

--- a/isvctl/configs/providers/aws/scripts/bare_metal/reinstall_instance.py
+++ b/isvctl/configs/providers/aws/scripts/bare_metal/reinstall_instance.py
@@ -241,7 +241,7 @@ def main() -> int:
         result["private_ip"] = instance.get("PrivateIpAddress")
 
         # Poll for the fresh public IP; do not fall back to a caller-supplied
-        # value — IPs are released on stop on NCPs and would be stale.
+        # value - IPs are released on stop on NCPs and would be stale.
         public_ip = instance.get("PublicIpAddress") or wait_for_public_ip(ec2, args.instance_id)
         if not public_ip:
             result["error"] = "Instance has no public IP after reinstall (timed out polling)"

--- a/isvctl/configs/providers/aws/scripts/bare_metal/start_instance.py
+++ b/isvctl/configs/providers/aws/scripts/bare_metal/start_instance.py
@@ -119,7 +119,7 @@ def main() -> int:
         result["private_ip"] = instance.get("PrivateIpAddress")
 
         # Poll for the fresh public IP rather than fall back to the
-        # pre-stop value — safe on AWS but silently stale on NCPs that
+        # pre-stop value - safe on AWS but silently stale on NCPs that
         # release the ephemeral IP on stop.
         fresh_ip = instance.get("PublicIpAddress") or wait_for_public_ip(ec2, args.instance_id)
         if not fresh_ip:

--- a/isvctl/configs/providers/aws/scripts/common/__init__.py
+++ b/isvctl/configs/providers/aws/scripts/common/__init__.py
@@ -10,8 +10,8 @@
 
 """Shared Python utilities for AWS stub scripts.
 
-Every AWS script reaches this package via a single ``sys.path`` entry —
-``providers/aws/scripts/`` — so ``from common.X import Y`` resolves
+Every AWS script reaches this package via a single ``sys.path`` entry -
+``providers/aws/scripts/`` - so ``from common.X import Y`` resolves
 without any namespace-package juggling. Modules:
 
 - ``ec2``: key pair / security group / public IP helpers

--- a/isvctl/configs/providers/aws/scripts/common/ec2.py
+++ b/isvctl/configs/providers/aws/scripts/common/ec2.py
@@ -37,7 +37,7 @@ from botocore.exceptions import (
 
 from common.errors import TRANSIENT_AWS_CODES
 
-# Conservative key-name pattern — letters, digits, dash, underscore, dot.
+# Conservative key-name pattern - letters, digits, dash, underscore, dot.
 # Deliberately excludes '/' and '..' to prevent path traversal when the
 # name is composed into a filesystem path like /tmp/{key_name}.pem
 # Length cap matches EC2's 255-char limit.
@@ -114,14 +114,14 @@ def wait_for_public_ip(
         except ClientError as e:
             # Only swallow throttling / server-side transient codes. Terminal
             # errors (InvalidInstanceID.NotFound, AuthFailure, AccessDenied)
-            # must surface — hiding them behind the timeout makes bad configs
+            # must surface - hiding them behind the timeout makes bad configs
             # look like slow IP assignment.
             code = e.response.get("Error", {}).get("Code", "")
             if code not in TRANSIENT_AWS_CODES:
                 raise
             print(f"Warning: describe_instances transient error ({code}): {e}", file=sys.stderr)
         except (EndpointConnectionError, ConnectTimeoutError, ReadTimeoutError, ConnectionClosedError) as e:
-            # Transport-level failures only — non-network BotoCoreErrors (e.g.
+            # Transport-level failures only - non-network BotoCoreErrors (e.g.
             # ParamValidationError, NoCredentialsError) should not be swallowed.
             print(f"Warning: describe_instances network error: {e}", file=sys.stderr)
         if time.monotonic() >= deadline:
@@ -247,21 +247,21 @@ def create_key_pair(
 
     key_path = key_dir / f"{key_name}.pem"
 
-    # Check if key already exists — verify shape before reusing.
+    # Check if key already exists - verify shape before reusing.
     try:
         describe = ec2.describe_key_pairs(KeyNames=[key_name])
         existing = describe.get("KeyPairs", [{}])[0]
         if not _has_isv_tag(existing.get("Tags")):
             raise RuntimeError(
                 f"key pair {key_name!r} already exists on AWS but is not tagged "
-                "CreatedBy=isvtest — refusing to adopt a resource this suite "
+                "CreatedBy=isvtest - refusing to adopt a resource this suite "
                 "did not create. Either "
                 "delete it manually or use a different --key-name."
             )
-        # Tag matches — verified reuse. If we have the file locally, reuse it.
+        # Tag matches - verified reuse. If we have the file locally, reuse it.
         if key_path.exists() and key_path.stat().st_size > 0:
             return str(key_path)
-        # Tag matches but local PEM is missing/empty — ours but unrecoverable;
+        # Tag matches but local PEM is missing/empty - ours but unrecoverable;
         # safe to delete and recreate.
         ec2.delete_key_pair(KeyName=key_name)
     except ClientError as e:
@@ -323,7 +323,7 @@ def create_security_group(
 
     Reuse is explicit and verified: if a security group with the same name
     already exists in the VPC, we describe it and verify the invariants the
-    caller expects — CreatedBy=isvtest tag, description match, and the
+    caller expects - CreatedBy=isvtest tag, description match, and the
     required SSH ingress rule. If any differs, raise rather than silently
     adopt a resource whose shape may not match what the caller needs.
 
@@ -384,19 +384,19 @@ def create_security_group(
             ]
         )
         if not sgs["SecurityGroups"]:
-            # Duplicate error claims it exists but describe can't find it —
+            # Duplicate error claims it exists but describe can't find it -
             # propagate the original error rather than silently swallow.
             raise
 
         existing = sgs["SecurityGroups"][0]
         sg_id = existing["GroupId"]
 
-        # Verified-reuse checks — any mismatch raises rather than silently
+        # Verified-reuse checks - any mismatch raises rather than silently
         # adopting a resource whose shape we didn't enforce.
         if not _has_isv_tag(existing.get("Tags")):
             raise RuntimeError(
                 f"security group {name!r} in VPC {vpc_id} already exists but is not tagged "
-                "CreatedBy=isvtest — refusing to adopt a resource this suite did not "
+                "CreatedBy=isvtest - refusing to adopt a resource this suite did not "
                 "create."
             )
         if existing.get("Description") != description:
@@ -407,7 +407,7 @@ def create_security_group(
         if not _sg_has_ssh_rule(existing.get("IpPermissions")):
             raise RuntimeError(
                 f"security group {name!r} ({sg_id}) exists but is missing the required "
-                "SSH ingress rule (tcp/22 from 0.0.0.0/0) — refusing to reuse."
+                "SSH ingress rule (tcp/22 from 0.0.0.0/0) - refusing to reuse."
             )
         print(f"Reusing verified security group: {sg_id}", file=sys.stderr)
         return sg_id

--- a/isvctl/configs/providers/aws/scripts/common/errors.py
+++ b/isvctl/configs/providers/aws/scripts/common/errors.py
@@ -30,7 +30,7 @@ from botocore.exceptions import (
 
 logger = logging.getLogger(__name__)
 
-# AWS error codes that indicate the resource is already gone — treat as success
+# AWS error codes that indicate the resource is already gone - treat as success
 # in cleanup paths since the desired end state (resource absent) is reached.
 ALREADY_GONE_CODES: frozenset[str] = frozenset(
     {
@@ -51,7 +51,7 @@ ALREADY_GONE_CODES: frozenset[str] = frozenset(
     }
 )
 
-# Transient AWS error codes — safe to retry after backoff.
+# Transient AWS error codes - safe to retry after backoff.
 TRANSIENT_AWS_CODES: frozenset[str] = frozenset(
     {
         "RequestLimitExceeded",
@@ -118,7 +118,7 @@ def delete_with_retry(
     attempt delete leaks resources whenever a transient error fires
     (e.g. throttling, endpoint connection resets, service unavailable).
 
-    Already-gone errors (``Invalid*.NotFound`` etc.) count as success — the
+    Already-gone errors (``Invalid*.NotFound`` etc.) count as success - the
     desired end state is reached. Non-transient errors are logged and
     return ``False`` without retry.
 
@@ -134,7 +134,7 @@ def delete_with_retry(
     Returns:
         True if the call succeeded or the resource was already gone;
         False if all attempts exhausted or a non-transient error was raised.
-        Never raises — failures are logged by the caller, which is expected to
+        Never raises - failures are logged by the caller, which is expected to
         reason about the returned ``False`` (e.g., record as orphan for later cleanup).
     """
     last_error: Exception | None = None

--- a/isvctl/configs/providers/aws/scripts/common/vpc.py
+++ b/isvctl/configs/providers/aws/scripts/common/vpc.py
@@ -75,7 +75,7 @@ def create_test_vpc(
 def delete_vpc(ec2: Any, vpc_id: str) -> None:
     """Delete a VPC with transient-error retry.
 
-    Routes through :func:`delete_with_retry` so a transient throttling or
+    Routes through ``delete_with_retry`` so a transient throttling or
     endpoint-reset does not leak the VPC on the finally-block path.
 
     Args:
@@ -100,7 +100,7 @@ def cleanup_vpc_resources(
     """Clean up VPC and associated resources with transient-error retry.
 
     Deletes resources in dependency order: SGs -> NACLs -> subnets -> VPC.
-    Every delete goes through :func:`delete_with_retry`, so a transient
+    Every delete goes through ``delete_with_retry``, so a transient
     failure on one resource does not orphan the rest of the dependency tree.
 
     Args:

--- a/isvctl/configs/providers/aws/scripts/eks/create_node_pool.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/create_node_pool.sh
@@ -69,7 +69,7 @@ TAINTS_JSON="${TF_VAR_test_pool_taints_json:-[]}"
 NODE_TYPE="${TF_VAR_test_pool_node_type:-cpu}"
 ACTION="${NODE_POOL_ACTION:-Creating}"
 
-# Validate JSON inputs up front with clear error messages — TF's own errors
+# Validate JSON inputs up front with clear error messages - TF's own errors
 # for malformed HCL vars are hard to read.
 echo "${INSTANCE_TYPES_JSON}" | jq -e 'type == "array"' > /dev/null \
     || { echo "Error: TF_VAR_test_pool_instance_types must be a JSON array" >&2; exit 1; }
@@ -122,7 +122,7 @@ else
 fi
 
 # Read what Terraform actually created. expected_taints comes back with
-# Kubernetes effect spelling — the validation compares directly against
+# Kubernetes effect spelling - the validation compares directly against
 # kubectl, so no further translation is needed.
 TF_OUT_NODE_POOL_NAME=$(terraform output -raw node_pool_name)
 TF_OUT_LABEL_SELECTOR=$(terraform output -raw label_selector)

--- a/isvctl/configs/providers/aws/scripts/eks/destroy_node_pool.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/destroy_node_pool.sh
@@ -37,7 +37,7 @@ if [ ! -f "${TF_DIR}/terraform.tfstate" ]; then
 {
   "success": true,
   "platform": "kubernetes",
-  "message": "Node pool state absent — nothing to destroy",
+  "message": "Node pool state absent - nothing to destroy",
   "resources_deleted": []
 }
 EOF

--- a/isvctl/configs/providers/aws/scripts/eks/setup.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/setup.sh
@@ -312,8 +312,8 @@ KUBECONFIG_PATH="${KUBECONFIG:-$HOME/.kube/config}"
 # pre-existing clusters (the Terraform apply is skipped when the cluster
 # already exists, so we can't rely on Terraform outputs here).
 #
-# EFS satisfies both shared-filesystem (RWX) and NFS semantics — the AWS EFS
-# CSI driver mounts via NFSv4.1 — so when efs.csi.aws.com is installed we
+# EFS satisfies both shared-filesystem (RWX) and NFS semantics - the AWS EFS
+# CSI driver mounts via NFSv4.1 - so when efs.csi.aws.com is installed we
 # surface the same StorageClass under both keys.
 
 BLOCK_SC=$(kubectl get sc -o json 2>/dev/null \

--- a/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/README.md
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/README.md
@@ -15,17 +15,17 @@ never written.
 
 ## Inputs
 
-| Variable          | Default                     | Notes                                                        |
-|-------------------|-----------------------------|--------------------------------------------------------------|
-| `region`          | `us-west-2`                 | Must match the cluster's region.                             |
-| `environment`     | `dev`                       | Default tag.                                                 |
-| `node_pool_name`  | `isv-test-pool`             | EKS `nodegroup` name; visible as `eks.amazonaws.com/nodegroup=<name>`. |
-| `instance_types`  | `["m6i.large"]`             | CPU default; set to `["c5n.18xlarge"]` etc. for high-perf-net. |
-| `ami_type`        | `AL2023_x86_64_STANDARD`    | Use `AL2_x86_64_GPU` for legacy GPU pools.                   |
-| `capacity_type`   | `ON_DEMAND`                 | `ON_DEMAND` or `SPOT`.                                       |
-| `desired_size`    | `1`                         | `min`/`max`/`desired` are pinned to this value.              |
-| `labels`          | `{}`                        | Merged on top of stable `isv.ncp.validation/pool` markers.   |
-| `taints`          | `[]`                        | Kubernetes effect spelling (`NoSchedule`…); module translates to EKS enum. |
+| Variable          | Default                  | Notes                                                        |
+|-------------------|--------------------------|--------------------------------------------------------------|
+| `region`          | `us-west-2`              | Must match the cluster's region.                             |
+| `environment`     | `dev`                    | Default tag.                                                 |
+| `node_pool_name`  | `isv-test-pool`          | EKS `nodegroup` name; visible as `eks.amazonaws.com/nodegroup=<name>`. |
+| `instance_types`  | `["m6i.large"]`          | CPU default; set to `["c5n.18xlarge"]` etc. for high-perf-net. |
+| `ami_type`        | `AL2023_x86_64_STANDARD` | Use `AL2_x86_64_GPU` for legacy GPU pools.                   |
+| `capacity_type`   | `ON_DEMAND`              | `ON_DEMAND` or `SPOT`.                                       |
+| `desired_size`    | `1`                      | `min`/`max`/`desired` are pinned to this value.              |
+| `labels`          | `{}`                     | Merged on top of stable `isv.ncp.validation/pool` markers.   |
+| `taints`          | `[]`                     | Kubernetes effect spelling (`NoSchedule`); module translates to EKS enum. |
 
 ## Outputs
 

--- a/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/README.md
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/README.md
@@ -2,7 +2,7 @@
 
 This module attaches a managed node group to the cluster provisioned by
 `../terraform/`, exercising the create, update (scale), and delete legs of
-the node-pool CRUD contract. It is driven by `../create_node_pool.sh` (setup —
+the node-pool CRUD contract. It is driven by `../create_node_pool.sh` (setup -
 used for both initial create and subsequent updates, since `terraform apply`
 is idempotent) and `../destroy_node_pool.sh` (teardown); end users should
 not `terraform apply` it by hand.

--- a/isvctl/configs/providers/aws/scripts/network/vpc_crud_test.py
+++ b/isvctl/configs/providers/aws/scripts/network/vpc_crud_test.py
@@ -242,7 +242,7 @@ def main() -> int:
     except Exception as e:
         result["error"] = str(e)
     finally:
-        # Cleanup if VPC still exists — retry on transient errors so a
+        # Cleanup if VPC still exists - retry on transient errors so a
         # connection reset or throttle doesn't leak the test VPC.
         if vpc_id:
             delete_with_retry(

--- a/isvctl/configs/providers/aws/scripts/security/api_endpoint_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/api_endpoint_test.py
@@ -57,7 +57,7 @@ def _check_vpc_endpoints_private(endpoints: list[dict[str, Any]]) -> dict[str, A
 
     public_endpoints = []
     for ep in endpoints:
-        # Gateway endpoints (S3, DynamoDB) are fine — they route via
+        # Gateway endpoints (S3, DynamoDB) are fine - they route via
         # the VPC route table, not a public IP.  Interface endpoints
         # are private by design.  Flag only if a custom endpoint uses
         # a public DNS name without private DNS enabled.
@@ -179,7 +179,7 @@ def main() -> int:
     }
 
     # AWS service APIs (EC2, S3, etc.) reach regional HTTPS SDK endpoints, not
-    # routable "public management IPs" — the real risk is EKS/API endpoints with
+    # routable "public management IPs" - the real risk is EKS/API endpoints with
     # public access enabled.
     result["tests"]["probe_api_from_public"] = {
         "passed": True,

--- a/isvctl/configs/providers/aws/scripts/security/bmc_isolation_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/bmc_isolation_test.py
@@ -11,7 +11,7 @@
 
 """Verify BMC interfaces are not reachable from tenant networks (AWS reference).
 
-In AWS, BMC/IPMI/Redfish are inherently inaccessible from EC2 instances —
+In AWS, BMC/IPMI/Redfish are inherently inaccessible from EC2 instances -
 there is no route from tenant VPCs to the hypervisor management plane.
 This test verifies the isolation by:
 
@@ -223,7 +223,7 @@ def main() -> int:
         result["tests"]["probe_bmc_from_tenant"] = _check_route_tables_for_vpcs(ec2, vpc_ids)
         result["tests"]["probe_ipmi_port"] = {
             "passed": True,
-            "message": f"IPMI UDP 623 unreachable — no route from {len(vpc_ids)} VPCs to link-local/mgmt CIDR",
+            "message": f"IPMI UDP 623 unreachable - no route from {len(vpc_ids)} VPCs to link-local/mgmt CIDR",
         }
         result["tests"]["probe_redfish_port"] = _check_sg_no_bmc_egress_for_vpcs(ec2, vpc_ids)
         result["tests"]["reverse_path_check"] = {

--- a/isvctl/configs/providers/aws/scripts/security/sa_credential_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/sa_credential_test.py
@@ -112,7 +112,7 @@ def main() -> int:
             aws_secret_access_key=secret_key,
         )
 
-        # IAM is eventually consistent — new keys can take 15-30s to
+        # IAM is eventually consistent - new keys can take 15-30s to
         # propagate to STS.  Retry with exponential backoff capped at 8s
         # (2, 4, 8, 8, 8, 8, 8 = 46s total worst case before final attempt).
         max_attempts = 8

--- a/isvctl/configs/providers/aws/scripts/vm/reboot_instance.py
+++ b/isvctl/configs/providers/aws/scripts/vm/reboot_instance.py
@@ -190,7 +190,7 @@ def main() -> int:
         result["private_ip"] = instance.get("PrivateIpAddress")
 
         # Poll for a fresh public IP. Dropping the `or args.public_ip`
-        # fallback — safe on AWS (preserves IPs) but silently stale on
+        # fallback - safe on AWS (preserves IPs) but silently stale on
         # NCPs that release the ephemeral IP on stop.
         public_ip = instance.get("PublicIpAddress") or wait_for_public_ip(ec2, args.instance_id)
         if not public_ip:
@@ -232,7 +232,7 @@ def main() -> int:
 
         # Compare the host's current boot time against when we issued the
         # reboot API call. If the boot timestamp is later, the kernel booted
-        # after our request — affirmative reboot proof that doesn't depend
+        # after our request - affirmative reboot proof that doesn't depend
         # on having a pre-reboot uptime sample.
         boot_started_at = time.time() - post_uptime
         if boot_started_at >= reboot_requested_at:

--- a/isvctl/configs/providers/k3s.yaml
+++ b/isvctl/configs/providers/k3s.yaml
@@ -77,7 +77,7 @@ tests:
 
     # k3s has no real network ACL on its API; this exercises the
     # check's probe logic end-to-end. The unauthorized probe targets a
-    # non-routable RFC 5737 address and will time out — proving the
+    # non-routable RFC 5737 address and will time out - proving the
     # check correctly interprets a failing probe as "ACL enforced".
     # Not a substitute for a real provider harness.
     k8s_network:

--- a/isvctl/configs/providers/k3s.yaml
+++ b/isvctl/configs/providers/k3s.yaml
@@ -84,6 +84,7 @@ tests:
       checks:
         K8sApiNetworkAclCheck:
           cluster_name: "{{ steps.setup.cluster_name | default('k3s', true) }}"
+          namespace: "default"
           require_endpoint_info: false
           authorized_probe_cmd: "kubectl get --raw /healthz"
           unauthorized_probe_cmd: "curl --max-time 3 -fsS https://192.0.2.1:6443/healthz"

--- a/isvctl/configs/providers/microk8s.yaml
+++ b/isvctl/configs/providers/microk8s.yaml
@@ -77,7 +77,7 @@ tests:
 
     # MicroK8s has no real network ACL on its API; this exercises the
     # check's probe logic end-to-end. The unauthorized probe targets a
-    # non-routable RFC 5737 address and will time out — proving the
+    # non-routable RFC 5737 address and will time out - proving the
     # check correctly interprets a failing probe as "ACL enforced".
     # Not a substitute for a real provider harness.
     k8s_network:

--- a/isvctl/configs/providers/microk8s.yaml
+++ b/isvctl/configs/providers/microk8s.yaml
@@ -84,6 +84,7 @@ tests:
       checks:
         K8sApiNetworkAclCheck:
           cluster_name: "{{ steps.setup.cluster_name | default('microk8s', true) }}"
+          namespace: "default"
           require_endpoint_info: false
           authorized_probe_cmd: "kubectl get --raw /healthz"
           unauthorized_probe_cmd: "curl --max-time 3 -fsS https://192.0.2.1:6443/healthz"

--- a/isvctl/configs/providers/minikube.yaml
+++ b/isvctl/configs/providers/minikube.yaml
@@ -84,6 +84,7 @@ tests:
       checks:
         K8sApiNetworkAclCheck:
           cluster_name: "{{ steps.setup.cluster_name | default('minikube', true) }}"
+          namespace: "default"
           require_endpoint_info: false
           authorized_probe_cmd: "kubectl get --raw /healthz"
           unauthorized_probe_cmd: "curl --max-time 3 -fsS https://192.0.2.1:6443/healthz"

--- a/isvctl/configs/providers/minikube.yaml
+++ b/isvctl/configs/providers/minikube.yaml
@@ -77,7 +77,7 @@ tests:
 
     # Minikube has no real network ACL on its API; this exercises the
     # check's probe logic end-to-end. The unauthorized probe targets a
-    # non-routable RFC 5737 address and will time out — proving the
+    # non-routable RFC 5737 address and will time out - proving the
     # check correctly interprets a failing probe as "ACL enforced".
     # Not a substitute for a real provider harness.
     k8s_network:

--- a/isvctl/configs/providers/my-isv/scripts/k8s/_common.sh
+++ b/isvctl/configs/providers/my-isv/scripts/k8s/_common.sh
@@ -162,7 +162,9 @@ cat << EOF
   "csi": {
     "block_storage_class": "${CSI_BLOCK_SC}",
     "shared_fs_storage_class": "${CSI_SHARED_FS_SC}",
-    "nfs_storage_class": "${CSI_NFS_SC}"
+    "nfs_storage_class": "${CSI_NFS_SC}",
+    "static_volume_handle": "",
+    "static_driver_name": ""
   }
 }
 EOF

--- a/isvctl/configs/providers/my-isv/scripts/security/bmc_isolation_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/security/bmc_isolation_test.py
@@ -13,7 +13,7 @@
 
 Verifies that BMC/IPMI/Redfish management interfaces are NOT reachable
 from tenant networks.  The test probes known BMC endpoints from a tenant
-network vantage point — all probes must fail (connection refused / timeout)
+network vantage point - all probes must fail (connection refused / timeout)
 for the test to pass.
 
 Required JSON output fields:

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -170,7 +170,7 @@ tests:
           reference_id: "{{steps.launch_instance.instance_id}}"
 
     # SSH/GPU checks bound to start_instance / reboot_instance use the IP
-    # captured by describe_instance (which runs last, post-power-cycle) — the
+    # captured by describe_instance (which runs last, post-power-cycle) - the
     # IPs in start/reboot step outputs are stale on platforms that reassign
     # public IPs across power-cycle.
     start_ssh:

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -203,7 +203,7 @@ tests:
     # `node_pool` JSON payload that seeds the expected shape below; labels,
     # taints, and instance types come across as JSON strings so Jinja
     # string rendering doesn't mangle the structure, and K8sNodePoolCheck
-    # json-parses them. The check is listed twice — once per operation —
+    # json-parses them. The check is listed twice - once per operation -
     # so list form is required (dict form would collide on the class name).
     k8s_node_pools:
       - K8sNodePoolCheck:
@@ -266,7 +266,7 @@ tests:
           # operator supplies two shell commands:
           #   - authorized_probe_cmd: a command expected to SUCCEED (e.g.
           #     a kubectl call from an allow-listed admin host). Serves as
-          #     a baseline — without it, a failing unauthorized probe is
+          #     a baseline - without it, a failing unauthorized probe is
           #     ambiguous (ACL works vs. API is down).
           #   - unauthorized_probe_cmd: a command expected to FAIL or time
           #     out (e.g. curling the endpoint via SSH on an external host

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -158,8 +158,13 @@ tests:
     k8s_conformance:
       checks:
         K8sCncfConformanceCheck:
-          # For valid `mode` values, see
-          # docs/guides/configuration.md#kubernetes-conformance-modes
+          # Valid `mode` values (see docs/guides/configuration.md#kubernetes-conformance-modes):
+          #   - "certified-conformance": full [Conformance] suite, serial. Required
+          #     for CNCF certification; expect multi-hour runtime.
+          #   - "non-disruptive-conformance": [Conformance] minus [Disruptive] and
+          #     [Serial]; safe against clusters carrying other workloads.
+          #   - "quick": single ConfigMap smoke test of the harness itself; no real
+          #     conformance coverage.
           mode: "quick"
           timeout: 7200
           startup_timeout: 600

--- a/isvctl/src/isvctl/orchestrator/context.py
+++ b/isvctl/src/isvctl/orchestrator/context.py
@@ -106,6 +106,12 @@ class Context:
         # Phases that were actually requested (set by orchestrator)
         self._requested_phases: set[str] | None = None
 
+        # Phase currently being rendered (set before each per-phase render).
+        # Used to suppress warnings for steps whose phase hasn't had a chance
+        # to run yet (i.e., their phase comes after the current phase).
+        self._current_phase: str | None = None
+        self._phase_order: list[str] = []
+
         # Layer 6: Environment variables (for {{env.VAR}} access)
         # Must be loaded before settings so settings can reference env vars.
         # Sensitive variables (API keys, secrets) are excluded to prevent
@@ -168,6 +174,25 @@ class Context:
             phases: Set of phase names that were requested
         """
         self._requested_phases = phases
+
+    def set_current_phase(self, phase: str, phase_order: list[str] | None = None) -> None:
+        """Record the phase currently being rendered.
+
+        Used by ``_warn_missing_step_defaults`` to suppress warnings for
+        steps whose phase hasn't had a chance to run yet (i.e., the step's
+        phase comes after ``phase`` in ``phase_order``). Without this, a
+        template in a later-phase validation (e.g. a ``test``-phase check
+        referencing ``steps.describe_instance``) would falsely warn while
+        validations are being rendered for an earlier phase.
+
+        Args:
+            phase: Current phase being rendered (e.g., ``'setup'``, ``'test'``).
+            phase_order: Ordered list of all configured phases. If provided,
+                replaces the known phase order used for ordering comparisons.
+        """
+        self._current_phase = phase
+        if phase_order is not None:
+            self._phase_order = list(phase_order)
 
     def set_step_phase(self, step_name: str, phase: str) -> None:
         """Record the phase a step belongs to.
@@ -299,6 +324,19 @@ class Context:
                 step_phase = self._step_phases.get(step_name)
                 if self._requested_phases and step_phase and step_phase not in self._requested_phases:
                     continue
+                # Suppress warning if the step's phase hasn't had a chance to
+                # run yet (i.e., it comes after the phase currently being
+                # rendered). Without this, rendering validations for an early
+                # phase falsely warns about every step referenced by later
+                # phases' validations.
+                if step_phase and self._current_phase and self._phase_order:
+                    try:
+                        step_idx = self._phase_order.index(step_phase)
+                        curr_idx = self._phase_order.index(self._current_phase)
+                    except ValueError:
+                        step_idx = curr_idx = -1
+                    if step_idx > curr_idx >= 0:
+                        continue
                 self._warned_missing_steps.add(warn_key)
                 msg = f"step '{step_name}' has no output (not run?), using defaults for: steps.{full_path}"
                 logger.warning(msg)

--- a/isvctl/src/isvctl/orchestrator/context.py
+++ b/isvctl/src/isvctl/orchestrator/context.py
@@ -112,6 +112,14 @@ class Context:
         self._current_phase: str | None = None
         self._phase_order: list[str] = []
 
+        # Validation class names whose templates should not emit "missing step"
+        # warnings. Populated with classes that pytest will deselect anyway
+        # (e.g. because their marker is in exclude.markers). render_dict enters
+        # a suppression zone when it recurses into a key matching one of these
+        # (exact or variant form "ClassName-*"). See set_silenced_validation_names.
+        self._silenced_validation_names: set[str] = set()
+        self._warning_suppression_depth: int = 0
+
         # Layer 6: Environment variables (for {{env.VAR}} access)
         # Must be loaded before settings so settings can reference env vars.
         # Sensitive variables (API keys, secrets) are excluded to prevent
@@ -174,6 +182,31 @@ class Context:
             phases: Set of phase names that were requested
         """
         self._requested_phases = phases
+
+    def set_silenced_validation_names(self, names: set[str]) -> None:
+        """Declare validation classes whose template refs must not warn.
+
+        Used by the orchestrator to point Context at classes that pytest
+        will deselect (marker or test-name exclusion). When ``render_dict``
+        recurses into a dict key that matches one of these names exactly
+        or as a variant prefix (``"ClassName-..."``), warnings about missing
+        step data are suppressed inside that subtree.
+
+        Args:
+            names: Class names to silence (e.g. ``{"K8sNodePoolCheck"}``).
+        """
+        self._silenced_validation_names = set(names or ())
+
+    def _is_silenced_validation_name(self, name: str) -> bool:
+        """Return True if ``name`` matches a silenced class exactly or as a variant."""
+        if not isinstance(name, str) or not self._silenced_validation_names:
+            return False
+        if name in self._silenced_validation_names:
+            return True
+        for base in self._silenced_validation_names:
+            if name.startswith(f"{base}-"):
+                return True
+        return False
 
     def set_current_phase(self, phase: str, phase_order: list[str] | None = None) -> None:
         """Record the phase currently being rendered.
@@ -309,6 +342,12 @@ class Context:
         Args:
             template_str: Jinja2 template string to scan for step references
         """
+        # Suppress everything while rendering a subtree that belongs to a
+        # validation class pytest will deselect anyway (see
+        # set_silenced_validation_names). Dead templates inside a never-running
+        # check should not warn.
+        if self._warning_suppression_depth > 0:
+            return
         steps_data = self.data.get("steps", {})
         for match in self._STEP_PATH_RE.finditer(template_str):
             full_path = match.group(1)
@@ -369,6 +408,12 @@ class Context:
     def render_dict(self, data: dict[str, Any]) -> dict[str, Any]:
         """Recursively render all string values in a dictionary.
 
+        When a key matches a silenced validation name (see
+        ``set_silenced_validation_names``), the entire subtree under that key
+        is rendered with missing-step warnings suppressed. That subtree's
+        templates point at a check pytest will deselect, so the refs are
+        effectively dead code and warnings would be noise.
+
         Args:
             data: Dictionary with potential template strings
 
@@ -377,14 +422,21 @@ class Context:
         """
         result = {}
         for key, value in data.items():
-            if isinstance(value, str):
-                result[key] = self.render_string(value)
-            elif isinstance(value, dict):
-                result[key] = self.render_dict(value)
-            elif isinstance(value, list):
-                result[key] = self._render_list(value)
-            else:
-                result[key] = value
+            silence = self._is_silenced_validation_name(key)
+            if silence:
+                self._warning_suppression_depth += 1
+            try:
+                if isinstance(value, str):
+                    result[key] = self.render_string(value)
+                elif isinstance(value, dict):
+                    result[key] = self.render_dict(value)
+                elif isinstance(value, list):
+                    result[key] = self._render_list(value)
+                else:
+                    result[key] = value
+            finally:
+                if silence:
+                    self._warning_suppression_depth -= 1
         return result
 
     def _render_list(self, items: list[Any]) -> list[Any]:

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -359,6 +359,12 @@ class Orchestrator:
                 if junit_tmpdir:
                     phase_junitxml = str(Path(junit_tmpdir) / f"junit-{phase_name}.xml")
 
+                # Tell the context which phase is being rendered so it can
+                # suppress "step has no output (not run?)" warnings for steps
+                # whose phase comes after the current one (they simply
+                # haven't had a chance to run yet).
+                self.context.set_current_phase(phase_name, config_phases)
+
                 # Run validations for this phase (excluding categories that match exclude markers)
                 test_settings = self.config.tests.settings if self.config.tests else {}
                 phase_validations = self.step_executor.run_validations_for_phase(

--- a/isvctl/src/isvctl/orchestrator/step_executor.py
+++ b/isvctl/src/isvctl/orchestrator/step_executor.py
@@ -101,6 +101,35 @@ def _find_missing_step_path(arg: str, steps_data: dict[str, Any]) -> str | None:
     return None
 
 
+def _deselected_validation_class_names(
+    exclude_markers: list[str] | None,
+    exclude_tests: list[str] | None,
+) -> set[str]:
+    """Return validation class names pytest would deselect for the given exclusions.
+
+    A class is deselected when its name is in ``exclude_tests`` or any of its
+    ``markers`` is in ``exclude_markers``. This mirrors conftest.py's
+    collection-time filtering so we can silence template-warning emission for
+    templates inside checks that will never run.
+
+    Returns an empty set if isvtest isn't importable (falls back to current
+    noisy behavior rather than crashing the orchestrator).
+    """
+    excluded: set[str] = set(exclude_tests or ())
+    if not exclude_markers:
+        return excluded
+    try:
+        from isvtest.core.discovery import discover_all_tests
+    except ImportError:
+        return excluded
+    ex_markers = set(exclude_markers)
+    for cls in discover_all_tests():
+        cls_markers = getattr(cls, "markers", None) or []
+        if any(m in ex_markers for m in cls_markers):
+            excluded.add(cls.__name__)
+    return excluded
+
+
 @dataclass
 class StepResult:
     """Result of executing a single step.
@@ -290,6 +319,15 @@ class StepExecutor:
 
             step_outputs = context.get_accumulated_context().get("steps", {})
             step_phases = context.get_all_step_phases()
+
+            # Tell the context which validation classes pytest will deselect
+            # (marker or test-name exclusion) so render_dict can suppress
+            # "missing step" warnings for templates inside those checks.
+            # Without this, a check like K8sNodePoolCheck (markers=["slow"])
+            # spams warnings about its create_test_node_pool / update_test_node_pool
+            # template refs on providers that don't run node-pool CRUD at all.
+            silenced = _deselected_validation_class_names(exclude_markers, exclude_tests)
+            context.set_silenced_validation_names(silenced)
 
             # Render Jinja2 templates in validation parameters using context
             # This handles templates like {{ steps.setup.slurm.partitions.cpu.nodes | length }}

--- a/isvctl/src/isvctl/orchestrator/step_executor.py
+++ b/isvctl/src/isvctl/orchestrator/step_executor.py
@@ -458,7 +458,7 @@ class StepExecutor:
 
         * If the template references a ``{{steps.X.Y}}`` path that is
           unresolved AND no ``default(...)`` filter is used, raise
-          :class:`MissingStepRefError` — the caller didn't express intent
+          ``MissingStepRefError`` - the caller didn't express intent
           to skip, so a silent drop would mask a real bug.
         * If the template uses ``default(...)`` or is a pure Jinja
           conditional (no ``steps.*`` reference), the empty result is

--- a/isvctl/src/isvctl/orchestrator/step_executor.py
+++ b/isvctl/src/isvctl/orchestrator/step_executor.py
@@ -67,7 +67,7 @@ class MissingStepRefError(Exception):
     """Raised when a step arg template references an undefined step output.
 
     This happens when a {{steps.X.Y}} path cannot be resolved in the context
-    and the template has no `| default(...)` fallback — typically because an
+    and the template has no `| default(...)` fallback - typically because an
     upstream step failed or was skipped. The caller should treat this as a
     signal to skip the step rather than passing a malformed empty argument
     to the underlying command.
@@ -462,7 +462,7 @@ class StepExecutor:
           to skip, so a silent drop would mask a real bug.
         * If the template uses ``default(...)`` or is a pure Jinja
           conditional (no ``steps.*`` reference), the empty result is
-          dropped from the argv — this is the explicit contract that
+          dropped from the argv - this is the explicit contract that
           supports "optional flag" YAML patterns like::
 
               args:
@@ -509,7 +509,7 @@ class StepExecutor:
                     continue
 
                 # Empty result: distinguish "explicit default(''/None)" from
-                # "silently-missing step output". The latter is an error —
+                # "silently-missing step output". The latter is an error -
                 # surface it so the caller can skip the step cleanly instead
                 # of invoking the command with a stripped-out required arg.
                 if "default(" in arg:

--- a/isvctl/tests/test_aws_delete_retry.py
+++ b/isvctl/tests/test_aws_delete_retry.py
@@ -47,7 +47,7 @@ class TestDeleteWithRetry:
         assert fn.call_count == 1
 
     def test_already_gone_is_success(self) -> None:
-        """InvalidVpcID.NotFound means end state reached — return True."""
+        """InvalidVpcID.NotFound means end state reached - return True."""
         fn = MagicMock(side_effect=_client_error("InvalidVpcID.NotFound"))
         assert delete_with_retry(fn, VpcId="vpc-gone", resource_desc="VPC") is True
         assert fn.call_count == 1
@@ -66,7 +66,7 @@ class TestDeleteWithRetry:
 
     @patch("common.errors.time.sleep")
     def test_retries_transient_client_error_then_succeeds(self, sleep: MagicMock) -> None:
-        """Throttling retries and succeeds on attempt 2 — orphan avoided."""
+        """Throttling retries and succeeds on attempt 2 - orphan avoided."""
         fn = MagicMock(side_effect=[_client_error("Throttling"), None])
         assert delete_with_retry(fn, resource_desc="VPC", backoff_seconds=0.0) is True
         assert fn.call_count == 2
@@ -108,7 +108,7 @@ class TestDeleteWithRetry:
 
     def test_non_transient_client_error_no_retry(self) -> None:
         """Non-transient codes (e.g. DependencyViolation) return False
-        immediately — no point spinning, and the caller's finally block
+        immediately - no point spinning, and the caller's finally block
         already accepts best-effort semantics."""
         fn = MagicMock(side_effect=_client_error("DependencyViolation"))
         assert delete_with_retry(fn, resource_desc="VPC", attempts=3, backoff_seconds=0.0) is False

--- a/isvctl/tests/test_aws_verified_reuse.py
+++ b/isvctl/tests/test_aws_verified_reuse.py
@@ -85,7 +85,7 @@ class TestCreateKeyPairVerifiedReuse:
             create_key_pair(ec2, "k1", key_dir=tmp_path)
 
     def test_recreates_when_tagged_but_local_file_missing(self, tmp_path: Path) -> None:
-        """Tag matches but PEM missing — delete and recreate (ours, unrecoverable)."""
+        """Tag matches but PEM missing - delete and recreate (ours, unrecoverable)."""
         ec2 = MagicMock()
         ec2.describe_key_pairs.return_value = {"KeyPairs": [{"KeyName": "k1", "Tags": _ISV_TAGS}]}
         ec2.create_key_pair.return_value = {
@@ -150,7 +150,7 @@ class TestCreateSecurityGroupVerifiedReuse:
         }
 
         assert create_security_group(ec2, "vpc-1", "sg1") == "sg-existing"
-        # Did NOT authorize ingress on reuse — the rule already exists.
+        # Did NOT authorize ingress on reuse - the rule already exists.
         ec2.authorize_security_group_ingress.assert_not_called()
 
     def test_raises_on_duplicate_missing_isv_tag(self) -> None:
@@ -212,7 +212,7 @@ class TestCreateSecurityGroupVerifiedReuse:
             create_security_group(ec2, "vpc-1", "sg1")
 
     def test_raises_on_duplicate_but_describe_empty(self) -> None:
-        """API race: duplicate error but describe returns nothing — raise the
+        """API race: duplicate error but describe returns nothing - raise the
         original ClientError rather than swallow silently."""
         ec2 = MagicMock()
         ec2.create_security_group.side_effect = _client_error("InvalidGroup.Duplicate")
@@ -229,7 +229,7 @@ class TestCreateSecurityGroupVerifiedReuse:
 
 
 class TestSanitizeKeyName:
-    """sanitize_key_name — prevent path traversal when
+    """sanitize_key_name - prevent path traversal when
     ``key_name`` is composed into a filesystem path like /tmp/<name>.pem."""
 
     @pytest.mark.parametrize(
@@ -267,7 +267,7 @@ class TestSanitizeKeyName:
 
 
 class TestWaitForPublicIp:
-    """wait_for_public_ip — always poll describe_instances,
+    """wait_for_public_ip - always poll describe_instances,
     never fall back to a pre-stop value."""
 
     def test_returns_fresh_ip_on_first_poll(self) -> None:

--- a/isvctl/tests/test_orchestrator.py
+++ b/isvctl/tests/test_orchestrator.py
@@ -451,3 +451,65 @@ class TestContext:
 
         assert len(caplog.records) == 1
         assert "step 'launch_instance' has no output" in caplog.records[0].message
+
+    def test_no_warning_inside_silenced_validation_subtree(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Templates inside a validation pytest will deselect must not warn.
+
+        Mirrors the microk8s case: K8sNodePoolCheck is marker-excluded (slow)
+        and references steps that don't exist on the provider. Since the check
+        never runs, its dead template refs should be silent.
+        """
+        config = RunConfig()
+        context = Context(config)
+        context.set_silenced_validation_names({"K8sNodePoolCheck"})
+
+        data = {
+            "k8s_node_pools": {
+                "checks": {
+                    "K8sNodePoolCheck-Create": {
+                        "label_selector": "{{ steps.create_test_node_pool.label_selector }}",
+                        "expected_replicas": "{{ steps.create_test_node_pool.expected_replicas | default(1, true) }}",
+                    },
+                    "K8sNodePoolCheck-Update": {
+                        "label_selector": "{{ steps.update_test_node_pool.label_selector }}",
+                    },
+                },
+            },
+        }
+
+        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
+            context.render_dict(data)
+
+        assert caplog.records == []
+        assert context.get_warnings() == []
+
+    def test_warnings_still_emitted_outside_silenced_subtrees(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Silencing must not leak past the silenced subtree."""
+        config = RunConfig()
+        context = Context(config)
+        context.set_silenced_validation_names({"K8sNodePoolCheck"})
+
+        data = {
+            "k8s_node_pools": {
+                "checks": {
+                    "K8sNodePoolCheck-Create": {
+                        "label_selector": "{{ steps.create_test_node_pool.label_selector }}",
+                    },
+                },
+            },
+            "kubernetes": {
+                "checks": {
+                    "K8sNodeCountCheck": {
+                        "count": "{{ steps.setup.kubernetes.node_count | default(1, true) }}",
+                    },
+                },
+            },
+        }
+
+        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
+            context.render_dict(data)
+
+        messages = [r.message for r in caplog.records]
+        assert len(messages) == 1
+        assert "step 'setup' has no output" in messages[0]
+        assert not any("create_test_node_pool" in m for m in messages)

--- a/isvctl/tests/test_orchestrator.py
+++ b/isvctl/tests/test_orchestrator.py
@@ -400,3 +400,54 @@ class TestContext:
         assert len(caplog.records) == 1
         assert "'typo_field' not found" in caplog.records[0].message
         assert "gpu_per_node" in caplog.records[0].message
+
+    def test_no_warning_when_step_phase_is_after_current_phase(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Rendering during an earlier phase must not warn about pending later-phase steps.
+
+        Validations are rendered once per phase against the full config, so a
+        ``test``-phase template like ``{{ steps.describe_instance.public_ip }}``
+        is evaluated while ``setup`` is still running. The step exists and will
+        run later; warning here is pure noise.
+        """
+        config = RunConfig()
+        context = Context(config)
+        context.set_requested_phases({"setup", "test", "teardown"})
+        context.set_step_phase("describe_instance", "test")
+        context.set_current_phase("setup", ["setup", "test", "teardown"])
+
+        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
+            result = context.render_string("{{ steps.describe_instance.public_ip | default('1.2.3.4', true) }}")
+
+        assert result == "1.2.3.4"
+        assert caplog.records == []
+        assert context.get_warnings() == []
+
+    def test_warns_when_step_phase_is_current_phase_with_no_output(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A step in the phase currently being rendered that produced no output should warn."""
+        config = RunConfig()
+        context = Context(config)
+        context.set_requested_phases({"setup", "test", "teardown"})
+        context.set_step_phase("launch_instance", "setup")
+        context.set_current_phase("setup", ["setup", "test", "teardown"])
+
+        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
+            context.render_string("{{ steps.launch_instance.instance_id | default('i-0', true) }}")
+
+        assert len(caplog.records) == 1
+        assert "step 'launch_instance' has no output" in caplog.records[0].message
+
+    def test_warns_when_step_phase_is_before_current_phase_with_no_output(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A step whose phase already completed but produced no output should still warn."""
+        config = RunConfig()
+        context = Context(config)
+        context.set_requested_phases({"setup", "test", "teardown"})
+        context.set_step_phase("launch_instance", "setup")
+        context.set_current_phase("test", ["setup", "test", "teardown"])
+
+        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
+            context.render_string("{{ steps.launch_instance.instance_id | default('i-0', true) }}")
+
+        assert len(caplog.records) == 1
+        assert "step 'launch_instance' has no output" in caplog.records[0].message

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -512,7 +512,7 @@ class TestMissingStepRefDetection:
         not invoked with a stripped-out required arg."""
         executor = StepExecutor()
         context = Context(RunConfig())
-        # No "create_network" step output — simulates a failed setup step.
+        # No "create_network" step output - simulates a failed setup step.
         steps = [
             StepConfig(
                 name="teardown_network",

--- a/isvtest/src/isvtest/config/settings.py
+++ b/isvtest/src/isvtest/config/settings.py
@@ -315,7 +315,7 @@ def get_nim_genai_perf_concurrency() -> int:
 
 
 def get_k8s_require_dual_stack() -> str:
-    """Get the dual-stack requirement for :class:`K8sDualStackNodeCheck`.
+    """Get the dual-stack requirement for ``K8sDualStackNodeCheck``.
 
     Returns:
         One of ``"true"``, ``"false"``, or ``"auto"`` (default: ``"auto"``).

--- a/isvtest/src/isvtest/config/settings.py
+++ b/isvtest/src/isvtest/config/settings.py
@@ -328,7 +328,7 @@ def get_k8s_csi_block_storage_class() -> str:
     """Get StorageClass name for CSI block storage validation.
 
     Returns:
-        StorageClass name (default: empty string — subtest will skip).
+        StorageClass name (default: empty string - subtest will skip).
     """
     return os.getenv("K8S_CSI_BLOCK_SC", "")
 
@@ -337,7 +337,7 @@ def get_k8s_csi_shared_fs_storage_class() -> str:
     """Get StorageClass name for CSI shared filesystem (RWX) validation.
 
     Returns:
-        StorageClass name (default: empty string — subtest will skip).
+        StorageClass name (default: empty string - subtest will skip).
     """
     return os.getenv("K8S_CSI_SHARED_FS_SC", "")
 
@@ -346,7 +346,7 @@ def get_k8s_csi_nfs_storage_class() -> str:
     """Get StorageClass name for CSI NFS validation.
 
     Returns:
-        StorageClass name (default: empty string — subtest will skip).
+        StorageClass name (default: empty string - subtest will skip).
     """
     return os.getenv("K8S_CSI_NFS_SC", "")
 

--- a/isvtest/src/isvtest/core/k8s.py
+++ b/isvtest/src/isvtest/core/k8s.py
@@ -29,7 +29,7 @@ from isvtest.core.logger import setup_logger
 logger = setup_logger(__name__)
 
 # Container waiting reasons that kubelet only reports after it has already
-# given up retrying — callers can fast-fail instead of waiting out a timeout.
+# given up retrying - callers can fast-fail instead of waiting out a timeout.
 TERMINAL_WAITING_REASONS: frozenset[str] = frozenset(
     {
         "ImagePullBackOff",
@@ -192,7 +192,7 @@ def get_kubectl_base_shell(*args: str) -> str:
     (``subprocess.run``), use ``get_kubectl_command`` instead.
 
     With no args, returns just the provider-aware kubectl prefix. With args,
-    returns the fully composed, shell-quoted command — useful for callers
+    returns the fully composed, shell-quoted command - useful for callers
     that would otherwise re-implement the quoting inline.
     """
     return " ".join(shlex.quote(part) for part in (*get_kubectl_command(), *args))

--- a/isvtest/src/isvtest/core/k8s.py
+++ b/isvtest/src/isvtest/core/k8s.py
@@ -189,7 +189,7 @@ def get_kubectl_base_shell(*args: str) -> str:
 
     Use this when interpolating kubectl into a shell command string (e.g.
     passing to ``run_command`` or composing pipes). For argv-style calls
-    (``subprocess.run``), use :func:`get_kubectl_command` instead.
+    (``subprocess.run``), use ``get_kubectl_command`` instead.
 
     With no args, returns just the provider-aware kubectl prefix. With args,
     returns the fully composed, shell-quoted command — useful for callers

--- a/isvtest/src/isvtest/core/k8s.py
+++ b/isvtest/src/isvtest/core/k8s.py
@@ -205,7 +205,7 @@ def render_k8s_manifest(
     """Load a multi-doc YAML manifest, apply ``mutate`` to each doc, and serialize it back.
 
     The manifest file must contain valid, parseable YAML with sensible default
-    values — callers mutate the parsed objects rather than templating strings.
+    values - callers mutate the parsed objects rather than templating strings.
     This keeps manifests readable in isolation and avoids quoting / escaping
     pitfalls of ``str.replace``-style substitution.
 

--- a/isvtest/src/isvtest/core/validation.py
+++ b/isvtest/src/isvtest/core/validation.py
@@ -35,7 +35,7 @@ def check_required_tests(
     """Check that step_output.tests contains every required key with passed=True.
 
     Sets failed on the validation if tests are missing or any required key did
-    not pass. On success, returns True without setting passed — the caller is
+    not pass. On success, returns True without setting passed - the caller is
     expected to call ``set_passed`` with a context-appropriate message.
     """
     step_output = validation.config.get("step_output", {})

--- a/isvtest/src/isvtest/validations/instance.py
+++ b/isvtest/src/isvtest/validations/instance.py
@@ -80,7 +80,7 @@ class InstanceRebootCheck(BaseValidation):
         state: Instance state after reboot
         ssh_ready: Whether SSH is accessible after reboot
         uptime_seconds: System uptime after reboot
-        reboot_confirmed: Whether uptime comparison confirms reboot — REQUIRED True
+        reboot_confirmed: Whether uptime comparison confirms reboot - REQUIRED True
     """
 
     description: ClassVar[str] = "Check instance rebooted successfully"

--- a/isvtest/src/isvtest/validations/k8s_api_network_acl.py
+++ b/isvtest/src/isvtest/validations/k8s_api_network_acl.py
@@ -125,12 +125,12 @@ class K8sApiNetworkAclCheck(BaseValidation):
             )
             return None
         raw = result.stdout.strip()
-        # jsonpath with two missing components renders as ":" — treat that as
+        # jsonpath with two missing components renders as ":" - treat that as
         # "endpoint not populated yet" rather than a valid host:port.
         if not raw or raw == ":":
             self.set_failed(
                 f"Cluster {cluster_name!r} in namespace {namespace!r} has no "
-                f"`spec.controlPlaneEndpoint` populated — the control plane "
+                f"`spec.controlPlaneEndpoint` populated - the control plane "
                 f"has not yet been provisioned, or this infra provider does "
                 f"not surface the endpoint here. Set "
                 f"`require_endpoint_info: false` if this is expected."
@@ -142,7 +142,7 @@ class K8sApiNetworkAclCheck(BaseValidation):
         """Run the authorized baseline probe and report failure on non-zero exit.
 
         Returns ``True`` if the probe succeeded, or ``False`` after calling
-        ``set_failed`` — a failing baseline makes the unauthorized-probe result
+        ``set_failed`` - a failing baseline makes the unauthorized-probe result
         ambiguous, so the check must stop before interpreting it.
         """
         result = self.run_command(authorized_probe_cmd, timeout=probe_timeout)
@@ -199,6 +199,6 @@ class K8sApiNetworkAclCheck(BaseValidation):
 
         self.set_passed(
             f"API endpoint{endpoint_clause} blocked the unauthorized probe "
-            f"(exit={result.exit_code}) and served the authorized probe — network "
+            f"(exit={result.exit_code}) and served the authorized probe - network "
             f"ACL verified."
         )

--- a/isvtest/src/isvtest/validations/k8s_conformance.py
+++ b/isvtest/src/isvtest/validations/k8s_conformance.py
@@ -16,7 +16,7 @@ image pins ``ginkgo`` + ``e2e.test`` to a Kubernetes release, invokes them
 through ``run_e2e.sh``, and writes a JUnit report to the results directory.
 
 The image's default entrypoint exits when the suite finishes, which would let
-the Pod transition to ``Succeeded`` — after which ``kubectl exec`` can no
+the Pod transition to ``Succeeded`` - after which ``kubectl exec`` can no
 longer enter the container to retrieve artifacts. To avoid that, we override
 the container command with a small shell wrapper that runs ``run_e2e.sh``,
 writes the exit code to ``/tmp/results/done``, and then ``sleep infinity`` so
@@ -82,7 +82,7 @@ class K8sCncfConformanceCheck(BaseValidation):
     _PROGRESS_INTERVAL = 60.0
 
     # Resource defaults chosen to keep the pod in Burstable QoS with real
-    # ephemeral-storage accounting — a BestEffort pod is the first kubelet
+    # ephemeral-storage accounting - a BestEffort pod is the first kubelet
     # evicts under node pressure, which kills long conformance runs. CPU limit
     # is intentionally omitted: CFS throttling on e2e.test causes spurious
     # test timeouts. Memory limit is generous because ginkgo + e2e.test can
@@ -185,7 +185,7 @@ class K8sCncfConformanceCheck(BaseValidation):
 
             completion_error = self._wait_for_completion(namespace, self._POD_NAME, conformance_timeout)
             if completion_error is not None:
-                # Logs may be empty if the pod is gone — fall back to events so
+                # Logs may be empty if the pod is gone - fall back to events so
                 # the report surfaces evictions / taints.
                 output = self._get_pod_logs(namespace, self._POD_NAME)
                 if not output:
@@ -220,7 +220,7 @@ class K8sCncfConformanceCheck(BaseValidation):
                 f"{summary.failed} failed, {summary.skipped} skipped"
             )
             if summary.total == 0:
-                self.set_failed(f"{msg} — no testcases parsed from JUnit output")
+                self.set_failed(f"{msg} - no testcases parsed from JUnit output")
             elif summary.failed > 0:
                 failed_names = [c.name for c in summary.cases if not c.passed and not c.skipped][:10]
                 self.set_failed(msg, output="First failures:\n" + "\n".join(failed_names))
@@ -299,7 +299,7 @@ class K8sCncfConformanceCheck(BaseValidation):
     def _wait_for_pod_running(self, namespace: str, pod_name: str, timeout: int) -> str | None:
         """Poll until the pod is Running. Return None on success, or a failure
         message explaining why startup is doomed (image pull errors, Failed
-        phase, deletion, or timeout) — the caller surfaces it via set_failed."""
+        phase, deletion, or timeout) - the caller surfaces it via set_failed."""
         deadline = time.time() + timeout
         last_progress = time.time()
         prev_transient_reason = ""
@@ -384,7 +384,7 @@ class K8sCncfConformanceCheck(BaseValidation):
     ) -> tuple[bool, str]:
         """Cat ``path`` inside the pod. Returns ``(ok, content)``.
 
-        ``quiet=True`` suppresses the warning log on failure — used for
+        ``quiet=True`` suppresses the warning log on failure - used for
         existence-polling where failure is the expected steady state until the
         file appears.
         """

--- a/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
+++ b/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
@@ -82,7 +82,7 @@ class K8sControlPlaneLogsCheck(BaseValidation):
         if raw_components is None:
             components = list(_DEFAULT_COMPONENTS)
         elif not isinstance(raw_components, (list, tuple)):
-            # str falls through here too — `isinstance("foo", (list, tuple))` is False —
+            # str falls through here too - `isinstance("foo", (list, tuple))` is False -
             # which stops YAML scalars from being iterated character-by-character.
             self.set_failed(
                 f"`components` must be a YAML list, got {type(raw_components).__name__}: "
@@ -152,7 +152,7 @@ class K8sControlPlaneLogsCheck(BaseValidation):
         """Resolve each component to a ``(component, path, target)`` triple.
 
         In ``auto`` mode we try kubectl first per-component and fall through
-        to ``commands[component]`` when the pod isn't present — this covers
+        to ``commands[component]`` when the pod isn't present - this covers
         hybrid clusters where some components are static pods and others are
         managed externally.
         """
@@ -185,13 +185,13 @@ class K8sControlPlaneLogsCheck(BaseValidation):
 
         # Auto mode: a probe_error means kubectl itself failed (kubeconfig,
         # RBAC, or context), not "no matching pods". Don't mask that by
-        # falling through to commands for every component — the operator
+        # falling through to commands for every component - the operator
         # needs to see the access failure and explicitly choose `mode: command`.
         if mode == "auto" and probe_error is not None:
             self.set_failed(
                 f"Unable to list pods in namespace {namespace!r} (kubectl error: "
                 f"{probe_error}). Auto mode cannot verify which components should "
-                f"use kubectl vs. commands — fix cluster access or set "
+                f"use kubectl vs. commands - fix cluster access or set "
                 f"`mode: command` to use the `commands` mapping explicitly."
             )
             return None
@@ -235,7 +235,7 @@ class K8sControlPlaneLogsCheck(BaseValidation):
             self.set_failed(
                 f"Unable to list pods in namespace {namespace!r} (kubectl "
                 f"error: {probe_error}). Cannot decide between kubectl and "
-                f"command paths — fix cluster access or set `mode: command` "
+                f"command paths - fix cluster access or set `mode: command` "
                 f"with a `commands` mapping."
             )
             return
@@ -322,7 +322,7 @@ class K8sControlPlaneLogsCheck(BaseValidation):
         """Return ``({component: pod_name}, probe_error)`` for the namespace.
 
         Resolution runs from a single ``kubectl get pods`` call that emits
-        ``<pod_name>\\t<component_label>`` per line — label matching and
+        ``<pod_name>\\t<component_label>`` per line - label matching and
         the name-prefix fallback are both resolved client-side from that
         one response, so the cost is one round-trip regardless of how
         many components are requested.
@@ -353,7 +353,7 @@ class K8sControlPlaneLogsCheck(BaseValidation):
 
         # Pass 1: exact ``component`` label match. On HA control planes a
         # component may have multiple replicas (e.g. 3 kube-apiservers);
-        # we intentionally pick the first pod kubectl returns — one log
+        # we intentionally pick the first pod kubectl returns - one log
         # sample is enough for this check, and probing every replica
         # would multiply round-trips without changing pass/fail.
         for component in components:

--- a/isvtest/src/isvtest/validations/k8s_network_policy.py
+++ b/isvtest/src/isvtest/validations/k8s_network_policy.py
@@ -12,10 +12,10 @@
 
 This module provides two independent ``BaseValidation`` subclasses:
 
-* :class:`K8sNetworkPolicyCheck` — applies a pair of NetworkPolicies in an
+* ``K8sNetworkPolicyCheck`` - applies a pair of NetworkPolicies in an
   ephemeral namespace and verifies that ingress/egress are enforced as
   expected against both IPv4 and (when available) IPv6 pod addresses.
-* :class:`K8sDualStackNodeCheck` — inspects every node's ``InternalIP``
+* ``K8sDualStackNodeCheck`` - inspects every node's ``InternalIP``
   addresses and verifies that the cluster is dual-stack (IPv4 + IPv6) when
   configuration requires it.
 
@@ -57,7 +57,7 @@ class K8sNetworkPolicyCheck(BaseValidation):
 
     Config keys (with defaults):
         image: Agnhost image providing ``connect`` / ``netexec``
-            (default from :func:`get_k8s_network_policy_image`).
+            (default from ``get_k8s_network_policy_image``).
         probe_port: TCP port exposed by the server pods (default: 8080).
         probe_timeout_s: ``agnhost connect`` timeout per probe (default: 10).
         settle_timeout_s: Max time to wait after applying the policies before
@@ -335,7 +335,7 @@ class K8sDualStackNodeCheck(BaseValidation):
     Config keys (with defaults):
         require_dual_stack: One of ``True``, ``False``, or ``"auto"``. Defaults
             to the value returned by
-            :func:`isvtest.config.settings.get_k8s_require_dual_stack`
+            ``isvtest.config.settings.get_k8s_require_dual_stack``
             (``"auto"`` unless ``K8S_REQUIRE_DUAL_STACK`` is set).
 
     Decision matrix:
@@ -468,7 +468,7 @@ def _classify_node(node: dict[str, Any]) -> tuple[bool, bool]:
 
     podCIDRs are deliberately ignored here — a node that advertises both pod CIDR
     families but only one InternalIP family is not dual-stack at the node level.
-    Use :func:`_node_podcidr_families` for cluster-level auto-detection hints.
+    Use ``_node_podcidr_families`` for cluster-level auto-detection hints.
     """
     has_v4 = False
     has_v6 = False

--- a/isvtest/src/isvtest/validations/k8s_network_policy.py
+++ b/isvtest/src/isvtest/validations/k8s_network_policy.py
@@ -127,7 +127,7 @@ class K8sNetworkPolicyCheck(BaseValidation):
                 for ip in server_ips:
                     if not self._probe(client, ip):
                         self.set_failed(
-                            f"Baseline connectivity broken — CNI issue? {client} could not reach server at {ip}"
+                            f"Baseline connectivity broken - CNI issue? {client} could not reach server at {ip}"
                         )
                         return
 
@@ -137,7 +137,7 @@ class K8sNetworkPolicyCheck(BaseValidation):
                 for ip in other_ips:
                     if not self._probe("allowed-client", ip):
                         self.set_failed(
-                            f"Baseline connectivity broken — CNI issue? allowed-client could not reach other-server at {ip}"
+                            f"Baseline connectivity broken - CNI issue? allowed-client could not reach other-server at {ip}"
                         )
                         return
 
@@ -339,9 +339,9 @@ class K8sDualStackNodeCheck(BaseValidation):
             (``"auto"`` unless ``K8S_REQUIRE_DUAL_STACK`` is set).
 
     Decision matrix:
-        * ``True`` — any node missing either family fails the validation.
-        * ``False`` — always passes; per-node summary is still emitted.
-        * ``"auto"`` — if at least one node has both families the cluster is
+        * ``True`` - any node missing either family fails the validation.
+        * ``False`` - always passes; per-node summary is still emitted.
+        * ``"auto"`` - if at least one node has both families the cluster is
           treated as dual-stack and every node must be; if no node has both
           the check skips.
     """
@@ -466,7 +466,7 @@ def _is_ipv6(addr: str) -> bool:
 def _classify_node(node: dict[str, Any]) -> tuple[bool, bool]:
     """Return ``(has_ipv4, has_ipv6)`` based on the node's InternalIP addresses.
 
-    podCIDRs are deliberately ignored here — a node that advertises both pod CIDR
+    podCIDRs are deliberately ignored here - a node that advertises both pod CIDR
     families but only one InternalIP family is not dual-stack at the node level.
     Use ``_node_podcidr_families`` for cluster-level auto-detection hints.
     """

--- a/isvtest/src/isvtest/validations/k8s_node_pool.py
+++ b/isvtest/src/isvtest/validations/k8s_node_pool.py
@@ -46,18 +46,18 @@ class K8sNodePoolCheck(BaseValidation):
 
     Config keys (populated from the provisioning step's JSON output):
 
-    * ``label_selector`` — kubectl label selector identifying the new nodes
+    * ``label_selector`` - kubectl label selector identifying the new nodes
       (e.g. ``eks.amazonaws.com/nodegroup=isv-test-pool``). Required.
-    * ``expected_replicas`` — node count that must reach Ready. Required.
-    * ``expected_labels`` — mapping or JSON string; subset check per node.
-    * ``expected_taints`` — list of ``{key, value, effect}`` or JSON string;
+    * ``expected_replicas`` - node count that must reach Ready. Required.
+    * ``expected_labels`` - mapping or JSON string; subset check per node.
+    * ``expected_taints`` - list of ``{key, value, effect}`` or JSON string;
       subset check per node.
-    * ``expected_instance_types`` — list of instance type strings or JSON
+    * ``expected_instance_types`` - list of instance type strings or JSON
       string; each node's type must be in this set.
-    * ``node_type`` — informational ``"cpu"`` or ``"gpu"`` tag surfaced in
+    * ``node_type`` - informational ``"cpu"`` or ``"gpu"`` tag surfaced in
       the result message.
-    * ``wait_timeout`` — seconds to wait for nodes to reach Ready (default 600).
-    * ``poll_interval`` — seconds between polls (default 5).
+    * ``wait_timeout`` - seconds to wait for nodes to reach Ready (default 600).
+    * ``poll_interval`` - seconds between polls (default 5).
 
     The label-check, taint-check, and instance-type-check are each skipped
     when their corresponding ``expected_*`` config is empty, so callers can

--- a/isvtest/src/isvtest/validations/k8s_node_pool.py
+++ b/isvtest/src/isvtest/validations/k8s_node_pool.py
@@ -157,7 +157,7 @@ class K8sNodePoolCheck(BaseValidation):
         """Poll until ``expected_replicas`` nodes match ``label_selector`` and are Ready.
 
         Returns the list of node objects on success. On failure/timeout,
-        calls :meth:`set_failed` and returns ``None``.
+        calls ``set_failed`` and returns ``None``.
         """
         cmd = f"{get_kubectl_base_shell()} get nodes -l {shlex.quote(label_selector)} -o json"
         deadline = time.monotonic() + wait_timeout

--- a/isvtest/src/isvtest/validations/k8s_storage.py
+++ b/isvtest/src/isvtest/validations/k8s_storage.py
@@ -12,17 +12,17 @@
 
 Implements:
 
-* :class:`K8sCsiStorageTypesCheck` — verify the cluster exposes a
+* :class:`K8sCsiStorageTypesCheck` - verify the cluster exposes a
   StorageClass for each of block / shared filesystem / NFS storage and that
   a PVC binds against each configured class.
-* :class:`K8sCsiStorageQuotaApiCheck` — verify Kubernetes-native
+* :class:`K8sCsiStorageQuotaApiCheck` - verify Kubernetes-native
   APIs expose storage quota and per-PVC/PV usage.
-* :class:`K8sCsiTenantScopedCredentialsCheck` — verify CSI
+* :class:`K8sCsiTenantScopedCredentialsCheck` - verify CSI
   credentials are tenant-scoped "by construction" by inspecting in-cluster
   observable state (Secret namespaces, labels, ServiceAccount RBAC, and
   node-plugin volume topology). Does not prove cross-cluster isolation from
   the outside.
-* :class:`K8sCsiProvisioningModesCheck` — verify CSI supports
+* :class:`K8sCsiProvisioningModesCheck` - verify CSI supports
   both dynamic and static provisioning, driving each through a real mount
   + canary-file write/read inside a BusyBox pod.
 """
@@ -135,8 +135,8 @@ class K8sCsiStorageTypesCheck(BaseValidation):
 
     For each configured storage type, two subtests run:
 
-    * ``sc-exists[<type>]`` — the named StorageClass is visible to kubectl.
-    * ``pvc-binds[<type>]`` — a fresh PVC against that StorageClass reaches
+    * ``sc-exists[<type>]`` - the named StorageClass is visible to kubectl.
+    * ``pvc-binds[<type>]`` - a fresh PVC against that StorageClass reaches
       ``Bound`` within ``bind_timeout_s``. A BusyBox consumer pod is
       scheduled alongside the PVC so this also works for StorageClasses
       with ``volumeBindingMode: WaitForFirstConsumer`` (the default for
@@ -370,17 +370,17 @@ class K8sCsiStorageQuotaApiCheck(BaseValidation):
 
     Four subtests run against a single ephemeral namespace:
 
-    * ``resourcequota-storage-api`` — a ResourceQuota carrying both
+    * ``resourcequota-storage-api`` - a ResourceQuota carrying both
       ``requests.storage`` and
       ``<sc>.storageclass.storage.k8s.io/requests.storage`` lands and its
       ``.status.hard`` publishes both keys.
-    * ``per-pvc-usage`` — a PVC against the configured StorageClass binds
+    * ``per-pvc-usage`` - a PVC against the configured StorageClass binds
       (via a BusyBox consumer pod so this works under
       ``WaitForFirstConsumer``), exposes ``.status.capacity.storage``, and
       its usage is reflected in the ResourceQuota's ``.status.used``.
-    * ``quota-enforcement`` — an over-quota PVC is rejected at admission
+    * ``quota-enforcement`` - an over-quota PVC is rejected at admission
       with an ``exceeded quota`` / ``forbidden`` message.
-    * ``pv-usage-api`` — the bound PV exposes ``.spec.capacity.storage``,
+    * ``pv-usage-api`` - the bound PV exposes ``.spec.capacity.storage``,
       ``.spec.claimRef.name`` matching the usage PVC, and
       ``.spec.csi.driver``.
 
@@ -766,7 +766,7 @@ class K8sCsiStorageQuotaApiCheck(BaseValidation):
         """Poll ``ResourceQuota.status.<section>`` until every ``required_keys`` entry appears.
 
         Returns the section dict once fully populated, or ``None`` on timeout
-        / parse failure. Keys are compared verbatim — the caller is
+        / parse failure. Keys are compared verbatim - the caller is
         responsible for passing the concrete per-StorageClass key name.
         """
         deadline = time.time() + timeout_s
@@ -859,25 +859,25 @@ class K8sCsiTenantScopedCredentialsCheck(BaseValidation):
 
     This check inspects in-cluster observable state only; it does **not**
     attempt any cross-cluster exfiltration, and so cannot prove isolation
-    between tenants from the outside — that is tracked separately.
+    between tenants from the outside - that is tracked separately.
 
     Five subtests run (all must pass):
 
-    * ``csi-secrets-discovered`` — enumerate CSI drivers and discover the
+    * ``csi-secrets-discovered`` - enumerate CSI drivers and discover the
       Secrets they reference via ``PersistentVolume.spec.csi.*SecretRef``
       and via CSI controller/node pod specs (``envFrom``, ``env.valueFrom``,
       Secret volume mounts). Skipped when no ``CSIDriver`` objects exist.
-    * ``secrets-not-cross-namespace`` — every discovered Secret lives in
+    * ``secrets-not-cross-namespace`` - every discovered Secret lives in
       ``csi_driver_namespaces`` (or ``allowed_workload_namespaces``), never
       in ``default`` or an unlisted workload namespace.
-    * ``no-shared-cluster-markers`` — no discovered Secret carries any of
+    * ``no-shared-cluster-markers`` - no discovered Secret carries any of
       ``forbidden_labels`` or an annotation like
       ``csi.nvidia.com/shared=true``.
-    * ``serviceaccount-rbac-scoped`` — CSI controller ServiceAccounts hold
+    * ``serviceaccount-rbac-scoped`` - CSI controller ServiceAccounts hold
       no ``ClusterRoleBinding`` that grants ``secrets`` verbs cluster-wide
       without a ``resourceNames`` restriction. Namespace-scoped
       ``RoleBinding`` grants are permitted.
-    * ``node-plugin-uses-hostpath-not-shared-mount`` — node-plugin pods
+    * ``node-plugin-uses-hostpath-not-shared-mount`` - node-plugin pods
       mount only local/pod-scoped volume types (hostPath, emptyDir, secret,
       configMap, projected, downwardAPI, serviceAccountToken, csi). Any
       ``nfs``/``iscsi``/``persistentVolumeClaim`` volume fails this subtest.
@@ -961,7 +961,7 @@ class K8sCsiTenantScopedCredentialsCheck(BaseValidation):
                 message=(
                     f"Discovered {len(discovered_secrets)} CSI Secret reference(s): "
                     f"{', '.join(f'{ns}/{name}' for ns, name in discovered_secrets[:10])}"
-                    + ("…" if len(discovered_secrets) > 10 else "")
+                    + ("..." if len(discovered_secrets) > 10 else "")
                 ),
             )
 
@@ -993,7 +993,7 @@ class K8sCsiTenantScopedCredentialsCheck(BaseValidation):
         for ns, name in discovered_secrets:
             secret, status = self._get_secret(ns, name)
             if status == "missing":
-                # Dangling Secret reference — the CSI pod declares it
+                # Dangling Secret reference - the CSI pod declares it
                 # (e.g. `envFrom.secretRef`) but the Secret was never
                 # created, which is the EKS / IRSA default for EFS and
                 # EBS CSI drivers. Nothing to carry a marker, so this
@@ -1024,7 +1024,7 @@ class K8sCsiTenantScopedCredentialsCheck(BaseValidation):
                     f"{len(discovered_secrets) - len(missing_secrets)} discovered Secret(s); "
                     f"{len(missing_secrets)} declared Secret ref(s) do not exist "
                     f"(likely IRSA / workload-identity): "
-                    f"{', '.join(missing_secrets[:5])}" + ("…" if len(missing_secrets) > 5 else "")
+                    f"{', '.join(missing_secrets[:5])}" + ("..." if len(missing_secrets) > 5 else "")
                 )
             else:
                 msg = f"No shared-cluster labels/annotations on {len(discovered_secrets)} discovered Secret(s)"
@@ -1125,12 +1125,12 @@ class K8sCsiTenantScopedCredentialsCheck(BaseValidation):
         """Fetch Secret ``namespace/name``; return ``(secret, status)``.
 
         ``status`` is one of:
-          * ``"found"`` — Secret exists and parsed (``secret`` is the dict).
-          * ``"missing"`` — Secret does not exist (``--ignore-not-found``
+          * ``"found"`` - Secret exists and parsed (``secret`` is the dict).
+          * ``"missing"`` - Secret does not exist (``--ignore-not-found``
             returned empty stdout). Common when a CSI pod declares an
-            ``envFrom.secretRef`` but the Secret is never created — e.g.
+            ``envFrom.secretRef`` but the Secret is never created - e.g.
             EKS CSI drivers running under IRSA.
-          * ``"error"`` — kubectl failed (Forbidden, RBAC, transient, …)
+          * ``"error"`` - kubectl failed (Forbidden, RBAC, transient, ...)
             or JSON parsing failed.
         """
         result = self.run_command(
@@ -1228,7 +1228,7 @@ def _collect_pod_secret_refs(pods_by_ns: dict[str, list[dict[str, Any]]]) -> set
     """Return Secret refs mounted / projected by CSI pods in each driver namespace.
 
     Pods whose containers do not carry a CSI-related image token are
-    ignored — this keeps noisy side-car / operator Secret references from
+    ignored - this keeps noisy side-car / operator Secret references from
     leaking into the check's scope.
     """
     refs: set[tuple[str, str]] = set()
@@ -1421,10 +1421,10 @@ class K8sCsiProvisioningModesCheck(BaseValidation):
 
     Two subtests run against a single ephemeral namespace:
 
-    * ``dynamic`` — a PVC against ``dynamic_storage_class`` reaches ``Bound``,
+    * ``dynamic`` - a PVC against ``dynamic_storage_class`` reaches ``Bound``,
       the backing PV exposes ``spec.csi.driver``, and a BusyBox pod mounts
       the PVC and round-trips a canary file (write then read back).
-    * ``static`` — a PersistentVolume with the configured ``volume_handle``
+    * ``static`` - a PersistentVolume with the configured ``volume_handle``
       + ``csi_driver`` is pre-created, a PVC with ``storageClassName: ""``
       and a matching ``volumeName`` pre-binds to that PV, and a BusyBox pod
       round-trips a canary file. Skipped when ``static_pv.volume_handle`` or
@@ -1759,7 +1759,7 @@ class K8sCsiProvisioningModesCheck(BaseValidation):
         return _poll_pvc_bound(self.run_command, self._kubectl_base, self._namespace, pvc_name, timeout_s)
 
     def _resolve_bound_pv_driver(self, pvc_name: str) -> tuple[str, str, str]:
-        """Return ``(pv_name, csi_driver, error)`` — ``error`` is empty on success."""
+        """Return ``(pv_name, csi_driver, error)`` - ``error`` is empty on success."""
         vol_cmd = (
             f"{self._kubectl_base} get pvc {shlex.quote(pvc_name)} "
             f"-n {shlex.quote(self._namespace)} -o jsonpath='{{.spec.volumeName}}'"

--- a/isvtest/src/isvtest/validations/manifests/k8s/k8s_conformance.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/k8s_conformance.yaml
@@ -46,7 +46,7 @@ spec:
     kubernetes.io/os: linux
   # Tolerate control-plane taints (legacy `master` + post-1.24 `control-plane`),
   # CriticalAddonsOnly, and the taint the k8s e2e suite itself applies during
-  # eviction tests — without the last one the conformance pod can be evicted
+  # eviction tests - without the last one the conformance pod can be evicted
   # by the suite it is running.
   tolerations:
     - key: node-role.kubernetes.io/master
@@ -64,7 +64,7 @@ spec:
       image: PLACEHOLDER_IMAGE
       imagePullPolicy: IfNotPresent
       # The image entrypoint exits when the suite finishes, which would let the
-      # Pod transition to Succeeded — after which kubectl exec can no longer
+      # Pod transition to Succeeded - after which kubectl exec can no longer
       # enter the container to retrieve artifacts. Wrap run_e2e.sh so we record
       # the exit code and keep the container Running for artifact retrieval.
       command: ["/bin/sh", "-c"]

--- a/isvtest/src/isvtest/validations/manifests/k8s/network_policy_egress.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/network_policy_egress.yaml
@@ -5,7 +5,7 @@
 #
 # Applied to pods labeled role=allowed-client. Allows egress traffic only to
 # pods labeled role=server. All other egress (including to other-server) is
-# denied. DNS is intentionally NOT allowed — the validation probes by pod IP.
+# denied. DNS is intentionally NOT allowed - the validation probes by pod IP.
 #
 # Placeholders (replaced by K8sNetworkPolicyCheck at runtime):
 #   __NAMESPACE__ - ephemeral test namespace

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -23,7 +23,7 @@ class BmcTenantIsolationCheck(BaseValidation):
     """Validate BMC interfaces are not reachable from tenant networks.
 
     Verifies that management interfaces (BMC/IPMI/Redfish) are isolated
-    from tenant-accessible networks — probes from the tenant network to
+    from tenant-accessible networks - probes from the tenant network to
     known BMC endpoints must be refused or time out.
 
     Config:
@@ -55,7 +55,7 @@ class ApiEndpointIsolationCheck(BaseValidation):
     """Validate no public internet access to API endpoints by default.
 
     Verifies that platform API endpoints (control plane, management APIs)
-    are not directly accessible from the public internet — connections
+    are not directly accessible from the public internet - connections
     from outside the private network must be refused.
 
     Config:

--- a/isvtest/tests/test_instance.py
+++ b/isvtest/tests/test_instance.py
@@ -32,7 +32,7 @@ def _reboot_output(**overrides: Any) -> dict[str, Any]:
 
 
 class TestInstanceRebootCheck:
-    """Tests for InstanceRebootCheck — the check must require an affirmative
+    """Tests for InstanceRebootCheck - the check must require an affirmative
     ``reboot_confirmed: True`` rather than treating absence as success."""
 
     def test_passes_with_affirmative_confirmation(self) -> None:
@@ -51,7 +51,7 @@ class TestInstanceRebootCheck:
         assert "not affirmatively confirmed" in result["error"]
 
     def test_fails_when_reboot_confirmed_none(self) -> None:
-        """Explicit None must FAIL — same semantic as absent."""
+        """Explicit None must FAIL - same semantic as absent."""
         v = InstanceRebootCheck(config={"step_output": _reboot_output(reboot_confirmed=None)})
         result = v.execute()
         assert result["passed"] is False

--- a/isvtest/tests/test_k8s_api_network_acl.py
+++ b/isvtest/tests/test_k8s_api_network_acl.py
@@ -117,7 +117,7 @@ class TestEndpointRead:
 
     def test_empty_endpoint_rejected(self) -> None:
         """A resource with no ``controlPlaneEndpoint`` renders as ``:`` under
-        the jsonpath format string — the check must refuse rather than
+        the jsonpath format string - the check must refuse rather than
         treating it as a valid host:port."""
         check = K8sApiNetworkAclCheck(config=_minimal_config())
 
@@ -133,7 +133,7 @@ class TestEndpointRead:
 
     def test_cluster_read_skipped_when_require_endpoint_info_false(self) -> None:
         """When the operator opts out, the cluster-read is skipped entirely
-        so probes are the only source of truth — needed for non-CAPI
+        so probes are the only source of truth - needed for non-CAPI
         providers where the Cluster CRD doesn't exist."""
         check = K8sApiNetworkAclCheck(config=_minimal_config(require_endpoint_info=False))
         observed: list[str] = []
@@ -174,7 +174,7 @@ class TestEndpointRead:
 class TestAuthorizedProbe:
     def test_authorized_failure_aborts_with_baseline_message(self) -> None:
         """A failing authorized probe means the API is unreachable even from
-        an allow-listed source. We can't then assert anything about ACLs —
+        an allow-listed source. We can't then assert anything about ACLs -
         a failing unauthorized probe could equally mean 'ACL works' or
         'API dead'. The check must refuse to guess."""
         check = K8sApiNetworkAclCheck(config=_minimal_config())
@@ -243,7 +243,7 @@ class TestUnauthorizedProbe:
         assert "exit=7" in check.message
 
     def test_passes_when_unauthorized_probe_times_out(self) -> None:
-        """A timeout surfaces as a non-zero exit from the runner — that must
+        """A timeout surfaces as a non-zero exit from the runner - that must
         count as a valid 'blocked' outcome identical to connection refused."""
         check = K8sApiNetworkAclCheck(config=_minimal_config())
 
@@ -286,7 +286,7 @@ class TestUnauthorizedProbe:
         assert "no network ACL is in place" in check.message
 
     def test_fails_when_unauthorized_probe_command_not_found(self) -> None:
-        """Exit 127 (command not found) must not be mistaken for an enforced ACL —
+        """Exit 127 (command not found) must not be mistaken for an enforced ACL -
         a broken probe would otherwise produce a false pass."""
         check = K8sApiNetworkAclCheck(config=_minimal_config())
 

--- a/isvtest/tests/test_k8s_conformance.py
+++ b/isvtest/tests/test_k8s_conformance.py
@@ -98,7 +98,7 @@ class CommandRouter:
 
     Results can be a single CommandResult or a list. Lists are consumed in
     order; the last element is repeated once exhausted. First matching
-    substring wins — put more specific patterns before general ones.
+    substring wins - put more specific patterns before general ones.
     """
 
     def __init__(self) -> None:
@@ -306,7 +306,7 @@ class TestRun:
         assert any("delete namespace" in cmd for cmd in router.seen)
 
     def test_image_pull_backoff_fails_fast(self) -> None:
-        """ImagePullBackOff is terminal — fail without burning startup_timeout."""
+        """ImagePullBackOff is terminal - fail without burning startup_timeout."""
         router = _happy_router(
             {
                 "get pod": ok(
@@ -345,7 +345,7 @@ class TestRun:
         assert "InvalidImageName" in check.message
 
     def test_err_image_pull_transient_then_recovers(self) -> None:
-        """A single ErrImagePull poll shouldn't fail — kubelet may succeed next attempt."""
+        """A single ErrImagePull poll shouldn't fail - kubelet may succeed next attempt."""
         router = _happy_router(
             {
                 # First poll: Pending with transient ErrImagePull. Second poll: Running.
@@ -509,7 +509,7 @@ class TestRenderManifest:
 
         A previous rendering used 4-space indentation for env entries, which made
         the YAML parser treat them as additional entries in the outer `containers`
-        list — causing kubectl to reject the Pod with
+        list - causing kubectl to reject the Pod with
         `unknown field "spec.containers[1].value"`.
         """
         docs = list(yaml.safe_load_all(_render()))
@@ -548,12 +548,12 @@ class TestRenderManifest:
         assert resources["requests"]["ephemeral-storage"] == "2Gi"
         assert resources["limits"]["memory"] == "4Gi"
         assert resources["limits"]["ephemeral-storage"] == "10Gi"
-        # CPU limit intentionally absent — CFS throttling causes e2e test timeouts.
+        # CPU limit intentionally absent - CFS throttling causes e2e test timeouts.
         assert "cpu" not in resources["limits"]
 
     def test_pod_tolerates_e2e_evict_taint(self) -> None:
         """The k8s e2e suite applies ``kubernetes.io/e2e-evict-taint-key`` during
-        eviction/NodeLifecycle tests — without this toleration the conformance
+        eviction/NodeLifecycle tests - without this toleration the conformance
         pod itself can be evicted by the suite it's running. Matches sonobuoy.
         """
         docs = list(yaml.safe_load_all(_render()))
@@ -561,7 +561,7 @@ class TestRenderManifest:
         toleration_keys = {t["key"] for t in pod["spec"]["tolerations"]}
         assert "kubernetes.io/e2e-evict-taint-key" in toleration_keys
         assert "CriticalAddonsOnly" in toleration_keys
-        # Both the legacy `master` key and the post-1.24 `control-plane` key —
+        # Both the legacy `master` key and the post-1.24 `control-plane` key -
         # running this against clusters spanning that rename must not pin the
         # pod onto a control-plane node either way.
         assert "node-role.kubernetes.io/control-plane" in toleration_keys
@@ -587,7 +587,7 @@ class TestRenderManifest:
         assert resources["limits"]["ephemeral-storage"] == "20Gi"
 
     def test_yaml_special_chars_in_env_values_round_trip(self) -> None:
-        # Focus/skip regexes contain backslashes, brackets, pipes, and quotes —
+        # Focus/skip regexes contain backslashes, brackets, pipes, and quotes -
         # all YAML-special. Verify the serializer quotes them such that parsing
         # yields the original string verbatim.
         tricky = {

--- a/isvtest/tests/test_k8s_control_plane_logs.py
+++ b/isvtest/tests/test_k8s_control_plane_logs.py
@@ -166,7 +166,7 @@ class TestAutoDispatch:
 
     def test_auto_surfaces_kubectl_error_even_when_commands_cover_all_components(self) -> None:
         """A probe failure (kubeconfig/RBAC/context broken) must not be
-        masked by falling through to commands for every component — the
+        masked by falling through to commands for every component - the
         operator needs to know cluster access is broken."""
         check = K8sControlPlaneLogsCheck(
             config={
@@ -338,7 +338,7 @@ class TestKubectlPath:
 
         def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
             if "get pods" in cmd:
-                # No component labels set — fallback must kick in.
+                # No component labels set - fallback must kick in.
                 return _ok(stdout=_pod_list(("kube-apiserver-node1", ""), ("coredns-abc", "")))
             if "logs kube-apiserver-node1" in cmd:
                 return _ok(stdout="logged\n")
@@ -398,7 +398,7 @@ class TestKubectlPath:
 
         def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
             if "get pods" in cmd:
-                # No component labels — forces pure name-prefix fallback.
+                # No component labels - forces pure name-prefix fallback.
                 return _ok(
                     stdout=_pod_list(
                         ("kube-scheduler-extender-abc", ""),

--- a/isvtest/tests/test_k8s_storage.py
+++ b/isvtest/tests/test_k8s_storage.py
@@ -57,7 +57,7 @@ class _FakeProc:
 
 
 class _FakeClock:
-    """Tiny fake clock — advances on each ``sleep`` call.
+    """Tiny fake clock - advances on each ``sleep`` call.
 
     Used to keep poll loops from burning real wall-clock time under mocked
     ``run_command`` / ``subprocess.run``: without it, patching only ``time.sleep``
@@ -93,7 +93,7 @@ def _patched_clock() -> Any:
 
 
 class TestSetPvcFields:
-    """Tests for ``_set_pvc_fields`` — the in-memory manifest mutator."""
+    """Tests for ``_set_pvc_fields`` - the in-memory manifest mutator."""
 
     def _base_doc(self) -> dict[str, Any]:
         return {
@@ -434,7 +434,7 @@ class TestK8sCsiStorageTypesCheck:
 
 
 class TestSetResourceQuotaFields:
-    """Tests for ``_set_resourcequota_fields`` — the in-memory manifest mutator."""
+    """Tests for ``_set_resourcequota_fields`` - the in-memory manifest mutator."""
 
     def _base_doc(self) -> dict[str, Any]:
         return {
@@ -1320,7 +1320,7 @@ class TestK8sCsiTenantScopedCredentialsCheck:
         we can exercise top-level error paths (e.g. ``"get csidriver"``,
         ``"get pv -o"``). ``secrets_by_ref`` maps (namespace, name) to a
         Secret object; a value of ``None`` simulates a Forbidden fetch.
-        ``missing_secret_refs`` simulates a Secret that does not exist —
+        ``missing_secret_refs`` simulates a Secret that does not exist -
         with ``--ignore-not-found=true`` kubectl returns rc=0 and empty
         stdout, which maps to the check's ``"missing"`` status.
         """
@@ -1475,7 +1475,7 @@ class TestK8sCsiTenantScopedCredentialsCheck:
                 volumes=[{"name": "plugin-dir", "hostPath": {"path": "/var/lib/kubelet/plugins"}}],
             )
         ]
-        # PV references a Secret in the "default" namespace — a workload ns.
+        # PV references a Secret in the "default" namespace - a workload ns.
         pvs = [_pv_with_csi_secrets(secret_namespace="default", secret_name="exposed-creds")]
         with patch.object(
             check,
@@ -1612,7 +1612,7 @@ class TestK8sCsiTenantScopedCredentialsCheck:
     def test_no_node_plugin_skips_mount_check(self) -> None:
         check = self._make({})
         csi_drivers = [{"kind": "CSIDriver", "metadata": {"name": "x"}}]
-        # Only a controller pod — no node-plugin.
+        # Only a controller pod - no node-plugin.
         pods = [
             _pod(
                 name="csi-controller",
@@ -1687,7 +1687,7 @@ class TestK8sCsiTenantScopedCredentialsCheck:
         # Realistic EKS EFS controller: the driver container sits alongside
         # the csi-provisioner sidecar that makes this pod recognisable as a
         # CSI controller. The aws-secret envFrom on the controller is
-        # optional — omitted on clusters using IRSA.
+        # optional - omitted on clusters using IRSA.
         pods = [
             _pod(
                 name="efs-csi-controller",
@@ -1747,7 +1747,7 @@ class TestK8sCsiTenantScopedCredentialsCheck:
 
 
 class TestSetPvFields:
-    """Tests for ``_set_pv_fields`` — the static PV mutator."""
+    """Tests for ``_set_pv_fields`` - the static PV mutator."""
 
     def _base_doc(self) -> dict[str, Any]:
         return {
@@ -1802,7 +1802,7 @@ class TestSetPvFields:
 
 
 class TestSetMountPodFields:
-    """Tests for ``_set_mount_pod_fields`` — the BusyBox mount-pod mutator."""
+    """Tests for ``_set_mount_pod_fields`` - the BusyBox mount-pod mutator."""
 
     def _base_doc(self) -> dict[str, Any]:
         return {


### PR DESCRIPTION
## Summary

Three orchestrator warning bugs were firing every run. Fixes those plus some cosmetic cleanup. Full microk8s run goes from 13 WARNINGS to 0.

### Fixes

- **Phase-lookahead warning** (`a57f70a`) - suppress "step has no output" when the referenced step's phase comes after the phase currently being rendered. Test-phase templates no longer falsely warn during setup.
- **Silenced validations** (`4ccb8c2`) - suppress warnings for templates inside checks that pytest will deselect (marker or test-name exclusion). Kills 12 node-pool warnings on non-CAPI providers.
- **CAPI namespace leak** (`de44a4d`) - microk8s/k3s/minikube were inheriting a CAPI-flavored `namespace` template in `K8sApiNetworkAclCheck`. Overridden to `"default"` at each site.
- **CSI inventory schema drift** (`57606a8`) - post-K8S23, base `k8s.yaml` templates `K8sCsiProvisioningCheck` with `steps.setup.csi.static_volume_handle` and `static_driver_name`. EKS's setup emits them; the shared `_common.sh` (microk8s/k3s/minikube) didn't. Pinned both to empty strings at the inventory source so the schema is consistent across providers.

### Cleanup

- Drop Sphinx `:class:` / `:func:` / `:meth:` roles from docstrings (`ab3b71f`)
- Em dashes -> hyphens (`3f132c1`, `0f6abdc`)
- Ellipsis character -> `...` (`17d75c1`)
- Drop redundant `TF_AUTO_APPROVE=true` from `eks.yaml` usage examples (step env already pins it, so shell-level setting is a no-op) (`4f9e765`)
- Inline the three valid `K8sCncfConformanceCheck.mode` values next to the setting in `k8s.yaml` (`73b46d0`)

## Test plan

- [x] `uv run pytest isvctl/tests/` - 453 passed (includes 5 new orchestrator tests)
- [x] Live microk8s run - zero warnings, 23 checks passed (pre-CSI-suite upstream)
- [x] Post-rebase microk8s run to confirm CSI fix - zero warnings expected
- [x] EKS/CAPI provider run still produces expected values
- [x] CI pre-commit hooks green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orchestration now tracks phases to suppress irrelevant missing-step warnings.
  * Kubernetes validations may include explicit namespace configuration.
  * Kubernetes inventory now emits new CSI fields: static_volume_handle and static_driver_name.

* **Tests**
  * Added coverage for phase-aware rendering and warning‑suppression scenarios.

* **Documentation**
  * Standardized punctuation and formatting across docs, comments, config text and user messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->