### PR TITLE
chore: refresh agent docs and extract generic guidelines to cursor rule

### DIFF
--- a/.cursor/rules/karpathy-guidelines.mdc
+++ b/.cursor/rules/karpathy-guidelines.mdc
@@ -1,0 +1,75 @@
+---
+description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
+alwaysApply: true
+---
+
+# Karpathy behavioral guidelines
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+
+```text
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,379 +1,143 @@
 # AGENTS.md
 
-This file provides guidance to AI coding assistants when working with code in this repository.
+General agent behavior lives in `.cursor/rules/karpathy-guidelines.mdc` (always applied).
+Python conventions live in `.cursor/rules/python-standards.mdc` (auto-applied to `*.py`).
+This file documents project-specific context an agent can't grep for.
 
 ## Project Overview
 
-NVIDIA ISV NCP Validation Suite - Validation and management tools for NVIDIA ISV Lab GPU cluster environments. A monorepo containing three Python packages managed as a uv workspace:
+NVIDIA ISV NCP Validation Suite - validation and management tools for NVIDIA ISV Lab GPU
+cluster environments. Monorepo with three Python packages managed as a uv workspace:
 
-- **isvctl** - Unified CLI controller for cluster lifecycle orchestration (setup -> test -> teardown)
-- **isvtest** - Internal validation framework engine (pytest-based with custom discovery)
+- **isvctl** - CLI controller for cluster lifecycle (setup → test → teardown)
+- **isvtest** - Validation framework engine (pytest-based with custom discovery)
 - **isvreporter** - Test results reporter for ISV Lab Service API
 
-## Development Commands
-
-### Package Management
+## Common Commands
 
 ```bash
-# Install all packages and dependencies
-uv sync
+uv sync                # install workspace
+make build             # build all packages
+make test              # run tests
+make demo-test         # run all my-isv configs end-to-end (ISVCTL_DEMO_MODE=1, ~10s, no cloud)
+make lint              # ruff
+make format            # ruff format
+uv run isvctl test run -f isvctl/configs/suites/k8s.yaml          # canonical invocation
+uv run isvctl test run -f config.yaml -- -v -s -k "test_name"     # forward pytest args
 ```
 
-### Building
+## Step-Based Execution Model
 
-```bash
-make build          # Build all packages (wheels output to dist/)
+The framework separates *doing* from *checking*:
+
+```text
+Config (YAML) → Script (any language) → JSON output → Validations (assertions)
 ```
 
-### Testing
+1. Scripts (Python, Bash, ...) perform cloud operations and print structured JSON to stdout.
+2. Validations are simple assertions over that JSON - no cloud SDK code in validations.
+3. Validations reference step output via Jinja2: `"{{steps.create_network.vpc_id}}"`,
+   `"{{region}}"`. The orchestrator warns when a template references a missing step or
+   field (catches `ChainableUndefined` silent fallbacks).
 
-```bash
-make test           # Run tests for all packages
-make demo-test     # Run all 6 my-isv provider configs end-to-end in demo mode
-                    # (sets ISVCTL_DEMO_MODE=1; no cloud needed; ~10s)
-uv run pytest       # Run tests in current package directory
+### Lifecycle invariants (non-obvious)
 
-# isvtest has separate markers:
-cd isvtest && uv run pytest -m unit              # Unit tests only
-cd isvtest && uv run pytest -m validation        # Validation tests
-cd isvtest && uv run pytest -m "not workload"    # Exclude long-running workload tests
-```
-
-### Linting and Formatting
-
-```bash
-make lint           # Run ruff linting on all packages
-make format         # Format code with ruff
-uvx pre-commit run -a                 # Run all pre-commit hooks
-uvx ruff check src/                   # Lint specific package
-uvx ruff format src/                  # Format specific package
-```
-
-### Cleaning
-
-```bash
-make clean          # Clean build artifacts and test outputs
-```
-
-### Running Tools
-
-```bash
-# isvctl - Main entry point for cluster validation
-uv run isvctl test run -f isvctl/configs/suites/k8s.yaml
-uv run isvctl test run -f isvctl/configs/suites/slurm.yaml -- -v -s -k "test_name"
-uv run isvctl test run -f isvctl/configs/providers/aws/config/eks.yaml      # AWS EKS validation
-uv run isvctl test run -f isvctl/configs/providers/aws/config/network.yaml  # AWS Network validation
-
-# Remote deployment
-uv run isvctl deploy run <target-ip> -f isvctl/configs/suites/k8s.yaml
-uv run isvctl deploy run <target-ip> -j <jumphost> -u ubuntu -f config.yaml
-
-# isvreporter - Upload test results to ISV Lab Service
-uv run isvreporter --help
-```
+- Phases run in order: `setup → test → teardown`.
+- **Teardown runs even if setup or test failed** - cloud resources still get cleaned up.
+- **Teardown is best-effort** - one failing teardown step does not block the others.
+- **Standalone teardown** is supported: `isvctl test run -f config.yaml --phase teardown`
+  (useful after a previous run with `AWS_SKIP_TEARDOWN`).
+- Multiple `-f` configs merge; later files override earlier ones.
 
 ## Architecture
 
-### Step-Based Execution Model
+### isvctl - orchestration
 
-The framework uses a **step-based execution model** where:
+Entry point: `isvctl/src/isvctl/main.py` (Typer).
 
-1. **Scripts do the work** - External scripts (Python, Bash, etc.) perform cloud operations
-2. **Scripts output JSON** - All operations output structured JSON to stdout
-3. **Validations check JSON** - Simple assertions verify the JSON output
+- `cli/` - subcommands (`test`, `deploy`, `clean`, `docs`, `report`)
+- `orchestrator/` - `loop.py` (phase loop), `step_executor.py` (step + validation
+  execution, supports `best_effort` mode), `commands.py` (timeouts), `context.py`
+  (Jinja2 with missing-reference warnings)
+- `config/` - `schema.py` (Pydantic), `output_schemas.py` (per-step JSON schemas),
+  `merger.py` (multi-file merge)
+- `remote/` - `ssh.py` (with jumphost), `archive.py`, `transfer.py` (SCP via jumphost proxy)
+- `cleaner/` - resource cleanup
 
-```text
-Config (YAML) -> Script (any language) -> JSON output -> Validations (assertions)
-```
+### isvtest - validation framework
 
-**Lifecycle phases** run in order: `setup -> test -> teardown`. Key behaviors:
+Entry point: `isvtest/src/isvtest/main.py`.
 
-- **Teardown runs after failures** - If setup or test validations fail, teardown still executes so cloud resources are cleaned up
-- **Best-effort teardown** - Individual teardown step failures don't block remaining teardown steps
-- **Standalone teardown** - `isvctl test run -f config.yaml --phase teardown` runs cleanup independently (e.g., after a previous `AWS_SKIP_TEARDOWN` run)
+`run_validations_via_pytest()` is the bridge isvctl calls. It transforms validation
+configs to pytest format, runs native pytest, and returns rich in-memory results
+(category, message) alongside the exit code.
 
-**Benefits:**
+- `core/validation.py` - `BaseValidation` abstract class
+- `core/discovery.py` - finds `BaseValidation` subclasses and ReFrame tests
+- `core/runners.py` - `LocalRunner`, `SlurmRunner`, ...
+- `core/{k8s,slurm,nvidia,ngc,workload}.py` - domain helpers
 
-- Language-agnostic: Scripts can be Python, Bash, Go, etc.
-- Simple validations: Just check JSON fields, no cloud SDK code
-- Reusable: Same script works across configs
-- Debuggable: Run scripts manually, inspect JSON
+Validation classes live in `isvtest/src/isvtest/validations/` grouped by domain
+(`generic.py`, `cluster.py`, `instance.py`, `network.py`, `iam.py`, `security.py`,
+`host.py`, `k8s_*.py`, `slurm_*.py`, `bm_*.py`). Each subclass declares
+`markers: ClassVar[list[str]]` for filtering and is auto-discovered.
 
-### isvctl - Orchestration Layer
+Workloads (`isvtest/src/isvtest/workloads/`) are long-running tests (NIM, NCCL,
+stress) marked `["workload", "slow"]` with manifests and helper scripts colocated.
 
-**Entry Point**: `isvctl/src/isvctl/main.py` - Typer-based CLI with subcommands
+Test config loaded from YAML/JSON via `config/loader.py`. Global fixtures in
+`tests/conftest.py`. `tests/test_validations.py` dynamically generates pytest tests
+from `BaseValidation` classes.
 
-**Core Modules**:
+### isvreporter - results upload
 
-- `cli/` - Subcommand implementations (test, deploy, clean, docs, report)
-- `orchestrator/` - Lifecycle orchestration engine
-  - `loop.py` - Main orchestration loop (setup -> test -> teardown phases); teardown runs even after earlier phase failures and uses best-effort execution
-  - `step_executor.py` - Step execution and validation orchestration (delegates to pytest); supports `best_effort` mode for teardown
-  - `commands.py` - Command execution with timeout handling
-  - `context.py` - Jinja2 templating context for config variables and step outputs; warns when templates reference missing step data or fields (catches `ChainableUndefined` silent fallbacks)
-- `config/` - Configuration schema and validation
-  - `schema.py` - Pydantic models for config structure (including StepConfig)
-  - `output_schemas.py` - JSON schema definitions for step outputs (auto-detection + validation)
-  - `merger.py` - Config file merging logic (supports `-f file1.yaml -f file2.yaml`)
-- `remote/` - Remote deployment functionality
-  - `ssh.py` - SSH connection management with jumphost support
-  - `archive.py` - Package tarball creation
-  - `transfer.py` - SCP file transfer with jumphost proxy
-- `cleaner/` - Resource cleanup operations
-
-**Configuration Files**: Located in `isvctl/configs/suites/` (test definitions) and `isvctl/configs/providers/` (provider implementations)
-
-- Configs define step-based commands with phases and validations
-- Support Jinja2 templating: `"{{steps.create_network.vpc_id}}"`, `"{{region}}"` - the orchestrator warns when templates reference steps that haven't run or fields that don't exist, helping catch typos and rename mismatches
-- Multiple configs can be merged with later files overriding earlier ones
-
-**Provider Scripts**: Located in `isvctl/configs/providers/`. Each provider has a `scripts/` subdirectory:
-
-- `providers/my-isv/scripts/` - the **scaffold**: copy-and-fill-in Python/Bash scripts for
-  every domain (iam, control-plane, vm, bare_metal, network, image-registry,
-  k8s, slurm). Each Python script has a TODO block and a
-  `DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"` gate:
-  default run returns `"Not implemented - ..."` errors;
-  `ISVCTL_DEMO_MODE=1` (what `make demo-test` sets) returns dummy-success
-  output. See `providers/my-isv/scripts/README.md` for the full explainer. ISVs copy
-  this tree as their starting point.
-- `providers/aws/scripts/` - fully implemented AWS reference using boto3/Terraform,
-  organized by domain (`aws/scripts/network/`, `aws/scripts/vm/`, `aws/scripts/iam/`, ...).
-- `providers/shared/` - cross-provider scripts invoked via YAML (`deploy_nim.py`,
-  `teardown_nim.py`). Python helpers imported via `from common.*` live under
-  each provider's scripts/common/, not here.
-- `providers/aws/scripts/common/` - AWS-only Python helpers imported by the
-  stubs: `ec2` (key/SG/public-IP utilities), `errors` (error classification +
-  `delete_with_retry`), `ssh_utils` (`wait_for_ssh`), `serial_console`, `vpc`.
-  Reachable via a single `sys.path.insert(0, Path(__file__).resolve().parents[1])`
-  in each script.
-- Each script is self-contained and can be run manually for debugging.
-
-### isvtest - Validation Framework
-
-**Entry Point**: `isvtest/src/isvtest/main.py` - Pytest integration layer
-
-**Key Functions**:
-
-- `run_validations_via_pytest()` - Bridge for isvctl to run validations via native pytest
-  - Transforms validation configs to pytest-compatible format
-  - Captures detailed results in-memory (no temp files)
-  - Returns both exit code and rich result objects with categories/messages
-
-**Core Modules**:
-
-- `core/validation.py` - `BaseValidation` abstract class that all validation tests inherit from
-- `core/discovery.py` - Dynamic test discovery (finds `BaseValidation` subclasses and ReFrame tests)
-- `core/runners.py` - Command execution abstraction (`LocalRunner`, `SlurmRunner`, etc.)
-- `core/k8s.py` - Kubernetes API utilities and helpers
-- `core/slurm.py` - Slurm cluster interaction utilities
-- `core/nvidia.py` - NVIDIA GPU detection and validation helpers
-- `core/ngc.py` - NGC container registry utilities
-- `core/workload.py` - Workload deployment and monitoring
-
-**Validation Tests**: Located in `isvtest/src/isvtest/validations/`
-
-Organized by category:
-
-- `generic.py` - `StepSuccessCheck`, `FieldExistsCheck`, `FieldValueCheck`, `SchemaValidation`
-- `cluster.py` - `ClusterHealthCheck`, `NodeCountCheck`, `GpuOperatorInstalledCheck`, `PerformanceCheck`
-- `instance.py` - `InstanceStateCheck`, `InstanceCreatedCheck`, `InstanceRebootCheck`, `InstancePowerCycleCheck`, `StableIdentifierCheck`, etc.
-- `network.py` - `NetworkProvisionedCheck`, `VpcCrudCheck`, `SubnetConfigCheck`, `SgCrudCheck`, `SecurityBlockingCheck`, `SgWorkloadScopingCheck`, `SgNodeScopingCheck`, `SgSubnetScopingCheck`, etc.
-- `iam.py` - `AccessKeyCreatedCheck`, `TenantCreatedCheck`, `ServiceAccountCredentialCheck`, etc.
-- `security.py` - `BmcTenantIsolationCheck`, `ApiEndpointIsolationCheck` (infrastructure hardening)
-- `host.py` - Host-level validations (connectivity, OS, CPU, GPU, drivers, containers, cloud-init/metadata with optional `metadata_headers` for non-AWS providers)
-- `ssh_helpers.py` - SSH connection and utility helpers (used by `host.py`)
-- `k8s_*.py` - Kubernetes-specific validations (nodes, GPU operator, scheduling, MIG)
-- `slurm_*.py` - Slurm-specific validations (partitions, jobs, GPU allocation)
-- `bm_*.py` - Bare metal validations (CUDA, driver, GPU)
-
-Each validation class:
-
-- Inherits from `BaseValidation`
-- Implements `run()` method that calls `self.set_passed()` or `self.set_failed()`
-- Uses `markers: ClassVar[list[str]]` for filtering (e.g., `["kubernetes"]`, `["ssh", "gpu"]`)
-- Is dynamically discovered by isvtest's discovery system
-
-**Workloads**: Located in `isvtest/src/isvtest/workloads/`
-
-- Long-running validation tests (NIM inference, NCCL benchmarks, stress tests)
-- Includes Kubernetes manifests and helper scripts
-- Use `markers: ClassVar[list[str]] = ["workload", "slow"]` for filtering
-- Each workload class has detailed docstrings covering config options and troubleshooting
-
-**Test Configuration**:
-
-- Global fixtures in `isvtest/src/isvtest/tests/conftest.py`
-- Custom pytest markers registered dynamically
-- Config loaded via `config/loader.py` from YAML/JSON files
-- `tests/test_validations.py` - Dynamically generates pytest tests from BaseValidation classes
-  - Captures detailed results in-memory via module-level storage
-  - Enables rich output (categories, messages) while using native pytest features
-
-### isvreporter - Results Reporting
-
-**Entry Point**: `isvreporter/src/isvreporter/main.py` - Typer-based CLI
-
-**Core Modules**:
+Entry point: `isvreporter/src/isvreporter/main.py` (Typer).
 
 - `client.py` - ISV Lab Service API client
-- `auth.py` - OAuth2 authentication handling
-- `junit_parser.py` - Parse pytest JUnit XML output
-- `platform.py` - Platform detection utilities
+- `auth.py` - OAuth2
+- `junit_parser.py` - pytest JUnit XML parsing
+- `platform.py` - platform detection
 
-## Python Standards (from .cursor/rules/python-standards.mdc)
+### Remote deploy flow
 
-### Language & Types
+`isvctl deploy run` → tarball repo (`remote/archive.py`) → SCP through optional
+jumphost (`remote/transfer.py`) → `install.sh` on target → `isvctl test run` with
+forwarded env vars → optional isvreporter upload.
 
-- Python 3.12 required
-- Use PEP 585 built-in collection types: `dict[str, Any]`, `list[int]`, `set[str]`
-- DO NOT import from typing: `Dict`, `List`, `Set` (only import special types like `Any`, `Union`, `TypeVar`, `Protocol`)
-- All functions and classes must have type annotations and docstrings (PEP 257)
-- Explicit return types required for all functions
+## Directory Layout
 
-### Testing Standards
+- Workspace root `pyproject.toml` defines members; each package has its own
+  `pyproject.toml`; all source under `src/`.
+- `isvctl/configs/suites/` - provider-agnostic test contracts.
+- `isvctl/configs/providers/<name>/` - one folder per provider (`aws/`, `my-isv/`, ...):
+  - `config/` - YAML wiring (imports a suite, supplies commands)
+  - `scripts/` - executable scripts (Python/Bash) that do the work, organized by
+    domain (`network/`, `vm/`, `iam/`, `k8s/`, ...)
+  - `scripts/common/` - provider-local Python helpers, imported via a single
+    `sys.path.insert(0, Path(__file__).resolve().parents[1])` per script
+- `isvctl/configs/providers/shared/` - cross-provider scripts (`deploy_nim.py`,
+  `teardown_nim.py`).
+- `isvctl/schemas/` - JSON Schema files.
 
-- Use pytest exclusively (no unittest)
-- Tests must be in `tests/` directory with type annotations
-- For isvtest: use `-m unit` for unit tests, `-m validation` for integration tests
+### Provider notes
 
-### Configuration
-
-- Use environment variables for configuration
-- Implement robust error handling and logging
-
-## Key Patterns
-
-### Creating a New Validation Test
-
-1. Create a new file in `isvtest/src/isvtest/validations/`
-2. Inherit from `BaseValidation` and implement `run()` method
-3. Set `markers: ClassVar[list[str]]` for filtering (e.g., `["kubernetes"]`)
-4. Use `self.run_command()` to execute commands
-5. Call `self.set_passed()` or `self.set_failed()` to set test result
-
-Example:
-
-```python
-from isvtest.core.validation import BaseValidation
-import pytest
-
-class K8sMyCheck(BaseValidation):
-    """Check something in Kubernetes."""
-
-    description: ClassVar[str] = "Validates my Kubernetes component"
-    timeout: ClassVar[int] = 60
-    markers: ClassVar[list[str]] = ["kubernetes"]
-
-    def run(self) -> None:
-        result = self.run_command("kubectl get nodes")
-        if result.returncode == 0:
-            self.set_passed("Nodes found")
-        else:
-            self.set_failed("No nodes found", result.stderr)
-```
-
-### Creating a New Script (Step-Based)
-
-Scripts perform cloud operations and output JSON:
-
-```python
-#!/usr/bin/env python3
-"""Create VPC and output JSON."""
-
-import argparse
-import json
-import sys
-import boto3
-
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--name", required=True)
-    parser.add_argument("--region", default="us-west-2")
-    args = parser.parse_args()
-
-    result = {"success": False, "platform": "network"}
-
-    try:
-        ec2 = boto3.client("ec2", region_name=args.region)
-        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
-        result["network_id"] = vpc["Vpc"]["VpcId"]
-        result["success"] = True
-    except Exception as e:
-        result["error"] = str(e)
-
-    print(json.dumps(result, indent=2))
-    return 0 if result["success"] else 1
-
-if __name__ == "__main__":
-    sys.exit(main())
-```
-
-### Adding a Config with Steps
-
-```yaml
-version: "1.0"
-
-commands:
-  network:
-    phases: ["setup", "test", "teardown"]
-    steps:
-      - name: create_network
-        phase: setup
-        command: "python ./providers/aws/scripts/network/create_vpc.py"
-        args: ["--name", "test-vpc", "--region", "{{region}}"]
-        timeout: 300
-
-      - name: teardown
-        phase: teardown
-        command: "python ./providers/aws/scripts/network/teardown.py"
-        args: ["--vpc-id", "{{steps.create_network.network_id}}"]
-
-tests:
-  platform: network
-  cluster_name: "network-test"
-  settings:
-    region: "us-west-2"
-
-  validations:
-    network:
-      - NetworkProvisionedCheck:
-          step: create_network
-      - StepSuccessCheck:
-          step: teardown
-```
-
-### Remote Deployment Flow
-
-1. `isvctl deploy run` packages repo into tarball (via `remote/archive.py`)
-2. Transfers via SCP through optional jumphost (via `remote/transfer.py`)
-3. Executes `install.sh` on remote target
-4. Runs `isvctl test run` on remote with forwarded environment variables
-5. Optionally uploads results via isvreporter
+- **`my-isv/`** - scaffold for ISVs to copy. Each script has a TODO block and a
+  `DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"` gate: real run returns
+  `"Not implemented - ..."`; demo mode returns dummy success. `make demo-test` sets
+  `ISVCTL_DEMO_MODE=1`. See `providers/my-isv/scripts/README.md`.
+- **`aws/`** - fully implemented reference using boto3/Terraform.
+  `aws/scripts/common/` provides `ec2`, `errors` (with `delete_with_retry`),
+  `ssh_utils.wait_for_ssh`, `serial_console`, `vpc`.
 
 ## Environment Variables
 
-| Variable | Description | Used By |
+| Variable | Description | Used by |
 | -------- | ----------- | ------- |
-| `ISV_SERVICE_ENDPOINT` | ISV Lab Service API endpoint URL | isvreporter |
-| `ISV_SSA_ISSUER` | ISV Lab Service SSA issuer URL | isvreporter |
-| `ISV_CLIENT_ID` | ISV Lab Service client ID | isvreporter |
-| `ISV_CLIENT_SECRET` | ISV Lab Service client secret | isvreporter |
-| `NGC_API_KEY` | NGC API key for NIM workloads and container registry | isvtest, isvctl |
-| `AWS_ACCESS_KEY_ID` | AWS access key | AWS scripts |
-| `AWS_SECRET_ACCESS_KEY` | AWS secret key | AWS scripts |
-| `AWS_REGION` | AWS region | AWS scripts |
-| `KUBECTL` | Optional kubectl-compatible CLI prefix (parsed with POSIX shlex in Python, word-split in shell scripts; overrides `K8S_PROVIDER` detection) | isvtest (`get_kubectl_command`), isvctl k8s scripts |
-
-## Directory Structure Notes
-
-- Workspace root `pyproject.toml` defines workspace members
-- Each package has its own `pyproject.toml` with dependencies
-- All source code in `src/` subdirectory per package
-- Validation suites in `isvctl/configs/suites/` (provider-agnostic contracts)
-- Provider configs and scripts in `isvctl/configs/providers/` (one folder per provider: `aws/`, `my-isv/`, etc.)
-  - `providers/<name>/config/` - YAML wiring that imports a suite and supplies commands
-  - `providers/<name>/scripts/` - executable scripts (Python/Bash) that perform the actual work
-- Shared cross-provider scripts in `isvctl/configs/providers/shared/`
-- AWS-specific Python helpers in `isvctl/configs/providers/aws/scripts/common/`
-- Schemas in `isvctl/schemas/` (JSON Schema files)
+| `ISV_SERVICE_ENDPOINT` | ISV Lab Service API endpoint | isvreporter |
+| `ISV_SSA_ISSUER` | ISV Lab Service SSA issuer | isvreporter |
+| `ISV_CLIENT_ID` / `ISV_CLIENT_SECRET` | ISV Lab Service credentials | isvreporter |
+| `NGC_API_KEY` | NGC key for NIM workloads / container registry | isvtest, isvctl |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` | AWS auth | AWS scripts |
+| `KUBECTL` | Optional kubectl-compatible CLI prefix (POSIX `shlex` in Python, word-split in shell; overrides `K8S_PROVIDER` detection) | isvtest `get_kubectl_command`, isvctl k8s scripts |
+| `ISVCTL_DEMO_MODE` | `"1"` makes `my-isv` scripts return dummy success | scripts |
+| `AWS_SKIP_TEARDOWN` | Skip teardown phase (run later with `--phase teardown`) | AWS configs |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,12 @@ Config (YAML) → Script (any language) → JSON output → Validations (asserti
 ### Lifecycle invariants (non-obvious)
 
 - Phases run in order: `setup → test → teardown`.
-- **Teardown runs even if setup or test failed** - cloud resources still get cleaned up.
+- **Teardown runs after setup/test failures by default** so cloud resources get
+  cleaned up - but it is skipped when `teardown_on_failure` is disabled, or when
+  setup was requested in the same invocation but no setup steps actually ran.
 - **Teardown is best-effort** - one failing teardown step does not block the others.
-- **Standalone teardown** is supported: `isvctl test run -f config.yaml --phase teardown`
-  (useful after a previous run with `AWS_SKIP_TEARDOWN`).
+- **Standalone teardown** (`isvctl test run -f config.yaml --phase teardown`) runs
+  unconditionally - useful after a previous run with `AWS_SKIP_TEARDOWN`.
 - Multiple `-f` configs merge; later files override earlier ones.
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
-AGENTS.md
+@AGENTS.md
+@.cursor/rules/karpathy-guidelines.mdc
+@.cursor/rules/python-standards.mdc


### PR DESCRIPTION
## Summary

- Add `.cursor/rules/karpathy-guidelines.mdc` (`alwaysApply: true`) holding the generic LLM behavioral guidelines (think before coding, simplicity, surgical changes, goal-driven execution). These were previously inlined at the top of `AGENTS.md` and are now consumed by Cursor as a rule.
- Trim `AGENTS.md` from 449 to 144 lines. Drop content already covered by cursor rules (karpathy guidelines, `python-standards.mdc`), drop tutorial-style code samples and the stale per-class validation list. Keep the project-specific context an agent can't grep for: step-based execution model, lifecycle invariants (best-effort teardown, teardown-after-fail, standalone teardown, multi-config merge), per-package architecture, directory layout, env vars.
- Add `CLAUDE.md` as a symlink to `AGENTS.md` so Claude Code reads the same project context without duplicate maintenance.

Net: +182 / -342 across three files.

## Test plan

- [x] `AGENTS.md` renders correctly on GitHub
- [x] `CLAUDE.md` resolves through the symlink on GitHub
- [x] No agent regressions — existing project context (lifecycle invariants, directory layout, env vars) is preserved

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new always-applied set of behavioral guidelines for AI-assisted development, outlining principles, minimal/surgical edits, and verifiable success criteria with optional verification plans.
  * Refactored the project handbook into a concise project-context document with common commands, explicit test lifecycle invariants, condensed component/remote-deploy notes, and streamlined directory/provider guidance.
  * Added a short directive file linking to the project context and relevant guideline documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->