### PR TITLE
feat: add SEC12-01 BMC management network validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.14.7
+    rev: v0.15.12
     hooks:
       # Run the linter.
       - id: ruff

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ DEMO_TARGETS := $(addprefix demo-,$(MY_ISV_DOMAINS))
 
 PACKAGES := isvctl isvreporter isvtest
 BUMP_SCRIPT := scripts/bump-version.py
+RUFF_VERSION := 0.15.12
+RUFF := uvx --from ruff==$(RUFF_VERSION) ruff
 
 # DISABLED (2026-03-24): Trivy supply chain compromise - see GHSA-69fq-xp46-6x23.
 # Do NOT pull aquasec/trivy images from Docker Hub until Aqua Security regains control.
@@ -38,13 +40,13 @@ pre-commit: ## Run pre-commit on all packages
 lint: ## Run ruff linting on all packages
 	@for pkg in $(PACKAGES); do \
 		echo "Linting $$pkg..."; \
-		(cd $$pkg && uvx ruff check src/) || exit 1; \
+		(cd $$pkg && $(RUFF) check src/) || exit 1; \
 	done
 
 format: ## Format code with ruff on all packages
 	@for pkg in $(PACKAGES); do \
 		echo "Formatting $$pkg..."; \
-		(cd $$pkg && uvx ruff format src/) || exit 1; \
+		(cd $$pkg && $(RUFF) format src/) || exit 1; \
 	done
 
 # DISABLED (2026-03-24): Trivy supply chain compromise - see GHSA-69fq-xp46-6x23.

--- a/isvctl/configs/providers/aws/config/security.yaml
+++ b/isvctl/configs/providers/aws/config/security.yaml
@@ -13,15 +13,16 @@
 # Imports validations from the provider-agnostic security canonical config.
 # This file only provides AWS-specific commands (boto3 scripts) and settings.
 #
-# Security tests (SEC* requirements):
-#   1. BMC Tenant Isolation  - Verify BMC/IPMI/Redfish unreachable from VPC
-#   2. API Endpoint Isolation - Verify management APIs are not publicly exposed
-#   3. SA Credential Auth     - Verify IAM user + long-lived access key auth
-#
 # Usage:
 #   uv run isvctl test run -f isvctl/configs/providers/aws/config/security.yaml
 #
 # Estimated runtime: ~1-2 minutes
+#
+# Security tests (SEC* requirements):
+#   1. BMC Management Network - Verify BMC management is dedicated/restricted
+#   2. BMC Tenant Isolation   - Verify BMC/IPMI/Redfish unreachable from VPC
+#   3. API Endpoint Isolation - Verify management APIs are not publicly exposed
+#   4. SA Credential Auth     - Verify IAM user + long-lived access key auth
 
 import:
   - ../../../suites/security.yaml
@@ -39,21 +40,28 @@ commands:
         args: ["{\"success\": true, \"platform\": \"security\", \"test_name\": \"preflight\"}"]
         timeout: 10
 
-      # Test 1: BMC Tenant Isolation (~10s)
+      # Test 1: BMC Management Network (~10s)
+      - name: bmc_management_network
+        phase: test
+        command: "python3 ../scripts/security/bmc_management_network_test.py"
+        args: ["--region", "{{region}}"]
+        timeout: 60
+
+      # Test 2: BMC Tenant Isolation (~10s)
       - name: bmc_tenant_isolation
         phase: test
         command: "python3 ../scripts/security/bmc_isolation_test.py"
         args: ["--region", "{{region}}"]
         timeout: 60
 
-      # Test 2: API Endpoint Isolation (~15s)
+      # Test 3: API Endpoint Isolation (~15s)
       - name: api_endpoint_isolation
         phase: test
         command: "python3 ../scripts/security/api_endpoint_test.py"
         args: ["--region", "{{region}}"]
         timeout: 60
 
-      # Test 3: Service Account Credential Auth (~30s, includes IAM propagation wait)
+      # Test 4: Service Account Credential Auth (~30s, includes IAM propagation wait)
       - name: sa_credential_test
         phase: test
         command: "python3 ../scripts/security/sa_credential_test.py"

--- a/isvctl/configs/providers/aws/scripts/security/bmc_isolation_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/bmc_isolation_test.py
@@ -13,17 +13,20 @@
 
 In AWS, BMC/IPMI/Redfish are inherently inaccessible from EC2 instances -
 there is no route from tenant VPCs to the hypervisor management plane.
-This test verifies the isolation by:
+This test verifies the customer-visible isolation boundary by:
 
-  1. Launching a lightweight instance inside a VPC
-  2. Running SSM commands to probe well-known BMC ports (IPMI UDP 623,
-     Redfish TCP 443 on link-local/management CIDRs)
-  3. Confirming all probes fail (timeout / connection refused)
-  4. Verifying no reverse path exists from management to tenant network
+  1. Scanning selected VPCs in the region (or a single --vpc-id)
+  2. Verifying route tables have no explicit routes to known BMC CIDRs
+  3. Verifying security groups have no explicit egress rules to BMC CIDRs
+  4. Reporting IPMI/Redfish unreachable based on the absence of tenant routes
+     and egress rules to those management ranges
 
-For non-hyperscaler NCPs, replace the SSM-based probes with your
-platform's equivalent: SSH into a tenant machine and attempt to reach
-BMC endpoints.
+This script does not launch probe instances or run SSM commands. It is a
+configuration/control-plane check for AWS's provider-owned management plane.
+
+For non-hyperscaler NCPs, replace or extend these checks with your platform's
+equivalent tenant-vantage probes: SSH into a tenant machine and attempt to
+reach BMC endpoints.
 
 Usage:
     python bmc_isolation_test.py --region us-west-2

--- a/isvctl/configs/providers/aws/scripts/security/bmc_management_network_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/bmc_management_network_test.py
@@ -41,6 +41,7 @@ import argparse
 import ipaddress
 import json
 import os
+import re
 import sys
 from typing import Any
 
@@ -53,7 +54,11 @@ BMC_MANAGEMENT_CIDRS = [
     ipaddress.ip_network("169.254.0.0/16"),
     ipaddress.ip_network("198.18.0.0/15"),
 ]
-MANAGEMENT_TAG_TOKENS = ("bmc", "ipmi", "redfish", "oob", "out-of-band", "outofband")
+# Word-boundary match so identifiers like "submarine-bmcollege" don't false-match "bmc".
+_MANAGEMENT_TAG_PATTERN = re.compile(
+    r"\b(?:bmc|ipmi|redfish|oob|out-of-band|outofband)\b",
+    re.IGNORECASE,
+)
 
 
 def _collect_paginated(ec2: Any, operation_name: str, result_key: str, **kwargs: Any) -> list[dict[str, Any]]:
@@ -65,20 +70,10 @@ def _collect_paginated(ec2: Any, operation_name: str, result_key: str, **kwargs:
     return items
 
 
-def _list_vpc_ids(ec2: Any, vpc_id: str | None) -> list[str]:
-    """Return the explicit VPC ID or every VPC ID in the region."""
-    if vpc_id:
-        return [vpc_id]
-
-    vpcs = _collect_paginated(ec2, "describe_vpcs", "Vpcs")
-    return [vpc["VpcId"] for vpc in vpcs if vpc.get("VpcId")]
-
-
-def _collect_vpcs(ec2: Any, vpc_ids: list[str]) -> list[dict[str, Any]]:
-    """Collect VPC records for the selected VPC IDs."""
-    if not vpc_ids:
-        return []
-    return _collect_paginated(ec2, "describe_vpcs", "Vpcs", VpcIds=vpc_ids)
+def _list_vpcs(ec2: Any, vpc_id: str | None) -> list[dict[str, Any]]:
+    """Return the requested VPC, or every VPC in the region."""
+    kwargs: dict[str, Any] = {"VpcIds": [vpc_id]} if vpc_id else {}
+    return _collect_paginated(ec2, "describe_vpcs", "Vpcs", **kwargs)
 
 
 def _iter_vpc_cidrs(vpc: dict[str, Any]) -> list[str]:
@@ -124,9 +119,8 @@ def _is_explicit_management_cidr(cidr: str | None) -> bool:
     )
 
 
-def _check_dedicated_management_network(ec2: Any, vpc_ids: list[str]) -> dict[str, Any]:
+def _check_dedicated_management_network(vpcs: list[dict[str, Any]]) -> dict[str, Any]:
     """Verify selected tenant VPC CIDRs do not overlap management ranges."""
-    vpcs = _collect_vpcs(ec2, vpc_ids)
     cidrs_checked = 0
     for vpc in vpcs:
         for cidr in _iter_vpc_cidrs(vpc):
@@ -148,52 +142,43 @@ def _check_dedicated_management_network(ec2: Any, vpc_ids: list[str]) -> dict[st
 
 def _check_restricted_management_routes(ec2: Any, vpc_ids: list[str]) -> dict[str, Any]:
     """Verify tenant route tables have no explicit BMC management routes."""
-    route_tables_checked = 0
-    for vpc_id in vpc_ids:
-        route_tables = _collect_paginated(
-            ec2,
-            "describe_route_tables",
-            "RouteTables",
-            Filters=[{"Name": "vpc-id", "Values": [vpc_id]}],
-        )
-        route_tables_checked += len(route_tables)
-        for route_table in route_tables:
-            for route in route_table.get("Routes", []):
-                destination = route.get("DestinationCidrBlock")
-                if _is_explicit_management_cidr(destination):
-                    return {
-                        "passed": False,
-                        "vpc_id": vpc_id,
-                        "route_tables_checked": route_tables_checked,
-                        "error": f"Route table {route_table['RouteTableId']} targets BMC management CIDR {destination}",
-                    }
+    if not vpc_ids:
+        return {"passed": True, "vpcs_tested": 0, "route_tables_checked": 0, "message": "No VPCs to scan"}
+
+    route_tables = _collect_paginated(
+        ec2,
+        "describe_route_tables",
+        "RouteTables",
+        Filters=[{"Name": "vpc-id", "Values": vpc_ids}],
+    )
+    for route_table in route_tables:
+        for route in route_table.get("Routes", []):
+            destination = route.get("DestinationCidrBlock")
+            if _is_explicit_management_cidr(destination):
+                return {
+                    "passed": False,
+                    "vpc_id": route_table.get("VpcId"),
+                    "route_tables_checked": len(route_tables),
+                    "error": f"Route table {route_table['RouteTableId']} targets BMC management CIDR {destination}",
+                }
 
     return {
         "passed": True,
         "vpcs_tested": len(vpc_ids),
-        "route_tables_checked": route_tables_checked,
-        "message": f"No explicit BMC management routes across {route_tables_checked} route tables",
+        "route_tables_checked": len(route_tables),
+        "message": f"No explicit BMC management routes across {len(route_tables)} route tables",
     }
 
 
 def _has_management_tag(resource: dict[str, Any]) -> bool:
     """Return True when a resource tag identifies it as a BMC management network."""
     tag_text = " ".join(f"{tag.get('Key', '')}={tag.get('Value', '')}" for tag in resource.get("Tags", []))
-    normalized = tag_text.lower()
-    return any(token in normalized for token in MANAGEMENT_TAG_TOKENS)
+    return bool(_MANAGEMENT_TAG_PATTERN.search(tag_text))
 
 
-def _check_tenant_network_not_management(ec2: Any, vpc_ids: list[str]) -> dict[str, Any]:
-    """Verify selected tenant VPCs are not management networks."""
-    vpcs = _collect_vpcs(ec2, vpc_ids)
+def _check_tenant_network_not_management(vpcs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Verify selected tenant VPCs are not tagged as BMC management networks."""
     for vpc in vpcs:
-        for cidr in _iter_vpc_cidrs(vpc):
-            if _cidr_overlaps_management(cidr):
-                return {
-                    "passed": False,
-                    "vpc_id": vpc.get("VpcId"),
-                    "error": f"Tenant VPC CIDR {cidr} overlaps reserved BMC management range",
-                }
         if _has_management_tag(vpc):
             return {
                 "passed": False,
@@ -204,37 +189,37 @@ def _check_tenant_network_not_management(ec2: Any, vpc_ids: list[str]) -> dict[s
     return {
         "passed": True,
         "vpcs_tested": len(vpcs),
-        "message": f"{len(vpcs)} tenant VPCs are not labeled or addressed as BMC management networks",
+        "message": f"{len(vpcs)} tenant VPCs are not labeled as BMC management networks",
     }
 
 
 def _check_management_acl_enforced(ec2: Any, vpc_ids: list[str]) -> dict[str, Any]:
     """Verify network ACLs do not explicitly allow BMC management CIDRs."""
-    acls_checked = 0
-    for vpc_id in vpc_ids:
-        network_acls = _collect_paginated(
-            ec2,
-            "describe_network_acls",
-            "NetworkAcls",
-            Filters=[{"Name": "vpc-id", "Values": [vpc_id]}],
-        )
-        acls_checked += len(network_acls)
-        for acl in network_acls:
-            for entry in acl.get("Entries", []):
-                cidr = entry.get("CidrBlock")
-                if entry.get("RuleAction") == "allow" and _is_explicit_management_cidr(cidr):
-                    return {
-                        "passed": False,
-                        "vpc_id": vpc_id,
-                        "network_acls_checked": acls_checked,
-                        "error": f"Network ACL {acl['NetworkAclId']} explicitly allows BMC management CIDR {cidr}",
-                    }
+    if not vpc_ids:
+        return {"passed": True, "vpcs_tested": 0, "network_acls_checked": 0, "message": "No VPCs to scan"}
+
+    network_acls = _collect_paginated(
+        ec2,
+        "describe_network_acls",
+        "NetworkAcls",
+        Filters=[{"Name": "vpc-id", "Values": vpc_ids}],
+    )
+    for acl in network_acls:
+        for entry in acl.get("Entries", []):
+            cidr = entry.get("CidrBlock")
+            if entry.get("RuleAction") == "allow" and _is_explicit_management_cidr(cidr):
+                return {
+                    "passed": False,
+                    "vpc_id": acl.get("VpcId"),
+                    "network_acls_checked": len(network_acls),
+                    "error": f"Network ACL {acl['NetworkAclId']} explicitly allows BMC management CIDR {cidr}",
+                }
 
     return {
         "passed": True,
         "vpcs_tested": len(vpc_ids),
-        "network_acls_checked": acls_checked,
-        "message": f"No explicit BMC management ACL allows across {acls_checked} network ACLs",
+        "network_acls_checked": len(network_acls),
+        "message": f"No explicit BMC management ACL allows across {len(network_acls)} network ACLs",
     }
 
 
@@ -248,18 +233,18 @@ def main() -> int:
 
     ec2 = boto3.client("ec2", region_name=args.region)
 
+    vpcs = _list_vpcs(ec2, args.vpc_id)
+    vpc_ids = [vpc["VpcId"] for vpc in vpcs if vpc.get("VpcId")]
+
     result: dict[str, Any] = {
         "success": False,
         "platform": "security",
         "test_name": "bmc_management_network",
-        "management_networks_checked": 0,
+        "management_networks_checked": len(vpc_ids),
+        "vpcs_tested": len(vpc_ids),
+        "vpc_ids_tested": vpc_ids,
         "tests": {},
     }
-
-    vpc_ids = _list_vpc_ids(ec2, args.vpc_id)
-    result["vpcs_tested"] = len(vpc_ids)
-    result["vpc_ids_tested"] = vpc_ids
-    result["management_networks_checked"] = len(vpc_ids)
 
     if not vpc_ids:
         result["tests"] = {
@@ -272,9 +257,9 @@ def main() -> int:
             "management_acl_enforced": {"passed": False, "error": "Validation not executed"},
         }
     else:
-        result["tests"]["dedicated_management_network"] = _check_dedicated_management_network(ec2, vpc_ids)
+        result["tests"]["dedicated_management_network"] = _check_dedicated_management_network(vpcs)
         result["tests"]["restricted_management_routes"] = _check_restricted_management_routes(ec2, vpc_ids)
-        result["tests"]["tenant_network_not_management"] = _check_tenant_network_not_management(ec2, vpc_ids)
+        result["tests"]["tenant_network_not_management"] = _check_tenant_network_not_management(vpcs)
         result["tests"]["management_acl_enforced"] = _check_management_acl_enforced(ec2, vpc_ids)
 
     result["success"] = all(test.get("passed") for test in result["tests"].values())

--- a/isvctl/configs/providers/aws/scripts/security/bmc_management_network_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/bmc_management_network_test.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Verify BMC management is on a dedicated, restricted network (AWS reference).
+
+In AWS, the BMC/hypervisor management plane is provider-owned and is not
+attached to customer VPCs. This reference check validates the customer-visible
+side of that boundary:
+
+  1. Tenant VPC CIDRs do not overlap reserved BMC/management ranges.
+  2. Tenant route tables do not explicitly target management CIDRs.
+  3. Tenant VPCs are not tagged as BMC/IPMI/Redfish management networks.
+  4. Network ACLs do not explicitly allow management CIDRs.
+
+Usage:
+    python bmc_management_network_test.py --region us-west-2
+
+Output JSON:
+  {
+    "success": true,
+    "platform": "security",
+    "test_name": "bmc_management_network",
+    "tests": {
+      "dedicated_management_network": {"passed": true},
+      "restricted_management_routes": {"passed": true},
+      "tenant_network_not_management": {"passed": true},
+      "management_acl_enforced": {"passed": true}
+    }
+  }
+"""
+
+import argparse
+import ipaddress
+import json
+import os
+import sys
+from typing import Any
+
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+
+import boto3
+from common.errors import handle_aws_errors
+
+BMC_MANAGEMENT_CIDRS = [
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("198.18.0.0/15"),
+]
+BMC_MANAGEMENT_CIDR_STRS = {str(cidr) for cidr in BMC_MANAGEMENT_CIDRS}
+MANAGEMENT_TAG_TOKENS = ("bmc", "ipmi", "redfish", "oob", "out-of-band", "outofband")
+
+
+def _collect_paginated(ec2: Any, operation_name: str, result_key: str, **kwargs: Any) -> list[dict[str, Any]]:
+    """Collect all items for a paginated EC2 describe operation."""
+    paginator = ec2.get_paginator(operation_name)
+    items: list[dict[str, Any]] = []
+    for page in paginator.paginate(**kwargs):
+        items.extend(page.get(result_key, []))
+    return items
+
+
+def _list_vpc_ids(ec2: Any, vpc_id: str | None) -> list[str]:
+    """Return the explicit VPC ID or every VPC ID in the region."""
+    if vpc_id:
+        return [vpc_id]
+
+    vpcs = _collect_paginated(ec2, "describe_vpcs", "Vpcs")
+    return [vpc["VpcId"] for vpc in vpcs if vpc.get("VpcId")]
+
+
+def _collect_vpcs(ec2: Any, vpc_ids: list[str]) -> list[dict[str, Any]]:
+    """Collect VPC records for the selected VPC IDs."""
+    if not vpc_ids:
+        return []
+    return _collect_paginated(ec2, "describe_vpcs", "Vpcs", VpcIds=vpc_ids)
+
+
+def _iter_vpc_cidrs(vpc: dict[str, Any]) -> list[str]:
+    """Return associated IPv4 CIDR blocks for a VPC."""
+    cidrs: list[str] = []
+    for association in vpc.get("CidrBlockAssociationSet", []):
+        state = association.get("CidrBlockState", {}).get("State", "associated")
+        cidr = association.get("CidrBlock")
+        if cidr and state != "disassociated":
+            cidrs.append(cidr)
+    fallback_cidr = vpc.get("CidrBlock")
+    if fallback_cidr and fallback_cidr not in cidrs:
+        cidrs.append(fallback_cidr)
+    return cidrs
+
+
+def _cidr_overlaps_management(cidr: str) -> bool:
+    """Return True when a CIDR overlaps a reserved BMC management range."""
+    try:
+        network = ipaddress.ip_network(cidr, strict=False)
+    except ValueError:
+        return False
+    return any(network.overlaps(management_cidr) for management_cidr in BMC_MANAGEMENT_CIDRS)
+
+
+def _is_explicit_management_cidr(cidr: str | None) -> bool:
+    """Return True for literal management CIDR targets.
+
+    Default internet routes such as 0.0.0.0/0 are intentionally not treated
+    as management routes here; this check catches explicit BMC network wiring.
+    """
+    return cidr in BMC_MANAGEMENT_CIDR_STRS
+
+
+def _check_dedicated_management_network(ec2: Any, vpc_ids: list[str]) -> dict[str, Any]:
+    """Verify selected tenant VPC CIDRs do not overlap management ranges."""
+    vpcs = _collect_vpcs(ec2, vpc_ids)
+    cidrs_checked = 0
+    for vpc in vpcs:
+        for cidr in _iter_vpc_cidrs(vpc):
+            cidrs_checked += 1
+            if _cidr_overlaps_management(cidr):
+                return {
+                    "passed": False,
+                    "vpc_id": vpc.get("VpcId"),
+                    "error": f"Tenant VPC CIDR {cidr} overlaps reserved BMC management range",
+                }
+
+    return {
+        "passed": True,
+        "vpcs_tested": len(vpcs),
+        "cidrs_checked": cidrs_checked,
+        "message": f"No tenant VPC CIDRs overlap BMC management ranges across {len(vpcs)} VPCs",
+    }
+
+
+def _check_restricted_management_routes(ec2: Any, vpc_ids: list[str]) -> dict[str, Any]:
+    """Verify tenant route tables have no explicit BMC management routes."""
+    route_tables_checked = 0
+    for vpc_id in vpc_ids:
+        route_tables = _collect_paginated(
+            ec2,
+            "describe_route_tables",
+            "RouteTables",
+            Filters=[{"Name": "vpc-id", "Values": [vpc_id]}],
+        )
+        route_tables_checked += len(route_tables)
+        for route_table in route_tables:
+            for route in route_table.get("Routes", []):
+                destination = route.get("DestinationCidrBlock")
+                if _is_explicit_management_cidr(destination):
+                    return {
+                        "passed": False,
+                        "vpc_id": vpc_id,
+                        "route_tables_checked": route_tables_checked,
+                        "error": f"Route table {route_table['RouteTableId']} targets BMC management CIDR {destination}",
+                    }
+
+    return {
+        "passed": True,
+        "vpcs_tested": len(vpc_ids),
+        "route_tables_checked": route_tables_checked,
+        "message": f"No explicit BMC management routes across {route_tables_checked} route tables",
+    }
+
+
+def _has_management_tag(resource: dict[str, Any]) -> bool:
+    """Return True when a resource tag identifies it as a BMC management network."""
+    tag_text = " ".join(f"{tag.get('Key', '')}={tag.get('Value', '')}" for tag in resource.get("Tags", []))
+    normalized = tag_text.lower()
+    return any(token in normalized for token in MANAGEMENT_TAG_TOKENS)
+
+
+def _check_tenant_network_not_management(ec2: Any, vpc_ids: list[str]) -> dict[str, Any]:
+    """Verify selected tenant VPCs are not management networks."""
+    vpcs = _collect_vpcs(ec2, vpc_ids)
+    for vpc in vpcs:
+        for cidr in _iter_vpc_cidrs(vpc):
+            if _cidr_overlaps_management(cidr):
+                return {
+                    "passed": False,
+                    "vpc_id": vpc.get("VpcId"),
+                    "error": f"Tenant VPC CIDR {cidr} overlaps reserved BMC management range",
+                }
+        if _has_management_tag(vpc):
+            return {
+                "passed": False,
+                "vpc_id": vpc.get("VpcId"),
+                "error": f"Tenant VPC {vpc.get('VpcId')} is tagged as a BMC management network",
+            }
+
+    return {
+        "passed": True,
+        "vpcs_tested": len(vpcs),
+        "message": f"{len(vpcs)} tenant VPCs are not labeled or addressed as BMC management networks",
+    }
+
+
+def _check_management_acl_enforced(ec2: Any, vpc_ids: list[str]) -> dict[str, Any]:
+    """Verify network ACLs do not explicitly allow BMC management CIDRs."""
+    acls_checked = 0
+    for vpc_id in vpc_ids:
+        network_acls = _collect_paginated(
+            ec2,
+            "describe_network_acls",
+            "NetworkAcls",
+            Filters=[{"Name": "vpc-id", "Values": [vpc_id]}],
+        )
+        acls_checked += len(network_acls)
+        for acl in network_acls:
+            for entry in acl.get("Entries", []):
+                cidr = entry.get("CidrBlock")
+                if entry.get("RuleAction") == "allow" and _is_explicit_management_cidr(cidr):
+                    return {
+                        "passed": False,
+                        "vpc_id": vpc_id,
+                        "network_acls_checked": acls_checked,
+                        "error": f"Network ACL {acl['NetworkAclId']} explicitly allows BMC management CIDR {cidr}",
+                    }
+
+    return {
+        "passed": True,
+        "vpcs_tested": len(vpc_ids),
+        "network_acls_checked": acls_checked,
+        "message": f"No explicit BMC management ACL allows across {acls_checked} network ACLs",
+    }
+
+
+@handle_aws_errors
+def main() -> int:
+    """Run BMC management-network checks and emit JSON result."""
+    parser = argparse.ArgumentParser(description="BMC management network test")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--vpc-id", help="Existing VPC to test (optional; scans all VPCs when omitted)")
+    args = parser.parse_args()
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "security",
+        "test_name": "bmc_management_network",
+        "management_networks_checked": 0,
+        "tests": {},
+    }
+
+    vpc_ids = _list_vpc_ids(ec2, args.vpc_id)
+    result["vpcs_tested"] = len(vpc_ids)
+    result["vpc_ids_tested"] = vpc_ids
+    result["management_networks_checked"] = len(vpc_ids)
+
+    if not vpc_ids:
+        result["tests"] = {
+            "dedicated_management_network": {
+                "passed": False,
+                "error": "No VPCs found to validate; provide --vpc-id",
+            },
+            "restricted_management_routes": {"passed": False, "error": "Validation not executed"},
+            "tenant_network_not_management": {"passed": False, "error": "Validation not executed"},
+            "management_acl_enforced": {"passed": False, "error": "Validation not executed"},
+        }
+    else:
+        result["tests"]["dedicated_management_network"] = _check_dedicated_management_network(ec2, vpc_ids)
+        result["tests"]["restricted_management_routes"] = _check_restricted_management_routes(ec2, vpc_ids)
+        result["tests"]["tenant_network_not_management"] = _check_tenant_network_not_management(ec2, vpc_ids)
+        result["tests"]["management_acl_enforced"] = _check_management_acl_enforced(ec2, vpc_ids)
+
+    result["success"] = all(test.get("passed") for test in result["tests"].values())
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/aws/scripts/security/bmc_management_network_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/bmc_management_network_test.py
@@ -54,9 +54,8 @@ BMC_MANAGEMENT_CIDRS = [
     ipaddress.ip_network("169.254.0.0/16"),
     ipaddress.ip_network("198.18.0.0/15"),
 ]
-# Word-boundary match so identifiers like "submarine-bmcollege" don't false-match "bmc".
 _MANAGEMENT_TAG_PATTERN = re.compile(
-    r"\b(?:bmc|ipmi|redfish|oob|out-of-band|outofband)\b",
+    r"(?<![A-Za-z0-9])(?:bmc|ipmi|redfish|oob|out[-_]?of[-_]?band)(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
 

--- a/isvctl/configs/providers/aws/scripts/security/bmc_management_network_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/bmc_management_network_test.py
@@ -53,7 +53,6 @@ BMC_MANAGEMENT_CIDRS = [
     ipaddress.ip_network("169.254.0.0/16"),
     ipaddress.ip_network("198.18.0.0/15"),
 ]
-BMC_MANAGEMENT_CIDR_STRS = {str(cidr) for cidr in BMC_MANAGEMENT_CIDRS}
 MANAGEMENT_TAG_TOKENS = ("bmc", "ipmi", "redfish", "oob", "out-of-band", "outofband")
 
 
@@ -106,12 +105,23 @@ def _cidr_overlaps_management(cidr: str) -> bool:
 
 
 def _is_explicit_management_cidr(cidr: str | None) -> bool:
-    """Return True for literal management CIDR targets.
+    """Return True when a CIDR explicitly targets a BMC management range.
 
     Default internet routes such as 0.0.0.0/0 are intentionally not treated
     as management routes here; this check catches explicit BMC network wiring.
     """
-    return cidr in BMC_MANAGEMENT_CIDR_STRS
+    if not cidr:
+        return False
+    try:
+        network = ipaddress.ip_network(cidr, strict=False)
+    except ValueError:
+        return False
+    if network.prefixlen == 0:
+        return False
+    return any(
+        network.version == management_cidr.version and network.overlaps(management_cidr)
+        for management_cidr in BMC_MANAGEMENT_CIDRS
+    )
 
 
 def _check_dedicated_management_network(ec2: Any, vpc_ids: list[str]) -> dict[str, Any]:

--- a/isvctl/configs/providers/my-isv/config/security.yaml
+++ b/isvctl/configs/providers/my-isv/config/security.yaml
@@ -16,6 +16,7 @@
 # without any real infrastructure.
 #
 # Coverage:
+#   SEC12-01: BMC management network (BmcManagementNetworkCheck)
 #   SEC12-02: BMC tenant isolation (BmcTenantIsolationCheck)
 #   SEC14-01: API endpoint isolation (ApiEndpointIsolationCheck)
 #   SEC03-01: Service account credentials (ServiceAccountCredentialCheck)
@@ -37,6 +38,12 @@ commands:
         command: "echo"
         args: ["{\"success\": true, \"platform\": \"security\", \"test_name\": \"preflight\"}"]
         timeout: 10
+
+      - name: bmc_management_network
+        phase: test
+        command: "python ../scripts/security/bmc_management_network_test.py"
+        args: ["--region", "{{region}}"]
+        timeout: 60
 
       - name: bmc_tenant_isolation
         phase: test

--- a/isvctl/configs/providers/my-isv/scripts/security/bmc_management_network_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/security/bmc_management_network_test.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""BMC management-network test - TEMPLATE (replace with your implementation).
+
+Verifies that BMC/IPMI/Redfish management is on a dedicated network that is
+not shared with tenant traffic and is protected by restricted routes and ACLs.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "security",
+    "test_name": "bmc_management_network",
+    "management_networks_checked": 1,
+    "tests": {
+      "dedicated_management_network": {"passed": true},
+      "restricted_management_routes": {"passed": true},
+      "tenant_network_not_management": {"passed": true},
+      "management_acl_enforced": {"passed": true}
+    }
+  }
+
+Usage:
+    python bmc_management_network_test.py --region <region>
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+
+
+def main() -> int:
+    """Run the BMC management-network template and emit structured JSON."""
+    parser = argparse.ArgumentParser(description="BMC management-network test (template)")
+    parser.add_argument("--region", required=True, help="Cloud region")
+    _args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "security",
+        "test_name": "bmc_management_network",
+        "management_networks_checked": 0,
+        "tests": {
+            "dedicated_management_network": {"passed": False},
+            "restricted_management_routes": {"passed": False},
+            "tenant_network_not_management": {"passed": False},
+            "management_acl_enforced": {"passed": False},
+        },
+    }
+
+    # ╔══════════════════════════════════════════════════════════════════╗
+    # ║  TODO: Replace this block with your platform's SEC12-01 BMC      ║
+    # ║  management-network validation.                                  ║
+    # ║                                                                  ║
+    # ║  Example (pseudocode):                                           ║
+    # ║    mgmt_networks = list_bmc_management_networks(region)          ║
+    # ║    assert all(net.dedicated for net in mgmt_networks)            ║
+    # ║    assert no_routes_from_tenant_networks(mgmt_networks)          ║
+    # ║    assert tenant_networks_are_not_mgmt_networks()                ║
+    # ║    assert management_acls_allow_only_hardened_admin_paths()      ║
+    # ╚══════════════════════════════════════════════════════════════════╝
+
+    if DEMO_MODE:
+        result["management_networks_checked"] = 1
+        result["tests"] = {
+            "dedicated_management_network": {"passed": True},
+            "restricted_management_routes": {"passed": True},
+            "tenant_network_not_management": {"passed": True},
+            "management_acl_enforced": {"passed": True},
+        }
+        result["success"] = True
+    else:
+        result["error"] = "Not implemented - replace with your platform's BMC management-network test"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/security.yaml
+++ b/isvctl/configs/suites/security.yaml
@@ -39,6 +39,11 @@ tests:
   # ─── Validations ─────────────────────────────────────────────────
   # These are PROVIDER-AGNOSTIC. They only check JSON field names/values.
   validations:
+    bmc_management_network:
+      checks:
+        BmcManagementNetworkCheck:
+          step: bmc_management_network
+
     bmc_isolation:
       checks:
         BmcTenantIsolationCheck:

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -20,7 +20,7 @@ import shutil
 import tempfile
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -33,7 +33,7 @@ from isvctl.redaction import redact_dict, redact_junit_xml_tree
 logger = logging.getLogger(__name__)
 
 
-class Phase(str, Enum):
+class Phase(StrEnum):
     """Test lifecycle phases."""
 
     ALL = "all"

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -301,13 +301,13 @@ def test_bmc_management_network_detects_tenant_cidr_overlap() -> None:
 
 
 def test_bmc_management_network_detects_explicit_management_routes() -> None:
-    """SEC12-01 fails when a tenant route table targets a management CIDR."""
+    """SEC12-01 fails when a tenant route table targets part of a management CIDR."""
     module = _load_security_script("bmc_management_network_test.py")
     ec2 = FakeBmcManagementEc2(
         route_tables=[
             {
                 "RouteTableId": "rtb-mgmt",
-                "Routes": [{"DestinationCidrBlock": "198.18.0.0/15"}],
+                "Routes": [{"DestinationCidrBlock": "198.18.1.0/24"}],
             }
         ]
     )
@@ -316,6 +316,46 @@ def test_bmc_management_network_detects_explicit_management_routes() -> None:
 
     assert result["passed"] is False
     assert "rtb-mgmt" in result["error"]
+
+
+def test_bmc_management_network_detects_management_acl_host_route() -> None:
+    """SEC12-01 fails when a NACL explicitly allows a host inside a management range."""
+    module = _load_security_script("bmc_management_network_test.py")
+    ec2 = FakeBmcManagementEc2(
+        network_acls=[
+            {
+                "NetworkAclId": "acl-mgmt",
+                "Entries": [
+                    {
+                        "RuleAction": "allow",
+                        "CidrBlock": "169.254.169.254/32",
+                    }
+                ],
+            }
+        ]
+    )
+
+    result = module._check_management_acl_enforced(ec2, ["vpc-tenant"])
+
+    assert result["passed"] is False
+    assert "acl-mgmt" in result["error"]
+
+
+def test_bmc_management_network_exempts_default_routes() -> None:
+    """SEC12-01 route checks do not treat default internet routes as management routes."""
+    module = _load_security_script("bmc_management_network_test.py")
+    ec2 = FakeBmcManagementEc2(
+        route_tables=[
+            {
+                "RouteTableId": "rtb-default",
+                "Routes": [{"DestinationCidrBlock": "0.0.0.0/0"}],
+            }
+        ]
+    )
+
+    result = module._check_restricted_management_routes(ec2, ["vpc-tenant"])
+
+    assert result["passed"] is True
 
 
 def test_bmc_management_network_main_emits_sec12_01_contract(

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -216,7 +216,8 @@ class FakeBmcManagementEc2:
                 [
                     {
                         "Vpcs": vpcs
-                        or [
+                        if vpcs is not None
+                        else [
                             {
                                 "VpcId": "vpc-tenant",
                                 "CidrBlock": "10.0.0.0/16",

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -284,20 +284,53 @@ def test_bmc_main_scans_non_default_vpcs_when_no_vpc_id(
 def test_bmc_management_network_detects_tenant_cidr_overlap() -> None:
     """SEC12-01 fails when tenant VPC CIDRs overlap reserved management ranges."""
     module = _load_security_script("bmc_management_network_test.py")
-    ec2 = FakeBmcManagementEc2(
-        vpcs=[
-            {
-                "VpcId": "vpc-mgmt-overlap",
-                "CidrBlock": "198.18.1.0/24",
-                "CidrBlockAssociationSet": [{"CidrBlock": "198.18.1.0/24"}],
-            }
-        ]
-    )
+    vpcs = [
+        {
+            "VpcId": "vpc-mgmt-overlap",
+            "CidrBlock": "198.18.1.0/24",
+            "CidrBlockAssociationSet": [{"CidrBlock": "198.18.1.0/24"}],
+        }
+    ]
 
-    result = module._check_tenant_network_not_management(ec2, ["vpc-mgmt-overlap"])
+    result = module._check_dedicated_management_network(vpcs)
 
     assert result["passed"] is False
     assert "198.18.1.0/24" in result["error"]
+
+
+def test_bmc_management_network_detects_management_tag() -> None:
+    """SEC12-01 fails when a tenant VPC is tagged as a BMC management network."""
+    module = _load_security_script("bmc_management_network_test.py")
+    vpcs = [
+        {
+            "VpcId": "vpc-mgmt-tag",
+            "CidrBlock": "10.0.0.0/16",
+            "CidrBlockAssociationSet": [{"CidrBlock": "10.0.0.0/16"}],
+            "Tags": [{"Key": "Role", "Value": "bmc-network"}],
+        }
+    ]
+
+    result = module._check_tenant_network_not_management(vpcs)
+
+    assert result["passed"] is False
+    assert "vpc-mgmt-tag" in result["error"]
+
+
+def test_bmc_management_tag_avoids_substring_false_positive() -> None:
+    """Tag matcher uses word boundaries so unrelated identifiers don't false-match."""
+    module = _load_security_script("bmc_management_network_test.py")
+    vpcs = [
+        {
+            "VpcId": "vpc-tenant",
+            "CidrBlock": "10.0.0.0/16",
+            "CidrBlockAssociationSet": [{"CidrBlock": "10.0.0.0/16"}],
+            "Tags": [{"Key": "Name", "Value": "submarine-bmcollege"}],
+        }
+    ]
+
+    result = module._check_tenant_network_not_management(vpcs)
+
+    assert result["passed"] is True
 
 
 def test_bmc_management_network_detects_explicit_management_routes() -> None:

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -200,6 +200,41 @@ class FakeBmcEc2:
         return {"Vpcs": []}
 
 
+class FakeBmcManagementEc2:
+    """Fake EC2 client for BMC management-network checks."""
+
+    def __init__(
+        self,
+        *,
+        vpcs: list[dict[str, Any]] | None = None,
+        route_tables: list[dict[str, Any]] | None = None,
+        network_acls: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Initialize paginated EC2 responses."""
+        self.paginators = {
+            "describe_vpcs": FakeEc2Paginator(
+                [
+                    {
+                        "Vpcs": vpcs
+                        or [
+                            {
+                                "VpcId": "vpc-tenant",
+                                "CidrBlock": "10.0.0.0/16",
+                                "CidrBlockAssociationSet": [{"CidrBlock": "10.0.0.0/16"}],
+                            }
+                        ]
+                    }
+                ]
+            ),
+            "describe_route_tables": FakeEc2Paginator([{"RouteTables": route_tables or []}]),
+            "describe_network_acls": FakeEc2Paginator([{"NetworkAcls": network_acls or []}]),
+        }
+
+    def get_paginator(self, operation_name: str) -> FakeEc2Paginator:
+        """Return a fake paginator for the requested EC2 operation."""
+        return self.paginators[operation_name]
+
+
 def test_bmc_checks_scan_paginated_route_tables_and_security_groups() -> None:
     """BMC route and SG checks inspect every EC2 paginator page."""
     module = _load_security_script("bmc_isolation_test.py")
@@ -244,6 +279,73 @@ def test_bmc_main_scans_non_default_vpcs_when_no_vpc_id(
     assert payload["tests"]["probe_bmc_from_tenant"]["passed"] is False
     assert "vpc-nondefault" in payload["tests"]["probe_bmc_from_tenant"]["error"]
     assert ec2.paginators["describe_vpcs"].calls == [{}]
+
+
+def test_bmc_management_network_detects_tenant_cidr_overlap() -> None:
+    """SEC12-01 fails when tenant VPC CIDRs overlap reserved management ranges."""
+    module = _load_security_script("bmc_management_network_test.py")
+    ec2 = FakeBmcManagementEc2(
+        vpcs=[
+            {
+                "VpcId": "vpc-mgmt-overlap",
+                "CidrBlock": "198.18.1.0/24",
+                "CidrBlockAssociationSet": [{"CidrBlock": "198.18.1.0/24"}],
+            }
+        ]
+    )
+
+    result = module._check_tenant_network_not_management(ec2, ["vpc-mgmt-overlap"])
+
+    assert result["passed"] is False
+    assert "198.18.1.0/24" in result["error"]
+
+
+def test_bmc_management_network_detects_explicit_management_routes() -> None:
+    """SEC12-01 fails when a tenant route table targets a management CIDR."""
+    module = _load_security_script("bmc_management_network_test.py")
+    ec2 = FakeBmcManagementEc2(
+        route_tables=[
+            {
+                "RouteTableId": "rtb-mgmt",
+                "Routes": [{"DestinationCidrBlock": "198.18.0.0/15"}],
+            }
+        ]
+    )
+
+    result = module._check_restricted_management_routes(ec2, ["vpc-tenant"])
+
+    assert result["passed"] is False
+    assert "rtb-mgmt" in result["error"]
+
+
+def test_bmc_management_network_main_emits_sec12_01_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Successful AWS reference run emits the SEC12-01 validation contract."""
+    module = _load_security_script("bmc_management_network_test.py")
+    ec2 = FakeBmcManagementEc2()
+
+    def fake_client(service_name: str, **kwargs: Any) -> FakeBmcManagementEc2:
+        """Return the fake EC2 client."""
+        assert service_name == "ec2"
+        return ec2
+
+    monkeypatch.setattr(module.boto3, "client", fake_client)
+    monkeypatch.setattr(module.sys, "argv", ["bmc_management_network_test.py", "--region", "us-west-2"])
+
+    exit_code = module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["success"] is True
+    assert payload["test_name"] == "bmc_management_network"
+    assert set(payload["tests"]) == {
+        "dedicated_management_network",
+        "restricted_management_routes",
+        "tenant_network_not_management",
+        "management_acl_enforced",
+    }
 
 
 class FakeIamTags:

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -317,8 +317,26 @@ def test_bmc_management_network_detects_management_tag() -> None:
     assert "vpc-mgmt-tag" in result["error"]
 
 
+def test_bmc_management_tag_matches_underscore_delimited() -> None:
+    """Tag matcher catches underscore-delimited management names like bmc_network."""
+    module = _load_security_script("bmc_management_network_test.py")
+    vpcs = [
+        {
+            "VpcId": "vpc-underscore",
+            "CidrBlock": "10.0.0.0/16",
+            "CidrBlockAssociationSet": [{"CidrBlock": "10.0.0.0/16"}],
+            "Tags": [{"Key": "Name", "Value": "bmc_network"}],
+        }
+    ]
+
+    result = module._check_tenant_network_not_management(vpcs)
+
+    assert result["passed"] is False
+    assert "vpc-underscore" in result["error"]
+
+
 def test_bmc_management_tag_avoids_substring_false_positive() -> None:
-    """Tag matcher uses word boundaries so unrelated identifiers don't false-match."""
+    """Tag matcher rejects unrelated identifiers that contain management substrings."""
     module = _load_security_script("bmc_management_network_test.py")
     vpcs = [
         {

--- a/isvtest/src/isvtest/main.py
+++ b/isvtest/src/isvtest/main.py
@@ -17,7 +17,7 @@ Note: For cluster lifecycle management, use isvctl instead:
 import json
 import os
 import tempfile
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -321,7 +321,7 @@ def _transform_validations_for_pytest(
     return result
 
 
-class Platform(str, Enum):
+class Platform(StrEnum):
     """Supported platforms for validation."""
 
     ALL = "all"

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -90,6 +90,7 @@ from isvtest.validations.nim import (
 )
 from isvtest.validations.security import (
     ApiEndpointIsolationCheck,
+    BmcManagementNetworkCheck,
     BmcTenantIsolationCheck,
 )
 
@@ -99,6 +100,7 @@ __all__ = [
     "AccessKeyDisabledCheck",
     "AccessKeyRejectedCheck",
     "ApiEndpointIsolationCheck",
+    "BmcManagementNetworkCheck",
     "BmcTenantIsolationCheck",
     "ByoipCheck",
     "CloudInitCheck",

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -19,6 +19,39 @@ from typing import ClassVar
 from isvtest.core.validation import BaseValidation, check_required_tests
 
 
+class BmcManagementNetworkCheck(BaseValidation):
+    """Validate BMC management is on a dedicated, restricted network.
+
+    Verifies that out-of-band BMC/IPMI/Redfish management networks are not
+    shared with tenant networks and that management routes and ACLs are
+    restricted.
+
+    Config:
+        step_output: The step output to check
+
+    Step output:
+        tests: dict with dedicated_management_network,
+               restricted_management_routes, tenant_network_not_management,
+               management_acl_enforced
+    """
+
+    description: ClassVar[str] = "Check BMC management network is dedicated and restricted"
+    markers: ClassVar[list[str]] = ["security", "network"]
+
+    def run(self) -> None:
+        """Validate required BMC management-network results from step output."""
+        required = [
+            "dedicated_management_network",
+            "restricted_management_routes",
+            "tenant_network_not_management",
+            "management_acl_enforced",
+        ]
+        if not check_required_tests(self, required, "BMC management network tests failed"):
+            return
+        network_count = self.config.get("step_output", {}).get("management_networks_checked", "N/A")
+        self.set_passed(f"BMC management network dedicated and restricted ({network_count} networks checked)")
+
+
 class BmcTenantIsolationCheck(BaseValidation):
     """Validate BMC interfaces are not reachable from tenant networks.
 

--- a/isvtest/tests/test_security.py
+++ b/isvtest/tests/test_security.py
@@ -62,6 +62,19 @@ class TestBmcManagementNetworkCheck:
         assert "management_acl_enforced" in result["error"]
         assert "ACL allows tenant CIDR" in result["error"]
 
+    def test_missing_required_key_fails(self) -> None:
+        """Fail when one of the four required contract keys is absent."""
+        tests = {
+            "dedicated_management_network": {"passed": True},
+            "restricted_management_routes": {"passed": True},
+            "tenant_network_not_management": {"passed": True},
+        }
+
+        result = BmcManagementNetworkCheck(config=_bmc_management_config(tests)).execute()
+
+        assert result["passed"] is False
+        assert "management_acl_enforced" in result["error"]
+
     def test_missing_tests_fails(self) -> None:
         """Fail when the step output does not include contract tests."""
         result = BmcManagementNetworkCheck(config={"step_output": {}}).execute()

--- a/isvtest/tests/test_security.py
+++ b/isvtest/tests/test_security.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Tests for security validation classes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from isvtest.validations.security import BmcManagementNetworkCheck
+
+
+def _bmc_management_config(tests: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    """Build a minimal BMC management-network validation config."""
+    return {
+        "step_output": {
+            "success": True,
+            "platform": "security",
+            "test_name": "bmc_management_network",
+            "management_networks_checked": 1,
+            "tests": tests,
+        }
+    }
+
+
+class TestBmcManagementNetworkCheck:
+    """Tests for SEC12-01 BMC management-network validation."""
+
+    def test_all_required_tests_pass(self) -> None:
+        """Pass when all SEC12-01 contract checks passed."""
+        tests = {
+            "dedicated_management_network": {"passed": True},
+            "restricted_management_routes": {"passed": True},
+            "tenant_network_not_management": {"passed": True},
+            "management_acl_enforced": {"passed": True},
+        }
+
+        result = BmcManagementNetworkCheck(config=_bmc_management_config(tests)).execute()
+
+        assert result["passed"] is True
+        assert "BMC management network dedicated and restricted" in result["output"]
+
+    def test_failed_acl_reports_contract_key(self) -> None:
+        """Fail with the specific contract key when ACL enforcement fails."""
+        tests = {
+            "dedicated_management_network": {"passed": True},
+            "restricted_management_routes": {"passed": True},
+            "tenant_network_not_management": {"passed": True},
+            "management_acl_enforced": {"passed": False, "error": "ACL allows tenant CIDR"},
+        }
+
+        result = BmcManagementNetworkCheck(config=_bmc_management_config(tests)).execute()
+
+        assert result["passed"] is False
+        assert "management_acl_enforced" in result["error"]
+        assert "ACL allows tenant CIDR" in result["error"]
+
+    def test_missing_tests_fails(self) -> None:
+        """Fail when the step output does not include contract tests."""
+        result = BmcManagementNetworkCheck(config={"step_output": {}}).execute()
+
+        assert result["passed"] is False
+        assert "tests" in result["error"]


### PR DESCRIPTION
## Summary

Adds SEC12-01 coverage to the security suite for verifying that BMC management is on a dedicated, restricted network.

## Changes

- Adds BmcManagementNetworkCheck and security suite wiring.
- Adds AWS and my-isv provider scripts/config for bmc_management_network.
- Adds AWS script tests for CIDR overlap routes, NACL allows, and default route exemption.
- Corrects the AWS BMC tenant-isolation script docstring.
- Aligns Ruff usage between Makefile and pre-commit.

## Validation

- make lint
- focused pytest set: 196 passed
- make demo-security
- make pre-commit

Closes #306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BMC management-network security validation (tenant CIDR overlap, restricted management routes, management tagging, ACL checks) that emits structured SEC12-01 JSON results.

* **Tests**
  * Added unit and end-to-end tests for the new management-network checks and validation contract.

* **Chores**
  * Updated Ruff linter to v0.15.12 and centralized lint/format invocation; migrated several enums to StrEnum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
