### PR TITLE
feat: add OIDC user authentication validation (SEC01-01 - M5 P0)

### DIFF
--- a/isvctl/configs/providers/aws/config/security.yaml
+++ b/isvctl/configs/providers/aws/config/security.yaml
@@ -24,6 +24,7 @@
 #   3. API Endpoint Isolation - Verify management APIs are not publicly exposed
 #   4. MFA Enforcement        - Verify admin interfaces (UI, CLI, API) require MFA
 #   5. SA Credential Auth     - Verify IAM user + long-lived access key auth
+#   6. OIDC User Auth         - Probe configured OIDC-protected platform endpoint (SEC01-01)
 
 import:
   - ../../../suites/security.yaml
@@ -76,6 +77,28 @@ commands:
         args: ["--region", "{{region}}"]
         timeout: 120
 
+      # Test 6: OIDC User Authentication
+      # Requires a real issuer, audience, protected target endpoint, and token
+      # fixtures. Non-sensitive endpoint settings can come from tests.settings
+      # below; token fixtures are read by the script from OIDC_*_TOKEN env vars
+      # or passed through token-file arguments in a custom overlay.
+      - name: oidc_user_auth_test
+        phase: test
+        command: "python3 ../scripts/security/oidc_user_auth_test.py"
+        args:
+          - "--region"
+          - "{{region}}"
+          - "--issuer-url={{oidc_issuer_url}}"
+          - "--audience={{oidc_audience}}"
+          - "--target-url={{oidc_target_url}}"
+        sensitive_args:
+          - "--valid-token"
+          - "--wrong-issuer-token"
+          - "--wrong-audience-token"
+          - "--expired-token"
+          - "--missing-required-claim-token"
+        timeout: 60
+
       # Teardown: Clean up leftover test IAM users
       - name: teardown
         phase: teardown
@@ -89,3 +112,6 @@ tests:
 
   settings:
     region: "us-west-2"
+    oidc_issuer_url: "{{env.OIDC_ISSUER_URL | default('', true)}}"
+    oidc_audience: "{{env.OIDC_AUDIENCE | default('', true)}}"
+    oidc_target_url: "{{env.OIDC_TARGET_URL | default('', true)}}"

--- a/isvctl/configs/providers/aws/scripts/security/oidc_user_auth_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/oidc_user_auth_test.py
@@ -1,0 +1,792 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Verify user authentication via OIDC for platform services (SEC01-01).
+
+This AWS reference step is a black-box probe against a configured platform
+endpoint. It fetches the platform issuer's real discovery document and JWKS,
+checks that a supplied valid JWT chains to that issuer/audience, then sends
+valid and invalid bearer tokens to the configured target endpoint.
+
+The step is intentionally fail-closed. If no real issuer, audience, target
+endpoint, or valid test token is configured, it reports failure rather than
+simulating an OIDC provider locally.
+
+Usage:
+    OIDC_VALID_TOKEN=... \\
+    OIDC_WRONG_ISSUER_TOKEN=... \\
+    OIDC_WRONG_AUDIENCE_TOKEN=... \\
+    OIDC_EXPIRED_TOKEN=... \\
+    OIDC_MISSING_REQUIRED_CLAIM_TOKEN=... \\
+    python oidc_user_auth_test.py \\
+      --region us-west-2 \\
+      --issuer-url https://issuer.example/realms/isv \\
+      --audience isv-validation \\
+      --target-url https://platform.example/protected
+
+Output JSON:
+  {
+    "success": true,
+    "platform": "security",
+    "test_name": "oidc_user_auth_test",
+    "issuer_url": "https://issuer.example/realms/isv",
+    "audience": "isv-validation",
+    "target_url": "https://platform.example/protected",
+    "endpoints_tested": 1,
+    "tests": {
+      "valid_token_accepted":            {"passed": true},
+      "bad_signature_rejected":          {"passed": true},
+      "wrong_issuer_rejected":           {"passed": true},
+      "wrong_audience_rejected":         {"passed": true},
+      "expired_token_rejected":          {"passed": true},
+      "missing_required_claim_rejected": {"passed": true},
+      "discovery_and_jwks_reachable":    {"passed": true}
+    }
+  }
+"""
+
+import argparse
+import base64
+import binascii
+import json
+import os
+import sys
+import time
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
+from urllib.request import Request, urlopen
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+DEFAULT_ACCEPT_STATUSES = "200-299"
+DEFAULT_REJECT_STATUSES = "401,403"
+DEFAULT_HTTP_TIMEOUT = 10
+REQUIRED_CLAIMS = ("iss", "sub", "aud", "exp", "iat")
+REQUIRED_PROBES = (
+    "valid_token_accepted",
+    "bad_signature_rejected",
+    "wrong_issuer_rejected",
+    "wrong_audience_rejected",
+    "expired_token_rejected",
+    "missing_required_claim_rejected",
+    "discovery_and_jwks_reachable",
+)
+INVALID_TOKEN_ENV = {
+    "wrong_issuer_rejected": "OIDC_WRONG_ISSUER_TOKEN",
+    "wrong_audience_rejected": "OIDC_WRONG_AUDIENCE_TOKEN",
+    "expired_token_rejected": "OIDC_EXPIRED_TOKEN",
+    "missing_required_claim_rejected": "OIDC_MISSING_REQUIRED_CLAIM_TOKEN",
+}
+
+
+def _b64url_encode(data: bytes) -> str:
+    """Base64url-encode bytes without padding."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(data: str) -> bytes:
+    """Base64url-decode a string, adding padding when needed."""
+    try:
+        pad = "=" * (-len(data) % 4)
+        return base64.urlsafe_b64decode(data + pad)
+    except (TypeError, binascii.Error, ValueError) as e:
+        raise ValueError(f"invalid base64url data: {e}") from e
+
+
+def _int_to_b64url(value: int) -> str:
+    """Encode an integer as base64url bytes."""
+    length = (value.bit_length() + 7) // 8
+    return _b64url_encode(value.to_bytes(length, "big"))
+
+
+def _public_jwk(public_key: rsa.RSAPublicKey, kid: str) -> dict[str, str]:
+    """Return a public RSA key as an RS256 JWK."""
+    numbers = public_key.public_numbers()
+    return {
+        "kty": "RSA",
+        "use": "sig",
+        "alg": "RS256",
+        "kid": kid,
+        "n": _int_to_b64url(numbers.n),
+        "e": _int_to_b64url(numbers.e),
+    }
+
+
+def _jwk_to_public_key(jwk: Mapping[str, Any]) -> rsa.RSAPublicKey:
+    """Convert an RSA JWK into a cryptography public key."""
+    n = int.from_bytes(_b64url_decode(jwk["n"]), "big")
+    e = int.from_bytes(_b64url_decode(jwk["e"]), "big")
+    return rsa.RSAPublicNumbers(e=e, n=n).public_key()
+
+
+def _sign_jwt(
+    claims: dict[str, Any],
+    private_key: rsa.RSAPrivateKey,
+    kid: str,
+    *,
+    drop_claims: tuple[str, ...] = (),
+) -> str:
+    """Sign a JWT with RS256 for unit tests and local fixture generation."""
+    payload = {k: v for k, v in claims.items() if k not in drop_claims}
+    header = {"alg": "RS256", "typ": "JWT", "kid": kid}
+    signing_input = (
+        _b64url_encode(json.dumps(header, separators=(",", ":")).encode())
+        + "."
+        + _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+    ).encode("ascii")
+    signature = private_key.sign(signing_input, padding.PKCS1v15(), hashes.SHA256())
+    return signing_input.decode("ascii") + "." + _b64url_encode(signature)
+
+
+def _verify_jwt(
+    token: str,
+    jwks: dict[str, Any],
+    expected_issuer: str,
+    expected_audience: str,
+    *,
+    now: int | None = None,
+) -> tuple[bool, str]:
+    """Strict OIDC verifier: signature via JWKS lookup, then claim checks."""
+    try:
+        header_b64, payload_b64, signature_b64 = token.split(".")
+    except ValueError:
+        return False, "malformed token"
+
+    try:
+        header = json.loads(_b64url_decode(header_b64))
+        payload = json.loads(_b64url_decode(payload_b64))
+        if not isinstance(header, dict):
+            raise ValueError(f"JWT header is not an object: {type(header).__name__}")
+        if not isinstance(payload, dict):
+            raise ValueError(f"JWT payload is not an object: {type(payload).__name__}")
+        signature = _b64url_decode(signature_b64)
+    except (ValueError, UnicodeDecodeError) as e:
+        return False, f"decode error: {e}"
+
+    if header.get("alg") != "RS256":
+        return False, f"unsupported alg: {header.get('alg')}"
+
+    kid = header.get("kid")
+    keys = jwks.get("keys")
+    if not isinstance(keys, list):
+        return False, "JWKS keys is not a list"
+
+    matching = [k for k in keys if isinstance(k, Mapping) and k.get("kty") == "RSA" and k.get("kid") == kid]
+    if not matching:
+        return False, f"kid not found in JWKS: {kid}"
+
+    public_key = _jwk_to_public_key(matching[0])
+    signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
+    try:
+        public_key.verify(signature, signing_input, padding.PKCS1v15(), hashes.SHA256())
+    except InvalidSignature:
+        return False, "invalid signature"
+
+    for required in REQUIRED_CLAIMS:
+        if required not in payload:
+            return False, f"missing required claim: {required}"
+
+    if payload.get("iss") != expected_issuer:
+        return False, f"issuer mismatch: {payload.get('iss')!r}"
+    aud = payload.get("aud")
+    aud_values = aud if isinstance(aud, list) else [aud]
+    if expected_audience not in aud_values:
+        return False, f"audience mismatch: {aud!r}"
+
+    current = now if now is not None else int(time.time())
+    try:
+        expires_at = int(payload.get("exp", 0))
+    except (TypeError, ValueError):
+        return False, f"invalid exp claim: {payload.get('exp')!r}"
+    if expires_at <= current:
+        return False, "token expired"
+
+    return True, "ok"
+
+
+def _verify_jwt_signature(token: str, jwks: dict[str, Any]) -> str | None:
+    """Return None when a JWT has a valid RS256 signature in the configured JWKS."""
+    try:
+        header_b64, payload_b64, signature_b64 = token.split(".")
+    except ValueError:
+        return "malformed token"
+
+    try:
+        header = json.loads(_b64url_decode(header_b64))
+        signature = _b64url_decode(signature_b64)
+    except (ValueError, UnicodeDecodeError) as e:
+        return f"decode error: {e}"
+
+    if not isinstance(header, dict):
+        return f"JWT header is not an object: {type(header).__name__}"
+
+    if header.get("alg") != "RS256":
+        return f"unsupported alg: {header.get('alg')}"
+
+    kid = header.get("kid")
+    keys = jwks.get("keys")
+    if not isinstance(keys, list):
+        return "JWKS keys is not a list"
+
+    matching = [k for k in keys if isinstance(k, Mapping) and k.get("kty") == "RSA" and k.get("kid") == kid]
+    if not matching:
+        return f"kid not found in JWKS: {kid}"
+
+    try:
+        public_key = _jwk_to_public_key(matching[0])
+        signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
+        public_key.verify(signature, signing_input, padding.PKCS1v15(), hashes.SHA256())
+    except InvalidSignature:
+        return "invalid signature"
+    except (KeyError, ValueError) as e:
+        return f"invalid JWK or signature: {e}"
+
+    return None
+
+
+def _decode_jwt_unverified(token: str) -> tuple[dict[str, Any] | None, dict[str, Any] | None, str | None]:
+    """Decode JWT header and payload without verifying the signature."""
+    try:
+        header_b64, payload_b64, _signature_b64 = token.split(".")
+    except ValueError:
+        return None, None, "malformed token"
+
+    try:
+        header = json.loads(_b64url_decode(header_b64))
+        payload = json.loads(_b64url_decode(payload_b64))
+    except (ValueError, UnicodeDecodeError) as e:
+        return None, None, f"decode error: {e}"
+
+    if not isinstance(header, dict):
+        return None, None, f"JWT header is not an object: {type(header).__name__}"
+    if not isinstance(payload, dict):
+        return None, None, f"JWT payload is not an object: {type(payload).__name__}"
+    return header, payload, None
+
+
+def _audience_values(payload: dict[str, Any]) -> list[Any]:
+    """Return the audience claim as a list for membership checks."""
+    aud = payload.get("aud")
+    return aud if isinstance(aud, list) else [aud]
+
+
+def _missing_required_claims(payload: dict[str, Any]) -> list[str]:
+    """Return required OIDC claims absent from the payload."""
+    return [claim for claim in REQUIRED_CLAIMS if claim not in payload]
+
+
+def _expires_at(payload: dict[str, Any]) -> tuple[int | None, str | None]:
+    """Return the integer exp claim or an error string."""
+    try:
+        return int(payload["exp"]), None
+    except KeyError:
+        return None, "missing required claim: exp"
+    except (TypeError, ValueError):
+        return None, f"invalid exp claim: {payload.get('exp')!r}"
+
+
+def _validate_negative_fixture(
+    probe_name: str,
+    token: str,
+    jwks: dict[str, Any],
+    expected_issuer: str,
+    expected_audience: str,
+    *,
+    now: int | None = None,
+) -> str | None:
+    """Validate that a signed negative JWT fixture exercises the intended defect."""
+    _header, payload, decode_error = _decode_jwt_unverified(token)
+    if decode_error:
+        return decode_error
+    if payload is None:
+        return "missing JWT payload"
+
+    signature_error = _verify_jwt_signature(token, jwks)
+    if signature_error:
+        return f"token signature invalid: {signature_error}"
+
+    missing = _missing_required_claims(payload)
+    if probe_name == "missing_required_claim_rejected":
+        if not missing:
+            return "token contains all required claims"
+
+        current = now if now is not None else int(time.time())
+        expires_at, exp_error = _expires_at(payload)
+        if exp_error:
+            return exp_error
+        if expires_at is None:
+            return "missing required claim: exp"
+
+        is_expired = expires_at <= current
+        has_expected_audience = expected_audience in _audience_values(payload)
+        has_expected_issuer = payload.get("iss") == expected_issuer
+        if not has_expected_issuer:
+            return "token also has the wrong issuer"
+        if not has_expected_audience:
+            return "token also has the wrong audience"
+        if is_expired:
+            return "token is expired instead"
+        return None
+
+    if missing:
+        return "token is missing required claims instead: " + ", ".join(missing)
+
+    current = now if now is not None else int(time.time())
+    expires_at, exp_error = _expires_at(payload)
+    if exp_error:
+        return exp_error
+    if expires_at is None:
+        return "missing required claim: exp"
+
+    is_expired = expires_at <= current
+    has_expected_audience = expected_audience in _audience_values(payload)
+    has_expected_issuer = payload.get("iss") == expected_issuer
+
+    if probe_name == "wrong_issuer_rejected":
+        if has_expected_issuer:
+            return "issuer matches the expected issuer"
+        if not has_expected_audience:
+            return "token also has the wrong audience"
+        if is_expired:
+            return "token is expired instead"
+        return None
+
+    if probe_name == "wrong_audience_rejected":
+        if not has_expected_issuer:
+            return "token also has the wrong issuer"
+        if has_expected_audience:
+            return "audience includes the expected audience"
+        if is_expired:
+            return "token is expired instead"
+        return None
+
+    if probe_name == "expired_token_rejected":
+        if not has_expected_issuer:
+            return "token also has the wrong issuer"
+        if not has_expected_audience:
+            return "token also has the wrong audience"
+        if not is_expired:
+            return "token is not expired"
+        return None
+
+    return f"unknown negative probe: {probe_name}"
+
+
+def _tamper_signature(token: str) -> str:
+    """Return the same JWT with a corrupted signature."""
+    head, payload, sig = token.split(".")
+    raw = bytearray(_b64url_decode(sig) or b"\x00")
+    raw[0] ^= 0xFF
+    return f"{head}.{payload}.{_b64url_encode(bytes(raw))}"
+
+
+def _check_discovery_and_jwks(
+    discovery: dict[str, Any], jwks: dict[str, Any], expected_issuer: str
+) -> tuple[bool, str]:
+    """Validate OIDC discovery metadata and JWKS shape."""
+    if discovery.get("issuer") != expected_issuer:
+        return False, "discovery issuer mismatch"
+
+    jwks_uri = discovery.get("jwks_uri")
+    if not isinstance(jwks_uri, str) or not jwks_uri:
+        return False, "discovery missing jwks_uri"
+    parsed_jwks_uri = urlsplit(jwks_uri)
+    if parsed_jwks_uri.scheme not in {"http", "https"} or not parsed_jwks_uri.netloc:
+        return False, f"discovery jwks_uri is not a valid URL: {jwks_uri}"
+
+    signing_algorithms = discovery.get("id_token_signing_alg_values_supported", [])
+    if not isinstance(signing_algorithms, list):
+        return False, "discovery id_token_signing_alg_values_supported is not a list"
+    if "RS256" not in signing_algorithms:
+        return False, "discovery does not advertise RS256"
+
+    keys = jwks.get("keys") or []
+    if not isinstance(keys, list):
+        return False, "JWKS keys is not a list"
+
+    has_valid_rsa_key = False
+    rsa_failures: list[str] = []
+    for index, key in enumerate(keys):
+        if not isinstance(key, Mapping):
+            continue
+        if key.get("kty") != "RSA":
+            continue
+        missing_fields = [field for field in ("kid", "n", "e") if not key.get(field)]
+        if missing_fields:
+            rsa_failures.append(f"JWKS RSA key at index {index} missing required fields: {', '.join(missing_fields)}")
+            continue
+        has_valid_rsa_key = True
+
+    if rsa_failures:
+        return False, "; ".join(rsa_failures)
+    if not has_valid_rsa_key:
+        return False, "JWKS has no usable RSA keys"
+    return True, "ok"
+
+
+def _parse_statuses(value: str) -> set[int]:
+    """Parse comma-separated HTTP status codes or inclusive ranges."""
+    statuses: set[int] = set()
+    for part in value.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        if "-" in token:
+            start_raw, end_raw = token.split("-", 1)
+            start = int(start_raw)
+            end = int(end_raw)
+            statuses.update(range(start, end + 1))
+        else:
+            statuses.add(int(token))
+    if not statuses:
+        msg = f"Invalid empty HTTP status set: {value!r}"
+        raise ValueError(msg)
+    return statuses
+
+
+def _fetch_json(url: str, timeout: int) -> dict[str, Any]:
+    """Fetch a JSON object from a URL."""
+    request = Request(url, headers={"Accept": "application/json"}, method="GET")
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+    except HTTPError as e:
+        msg = f"HTTP {e.code} fetching {url}: {e.reason}"
+        raise RuntimeError(msg) from e
+    except URLError as e:
+        msg = f"Failed to fetch {url}: {e.reason}"
+        raise RuntimeError(msg) from e
+
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as e:
+        msg = f"Failed to parse JSON from {url}: {e}"
+        raise RuntimeError(msg) from e
+
+    if not isinstance(payload, dict):
+        msg = f"Expected JSON object from {url}, got {type(payload).__name__}"
+        raise RuntimeError(msg)
+    return payload
+
+
+def _fetch_discovery_and_jwks(issuer: str, timeout: int) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Fetch OIDC discovery metadata and the referenced JWKS."""
+    discovery_url = f"{issuer.rstrip('/')}/.well-known/openid-configuration"
+    discovery = _fetch_json(discovery_url, timeout)
+    jwks_uri = discovery.get("jwks_uri")
+    if not isinstance(jwks_uri, str) or not jwks_uri:
+        return discovery, {}
+    return discovery, _fetch_json(jwks_uri, timeout)
+
+
+def _probe_endpoint(
+    target_url: str,
+    token: str,
+    *,
+    method: str,
+    timeout: int,
+    expected_statuses: set[int],
+) -> dict[str, Any]:
+    """Send a bearer token to the target endpoint and validate the status code."""
+    request = Request(
+        target_url,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+        method=method.upper(),
+    )
+
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            status_code = response.getcode()
+            reason = "OK"
+    except HTTPError as e:
+        status_code = e.code
+        reason = e.reason
+    except URLError as e:
+        return {"passed": False, "error": f"Failed to probe target endpoint: {e.reason}"}
+
+    if status_code in expected_statuses:
+        return {"passed": True, "status_code": status_code}
+
+    expected = ", ".join(str(code) for code in sorted(expected_statuses))
+    return {
+        "passed": False,
+        "status_code": status_code,
+        "error": f"Unexpected status {status_code} from target endpoint ({reason}); expected one of {expected}",
+    }
+
+
+def _failed_probe(error: str) -> dict[str, Any]:
+    """Return a failed probe result with a consistent shape."""
+    return {"passed": False, "error": error}
+
+
+def _not_executed_probes(error: str) -> dict[str, dict[str, Any]]:
+    """Return every required probe as failed because execution could not start."""
+    return {name: _failed_probe(error) for name in REQUIRED_PROBES}
+
+
+def _token_from_sources(value: str, file_path: str, env_var: str) -> str:
+    """Resolve a token from a direct value, file path, or environment variable."""
+    if value.strip():
+        return value.strip()
+    if file_path.strip():
+        return Path(file_path).read_text(encoding="utf-8").strip()
+    return os.environ.get(env_var, "").strip()
+
+
+def _reject_probe(
+    target_url: str,
+    token: str,
+    *,
+    method: str,
+    timeout: int,
+    reject_statuses: set[int],
+) -> dict[str, Any]:
+    """Probe the target endpoint expecting an invalid token to be rejected."""
+    if not token:
+        return _failed_probe("Token not configured")
+    return _probe_endpoint(
+        target_url,
+        token,
+        method=method,
+        timeout=timeout,
+        expected_statuses=reject_statuses,
+    )
+
+
+def _negative_fixture_probe(
+    probe_name: str,
+    target_url: str,
+    token: str,
+    jwks: dict[str, Any],
+    expected_issuer: str,
+    expected_audience: str,
+    *,
+    method: str,
+    timeout: int,
+    reject_statuses: set[int],
+    now: int,
+) -> dict[str, Any]:
+    """Validate a negative fixture locally, then expect the endpoint to reject it."""
+    if not token:
+        return _failed_probe("Token not configured")
+
+    fixture_error = _validate_negative_fixture(
+        probe_name,
+        token,
+        jwks,
+        expected_issuer,
+        expected_audience,
+        now=now,
+    )
+    if fixture_error:
+        return _failed_probe(f"{probe_name} fixture invalid: {fixture_error}")
+
+    return _probe_endpoint(
+        target_url,
+        token,
+        method=method,
+        timeout=timeout,
+        expected_statuses=reject_statuses,
+    )
+
+
+def run_probes(
+    issuer: str,
+    audience: str,
+    target_url: str,
+    valid_token: str,
+    invalid_tokens: dict[str, str],
+    *,
+    method: str = "GET",
+    timeout: int = DEFAULT_HTTP_TIMEOUT,
+    accept_statuses: set[int] | None = None,
+    reject_statuses: set[int] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Execute OIDC probes against the configured issuer and target endpoint."""
+    accept_codes = accept_statuses or _parse_statuses(DEFAULT_ACCEPT_STATUSES)
+    reject_codes = reject_statuses or _parse_statuses(DEFAULT_REJECT_STATUSES)
+    probes: dict[str, dict[str, Any]] = _not_executed_probes("Validation not executed")
+    current = int(time.time())
+
+    try:
+        discovery, jwks = _fetch_discovery_and_jwks(issuer, timeout)
+    except Exception as e:
+        probes["discovery_and_jwks_reachable"] = _failed_probe(f"{type(e).__name__}: {e}")
+        return probes
+
+    ok, detail = _check_discovery_and_jwks(discovery, jwks, issuer)
+    probes["discovery_and_jwks_reachable"] = {"passed": True} if ok else _failed_probe(detail)
+    if not ok:
+        return probes
+
+    token_ok, token_detail = _verify_jwt(valid_token, jwks, issuer, audience)
+    if not token_ok:
+        probes["valid_token_accepted"] = _failed_probe(f"valid token failed local OIDC validation: {token_detail}")
+    else:
+        probes["valid_token_accepted"] = _probe_endpoint(
+            target_url,
+            valid_token,
+            method=method,
+            timeout=timeout,
+            expected_statuses=accept_codes,
+        )
+
+    try:
+        bad_signature_token = _tamper_signature(valid_token)
+    except ValueError as e:
+        probes["bad_signature_rejected"] = _failed_probe(f"could not tamper valid token: {e}")
+    else:
+        probes["bad_signature_rejected"] = _reject_probe(
+            target_url,
+            bad_signature_token,
+            method=method,
+            timeout=timeout,
+            reject_statuses=reject_codes,
+        )
+
+    for probe_name in (
+        "wrong_issuer_rejected",
+        "wrong_audience_rejected",
+        "expired_token_rejected",
+        "missing_required_claim_rejected",
+    ):
+        probes[probe_name] = _negative_fixture_probe(
+            probe_name,
+            target_url,
+            invalid_tokens.get(probe_name, ""),
+            jwks,
+            issuer,
+            audience,
+            method=method,
+            timeout=timeout,
+            reject_statuses=reject_codes,
+            now=current,
+        )
+
+    return probes
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser for the OIDC probe."""
+    parser = argparse.ArgumentParser(description="OIDC user authentication test (SEC01-01)")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--issuer-url", default=os.environ.get("OIDC_ISSUER_URL", ""))
+    parser.add_argument("--audience", default=os.environ.get("OIDC_AUDIENCE", ""))
+    parser.add_argument("--target-url", default=os.environ.get("OIDC_TARGET_URL", ""))
+    parser.add_argument("--method", default=os.environ.get("OIDC_TARGET_METHOD", "GET"))
+    parser.add_argument("--http-timeout", type=int, default=DEFAULT_HTTP_TIMEOUT)
+    parser.add_argument("--accept-statuses", default=os.environ.get("OIDC_ACCEPT_STATUSES", DEFAULT_ACCEPT_STATUSES))
+    parser.add_argument("--reject-statuses", default=os.environ.get("OIDC_REJECT_STATUSES", DEFAULT_REJECT_STATUSES))
+    parser.add_argument("--valid-token", default="", help="Valid OIDC JWT; prefer OIDC_VALID_TOKEN or file input")
+    parser.add_argument("--valid-token-file", default="", help="File containing a valid OIDC JWT")
+    parser.add_argument("--wrong-issuer-token", default="", help="JWT expected to fail issuer validation")
+    parser.add_argument("--wrong-issuer-token-file", default="", help="File containing a wrong-issuer JWT")
+    parser.add_argument("--wrong-audience-token", default="", help="JWT expected to fail audience validation")
+    parser.add_argument("--wrong-audience-token-file", default="", help="File containing a wrong-audience JWT")
+    parser.add_argument("--expired-token", default="", help="Expired JWT expected to be rejected")
+    parser.add_argument("--expired-token-file", default="", help="File containing an expired JWT")
+    parser.add_argument("--missing-required-claim-token", default="", help="JWT missing a required claim")
+    parser.add_argument("--missing-required-claim-token-file", default="", help="File containing a missing-claim JWT")
+    return parser
+
+
+def _missing_config_errors(issuer: str, audience: str, target_url: str, valid_token: str) -> list[str]:
+    """Return missing mandatory configuration fields."""
+    missing: list[str] = []
+    if not issuer:
+        missing.append("--issuer-url or OIDC_ISSUER_URL")
+    if not audience:
+        missing.append("--audience or OIDC_AUDIENCE")
+    if not target_url:
+        missing.append("--target-url or OIDC_TARGET_URL")
+    if not valid_token:
+        missing.append("--valid-token, --valid-token-file, or OIDC_VALID_TOKEN")
+    return missing
+
+
+def main() -> int:
+    """Run OIDC user authentication test and emit JSON result."""
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "security",
+        "test_name": "oidc_user_auth_test",
+        "issuer_url": args.issuer_url,
+        "audience": args.audience,
+        "target_url": args.target_url,
+        "endpoints_tested": 1 if args.target_url else 0,
+        "tests": {},
+    }
+
+    try:
+        valid_token = _token_from_sources(args.valid_token, args.valid_token_file, "OIDC_VALID_TOKEN")
+        invalid_tokens = {
+            "wrong_issuer_rejected": _token_from_sources(
+                args.wrong_issuer_token,
+                args.wrong_issuer_token_file,
+                INVALID_TOKEN_ENV["wrong_issuer_rejected"],
+            ),
+            "wrong_audience_rejected": _token_from_sources(
+                args.wrong_audience_token,
+                args.wrong_audience_token_file,
+                INVALID_TOKEN_ENV["wrong_audience_rejected"],
+            ),
+            "expired_token_rejected": _token_from_sources(
+                args.expired_token,
+                args.expired_token_file,
+                INVALID_TOKEN_ENV["expired_token_rejected"],
+            ),
+            "missing_required_claim_rejected": _token_from_sources(
+                args.missing_required_claim_token,
+                args.missing_required_claim_token_file,
+                INVALID_TOKEN_ENV["missing_required_claim_rejected"],
+            ),
+        }
+
+        missing = _missing_config_errors(args.issuer_url, args.audience, args.target_url, valid_token)
+        if missing:
+            error = "OIDC validation not configured; missing " + ", ".join(missing)
+            result["error"] = error
+            result["tests"] = _not_executed_probes(error)
+        else:
+            result["tests"] = run_probes(
+                args.issuer_url,
+                args.audience,
+                args.target_url,
+                valid_token,
+                invalid_tokens,
+                method=args.method,
+                timeout=args.http_timeout,
+                accept_statuses=_parse_statuses(args.accept_statuses),
+                reject_statuses=_parse_statuses(args.reject_statuses),
+            )
+            result["success"] = all(probe.get("passed") for probe in result["tests"].values())
+    except Exception as e:
+        result["error"] = f"{type(e).__name__}: {e}"
+        result["tests"] = _not_executed_probes(result["error"])
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/my-isv/config/security.yaml
+++ b/isvctl/configs/providers/my-isv/config/security.yaml
@@ -21,6 +21,7 @@
 #   SEC14-01: API endpoint isolation (ApiEndpointIsolationCheck)
 #   SEC07-01: MFA enforcement (MfaEnforcedCheck)
 #   SEC03-01: Service account credentials (ServiceAccountCredentialCheck)
+#   SEC01-01: OIDC user authentication (OidcUserAuthCheck)
 #
 # Usage:
 #   uv run isvctl test run -f isvctl/configs/providers/my-isv/config/security.yaml
@@ -67,6 +68,12 @@ commands:
       - name: sa_credential_test
         phase: test
         command: "python ../scripts/security/sa_credential_test.py"
+        args: ["--region", "{{region}}"]
+        timeout: 60
+
+      - name: oidc_user_auth_test
+        phase: test
+        command: "python ../scripts/security/oidc_user_auth_test.py"
         args: ["--region", "{{region}}"]
         timeout: 60
 

--- a/isvctl/configs/providers/my-isv/scripts/security/oidc_user_auth_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/security/oidc_user_auth_test.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""OIDC user authentication test - TEMPLATE (replace with your platform implementation).
+
+Verifies that an OIDC-compliant verifier in your platform accepts properly
+issued tokens and rejects tokens with bad signature, wrong issuer, wrong
+audience, expired exp, or missing required claims, and that the discovery +
+JWKS endpoints serve the expected metadata.  Covers SEC01-01.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "security",
+    "test_name": "oidc_user_auth_test",
+    "issuer_url": "https://...",
+    "audience": "...",
+    "target_url": "https://...",
+    "endpoints_tested": 1,
+    "tests": {
+      "valid_token_accepted":            {"passed": true},
+      "bad_signature_rejected":          {"passed": true},
+      "wrong_issuer_rejected":           {"passed": true},
+      "wrong_audience_rejected":         {"passed": true},
+      "expired_token_rejected":          {"passed": true},
+      "missing_required_claim_rejected": {"passed": true},
+      "discovery_and_jwks_reachable":    {"passed": true}
+    }
+  }
+
+Usage:
+    python oidc_user_auth_test.py --region <region>
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+
+
+def main() -> int:
+    """OIDC user auth test (template) and emit structured JSON result."""
+    parser = argparse.ArgumentParser(description="OIDC user auth test (template)")
+    parser.add_argument("--region", required=True, help="Cloud region")
+    parser.add_argument("--issuer-url", default="", help="OIDC issuer URL (optional)")
+    parser.add_argument("--audience", default="", help="Expected audience claim (optional)")
+    parser.add_argument("--target-url", default="", help="Platform endpoint to probe with tokens (optional)")
+    _args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "security",
+        "test_name": "oidc_user_auth_test",
+        "issuer_url": "",
+        "audience": "",
+        "target_url": "",
+        "endpoints_tested": 0,
+        "tests": {
+            "valid_token_accepted": {"passed": False},
+            "bad_signature_rejected": {"passed": False},
+            "wrong_issuer_rejected": {"passed": False},
+            "wrong_audience_rejected": {"passed": False},
+            "expired_token_rejected": {"passed": False},
+            "missing_required_claim_rejected": {"passed": False},
+            "discovery_and_jwks_reachable": {"passed": False},
+        },
+    }
+
+    # ╔══════════════════════════════════════════════════════════════════╗
+    # ║  TODO: Replace this block with your platform's OIDC user auth    ║
+    # ║  test.                                                           ║
+    # ║                                                                  ║
+    # ║  Example (pseudocode):                                           ║
+    # ║    discovery = fetch(f"{issuer_url}/.well-known/openid-config")  ║
+    # ║    jwks = fetch(discovery["jwks_uri"])                           ║
+    # ║    valid = mint_token(audience=audience)                         ║
+    # ║    assert target_accepts(target_url, valid)                      ║
+    # ║    bad_sig = mutate_signature(valid)                             ║
+    # ║    assert target_rejects(target_url, bad_sig)                    ║
+    # ║    assert target_rejects(target_url, token_with(iss="x"))        ║
+    # ║    assert target_rejects(target_url, token_with(aud="x"))        ║
+    # ║    assert target_rejects(target_url, token_with_exp_in_past())   ║
+    # ║    assert target_rejects(target_url, token_without("sub"))       ║
+    # ╚══════════════════════════════════════════════════════════════════╝
+
+    if DEMO_MODE:
+        result["issuer_url"] = "https://oidc.my-isv.example/realms/test"
+        result["audience"] = "isv-validation"
+        result["target_url"] = "https://api.my-isv.example/protected"
+        result["endpoints_tested"] = 1
+        result["tests"] = {
+            "valid_token_accepted": {"passed": True},
+            "bad_signature_rejected": {"passed": True},
+            "wrong_issuer_rejected": {"passed": True},
+            "wrong_audience_rejected": {"passed": True},
+            "expired_token_rejected": {"passed": True},
+            "missing_required_claim_rejected": {"passed": True},
+            "discovery_and_jwks_reachable": {"passed": True},
+        }
+        result["success"] = True
+    else:
+        result["error"] = "Not implemented - replace with your platform's OIDC user auth test"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -145,6 +145,7 @@ Validations use `sinfo`/`srun` directly: partitions, GPU allocation, job schedul
 | `bmc_tenant_isolation` | test | `providers/my-isv/scripts/security/bmc_isolation_test.py` | BMC/IPMI/Redfish unreachable from tenant network |
 | `api_endpoint_isolation` | test | `providers/my-isv/scripts/security/api_endpoint_test.py` | API endpoints not publicly accessible |
 | `sa_credential_test` | test | `providers/my-isv/scripts/security/sa_credential_test.py` | Service account long-lived credential auth |
+| `oidc_user_auth_test` | test | `providers/my-isv/scripts/security/oidc_user_auth_test.py` | OIDC issuer metadata and protected endpoint token acceptance/rejection |
 | `teardown` | teardown | `providers/my-isv/scripts/security/teardown.py` | Cleanup test resources |
 
 ## Related Documentation

--- a/isvctl/configs/suites/security.yaml
+++ b/isvctl/configs/suites/security.yaml
@@ -64,6 +64,11 @@ tests:
         ServiceAccountCredentialCheck:
           step: sa_credential_test
 
+    user_auth_oidc:
+      checks:
+        OidcUserAuthCheck:
+          step: oidc_user_auth_test
+
     teardown_checks:
       step: teardown
       checks:

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -13,10 +13,13 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
+from email.message import Message
 from pathlib import Path
 from types import ModuleType
 from typing import Any
+from urllib.error import HTTPError
 
 import pytest
 from botocore.exceptions import ClientError
@@ -618,3 +621,609 @@ def test_teardown_main_fails_when_owned_user_cleanup_fails(
     assert payload["resources_failed"][0]["username"] == "isv-sa-test-leftover"
     assert len(payload["resources_failed"][0]["errors"]) == 2
     assert iam.delete_user_called is True
+
+
+@pytest.fixture(scope="module")
+def oidc_module() -> ModuleType:
+    """Load the OIDC user auth script as a module."""
+    return _load_security_script("oidc_user_auth_test.py")
+
+
+class FakeHttpResponse:
+    """Small context-manager response for urllib-based OIDC tests."""
+
+    def __init__(self, payload: dict[str, Any] | None = None, status_code: int = 200) -> None:
+        """Store response payload and status code."""
+        self.payload = payload or {}
+        self.status_code = status_code
+
+    def __enter__(self) -> FakeHttpResponse:
+        """Enter response context."""
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        """Exit response context."""
+        return None
+
+    def read(self) -> bytes:
+        """Return JSON response bytes."""
+        return json.dumps(self.payload).encode("utf-8")
+
+    def getcode(self) -> int:
+        """Return HTTP status code."""
+        return self.status_code
+
+
+def _make_oidc_fixture(oidc_module: ModuleType) -> dict[str, Any]:
+    """Build tokens, discovery metadata, and JWKS for OIDC script tests."""
+    from cryptography.hazmat.primitives.asymmetric import rsa as _rsa
+
+    issuer = "https://oidc.test.local/realms/isv"
+    audience = "isv-validation"
+    target_url = "https://platform.test.local/protected"
+    private_key = _rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    kid = "kid-1"
+    jwks = {"keys": [oidc_module._public_jwk(private_key.public_key(), kid)]}
+    discovery = {
+        "issuer": issuer,
+        "jwks_uri": f"{issuer}/protocol/openid-connect/certs",
+        "response_types_supported": ["code", "id_token"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+    }
+    now = int(oidc_module.time.time())
+    base_claims = {
+        "iss": issuer,
+        "sub": "isv-test-user",
+        "aud": audience,
+        "iat": now,
+        "exp": now + 600,
+    }
+    return {
+        "issuer": issuer,
+        "audience": audience,
+        "target_url": target_url,
+        "discovery": discovery,
+        "jwks": jwks,
+        "valid_token": oidc_module._sign_jwt(base_claims, private_key, kid),
+        "invalid_tokens": {
+            "wrong_issuer_rejected": oidc_module._sign_jwt({**base_claims, "iss": f"{issuer}-evil"}, private_key, kid),
+            "wrong_audience_rejected": oidc_module._sign_jwt(
+                {**base_claims, "aud": "wrong-audience"}, private_key, kid
+            ),
+            "expired_token_rejected": oidc_module._sign_jwt(
+                {**base_claims, "iat": now - 120, "exp": now - 60}, private_key, kid
+            ),
+            "missing_required_claim_rejected": oidc_module._sign_jwt(
+                base_claims, private_key, kid, drop_claims=("sub",)
+            ),
+        },
+    }
+
+
+def _patch_oidc_urlopen(
+    monkeypatch: pytest.MonkeyPatch,
+    oidc_module: ModuleType,
+    fixture: dict[str, Any],
+) -> list[str]:
+    """Patch urlopen so OIDC probes exercise fake remote HTTP endpoints."""
+    seen_tokens: list[str] = []
+
+    def fake_urlopen(request: Any, timeout: int = 0) -> FakeHttpResponse:
+        """Serve discovery/JWKS and enforce target bearer-token behavior."""
+        url = request.full_url
+        if url == f"{fixture['issuer']}/.well-known/openid-configuration":
+            return FakeHttpResponse(fixture["discovery"])
+        if url == fixture["discovery"]["jwks_uri"]:
+            return FakeHttpResponse(fixture["jwks"])
+        if url == fixture["target_url"]:
+            auth_header = request.get_header("Authorization", "")
+            token = auth_header.removeprefix("Bearer ")
+            seen_tokens.append(token)
+            if token == fixture["valid_token"]:
+                return FakeHttpResponse({}, status_code=200)
+            raise HTTPError(url, 401, "Unauthorized", Message(), io.BytesIO(b""))
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(oidc_module, "urlopen", fake_urlopen)
+    return seen_tokens
+
+
+def test_oidc_run_probes_all_pass(oidc_module: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    """All seven OIDC probes pass against configured remote endpoints."""
+    fixture = _make_oidc_fixture(oidc_module)
+    seen_tokens = _patch_oidc_urlopen(monkeypatch, oidc_module, fixture)
+
+    probes = oidc_module.run_probes(
+        fixture["issuer"],
+        fixture["audience"],
+        fixture["target_url"],
+        fixture["valid_token"],
+        fixture["invalid_tokens"],
+    )
+
+    expected = {
+        "valid_token_accepted",
+        "bad_signature_rejected",
+        "wrong_issuer_rejected",
+        "wrong_audience_rejected",
+        "expired_token_rejected",
+        "missing_required_claim_rejected",
+        "discovery_and_jwks_reachable",
+    }
+    assert set(probes) == expected
+    for name, probe in probes.items():
+        assert probe["passed"], f"{name} did not pass: {probe}"
+    assert len(seen_tokens) == 6
+
+
+@pytest.mark.parametrize(
+    ("jwks", "expected_error"),
+    [
+        ({"keys": {"kid": "kid-1"}}, "JWKS keys is not a list"),
+        ({"keys": []}, "JWKS has no usable RSA keys"),
+        ({"keys": ["not-a-key", {"kty": "EC", "kid": "kid-1"}]}, "JWKS has no usable RSA keys"),
+        ({"keys": [{"kty": "RSA", "kid": "kid-1"}]}, "JWKS RSA key at index 0 missing required fields: n, e"),
+    ],
+)
+def test_oidc_run_probes_fails_cleanly_for_malformed_jwks(
+    oidc_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    jwks: dict[str, Any],
+    expected_error: str,
+) -> None:
+    """Malformed JWKS discovery data fails the discovery probe without raising."""
+    fixture = _make_oidc_fixture(oidc_module)
+    fixture["jwks"] = jwks
+    seen_tokens = _patch_oidc_urlopen(monkeypatch, oidc_module, fixture)
+
+    probes = oidc_module.run_probes(
+        fixture["issuer"],
+        fixture["audience"],
+        fixture["target_url"],
+        fixture["valid_token"],
+        fixture["invalid_tokens"],
+    )
+
+    assert probes["discovery_and_jwks_reachable"]["passed"] is False
+    assert probes["discovery_and_jwks_reachable"]["error"] == expected_error
+    assert len(seen_tokens) == 0
+
+
+def test_oidc_run_probes_accepts_jwks_with_non_rsa_entries(
+    oidc_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """JWKS discovery accepts mixed key sets when at least one RSA key is usable."""
+    fixture = _make_oidc_fixture(oidc_module)
+    fixture["jwks"]["keys"] = [
+        "not-a-key",
+        {"kty": "EC", "kid": "kid-1"},
+        *fixture["jwks"]["keys"],
+    ]
+    seen_tokens = _patch_oidc_urlopen(monkeypatch, oidc_module, fixture)
+
+    probes = oidc_module.run_probes(
+        fixture["issuer"],
+        fixture["audience"],
+        fixture["target_url"],
+        fixture["valid_token"],
+        fixture["invalid_tokens"],
+    )
+
+    assert probes["discovery_and_jwks_reachable"]["passed"] is True
+    assert all(probe["passed"] for probe in probes.values())
+    assert len(seen_tokens) == 6
+
+
+def test_oidc_run_probes_rejects_malformed_rsa_jwks_even_with_valid_rsa(
+    oidc_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed RSA JWKS entries fail discovery even when another RSA key is usable."""
+    fixture = _make_oidc_fixture(oidc_module)
+    fixture["jwks"]["keys"].append({"kty": "RSA", "kid": "kid-2", "n": "abc"})
+    seen_tokens = _patch_oidc_urlopen(monkeypatch, oidc_module, fixture)
+
+    probes = oidc_module.run_probes(
+        fixture["issuer"],
+        fixture["audience"],
+        fixture["target_url"],
+        fixture["valid_token"],
+        fixture["invalid_tokens"],
+    )
+
+    assert probes["discovery_and_jwks_reachable"]["passed"] is False
+    assert probes["discovery_and_jwks_reachable"]["error"] == "JWKS RSA key at index 1 missing required fields: e"
+    assert len(seen_tokens) == 0
+
+
+def test_oidc_run_probes_fails_cleanly_for_malformed_discovery_signing_algorithms(
+    oidc_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed discovery algorithm metadata fails the discovery probe without raising."""
+    fixture = _make_oidc_fixture(oidc_module)
+    fixture["discovery"]["id_token_signing_alg_values_supported"] = 123
+    seen_tokens = _patch_oidc_urlopen(monkeypatch, oidc_module, fixture)
+
+    probes = oidc_module.run_probes(
+        fixture["issuer"],
+        fixture["audience"],
+        fixture["target_url"],
+        fixture["valid_token"],
+        fixture["invalid_tokens"],
+    )
+
+    assert probes["discovery_and_jwks_reachable"]["passed"] is False
+    assert (
+        probes["discovery_and_jwks_reachable"]["error"]
+        == "discovery id_token_signing_alg_values_supported is not a list"
+    )
+    assert len(seen_tokens) == 0
+
+
+def test_oidc_run_probes_rejects_miswired_negative_fixture(
+    oidc_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Negative fixtures must match the specific defect they claim to exercise."""
+    fixture = _make_oidc_fixture(oidc_module)
+    seen_tokens = _patch_oidc_urlopen(monkeypatch, oidc_module, fixture)
+    invalid_tokens = dict(fixture["invalid_tokens"])
+    invalid_tokens["wrong_audience_rejected"] = fixture["invalid_tokens"]["expired_token_rejected"]
+
+    probes = oidc_module.run_probes(
+        fixture["issuer"],
+        fixture["audience"],
+        fixture["target_url"],
+        fixture["valid_token"],
+        invalid_tokens,
+    )
+
+    assert probes["wrong_audience_rejected"]["passed"] is False
+    assert "wrong_audience_rejected fixture invalid" in probes["wrong_audience_rejected"]["error"]
+    assert "audience includes the expected audience" in probes["wrong_audience_rejected"]["error"]
+    assert len(seen_tokens) == 5
+
+
+@pytest.mark.parametrize(
+    ("claim_overrides", "drop_claims", "expected_error"),
+    [
+        ({"iss": "https://issuer.example.com/evil"}, ("sub",), "token also has the wrong issuer"),
+        ({"aud": "wrong-audience"}, ("sub",), "token also has the wrong audience"),
+        ({"exp": 1_699_999_940}, ("sub",), "token is expired instead"),
+        ({}, ("sub", "exp"), "missing required claim: exp"),
+    ],
+)
+def test_oidc_missing_claim_fixture_rejects_additional_defects(
+    oidc_module: ModuleType,
+    claim_overrides: dict[str, Any],
+    drop_claims: tuple[str, ...],
+    expected_error: str,
+) -> None:
+    """Missing-claim fixtures fail locally when they also have unrelated defects."""
+    from cryptography.hazmat.primitives.asymmetric import rsa as _rsa
+
+    issuer = "https://issuer.example.com"
+    audience = "isv-validation"
+    now = 1_700_000_000
+    private_key = _rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    jwks = {"keys": [oidc_module._public_jwk(private_key.public_key(), "kid-1")]}
+    claims = {
+        "iss": issuer,
+        "sub": "isv-test-user",
+        "aud": audience,
+        "iat": now,
+        "exp": now + 600,
+        **claim_overrides,
+    }
+    token = oidc_module._sign_jwt(claims, private_key, "kid-1", drop_claims=drop_claims)
+
+    fixture_error = oidc_module._validate_negative_fixture(
+        "missing_required_claim_rejected",
+        token,
+        jwks,
+        issuer,
+        audience,
+        now=now,
+    )
+
+    assert fixture_error == expected_error
+
+
+def test_oidc_run_probes_rejects_malformed_negative_fixture(
+    oidc_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed negative fixtures fail locally instead of counting as claim coverage."""
+    fixture = _make_oidc_fixture(oidc_module)
+    seen_tokens = _patch_oidc_urlopen(monkeypatch, oidc_module, fixture)
+    invalid_tokens = dict(fixture["invalid_tokens"])
+    invalid_tokens["wrong_issuer_rejected"] = "not-a-jwt"
+
+    probes = oidc_module.run_probes(
+        fixture["issuer"],
+        fixture["audience"],
+        fixture["target_url"],
+        fixture["valid_token"],
+        invalid_tokens,
+    )
+
+    assert probes["wrong_issuer_rejected"]["passed"] is False
+    assert "wrong_issuer_rejected fixture invalid: malformed token" in probes["wrong_issuer_rejected"]["error"]
+    assert len(seen_tokens) == 5
+
+
+def test_oidc_run_probes_rejects_bad_signature_negative_fixture(
+    oidc_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Claim-specific negative fixtures must be validly signed before endpoint probing."""
+    fixture = _make_oidc_fixture(oidc_module)
+    seen_tokens = _patch_oidc_urlopen(monkeypatch, oidc_module, fixture)
+    invalid_tokens = dict(fixture["invalid_tokens"])
+    invalid_tokens["wrong_audience_rejected"] = oidc_module._tamper_signature(
+        fixture["invalid_tokens"]["wrong_audience_rejected"]
+    )
+
+    probes = oidc_module.run_probes(
+        fixture["issuer"],
+        fixture["audience"],
+        fixture["target_url"],
+        fixture["valid_token"],
+        invalid_tokens,
+    )
+
+    assert probes["wrong_audience_rejected"]["passed"] is False
+    assert "wrong_audience_rejected fixture invalid" in probes["wrong_audience_rejected"]["error"]
+    assert "token signature invalid: invalid signature" in probes["wrong_audience_rejected"]["error"]
+    assert len(seen_tokens) == 5
+
+
+def test_oidc_run_probes_fails_when_negative_fixture_missing(
+    oidc_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing negative fixture still fails the corresponding probe."""
+    fixture = _make_oidc_fixture(oidc_module)
+    seen_tokens = _patch_oidc_urlopen(monkeypatch, oidc_module, fixture)
+    invalid_tokens = dict(fixture["invalid_tokens"])
+    invalid_tokens["expired_token_rejected"] = ""
+
+    probes = oidc_module.run_probes(
+        fixture["issuer"],
+        fixture["audience"],
+        fixture["target_url"],
+        fixture["valid_token"],
+        invalid_tokens,
+    )
+
+    assert probes["expired_token_rejected"] == {"passed": False, "error": "Token not configured"}
+    assert len(seen_tokens) == 5
+
+
+def test_oidc_main_emits_success_json(
+    oidc_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """main() emits success=True only when real OIDC inputs are configured."""
+    fixture = _make_oidc_fixture(oidc_module)
+    _patch_oidc_urlopen(monkeypatch, oidc_module, fixture)
+    monkeypatch.setenv("OIDC_VALID_TOKEN", fixture["valid_token"])
+    monkeypatch.setenv("OIDC_WRONG_ISSUER_TOKEN", fixture["invalid_tokens"]["wrong_issuer_rejected"])
+    monkeypatch.setenv("OIDC_WRONG_AUDIENCE_TOKEN", fixture["invalid_tokens"]["wrong_audience_rejected"])
+    monkeypatch.setenv("OIDC_EXPIRED_TOKEN", fixture["invalid_tokens"]["expired_token_rejected"])
+    monkeypatch.setenv(
+        "OIDC_MISSING_REQUIRED_CLAIM_TOKEN",
+        fixture["invalid_tokens"]["missing_required_claim_rejected"],
+    )
+    monkeypatch.setattr(
+        oidc_module.sys,
+        "argv",
+        [
+            "oidc_user_auth_test.py",
+            "--region",
+            "us-west-2",
+            "--issuer-url",
+            fixture["issuer"],
+            "--audience",
+            fixture["audience"],
+            "--target-url",
+            fixture["target_url"],
+        ],
+    )
+
+    exit_code = oidc_module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["success"] is True
+    assert payload["test_name"] == "oidc_user_auth_test"
+    assert payload["platform"] == "security"
+    assert payload["target_url"] == fixture["target_url"]
+    assert len(payload["tests"]) == 7
+    assert all(p["passed"] for p in payload["tests"].values())
+
+
+def test_oidc_main_fails_closed_without_real_configuration(
+    oidc_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """main() must not pass with the default unconfigured OIDC settings."""
+    for env_var in (
+        "OIDC_ISSUER_URL",
+        "OIDC_AUDIENCE",
+        "OIDC_TARGET_URL",
+        "OIDC_VALID_TOKEN",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.setattr(oidc_module.sys, "argv", ["oidc_user_auth_test.py", "--region", "us-west-2"])
+
+    exit_code = oidc_module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert payload["endpoints_tested"] == 0
+    assert "OIDC validation not configured" in payload["error"]
+    assert all(not probe["passed"] for probe in payload["tests"].values())
+
+
+def test_oidc_main_fails_closed_with_inline_empty_config_args(
+    oidc_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Inline empty args reach the script and produce structured fail-closed JSON."""
+    for env_var in (
+        "OIDC_ISSUER_URL",
+        "OIDC_AUDIENCE",
+        "OIDC_TARGET_URL",
+        "OIDC_VALID_TOKEN",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.setattr(
+        oidc_module.sys,
+        "argv",
+        [
+            "oidc_user_auth_test.py",
+            "--region",
+            "us-west-2",
+            "--issuer-url=",
+            "--audience=",
+            "--target-url=",
+        ],
+    )
+
+    exit_code = oidc_module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert payload["endpoints_tested"] == 0
+    assert "OIDC validation not configured" in payload["error"]
+    assert all(not probe["passed"] for probe in payload["tests"].values())
+
+
+def test_oidc_main_fails_when_probes_fail(
+    oidc_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """main() returns non-zero and success=False when probes regress."""
+    failing = {
+        name: {"passed": False, "error": "forced"}
+        for name in (
+            "valid_token_accepted",
+            "bad_signature_rejected",
+            "wrong_issuer_rejected",
+            "wrong_audience_rejected",
+            "expired_token_rejected",
+            "missing_required_claim_rejected",
+            "discovery_and_jwks_reachable",
+        )
+    }
+    fixture = _make_oidc_fixture(oidc_module)
+    monkeypatch.setattr(oidc_module, "run_probes", lambda *_a, **_kw: failing)
+    monkeypatch.setenv("OIDC_VALID_TOKEN", fixture["valid_token"])
+    monkeypatch.setattr(
+        oidc_module.sys,
+        "argv",
+        [
+            "oidc_user_auth_test.py",
+            "--region",
+            "us-west-2",
+            "--issuer-url",
+            fixture["issuer"],
+            "--audience",
+            fixture["audience"],
+            "--target-url",
+            fixture["target_url"],
+        ],
+    )
+
+    exit_code = oidc_module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+
+
+def test_oidc_verify_rejects_alg_none(oidc_module: ModuleType) -> None:
+    """Verifier must reject alg!=RS256 even when signature bytes are valid."""
+    from cryptography.hazmat.primitives.asymmetric import rsa as _rsa
+
+    private_key = _rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+    jwks = {"keys": [oidc_module._public_jwk(public_key, "kid-1")]}
+
+    header = {"alg": "none", "typ": "JWT", "kid": "kid-1"}
+    payload = {
+        "iss": "iss",
+        "sub": "s",
+        "aud": "aud",
+        "iat": 0,
+        "exp": 9999999999,
+    }
+    b64h = oidc_module._b64url_encode(json.dumps(header, separators=(",", ":")).encode())
+    b64p = oidc_module._b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+    token = f"{b64h}.{b64p}."
+
+    ok, detail = oidc_module._verify_jwt(token, jwks, "iss", "aud")
+    assert not ok
+    assert "alg" in detail
+
+
+def test_oidc_verify_rejects_non_object_jwt_parts(oidc_module: ModuleType) -> None:
+    """Verifier must report malformed JWT JSON parts instead of raising AttributeError."""
+    valid_header = {"alg": "RS256", "typ": "JWT", "kid": "kid-1"}
+    valid_payload = {
+        "iss": "iss",
+        "sub": "s",
+        "aud": "aud",
+        "iat": 0,
+        "exp": 9999999999,
+    }
+    non_object_header = oidc_module._b64url_encode(json.dumps(["bad-header"]).encode())
+    object_payload = oidc_module._b64url_encode(json.dumps(valid_payload).encode())
+    object_header = oidc_module._b64url_encode(json.dumps(valid_header).encode())
+    non_object_payload = oidc_module._b64url_encode(json.dumps(["bad-payload"]).encode())
+
+    ok, detail = oidc_module._verify_jwt(f"{non_object_header}.{object_payload}.", {"keys": []}, "iss", "aud")
+    assert not ok
+    assert "JWT header is not an object: list" in detail
+
+    ok, detail = oidc_module._verify_jwt(f"{object_header}.{non_object_payload}.", {"keys": []}, "iss", "aud")
+    assert not ok
+    assert "JWT payload is not an object: list" in detail
+
+
+def test_oidc_verify_normalizes_base64_decode_errors(oidc_module: ModuleType) -> None:
+    """Malformed base64url input must surface as verifier decode errors."""
+    ok, detail = oidc_module._verify_jwt("a.b.c", {"keys": []}, "iss", "aud")
+
+    assert not ok
+    assert "decode error: invalid base64url data:" in detail
+
+
+def test_oidc_verify_handles_aud_list(oidc_module: ModuleType) -> None:
+    """Audience claim may be a list - membership counts as match."""
+    from cryptography.hazmat.primitives.asymmetric import rsa as _rsa
+
+    private_key = _rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    jwks = {"keys": [oidc_module._public_jwk(private_key.public_key(), "kid-1")]}
+    now = 1_700_000_000
+    claims = {
+        "iss": "iss",
+        "sub": "s",
+        "aud": ["other", "isv-validation"],
+        "iat": now,
+        "exp": now + 600,
+    }
+    token = oidc_module._sign_jwt(claims, private_key, "kid-1")
+
+    ok, _ = oidc_module._verify_jwt(token, jwks, "iss", "isv-validation", now=now)
+    assert ok

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -556,6 +556,31 @@ class TestMissingStepRefDetection:
         # "--region" stripped (matching previous behavior for explicit defaults).
         assert results.steps[0].success
 
+    def test_inline_empty_template_value_keeps_flag_value_pair(self) -> None:
+        """Empty optional values stay attached when YAML uses ``--flag={{value}}``."""
+        executor = StepExecutor()
+        config = RunConfig(
+            tests=ValidationConfig(
+                settings={
+                    "oidc_issuer_url": "",
+                    "oidc_audience": "",
+                    "oidc_target_url": "",
+                }
+            )
+        )
+        context = Context(config)
+
+        rendered = executor._render_args(
+            [
+                "--issuer-url={{oidc_issuer_url}}",
+                "--audience={{oidc_audience}}",
+                "--target-url={{oidc_target_url}}",
+            ],
+            context,
+        )
+
+        assert rendered == ["--issuer-url=", "--audience=", "--target-url="]
+
     def test_missing_ref_raised_from_render_args_directly(self) -> None:
         """_render_args raises MissingStepRefError for bare references."""
         import pytest

--- a/isvctl/tests/test_stub_contracts.py
+++ b/isvctl/tests/test_stub_contracts.py
@@ -126,15 +126,24 @@ def _yaml_flag_tokens(args: list[str]) -> list[str]:
     """Return the ``--flag`` tokens from a step's ``args:`` list.
 
     Jinja placeholders (``{{teardown_flag}}``) and plain values are ignored --
-    only literal ``--flag`` strings are returned.
+    only literal ``--flag`` strings are returned. Inline ``--flag=value``
+    arguments are normalized to ``--flag`` before comparing with argparse.
     """
     flags: list[str] = []
     for arg in args or []:
         if not isinstance(arg, str):
             continue
         if arg.startswith("--"):
-            flags.append(arg)
+            flags.append(arg.split("=", 1)[0])
     return flags
+
+
+def test_yaml_flag_tokens_normalizes_inline_values() -> None:
+    """Inline-value YAML args still match argparse's ``--flag`` declaration."""
+    assert _yaml_flag_tokens(["--issuer-url={{oidc_issuer_url}}", "--region", "{{region}}"]) == [
+        "--issuer-url",
+        "--region",
+    ]
 
 
 def _collect_yaml_checks() -> list[StepArgCheck]:

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -95,6 +95,7 @@ from isvtest.validations.security import (
     BmcTenantIsolationCheck,
     ConsoleRbacCheck,
     MfaEnforcedCheck,
+    OidcUserAuthCheck,
 )
 
 __all__ = [
@@ -134,6 +135,7 @@ __all__ = [
     "NimInferenceCheck",
     "NimModelCheck",
     "NodeCountCheck",
+    "OidcUserAuthCheck",
     "PerformanceCheck",
     "SchemaValidation",
     "SecurityBlockingCheck",

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -201,3 +201,61 @@ class ConsoleRbacCheck(BaseValidation):
             f"Console RBAC restricted for {instance_id} "
             f"(model={rbac_model}, actions={', '.join(str(action) for action in restricted_actions)})"
         )
+
+
+class OidcUserAuthCheck(BaseValidation):
+    """Validate user authentication via OIDC for platform services.
+
+    Verifies that a configured platform endpoint accepts a properly issued
+    token and rejects tokens with bad signature, wrong issuer, wrong
+    audience, expired exp, or missing required claims, and that the
+    issuer's discovery + JWKS endpoints serve the expected metadata.
+
+    Config:
+        step_output: The step output to check
+
+    Step output:
+        issuer_url: Non-empty OIDC issuer URL
+        audience: Non-empty expected audience
+        target_url: Non-empty platform endpoint probed with bearer tokens
+        endpoints_tested: Positive integer
+        tests: dict with valid_token_accepted, bad_signature_rejected,
+               wrong_issuer_rejected, wrong_audience_rejected,
+               expired_token_rejected, missing_required_claim_rejected,
+               discovery_and_jwks_reachable
+    """
+
+    description: ClassVar[str] = (
+        "Check user auth via OIDC validates signature, issuer, audience, expiration, and required claims"
+    )
+    markers: ClassVar[list[str]] = ["security", "iam"]
+
+    def run(self) -> None:
+        """Validate required OIDC token verification probe results from step output."""
+        required = [
+            "valid_token_accepted",
+            "bad_signature_rejected",
+            "wrong_issuer_rejected",
+            "wrong_audience_rejected",
+            "expired_token_rejected",
+            "missing_required_claim_rejected",
+            "discovery_and_jwks_reachable",
+        ]
+        if not check_required_tests(self, required, "OIDC user auth tests failed"):
+            return
+
+        step_output = self.config.get("step_output", {})
+        for field in ("issuer_url", "audience", "target_url"):
+            value = step_output.get(field)
+            if not isinstance(value, str) or not value.strip():
+                self.set_failed(f"OIDC user auth output missing non-empty '{field}'")
+                return
+
+        endpoints_tested = step_output.get("endpoints_tested")
+        if type(endpoints_tested) is not int or endpoints_tested < 1:
+            self.set_failed("OIDC user auth did not probe any platform endpoint")
+            return
+
+        issuer = step_output["issuer_url"]
+        target_url = step_output["target_url"]
+        self.set_passed(f"OIDC user auth verified (issuer={issuer}, target={target_url})")

--- a/isvtest/tests/test_catalog.py
+++ b/isvtest/tests/test_catalog.py
@@ -80,6 +80,7 @@ class TestBuildCatalog:
         assert by_name["BmcTenantIsolationCheck"]["platforms"] == ["SECURITY"]
         assert by_name["ServiceAccountCredentialCheck"]["platforms"] == ["SECURITY"]
         assert by_name["ConsoleRbacCheck"]["platforms"] == ["VM"]
+        assert by_name["OidcUserAuthCheck"]["platforms"] == ["SECURITY"]
 
 
 class TestGetCatalogVersion:

--- a/isvtest/tests/test_security.py
+++ b/isvtest/tests/test_security.py
@@ -14,7 +14,21 @@ from __future__ import annotations
 
 from typing import Any
 
-from isvtest.validations.security import BmcManagementNetworkCheck, MfaEnforcedCheck
+from isvtest.validations.security import (
+    BmcManagementNetworkCheck,
+    MfaEnforcedCheck,
+    OidcUserAuthCheck,
+)
+
+OIDC_REQUIRED_TESTS = {
+    "valid_token_accepted": {"passed": True},
+    "bad_signature_rejected": {"passed": True},
+    "wrong_issuer_rejected": {"passed": True},
+    "wrong_audience_rejected": {"passed": True},
+    "expired_token_rejected": {"passed": True},
+    "missing_required_claim_rejected": {"passed": True},
+    "discovery_and_jwks_reachable": {"passed": True},
+}
 
 
 def _bmc_management_config(tests: dict[str, dict[str, Any]]) -> dict[str, Any]:
@@ -170,3 +184,47 @@ class TestMfaEnforcedCheck:
         result = v.execute()
         assert result["passed"] is True
         assert "7 interfaces checked" in result["output"]
+
+
+def _oidc_step_output(**overrides: Any) -> dict[str, Any]:
+    """Return a valid OIDC step output with optional overrides."""
+    output: dict[str, Any] = {
+        "success": True,
+        "issuer_url": "https://oidc.example/realms/isv",
+        "audience": "isv-validation",
+        "target_url": "https://api.example/protected",
+        "endpoints_tested": 1,
+        "tests": OIDC_REQUIRED_TESTS,
+    }
+    output.update(overrides)
+    return output
+
+
+def test_oidc_user_auth_check_passes_with_real_endpoint_metadata() -> None:
+    """OidcUserAuthCheck passes when all probes and endpoint metadata are present."""
+    check = OidcUserAuthCheck(config={"step_output": _oidc_step_output()})
+
+    result = check.execute()
+
+    assert result["passed"] is True
+    assert "https://api.example/protected" in result["output"]
+
+
+def test_oidc_user_auth_check_rejects_missing_target_url() -> None:
+    """OidcUserAuthCheck fails old self-contained outputs without a target URL."""
+    check = OidcUserAuthCheck(config={"step_output": _oidc_step_output(target_url="")})
+
+    result = check.execute()
+
+    assert result["passed"] is False
+    assert "target_url" in result["error"]
+
+
+def test_oidc_user_auth_check_requires_endpoint_probe_count() -> None:
+    """OidcUserAuthCheck fails when no platform endpoint was probed."""
+    check = OidcUserAuthCheck(config={"step_output": _oidc_step_output(endpoints_tested=0)})
+
+    result = check.execute()
+
+    assert result["passed"] is False
+    assert "did not probe any platform endpoint" in result["error"]


### PR DESCRIPTION
## Summary

Adds SEC01-01 coverage to the security suite for verifying OIDC user authentication against platform services.

## Changes

- Adds `OidcUserAuthCheck` and security suite wiring.
- Adds AWS reference coverage for OIDC discovery/JWKS metadata, JWT fixture validation, and protected endpoint bearer-token checks.
- Updates the my-isv security scaffold/demo output so endpoint metadata is required before the validation can pass.
- Adds focused validation, provider script, orchestrator, stub contract, and catalog tests.

## Validation

- [x] Focused pytest set - 194 passed
- [x] `make demo-security`
- [x] `uvx ruff check` on changed validation, provider script, and test files

## Test Plan

- Manual AWS EKS smoke test: ran the SEC01-01 security suite against an EKS cluster and verified OIDC discovery, JWKS, JWT fixture, and bearer-token endpoint checks passed.

Closes #293


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OIDC user-auth validation to security runs with configurable issuer/audience/target, multiple token acceptance/rejection probes, aggregated JSON pass/fail output and exit codes, and provider config integration (including demo-mode behavior and fail-closed handling).

* **Documentation**
  * Documented the new OIDC test step and its validation scope in the security suite README.

* **Tests**
  * Expanded tests for discovery, JWKS, JWT scenarios, negative fixtures, probe behavior, orchestration argument handling, and validation catalog registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

