### PR TITLE
feat: add VM console RBAC validation (CNP01-16 - M5 P0)

### DIFF
--- a/isvctl/configs/providers/aws/config/vm.yaml
+++ b/isvctl/configs/providers/aws/config/vm.yaml
@@ -18,14 +18,15 @@
 #   2. list_instances     - boto3: Lists instances in VPC (test)
 #   3. verify_tags        - boto3: Verifies user-defined tags (test)
 #   4. serial_console     - boto3: Retrieves serial console output (test)
-#   5. stop_instance      - boto3: Stops EC2, verifies stopped state (test)
-#   6. start_instance     - boto3: Starts stopped EC2, verifies recovery (test)
-#   7. reboot_instance    - boto3: Reboots EC2, validates recovery (test)
-#   8. describe_instance  - boto3: Describes current state, passes SSH info (test)
+#   5. console_rbac       - boto3: Simulates EC2 serial console IAM access (test)
+#   6. stop_instance      - boto3: Stops EC2, verifies stopped state (test)
+#   7. start_instance     - boto3: Starts stopped EC2, verifies recovery (test)
+#   8. reboot_instance    - boto3: Reboots EC2, validates recovery (test)
+#   9. describe_instance  - boto3: Describes current state, passes SSH info (test)
 #                           (runs after reboot so IP is current; validation anchor)
-#   9. deploy_nim         - paramiko: Deploys NIM container via SSH (test)
-#  10. teardown_nim       - paramiko: Stops NIM container via SSH (teardown)
-#  11. teardown           - boto3: Terminates EC2 (teardown)
+#  10. deploy_nim         - paramiko: Deploys NIM container via SSH (test)
+#  11. teardown_nim       - paramiko: Stops NIM container via SSH (teardown)
+#  12. teardown           - boto3: Terminates EC2 (teardown)
 #
 # Usage:
 #   uv run isvctl test run -f isvctl/configs/providers/aws/config/vm.yaml
@@ -87,6 +88,17 @@ commands:
           - "--region"
           - "{{region}}"
         timeout: 60
+
+      # AWS-specific: Console RBAC policy simulation (IAM)
+      - name: console_rbac
+        phase: test
+        command: "python3 ../scripts/vm/console_rbac.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 120
 
       # AWS-specific: Stop instance and verify stopped state (boto3)
       - name: stop_instance

--- a/isvctl/configs/providers/aws/scripts/vm/console_rbac.py
+++ b/isvctl/configs/providers/aws/scripts/vm/console_rbac.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Validate EC2 serial console RBAC using IAM principal policy simulation.
+
+The EC2 serial console SSH path is authorized by
+``ec2-instance-connect:SendSerialConsoleSSHPublicKey``. This script verifies
+account-level serial-console availability, then creates temporary IAM test
+principals and simulates their actual attached policies. The denied principal
+has no console policy, while the allowed principal has a scoped inline policy
+for the target instance only.
+
+Usage:
+    python console_rbac.py --instance-id i-xxx --region us-west-2
+"""
+
+import argparse
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import boto3
+import botocore.session
+from botocore.exceptions import ClientError
+from common.errors import handle_aws_errors
+from common.serial_console import check_serial_access
+
+CONSOLE_ACTION = "ec2-instance-connect:SendSerialConsoleSSHPublicKey"
+TEST_USER_PREFIX = "isv-console-rbac-test-"
+ALLOW_POLICY_NAME = "IsvConsoleRbacScopedAccess"
+OWNER_TAG = {"Key": "CreatedBy", "Value": "isvtest"}
+REQUIRED_TESTS = (
+    "serial_console_access_enabled",
+    "denied_principal_cannot_access_console",
+    "allowed_principal_can_access_console",
+    "allowed_principal_is_resource_scoped",
+)
+
+
+def _partition_from_identity(identity: dict[str, Any], region: str) -> str:
+    """Derive the AWS partition from STS identity, falling back to region metadata."""
+    arn = identity.get("Arn", "")
+    if arn.startswith("arn:"):
+        parts = arn.split(":", 2)
+        if len(parts) >= 2 and parts[1]:
+            return parts[1]
+    try:
+        partition = botocore.session.get_session().get_partition_for_region(region)
+    except Exception:
+        return "aws"
+    return str(partition or "aws")
+
+
+def _instance_arn(partition: str, region: str, account_id: str, instance_id: str) -> str:
+    """Build an EC2 instance ARN for IAM simulation."""
+    return f"arn:{partition}:ec2:{region}:{account_id}:instance/{instance_id}"
+
+
+def _iam_user_arn(partition: str, account_id: str, username: str) -> str:
+    """Build a default-path IAM user ARN for a temporary test principal."""
+    return f"arn:{partition}:iam::{account_id}:user/{username}"
+
+
+def _other_instance_id(instance_id: str) -> str:
+    """Return a different well-formed EC2 instance ID for scoping simulation."""
+    candidate = "i-00000000000000000"
+    if instance_id == candidate:
+        return "i-11111111111111111"
+    return candidate
+
+
+def _make_test_result(passed: bool, **details: Any) -> dict[str, Any]:
+    """Build a standard test result dictionary."""
+    return {"passed": passed, **details}
+
+
+def _policy_document(statements: list[dict[str, Any]]) -> str:
+    """Return a JSON IAM policy document for simulation."""
+    return json.dumps({"Version": "2012-10-17", "Statement": statements})
+
+
+def _allow_console_policy(instance_arn: str) -> str:
+    """Return an inline IAM policy allowing console access to one instance."""
+    return _policy_document(
+        [
+            {
+                "Effect": "Allow",
+                "Action": CONSOLE_ACTION,
+                "Resource": instance_arn,
+            }
+        ]
+    )
+
+
+def _create_test_user(iam: Any, username: str, partition: str, account_id: str) -> str:
+    """Create one tagged IAM user and return its ARN."""
+    response = iam.create_user(UserName=username, Tags=[OWNER_TAG])
+    return str(response.get("User", {}).get("Arn") or _iam_user_arn(partition, account_id, username))
+
+
+def _simulate_principal_console_decision(iam: Any, principal_arn: str, instance_arn: str) -> str:
+    """Simulate console-access authorization for an actual IAM principal."""
+    response = iam.simulate_principal_policy(
+        PolicySourceArn=principal_arn,
+        ActionNames=[CONSOLE_ACTION],
+        ResourceArns=[instance_arn],
+    )
+    results = response.get("EvaluationResults", [])
+    if not results:
+        msg = "IAM simulation returned no evaluation results"
+        raise RuntimeError(msg)
+    return str(results[0].get("EvalDecision", ""))
+
+
+def _cleanup_test_users(iam: Any, created_policies: dict[str, set[str]], created_users: list[str]) -> list[str]:
+    """Delete inline policies and IAM users created by this script."""
+    cleanup_errors: list[str] = []
+
+    for username in reversed(created_users):
+        policy_names = set(created_policies.get(username, set()))
+        try:
+            response = iam.list_user_policies(UserName=username)
+            policy_names.update(str(name) for name in response.get("PolicyNames", []))
+        except ClientError as e:
+            cleanup_errors.append(f"list inline policies for {username}: {e}")
+
+        for policy_name in sorted(policy_names):
+            try:
+                iam.delete_user_policy(UserName=username, PolicyName=policy_name)
+            except ClientError as e:
+                cleanup_errors.append(f"delete inline policy {policy_name} for {username}: {e}")
+
+        try:
+            iam.delete_user(UserName=username)
+        except ClientError as e:
+            cleanup_errors.append(f"delete user {username}: {e}")
+
+    return cleanup_errors
+
+
+def _is_allowed(decision: str) -> bool:
+    """Return True when the IAM simulation decision allows access."""
+    return decision.lower() == "allowed"
+
+
+def _run_console_rbac_check(iam: Any, sts: Any, ec2: Any, instance_id: str, region: str) -> dict[str, Any]:
+    """Run the console RBAC policy simulation workflow."""
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "vm",
+        "test_name": "console_rbac",
+        "instance_id": instance_id,
+        "serial_access_enabled": False,
+        "rbac_model": "aws-iam-principal-policy",
+        "access_restricted": False,
+        "restricted_actions": [CONSOLE_ACTION],
+        "tests": {},
+    }
+
+    created_users: list[str] = []
+    created_policies: dict[str, set[str]] = {}
+
+    try:
+        identity = sts.get_caller_identity()
+        account_id = identity["Account"]
+        partition = _partition_from_identity(identity, region)
+        target_arn = _instance_arn(partition, region, account_id, instance_id)
+        other_arn = _instance_arn(partition, region, account_id, _other_instance_id(instance_id))
+        scoped_allow_policy = _allow_console_policy(target_arn)
+        suffix = uuid.uuid4().hex[:8]
+        denied_username = f"{TEST_USER_PREFIX}denied-{suffix}"
+        allowed_username = f"{TEST_USER_PREFIX}allowed-{suffix}"
+        denied_principal_arn = _create_test_user(iam, denied_username, partition, account_id)
+        created_users.append(denied_username)
+        allowed_principal_arn = _create_test_user(iam, allowed_username, partition, account_id)
+        created_users.append(allowed_username)
+        result["principals"] = {
+            "denied": denied_principal_arn,
+            "allowed": allowed_principal_arn,
+        }
+
+        serial_access = check_serial_access(ec2)
+        serial_access_enabled = serial_access.get("enabled") is True
+        result["serial_access_enabled"] = serial_access_enabled
+        result["tests"]["serial_console_access_enabled"] = _make_test_result(serial_access_enabled)
+        if serial_access.get("error"):
+            result["tests"]["serial_console_access_enabled"]["error"] = serial_access["error"]
+        if not serial_access_enabled:
+            result["error"] = serial_access.get("error") or "EC2 serial console access is disabled"
+
+        denied_decision = _simulate_principal_console_decision(iam, denied_principal_arn, target_arn)
+        denied_passed = not _is_allowed(denied_decision)
+        result["tests"]["denied_principal_cannot_access_console"] = _make_test_result(
+            denied_passed,
+            principal=denied_principal_arn,
+            decision=denied_decision,
+        )
+
+        iam.put_user_policy(
+            UserName=allowed_username,
+            PolicyName=ALLOW_POLICY_NAME,
+            PolicyDocument=scoped_allow_policy,
+        )
+        created_policies.setdefault(allowed_username, set()).add(ALLOW_POLICY_NAME)
+
+        allowed_decision = _simulate_principal_console_decision(iam, allowed_principal_arn, target_arn)
+        allowed_passed = _is_allowed(allowed_decision) and serial_access_enabled
+        result["tests"]["allowed_principal_can_access_console"] = _make_test_result(
+            allowed_passed,
+            principal=allowed_principal_arn,
+            decision=allowed_decision,
+            resource=target_arn,
+            serial_access_enabled=serial_access_enabled,
+        )
+        if not serial_access_enabled:
+            result["tests"]["allowed_principal_can_access_console"]["error"] = (
+                "IAM allows the principal, but EC2 serial console access is disabled"
+            )
+
+        scoped_decision = _simulate_principal_console_decision(iam, allowed_principal_arn, other_arn)
+        scoped_passed = not _is_allowed(scoped_decision)
+        result["tests"]["allowed_principal_is_resource_scoped"] = _make_test_result(
+            scoped_passed,
+            principal=allowed_principal_arn,
+            decision=scoped_decision,
+            resource=other_arn,
+        )
+
+        result["access_restricted"] = denied_passed and scoped_passed
+        result["success"] = all(result["tests"].get(name, {}).get("passed") is True for name in REQUIRED_TESTS)
+    except Exception as e:
+        result["error"] = str(e)
+    finally:
+        cleanup_errors = _cleanup_test_users(iam, created_policies, created_users)
+        if cleanup_errors:
+            result["cleanup_errors"] = cleanup_errors
+            cleanup_error = f"Cleanup failed: {'; '.join(cleanup_errors)}"
+            result["error"] = f"{result['error']}; {cleanup_error}" if result.get("error") else cleanup_error
+            result["success"] = False
+
+    return result
+
+
+@handle_aws_errors
+def main() -> int:
+    """Validate console RBAC and emit structured JSON result."""
+    parser = argparse.ArgumentParser(description="Validate EC2 serial console RBAC")
+    parser.add_argument("--instance-id", required=True, help="EC2 instance ID")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    args = parser.parse_args()
+
+    iam = boto3.client("iam", region_name=args.region)
+    sts = boto3.client("sts", region_name=args.region)
+    ec2 = boto3.client("ec2", region_name=args.region)
+
+    result = _run_console_rbac_check(iam, sts, ec2, args.instance_id, args.region)
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/my-isv/config/vm.yaml
+++ b/isvctl/configs/providers/my-isv/config/vm.yaml
@@ -20,7 +20,7 @@
 #   (InstanceStateCheck, InstanceCreatedCheck, InstanceListCheck,
 #    InstanceTagCheck, InstanceStopCheck, InstanceStartCheck,
 #    StableIdentifierCheck, InstanceRebootCheck, SerialConsoleCheck,
-#    StepSuccessCheck). SSH-based host checks (ConnectivityCheck,
+#    ConsoleRbacCheck, StepSuccessCheck). SSH-based host checks (ConnectivityCheck,
 #    GpuCheck, DriverCheck, CpuInfoCheck, NIM checks, etc.) are excluded
 #    via `exclude.markers: [ssh]` because a dummy-success stub cannot
 #    spin up a real host to SSH into. The deploy_nim / teardown_nim
@@ -39,10 +39,11 @@
 #     5. start_instance   - Start it back up
 #     6. reboot_instance  - Reboot it
 #     7. serial_console   - Confirm serial console access
-#     8. deploy_nim       - SKIPPED (needs real SSH)
+#     8. console_rbac     - Verify console access is RBAC-scoped
+#     9. deploy_nim       - SKIPPED (needs real SSH)
 #   TEARDOWN
-#     9. teardown_nim     - SKIPPED (needs real SSH)
-#    10. teardown         - Terminate the VM
+#    10. teardown_nim     - SKIPPED (needs real SSH)
+#    11. teardown         - Terminate the VM
 #
 # Usage:
 #   uv run isvctl test run -f isvctl/configs/providers/my-isv/config/vm.yaml
@@ -131,6 +132,16 @@ commands:
       - name: serial_console
         phase: test
         command: "python ../scripts/vm/serial_console.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+        timeout: 60
+
+      - name: console_rbac
+        phase: test
+        command: "python ../scripts/vm/console_rbac.py"
         args:
           - "--instance-id"
           - "{{steps.launch_instance.instance_id}}"

--- a/isvctl/configs/providers/my-isv/scripts/vm/console_rbac.py
+++ b/isvctl/configs/providers/my-isv/scripts/vm/console_rbac.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Console RBAC validation - TEMPLATE (replace with your platform implementation).
+
+This script must prove interactive console access is controlled by RBAC for
+the target VM, not merely that serial console output exists.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "vm",
+    "test_name": "console_rbac",
+    "instance_id": "<id>",
+    "rbac_model": "<provider-rbac-model>",
+    "access_restricted": true,
+    "restricted_actions": ["console:Connect"],
+    "tests": {
+      "denied_principal_cannot_access_console": {"passed": true},
+      "allowed_principal_can_access_console": {"passed": true},
+      "allowed_principal_is_resource_scoped": {"passed": true}
+    }
+  }
+
+Usage:
+    python console_rbac.py --instance-id <id> --region <region>
+
+Reference implementation: ../../../aws/scripts/vm/console_rbac.py
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+# ISVCTL_DEMO_MODE=1 enables demo-success output (used by `make demo-test`).
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+
+
+def _demo_result(instance_id: str) -> dict[str, Any]:
+    """Return a passing demo payload for the console RBAC contract."""
+    return {
+        "success": True,
+        "platform": "vm",
+        "test_name": "console_rbac",
+        "instance_id": instance_id,
+        "rbac_model": "my-isv-rbac",
+        "access_restricted": True,
+        "restricted_actions": ["console:Connect"],
+        "tests": {
+            "denied_principal_cannot_access_console": {
+                "passed": True,
+                "principal": "console-rbac-denied-demo",
+            },
+            "allowed_principal_can_access_console": {
+                "passed": True,
+                "principal": "console-rbac-allowed-demo",
+            },
+            "allowed_principal_is_resource_scoped": {
+                "passed": True,
+                "principal": "console-rbac-allowed-demo",
+            },
+        },
+    }
+
+
+def main() -> int:
+    """Validate console RBAC and emit structured JSON result."""
+    parser = argparse.ArgumentParser(description="Console RBAC validation (template)")
+    parser.add_argument("--instance-id", required=True, help="Instance ID")
+    parser.add_argument("--region", required=True, help="Cloud region")
+    args = parser.parse_args()
+
+    # ╔══════════════════════════════════════════════════════════════════╗
+    # ║  TODO: Replace this block with your platform's console RBAC      ║
+    # ║  validation.                                                     ║
+    # ║                                                                  ║
+    # ║  Example (pseudocode):                                           ║
+    # ║    denied = create_principal_without_console_access()            ║
+    # ║    denied_error = attempt_console_access(denied, args.instance_id)║
+    # ║    allowed = create_principal_with_console_access(args.instance_id)║
+    # ║    allowed_session = attempt_console_access(allowed, instance_id) ║
+    # ║    other_denied = attempt_console_access(allowed, other_vm_id)    ║
+    # ║                                                                  ║
+    # ║  The result must prove:                                          ║
+    # ║    1. A principal without console rights is denied.              ║
+    # ║    2. A principal with scoped console rights is allowed.         ║
+    # ║    3. The allowed principal is denied for a different VM.        ║
+    # ║                                                                  ║
+    # ║  Populate all required `tests` entries with {"passed": true}.    ║
+    # ╚══════════════════════════════════════════════════════════════════╝
+
+    if DEMO_MODE:
+        result = _demo_result(args.instance_id)
+    else:
+        result = {
+            "success": False,
+            "platform": "vm",
+            "test_name": "console_rbac",
+            "instance_id": args.instance_id,
+            "rbac_model": "",
+            "access_restricted": False,
+            "restricted_actions": [],
+            "tests": {
+                "denied_principal_cannot_access_console": {"passed": False},
+                "allowed_principal_can_access_console": {"passed": False},
+                "allowed_principal_is_resource_scoped": {"passed": False},
+            },
+            "error": "Not implemented - replace with your platform's console RBAC validation",
+        }
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/vm.yaml
+++ b/isvctl/configs/suites/vm.yaml
@@ -44,7 +44,7 @@ tests:
   # These are PROVIDER-AGNOSTIC. They only check JSON field names/values.
   #
   # Layout mirrors bare_metal.yaml:
-  #   launch checks -> list -> tags -> serial_console -> cloud_init
+  #   launch checks -> list -> tags -> serial_console -> console_rbac -> cloud_init
   #   -> describe_instance (SSH / GPU / host anchor, post-reboot)
   #   -> lifecycle (stop / start / reboot)
   #   -> NIM -> teardown
@@ -76,6 +76,11 @@ tests:
       step: serial_console
       checks:
         SerialConsoleCheck: {}
+
+    console_rbac:
+      step: console_rbac
+      checks:
+        ConsoleRbacCheck: {}
 
     cloud_init:
       step: launch_instance

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -20,7 +20,7 @@ import shutil
 import tempfile
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -33,7 +33,7 @@ from isvctl.redaction import redact_dict, redact_junit_xml_tree
 logger = logging.getLogger(__name__)
 
 
-class Phase(str, Enum):
+class Phase(StrEnum):
     """Test lifecycle phases."""
 
     ALL = "all"

--- a/isvctl/tests/test_aws_vm_console_rbac.py
+++ b/isvctl/tests/test_aws_vm_console_rbac.py
@@ -1,0 +1,331 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Tests for the AWS VM console RBAC reference script."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from botocore.exceptions import ClientError
+
+ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+AWS_VM_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "vm"
+
+_LOADED_MODULES: dict[str, ModuleType] = {}
+
+
+def _load_vm_script(script_name: str) -> ModuleType:
+    """Load an AWS VM script as a module for direct helper testing.
+
+    Cached per script name so tests don't re-import boto3 on every call.
+    """
+    if script_name in _LOADED_MODULES:
+        return _LOADED_MODULES[script_name]
+    script_path = AWS_VM_SCRIPTS / script_name
+    spec = importlib.util.spec_from_file_location(f"test_{script_path.stem}", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    _LOADED_MODULES[script_name] = module
+    return module
+
+
+class FakeSts:
+    """Fake STS client for account ID resolution."""
+
+    def __init__(
+        self,
+        account_id: str = "123456789012",
+        partition: str = "aws",
+        include_arn: bool = True,
+    ) -> None:
+        """Initialize the fake identity response."""
+        self.account_id = account_id
+        self.partition = partition
+        self.include_arn = include_arn
+
+    def get_caller_identity(self) -> dict[str, str]:
+        """Return a fake caller identity."""
+        identity = {"Account": self.account_id}
+        if self.include_arn:
+            identity["Arn"] = f"arn:{self.partition}:sts::{self.account_id}:assumed-role/TestRole/session"
+        return identity
+
+
+class FakeEc2:
+    """Fake EC2 client for serial console access status."""
+
+    def __init__(self, serial_access_enabled: bool = True) -> None:
+        """Initialize the fake serial console access status."""
+        self.serial_access_enabled = serial_access_enabled
+
+    def get_serial_console_access_status(self) -> dict[str, bool]:
+        """Return fake EC2 serial console access status."""
+        return {"SerialConsoleAccessEnabled": self.serial_access_enabled}
+
+
+def _client_error(operation: str, code: str = "TestFailure") -> ClientError:
+    """Build a botocore ClientError for fake IAM failures."""
+    return ClientError({"Error": {"Code": code, "Message": f"{operation} failed"}}, operation)
+
+
+class FakeConsoleRbacIam:
+    """Fake IAM client for console RBAC principal policy simulation."""
+
+    def __init__(
+        self,
+        empty_results: bool = False,
+        force_allowed_policy_resource: str | None = None,
+        fail_delete_user: bool = False,
+    ) -> None:
+        """Initialize fake IAM state and optional failure modes."""
+        self.empty_results = empty_results
+        self.force_allowed_policy_resource = force_allowed_policy_resource
+        self.fail_delete_user = fail_delete_user
+        self.simulation_calls: list[dict[str, Any]] = []
+        self.create_user_calls: list[dict[str, Any]] = []
+        self.put_user_policy_calls: list[dict[str, Any]] = []
+        self.deleted_users: list[str] = []
+        self.deleted_policies: list[dict[str, str]] = []
+        self.users: dict[str, dict[str, Any]] = {}
+
+    def create_user(self, UserName: str, Tags: list[dict[str, str]]) -> dict[str, dict[str, str]]:
+        """Create a fake IAM user."""
+        arn = f"arn:aws:iam::123456789012:user/{UserName}"
+        self.create_user_calls.append({"UserName": UserName, "Tags": Tags})
+        self.users[UserName] = {"Arn": arn, "Tags": Tags, "Policies": {}}
+        return {"User": {"UserName": UserName, "Arn": arn}}
+
+    def put_user_policy(self, UserName: str, PolicyName: str, PolicyDocument: str) -> None:
+        """Attach a fake inline policy to a user."""
+        policy = json.loads(PolicyDocument)
+        if self.force_allowed_policy_resource:
+            for statement in policy.get("Statement", []):
+                if statement.get("Action") == "ec2-instance-connect:SendSerialConsoleSSHPublicKey":
+                    statement["Resource"] = self.force_allowed_policy_resource
+            PolicyDocument = json.dumps(policy)
+
+        self.put_user_policy_calls.append(
+            {
+                "UserName": UserName,
+                "PolicyName": PolicyName,
+                "PolicyDocument": PolicyDocument,
+            }
+        )
+        self.users[UserName]["Policies"][PolicyName] = PolicyDocument
+
+    def list_user_policies(self, UserName: str) -> dict[str, list[str]]:
+        """List fake inline policy names for a user."""
+        return {"PolicyNames": list(self.users[UserName]["Policies"])}
+
+    def delete_user_policy(self, UserName: str, PolicyName: str) -> None:
+        """Delete a fake inline policy from a user."""
+        self.deleted_policies.append({"UserName": UserName, "PolicyName": PolicyName})
+        self.users[UserName]["Policies"].pop(PolicyName, None)
+
+    def delete_user(self, UserName: str) -> None:
+        """Delete a fake IAM user."""
+        if self.fail_delete_user:
+            raise _client_error("DeleteUser")
+        if self.users[UserName]["Policies"]:
+            raise _client_error("DeleteUser", code="DeleteConflict")
+        self.deleted_users.append(UserName)
+        self.users.pop(UserName, None)
+
+    def simulate_principal_policy(
+        self,
+        PolicySourceArn: str,
+        ActionNames: list[str],
+        ResourceArns: list[str],
+    ) -> dict[str, list[dict[str, str]]]:
+        """Evaluate a fake user's inline policies against one action and resource."""
+        self.simulation_calls.append(
+            {
+                "PolicySourceArn": PolicySourceArn,
+                "ActionNames": ActionNames,
+                "ResourceArns": ResourceArns,
+            }
+        )
+        if self.empty_results:
+            return {"EvaluationResults": []}
+
+        action = ActionNames[0]
+        resource = ResourceArns[0]
+        decision = "implicitDeny"
+
+        for user in self.users.values():
+            if user["Arn"] != PolicySourceArn:
+                continue
+            for policy_document in user["Policies"].values():
+                policy = json.loads(policy_document)
+                for statement in policy.get("Statement", []):
+                    actions = statement.get("Action", [])
+                    resources = statement.get("Resource", [])
+                    if isinstance(actions, str):
+                        actions = [actions]
+                    if isinstance(resources, str):
+                        resources = [resources]
+                    action_matches = action in actions or "*" in actions
+                    resource_matches = resource in resources or "*" in resources
+                    if statement.get("Effect") == "Allow" and action_matches and resource_matches:
+                        decision = "allowed"
+
+        return {
+            "EvaluationResults": [{"EvalActionName": action, "EvalResourceName": resource, "EvalDecision": decision}]
+        }
+
+
+def _run_fake_console_rbac(
+    module: ModuleType,
+    iam: FakeConsoleRbacIam | None = None,
+    sts: FakeSts | None = None,
+    ec2: FakeEc2 | None = None,
+    instance_id: str = "i-0123456789abcdef0",
+    region: str = "us-west-2",
+) -> tuple[dict[str, Any], FakeConsoleRbacIam]:
+    """Run the console RBAC helper with fake AWS clients."""
+    fake_iam = iam or FakeConsoleRbacIam()
+    fake_sts = sts or FakeSts()
+    fake_ec2 = ec2 or FakeEc2()
+    result = module._run_console_rbac_check(fake_iam, fake_sts, fake_ec2, instance_id, region)
+    return result, fake_iam
+
+
+def test_denied_principal_without_policy_is_denied() -> None:
+    """A policy without console rights produces a passing denied subtest."""
+    module = _load_vm_script("console_rbac.py")
+    result, _iam = _run_fake_console_rbac(module)
+
+    subtest = result["tests"]["denied_principal_cannot_access_console"]
+    assert subtest["passed"] is True
+    assert subtest["decision"] == "implicitDeny"
+    assert subtest["principal"].startswith("arn:aws:iam::123456789012:user/isv-console-rbac-test-denied-")
+
+
+def test_allowed_principal_with_scoped_policy_is_allowed() -> None:
+    """Allowed principal with a target-instance policy is allowed."""
+    module = _load_vm_script("console_rbac.py")
+    result, _iam = _run_fake_console_rbac(module)
+
+    subtest = result["tests"]["allowed_principal_can_access_console"]
+    assert subtest["passed"] is True
+    assert subtest["decision"] == "allowed"
+    assert subtest["principal"].startswith("arn:aws:iam::123456789012:user/isv-console-rbac-test-allowed-")
+    assert subtest["serial_access_enabled"] is True
+    assert subtest["resource"] == "arn:aws:ec2:us-west-2:123456789012:instance/i-0123456789abcdef0"
+
+
+def test_allowed_principal_fails_when_serial_console_access_is_disabled() -> None:
+    """Allowed IAM policy alone is not enough when EC2 serial console access is disabled."""
+    module = _load_vm_script("console_rbac.py")
+    result, _iam = _run_fake_console_rbac(module, ec2=FakeEc2(serial_access_enabled=False))
+
+    serial_subtest = result["tests"]["serial_console_access_enabled"]
+    allowed_subtest = result["tests"]["allowed_principal_can_access_console"]
+    assert result["success"] is False
+    assert result["serial_access_enabled"] is False
+    assert serial_subtest["passed"] is False
+    assert allowed_subtest["passed"] is False
+    assert allowed_subtest["decision"] == "allowed"
+    assert allowed_subtest["serial_access_enabled"] is False
+
+
+def test_allowed_principal_is_denied_for_other_instance() -> None:
+    """Allowed principal remains denied for an unscoped instance ARN."""
+    module = _load_vm_script("console_rbac.py")
+    result, _iam = _run_fake_console_rbac(module)
+
+    subtest = result["tests"]["allowed_principal_is_resource_scoped"]
+    assert subtest["passed"] is True
+    assert subtest["decision"] == "implicitDeny"
+    assert subtest["resource"] == "arn:aws:ec2:us-west-2:123456789012:instance/i-00000000000000000"
+    assert result["access_restricted"] is True
+    assert result["success"] is True
+
+
+def test_unscoped_attached_policy_fails_resource_scoping() -> None:
+    """An actual unscoped inline policy on the allowed principal fails the check."""
+    module = _load_vm_script("console_rbac.py")
+    iam = FakeConsoleRbacIam(force_allowed_policy_resource="*")
+    result, _iam = _run_fake_console_rbac(module, iam=iam)
+
+    subtest = result["tests"]["allowed_principal_is_resource_scoped"]
+    assert result["success"] is False
+    assert result["access_restricted"] is False
+    assert subtest["passed"] is False
+    assert subtest["decision"] == "allowed"
+    assert len(iam.simulation_calls) == 3
+    assert all("PolicySourceArn" in call for call in iam.simulation_calls)
+
+
+def test_instance_arn_uses_partition_from_sts_identity() -> None:
+    """Simulated instance ARNs use the caller's AWS partition."""
+    module = _load_vm_script("console_rbac.py")
+    result, _iam = _run_fake_console_rbac(
+        module,
+        sts=FakeSts(partition="aws-us-gov"),
+        region="us-gov-west-1",
+    )
+
+    subtest = result["tests"]["allowed_principal_can_access_console"]
+    assert subtest["passed"] is True
+    assert subtest["resource"] == "arn:aws-us-gov:ec2:us-gov-west-1:123456789012:instance/i-0123456789abcdef0"
+
+
+def test_instance_arn_partition_falls_back_to_region_metadata() -> None:
+    """Simulated instance ARNs use region metadata when STS omits the caller ARN."""
+    module = _load_vm_script("console_rbac.py")
+    result, _iam = _run_fake_console_rbac(
+        module,
+        sts=FakeSts(include_arn=False),
+        region="cn-north-1",
+    )
+
+    subtest = result["tests"]["allowed_principal_can_access_console"]
+    assert subtest["passed"] is True
+    assert subtest["resource"] == "arn:aws-cn:ec2:cn-north-1:123456789012:instance/i-0123456789abcdef0"
+
+
+def test_empty_iam_simulation_results_mark_result_failed() -> None:
+    """Empty IAM simulation output is reported as a failed script result."""
+    module = _load_vm_script("console_rbac.py")
+    iam = FakeConsoleRbacIam(empty_results=True)
+    result, _iam = _run_fake_console_rbac(module, iam=iam)
+
+    assert result["success"] is False
+    assert result["access_restricted"] is False
+    assert result["error"] == "IAM simulation returned no evaluation results"
+
+
+def test_temporary_users_are_tagged_and_cleaned_up() -> None:
+    """Temporary IAM users are owned with tags and deleted after simulation."""
+    module = _load_vm_script("console_rbac.py")
+    result, iam = _run_fake_console_rbac(module)
+
+    assert result["success"] is True
+    assert len(iam.create_user_calls) == 2
+    assert all({"Key": "CreatedBy", "Value": "isvtest"} in call["Tags"] for call in iam.create_user_calls)
+    assert len(iam.deleted_users) == 2
+    assert iam.users == {}
+
+
+def test_cleanup_failure_marks_result_failed() -> None:
+    """Owned cleanup failures fail the script result."""
+    module = _load_vm_script("console_rbac.py")
+    result, _iam = _run_fake_console_rbac(module, iam=FakeConsoleRbacIam(fail_delete_user=True))
+
+    assert result["success"] is False
+    assert "cleanup_errors" in result
+    assert "Cleanup failed" in result["error"]

--- a/isvtest/src/isvtest/main.py
+++ b/isvtest/src/isvtest/main.py
@@ -17,7 +17,7 @@ Note: For cluster lifecycle management, use isvctl instead:
 import json
 import os
 import tempfile
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -321,7 +321,7 @@ def _transform_validations_for_pytest(
     return result
 
 
-class Platform(str, Enum):
+class Platform(StrEnum):
     """Supported platforms for validation."""
 
     ALL = "all"

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -91,6 +91,7 @@ from isvtest.validations.nim import (
 from isvtest.validations.security import (
     ApiEndpointIsolationCheck,
     BmcTenantIsolationCheck,
+    ConsoleRbacCheck,
 )
 
 __all__ = [
@@ -103,6 +104,7 @@ __all__ = [
     "ByoipCheck",
     "CloudInitCheck",
     "ClusterHealthCheck",
+    "ConsoleRbacCheck",
     "ContainerRuntimeCheck",
     "CpuInfoCheck",
     "DhcpIpManagementCheck",

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -11,7 +11,7 @@
 """Security validations for infrastructure hardening.
 
 Validations for BMC isolation, API endpoint exposure, tenant isolation,
-and other platform security requirements (SEC* test IDs).
+console RBAC, and other platform security requirements.
 """
 
 from typing import ClassVar
@@ -81,3 +81,58 @@ class ApiEndpointIsolationCheck(BaseValidation):
             return
         endpoints = self.config.get("step_output", {}).get("endpoints_tested", "N/A")
         self.set_passed(f"API endpoints not publicly accessible ({endpoints} endpoints tested)")
+
+
+class ConsoleRbacCheck(BaseValidation):
+    """Validate interactive console access is restricted by RBAC.
+
+    Config:
+        step_output: The console_rbac step output to check
+
+    Step output:
+        instance_id: VM identifier
+        access_restricted: True when unauthorized console access is denied
+        restricted_actions: Non-empty list of console access permissions
+        tests: dict with denied_principal_cannot_access_console,
+               allowed_principal_can_access_console,
+               allowed_principal_is_resource_scoped
+    """
+
+    description: ClassVar[str] = "Check console access is restricted by RBAC"
+    markers: ClassVar[list[str]] = ["vm", "security", "iam"]
+
+    def run(self) -> None:
+        """Validate console RBAC provider proof from step output."""
+        step_output = self.config.get("step_output", {})
+
+        instance_id = step_output.get("instance_id")
+        if not instance_id:
+            self.set_failed("No 'instance_id' in step output")
+            return
+
+        access_restricted = step_output.get("access_restricted")
+        if access_restricted is not True:
+            self.set_failed(
+                f"Console access for {instance_id} is not affirmatively restricted "
+                f"(access_restricted={access_restricted!r})"
+            )
+            return
+
+        restricted_actions = step_output.get("restricted_actions")
+        if not isinstance(restricted_actions, list) or not restricted_actions:
+            self.set_failed(f"No restricted console actions reported for {instance_id}")
+            return
+
+        required = [
+            "denied_principal_cannot_access_console",
+            "allowed_principal_can_access_console",
+            "allowed_principal_is_resource_scoped",
+        ]
+        if not check_required_tests(self, required, "Console RBAC tests failed"):
+            return
+
+        rbac_model = step_output.get("rbac_model", "unknown")
+        self.set_passed(
+            f"Console RBAC restricted for {instance_id} "
+            f"(model={rbac_model}, actions={', '.join(str(action) for action in restricted_actions)})"
+        )

--- a/isvtest/tests/test_catalog.py
+++ b/isvtest/tests/test_catalog.py
@@ -79,6 +79,7 @@ class TestBuildCatalog:
         assert by_name["SgCrudCheck"]["platforms"] == ["NETWORK"]
         assert by_name["BmcTenantIsolationCheck"]["platforms"] == ["SECURITY"]
         assert by_name["ServiceAccountCredentialCheck"]["platforms"] == ["SECURITY"]
+        assert by_name["ConsoleRbacCheck"]["platforms"] == ["VM"]
 
 
 class TestGetCatalogVersion:

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -11,6 +11,7 @@
 """Tests for validation module."""
 
 import json
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -40,6 +41,7 @@ from isvtest.validations.network import (
     VpcPeeringCheck,
 )
 from isvtest.validations.nim import NimHealthCheck, NimInferenceCheck, NimModelCheck
+from isvtest.validations.security import ConsoleRbacCheck
 
 
 class ConcreteValidation(BaseValidation):
@@ -670,6 +672,85 @@ class TestInstancePowerCycleCheck:
         result = v.execute()
         assert result["passed"] is True
         assert "i-abc123" in result["output"]
+
+
+def _console_rbac_config(step_output: dict[str, Any] | None = None) -> dict[str, dict[str, Any]]:
+    """Build a minimal ConsoleRbacCheck config."""
+    output: dict[str, Any] = {
+        "success": True,
+        "platform": "vm",
+        "test_name": "console_rbac",
+        "instance_id": "i-abc123",
+        "rbac_model": "aws-iam",
+        "access_restricted": True,
+        "restricted_actions": ["ec2-instance-connect:SendSerialConsoleSSHPublicKey"],
+        "tests": {
+            "denied_principal_cannot_access_console": {"passed": True},
+            "allowed_principal_can_access_console": {"passed": True},
+            "allowed_principal_is_resource_scoped": {"passed": True},
+        },
+    }
+    if step_output:
+        output.update(step_output)
+    return {"step_output": output}
+
+
+class TestConsoleRbacCheck:
+    """Tests for ConsoleRbacCheck validation."""
+
+    def test_all_required_fields_and_subtests_pass(self) -> None:
+        """Console RBAC passes when all required proof fields are present."""
+        v = ConsoleRbacCheck(config=_console_rbac_config())
+        result = v.execute()
+
+        assert result["passed"] is True
+        assert "i-abc123" in result["output"]
+        assert "aws-iam" in result["output"]
+
+    @pytest.mark.parametrize("access_restricted", [None, False])
+    def test_access_restricted_must_be_true(self, access_restricted: bool | None) -> None:
+        """Console RBAC fails when access_restricted is missing or false."""
+        v = ConsoleRbacCheck(config=_console_rbac_config({"access_restricted": access_restricted}))
+        result = v.execute()
+
+        assert result["passed"] is False
+        assert "access_restricted" in result["error"]
+
+    def test_restricted_actions_must_be_non_empty(self) -> None:
+        """Console RBAC fails when no restricted action is reported."""
+        v = ConsoleRbacCheck(config=_console_rbac_config({"restricted_actions": []}))
+        result = v.execute()
+
+        assert result["passed"] is False
+        assert "restricted console actions" in result["error"]
+
+    @pytest.mark.parametrize(
+        ("tests", "expected_error"),
+        [
+            (
+                {
+                    "allowed_principal_can_access_console": {"passed": True},
+                    "allowed_principal_is_resource_scoped": {"passed": True},
+                },
+                "denied_principal_cannot_access_console",
+            ),
+            (
+                {
+                    "denied_principal_cannot_access_console": {"passed": True},
+                    "allowed_principal_can_access_console": {"passed": False, "error": "denied"},
+                    "allowed_principal_is_resource_scoped": {"passed": True},
+                },
+                "allowed_principal_can_access_console",
+            ),
+        ],
+    )
+    def test_required_subtests_must_pass(self, tests: dict[str, Any], expected_error: str) -> None:
+        """Console RBAC fails when a required subtest is missing or failed."""
+        v = ConsoleRbacCheck(config=_console_rbac_config({"tests": tests}))
+        result = v.execute()
+
+        assert result["passed"] is False
+        assert expected_error in result["error"]
 
 
 def _mock_ssh_run(responses: dict[str, tuple[int, str, str]]):


### PR DESCRIPTION
## Summary

Adds CNP01-16 coverage to the VM suite for verifying interactive console access is restricted by RBAC.

## Changes

- Adds `ConsoleRbacCheck` and VM suite wiring for the `console_rbac` step.
- Adds AWS reference coverage using EC2 serial console access detection plus temporary IAM principals with scoped policy simulation.
- Adds my-isv scaffold/demo output for the console RBAC contract.
- Adds focused validation, catalog, and AWS provider script tests, including cleanup failure coverage.

## Validation

- [x] `uv run pytest isvctl/tests/test_aws_vm_console_rbac.py isvtest/tests/test_validation.py isvtest/tests/test_catalog.py` - 117 passed
- [x] `uvx ruff check` on changed validation, provider script, and test files
- [x] `make demo-test`

Closes #256


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Console RBAC validation to VM test flows that verifies interactive EC2 serial console access is restricted by RBAC and is run as a dedicated validation step.

* **Tests**
  * Added comprehensive tests for allowed/denied principals, resource scoping, partition handling, cleanup behavior, error cases, and demo/CLI outputs.

* **Chores**
  * Small enum base-type updates for consistency.

* **Documentation**
  * Updated step ordering, walkthrough comments, and validation catalog entries to include the new check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->