### PR TITLE
feat: add CNP10-01 BMC protocol security validation (M5 P0)

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -527,6 +527,14 @@ Below is a summary by category.
 | `TrafficFlowCheck` | Check traffic flow |
 | `DhcpIpManagementCheck` | Check DHCP/IP management via SSH |
 
+### Security (`validations/security.py`)
+
+| Validation | Description |
+| ---------- | ----------- |
+| `BmcTenantIsolationCheck` | Check BMC/IPMI/Redfish are unreachable from tenant networks |
+| `BmcProtocolSecurityCheck` | Check CNP10-01: IPMI disabled; Redfish over TLS with AAA |
+| `ApiEndpointIsolationCheck` | Check management/API endpoints are not publicly accessible |
+
 ### Host (`validations/host.py`)
 
 | Validation | Description |

--- a/docs/packages/isvtest.md
+++ b/docs/packages/isvtest.md
@@ -110,6 +110,16 @@ VPC, subnet, security group, DNS, and connectivity checks.
 | `TrafficFlowCheck` | network | Check traffic flow |
 | `DhcpIpManagementCheck` | network, ssh | Check DHCP/IP management via SSH |
 
+### Security (`validations/security.py`)
+
+Infrastructure security hardening checks for management-plane exposure and BMC protocol posture.
+
+| Validation | Platforms | Description |
+| ---------- | --------- | ----------- |
+| `BmcTenantIsolationCheck` | security, network | Check BMC/IPMI/Redfish are unreachable from tenant networks |
+| `BmcProtocolSecurityCheck` | security, network | Check CNP10-01: IPMI disabled; Redfish over TLS with AAA |
+| `ApiEndpointIsolationCheck` | security, network | Check management/API endpoints are not publicly accessible |
+
 ### Host (`validations/host.py`)
 
 SSH-based host validations for GPU, driver, OS, networking, and workloads.

--- a/docs/references/aws.md
+++ b/docs/references/aws.md
@@ -25,6 +25,7 @@ Each template has a corresponding AWS config and scripts that show exactly how t
 | **EKS** | [`providers/aws/config/eks.yaml`](../../isvctl/configs/providers/aws/config/eks.yaml) | [`providers/aws/scripts/eks/`](../../isvctl/configs/providers/aws/scripts/eks/) | [Guide](../../isvctl/configs/providers/aws/scripts/eks/docs/aws-eks.md) | [`suites/k8s.yaml`](../../isvctl/configs/suites/k8s.yaml) |
 | **Control Plane** | [`providers/aws/config/control-plane.yaml`](../../isvctl/configs/providers/aws/config/control-plane.yaml) | [`providers/aws/scripts/control-plane/`](../../isvctl/configs/providers/aws/scripts/control-plane/) | [Guide](../../isvctl/configs/providers/aws/scripts/control-plane/docs/aws-control-plane.md) | [`suites/control-plane.yaml`](../../isvctl/configs/suites/control-plane.yaml) |
 | **Image Registry** | [`providers/aws/config/image-registry.yaml`](../../isvctl/configs/providers/aws/config/image-registry.yaml) | [`providers/aws/scripts/image-registry/`](../../isvctl/configs/providers/aws/scripts/image-registry/) | [Guide](../../isvctl/configs/providers/aws/scripts/image-registry/docs/aws-image-registry.md) | [`suites/image-registry.yaml`](../../isvctl/configs/suites/image-registry.yaml) |
+| **Security** | [`providers/aws/config/security.yaml`](../../isvctl/configs/providers/aws/config/security.yaml) | [`providers/aws/scripts/security/`](../../isvctl/configs/providers/aws/scripts/security/) | - | [`suites/security.yaml`](../../isvctl/configs/suites/security.yaml) |
 
 Shared AWS utilities (error handling, EC2/VPC helpers) are in [`providers/aws/scripts/common/`](../../isvctl/configs/providers/aws/scripts/common/).
 
@@ -40,6 +41,7 @@ uv run isvctl test run -f isvctl/configs/providers/aws/config/bare_metal.yaml
 uv run isvctl test run -f isvctl/configs/providers/aws/config/eks.yaml
 uv run isvctl test run -f isvctl/configs/providers/aws/config/control-plane.yaml
 uv run isvctl test run -f isvctl/configs/providers/aws/config/image-registry.yaml
+uv run isvctl test run -f isvctl/configs/providers/aws/config/security.yaml
 ```
 
 ## Using AWS as a Reference

--- a/isvctl/configs/providers/aws/README.md
+++ b/isvctl/configs/providers/aws/README.md
@@ -13,7 +13,7 @@ Provider configs that wire the [provider-agnostic test suites](../../suites/READ
 | [`config/eks.yaml`](config/eks.yaml) | Kubernetes GPU cluster (nodes, GPU operator, workloads) | [AWS EKS Guide](scripts/eks/docs/aws-eks.md) |
 | [`config/control-plane.yaml`](config/control-plane.yaml) | API health, access keys, tenant lifecycle | [AWS Control Plane Guide](scripts/control-plane/docs/aws-control-plane.md) |
 | [`config/image-registry.yaml`](config/image-registry.yaml) | Image upload, CRUD, VM launch, install config | [AWS Image Registry Guide](scripts/image-registry/docs/aws-image-registry.md) |
-| [`config/security.yaml`](config/security.yaml) | BMC isolation, API endpoint isolation, SA credential auth | - |
+| [`config/security.yaml`](config/security.yaml) | BMC isolation, BMC protocol security, API endpoint isolation, SA credential auth | - |
 
 ## Quick Start
 

--- a/isvctl/configs/providers/aws/config/security.yaml
+++ b/isvctl/configs/providers/aws/config/security.yaml
@@ -21,10 +21,11 @@
 # Security tests (SEC* requirements):
 #   1. BMC Management Network - Verify BMC management is dedicated/restricted
 #   2. BMC Tenant Isolation   - Verify BMC/IPMI/Redfish unreachable from VPC
-#   3. API Endpoint Isolation - Verify management APIs are not publicly exposed
-#   4. MFA Enforcement        - Verify admin interfaces (UI, CLI, API) require MFA
-#   5. SA Credential Auth     - Verify IAM user + long-lived access key auth
-#   6. OIDC User Auth         - Probe configured OIDC-protected platform endpoint (SEC01-01)
+#   3. BMC Protocol Security  - Verify CNP10-01 BMC protocol posture
+#   4. API Endpoint Isolation - Verify management APIs are not publicly exposed
+#   5. MFA Enforcement        - Verify admin interfaces (UI, CLI, API) require MFA
+#   6. SA Credential Auth     - Verify IAM user + long-lived access key auth
+#   7. OIDC User Auth         - Probe configured OIDC-protected platform endpoint (SEC01-01)
 
 import:
   - ../../../suites/security.yaml
@@ -56,28 +57,35 @@ commands:
         args: ["--region", "{{region}}"]
         timeout: 60
 
-      # Test 3: API Endpoint Isolation (~15s)
+      # Test 3: BMC Protocol Security (AWS has no customer BMC endpoint)
+      - name: bmc_protocol_security
+        phase: test
+        command: "python3 ../scripts/security/bmc_protocol_security_test.py"
+        args: ["--region", "{{region}}"]
+        timeout: 60
+
+      # Test 4: API Endpoint Isolation (~15s)
       - name: api_endpoint_isolation
         phase: test
         command: "python3 ../scripts/security/api_endpoint_test.py"
         args: ["--region", "{{region}}"]
         timeout: 60
 
-      # Test 4: MFA Enforcement (~10s)
+      # Test 5: MFA Enforcement (~10s)
       - name: mfa_enforcement
         phase: test
         command: "python3 ../scripts/security/mfa_enforcement_test.py"
         args: ["--region", "{{region}}"]
         timeout: 60
 
-      # Test 5: Service Account Credential Auth (~30s, includes IAM propagation wait)
+      # Test 6: Service Account Credential Auth (~30s, includes IAM propagation wait)
       - name: sa_credential_test
         phase: test
         command: "python3 ../scripts/security/sa_credential_test.py"
         args: ["--region", "{{region}}"]
         timeout: 120
 
-      # Test 6: OIDC User Authentication
+      # Test 7: OIDC User Authentication
       # Requires a real issuer, audience, protected target endpoint, and token
       # fixtures. Non-sensitive endpoint settings can come from tests.settings
       # below; token fixtures are read by the script from OIDC_*_TOKEN env vars

--- a/isvctl/configs/providers/aws/scripts/README.md
+++ b/isvctl/configs/providers/aws/scripts/README.md
@@ -15,6 +15,7 @@ These scripts are invoked by the [AWS provider configs](../config/).
 | [`eks/`](eks/) | EKS cluster setup/teardown (Terraform) | [AWS EKS Guide](eks/docs/aws-eks.md) |
 | [`control-plane/`](control-plane/) | API checks, access keys, tenant management | [AWS Control Plane Guide](control-plane/docs/aws-control-plane.md) |
 | [`image-registry/`](image-registry/) | Image upload/CRUD, install configs, BM provisioning | [AWS Image Registry Guide](image-registry/docs/aws-image-registry.md) |
+| [`security/`](security/) | BMC isolation, BMC protocol posture, API endpoint isolation, SA credential auth | - |
 | [`common/`](common/) | Shared utilities (error handling, EC2/VPC helpers) | - |
 
 ## See Also

--- a/isvctl/configs/providers/aws/scripts/security/bmc_protocol_security_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/bmc_protocol_security_test.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Verify CNP10-01 BMC protocol posture for AWS tenant environments.
+
+AWS does not expose customer-accessible IPMI or Redfish BMC endpoints for
+EC2/EKS tenant workloads. The BMC protocol attack surface is owned by the
+AWS managed infrastructure plane rather than the customer VPC or instance
+network. This reference script emits the provider-agnostic CNP10-01 contract
+with evidence explaining that no tenant/customer BMC protocol surface exists.
+
+Usage:
+    python bmc_protocol_security_test.py --region us-west-2
+
+Output JSON:
+  {
+    "success": true,
+    "platform": "security",
+    "test_name": "bmc_protocol_security",
+    "bmc_endpoints_tested": 0,
+    "tests": { ... }
+  }
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+import boto3
+
+AWS_NO_CUSTOMER_BMC_MESSAGE = "AWS EC2/EKS tenants do not receive customer-accessible IPMI or Redfish BMC endpoints"
+
+
+def _aws_no_customer_bmc_result(region: str) -> dict[str, Any]:
+    """Build the AWS CNP10-01 result for the managed BMC protocol surface."""
+    evidence = f"{AWS_NO_CUSTOMER_BMC_MESSAGE} in region {region}"
+    return {
+        "success": True,
+        "platform": "security",
+        "test_name": "bmc_protocol_security",
+        "region": region,
+        "bmc_endpoints_tested": 0,
+        "bmc_protocol_surface": "none",
+        "evidence": evidence,
+        "tests": {
+            "ipmi_disabled": {
+                "passed": True,
+                "message": f"{evidence}; IPMI UDP 623 is not exposed to tenant networks",
+            },
+            "redfish_tls_enabled": {
+                "passed": True,
+                "message": f"{evidence}; no customer Redfish endpoint requires TLS validation",
+            },
+            "redfish_plain_http_disabled": {
+                "passed": True,
+                "message": f"{evidence}; plain HTTP Redfish is not exposed",
+            },
+            "redfish_authentication_required": {
+                "passed": True,
+                "message": f"{evidence}; unauthenticated Redfish access is not available",
+            },
+            "redfish_authorization_enforced": {
+                "passed": True,
+                "message": f"{evidence}; customer Redfish role actions are not available",
+            },
+            "redfish_accounting_enabled": {
+                "passed": True,
+                "message": f"{evidence}; customer Redfish accounting is not applicable",
+            },
+        },
+    }
+
+
+def _aws_probe_failure_result(region: str, error: str) -> dict[str, Any]:
+    """Build a failed CNP10-01 result when the AWS identity probe fails."""
+    evidence = f"AWS STS identity probe failed in region {region}: {error}"
+    return {
+        "success": False,
+        "platform": "security",
+        "test_name": "bmc_protocol_security",
+        "region": region,
+        "bmc_endpoints_tested": 0,
+        "bmc_protocol_surface": "unknown",
+        "evidence": evidence,
+        "tests": {
+            "ipmi_disabled": {
+                "passed": False,
+                "error": evidence,
+            },
+            "redfish_tls_enabled": {
+                "passed": False,
+                "error": evidence,
+            },
+            "redfish_plain_http_disabled": {
+                "passed": False,
+                "error": evidence,
+            },
+            "redfish_authentication_required": {
+                "passed": False,
+                "error": evidence,
+            },
+            "redfish_authorization_enforced": {
+                "passed": False,
+                "error": evidence,
+            },
+            "redfish_accounting_enabled": {
+                "passed": False,
+                "error": evidence,
+            },
+        },
+    }
+
+
+def main() -> int:
+    """Emit AWS CNP10-01 BMC protocol posture evidence."""
+    parser = argparse.ArgumentParser(description="BMC protocol security test")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    args = parser.parse_args()
+
+    try:
+        sts = boto3.client("sts", region_name=args.region)
+        sts.get_caller_identity()
+    except Exception as e:
+        result = _aws_probe_failure_result(args.region, str(e))
+        print(json.dumps(result, indent=2))
+        return 1
+
+    result = _aws_no_customer_bmc_result(args.region)
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/my-isv/README.md
+++ b/isvctl/configs/providers/my-isv/README.md
@@ -18,7 +18,7 @@ exercises.
 | [`config/bare_metal.yaml`](config/bare_metal.yaml) | BMaaS lifecycle (launch -> topology -> serial -> power-cycle -> teardown) | [`scripts/bare_metal/`](scripts/bare_metal/) |
 | [`config/network.yaml`](config/network.yaml) | VPC CRUD, subnets, isolation, SG, connectivity, traffic, DDI | [`scripts/network/`](scripts/network/) |
 | [`config/image-registry.yaml`](config/image-registry.yaml) | Image upload, CRUD, VM launch, install config, BMaaS install | [`scripts/image-registry/`](scripts/image-registry/) |
-| [`config/security.yaml`](config/security.yaml) | BMC isolation, API endpoint isolation, SA credential auth | [`scripts/security/`](scripts/security/) |
+| [`config/security.yaml`](config/security.yaml) | BMC isolation, BMC protocol security, API endpoint isolation, SA credential auth | [`scripts/security/`](scripts/security/) |
 
 ## Coverage note
 

--- a/isvctl/configs/providers/my-isv/config/security.yaml
+++ b/isvctl/configs/providers/my-isv/config/security.yaml
@@ -18,6 +18,7 @@
 # Coverage:
 #   SEC12-01: BMC management network (BmcManagementNetworkCheck)
 #   SEC12-02: BMC tenant isolation (BmcTenantIsolationCheck)
+#   CNP10-01: BMC protocol security (BmcProtocolSecurityCheck)
 #   SEC14-01: API endpoint isolation (ApiEndpointIsolationCheck)
 #   SEC07-01: MFA enforcement (MfaEnforcedCheck)
 #   SEC03-01: Service account credentials (ServiceAccountCredentialCheck)
@@ -50,6 +51,12 @@ commands:
       - name: bmc_tenant_isolation
         phase: test
         command: "python ../scripts/security/bmc_isolation_test.py"
+        args: ["--region", "{{region}}"]
+        timeout: 60
+
+      - name: bmc_protocol_security
+        phase: test
+        command: "python ../scripts/security/bmc_protocol_security_test.py"
         args: ["--region", "{{region}}"]
         timeout: 60
 

--- a/isvctl/configs/providers/my-isv/scripts/README.md
+++ b/isvctl/configs/providers/my-isv/scripts/README.md
@@ -34,7 +34,7 @@ the TODOs.
 | `bare_metal/` | 12 | [`suites/bare_metal.yaml`](../../../suites/bare_metal.yaml) | [`config/bare_metal.yaml`](../config/bare_metal.yaml) | [`providers/aws/scripts/bare_metal/`](../../aws/scripts/bare_metal/) |
 | `network/` | 16 | [`suites/network.yaml`](../../../suites/network.yaml) | [`config/network.yaml`](../config/network.yaml) | [`providers/aws/scripts/network/`](../../aws/scripts/network/) |
 | `image-registry/` | 7 | [`suites/image-registry.yaml`](../../../suites/image-registry.yaml) | [`config/image-registry.yaml`](../config/image-registry.yaml) | [`providers/aws/scripts/image-registry/`](../../aws/scripts/image-registry/) |
-| `security/` | 4 | [`suites/security.yaml`](../../../suites/security.yaml) | [`config/security.yaml`](../config/security.yaml) | [`providers/aws/scripts/security/`](../../aws/scripts/security/) |
+| `security/` | 5 | [`suites/security.yaml`](../../../suites/security.yaml) | [`config/security.yaml`](../config/security.yaml) | [`providers/aws/scripts/security/`](../../aws/scripts/security/) |
 | `k8s/` | 9 shell | [`suites/k8s.yaml`](../../../suites/k8s.yaml) | - | [`providers/aws/scripts/eks/`](../../aws/scripts/eks/) |
 | `slurm/` | 2 shell | [`suites/slurm.yaml`](../../../suites/slurm.yaml) | - | - |
 

--- a/isvctl/configs/providers/my-isv/scripts/security/bmc_protocol_security_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/security/bmc_protocol_security_test.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""BMC protocol security test - TEMPLATE (replace with your platform implementation).
+
+Verifies CNP10-01 management protocol posture for BMC endpoints:
+
+* IPMI is disabled.
+* Redfish is served only over TLS.
+* Plain HTTP Redfish is disabled.
+* Unauthenticated Redfish requests are rejected.
+* Authenticated Redfish users are authorized according to role.
+* Redfish AAA/accounting evidence is present.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "security",
+    "test_name": "bmc_protocol_security",
+    "bmc_endpoints_tested": 1,
+    "tests": {
+      "ipmi_disabled": {"passed": true},
+      "redfish_tls_enabled": {"passed": true},
+      "redfish_plain_http_disabled": {"passed": true},
+      "redfish_authentication_required": {"passed": true},
+      "redfish_authorization_enforced": {"passed": true},
+      "redfish_accounting_enabled": {"passed": true}
+    }
+  }
+
+Implementation guidance:
+  Discover the BMC endpoints for the tenant or bare-metal host under test.
+  For each endpoint, probe UDP 623/IPMI and assert it is closed or refused.
+  Probe Redfish over HTTPS and validate TLS protocol/certificate posture.
+  Probe Redfish over plain HTTP and assert it is refused or redirects only to
+  HTTPS. Send an unauthenticated Redfish request and assert HTTP 401/403.
+  Authenticate as a low-privilege Redfish user and assert privileged actions
+  are rejected. Finally, retrieve BMC audit logs or provider control-plane
+  audit records proving Redfish activity is accounted.
+
+Usage:
+    python bmc_protocol_security_test.py --region <region>
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+# ISVCTL_DEMO_MODE=1 enables demo-success output (used by `make demo-test`).
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+
+REQUIRED_TESTS = [
+    "ipmi_disabled",
+    "redfish_tls_enabled",
+    "redfish_plain_http_disabled",
+    "redfish_authentication_required",
+    "redfish_authorization_enforced",
+    "redfish_accounting_enabled",
+]
+
+
+def main() -> int:
+    """Run the BMC protocol security template and emit structured JSON."""
+    parser = argparse.ArgumentParser(description="BMC protocol security test (template)")
+    parser.add_argument("--region", required=True, help="Cloud region")
+    _args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "security",
+        "test_name": "bmc_protocol_security",
+        "bmc_endpoints_tested": 0,
+        "tests": {name: {"passed": False} for name in REQUIRED_TESTS},
+    }
+
+    # ╔══════════════════════════════════════════════════════════════════╗
+    # ║  TODO: Replace this block with your platform's BMC protocol      ║
+    # ║  security probes.                                                ║
+    # ║                                                                  ║
+    # ║  Example (pseudocode):                                           ║
+    # ║    endpoints = get_bmc_endpoints(region=args.region)             ║
+    # ║    for endpoint in endpoints:                                    ║
+    # ║        assert not udp_probe(endpoint.host, port=623)  # IPMI     ║
+    # ║        assert redfish_tls_valid(endpoint.https_url)              ║
+    # ║        assert not redfish_plain_http_allowed(endpoint.http_url)  ║
+    # ║        assert redfish_rejects_unauthenticated(endpoint)          ║
+    # ║        assert redfish_rejects_low_privilege_actions(endpoint)    ║
+    # ║    assert redfish_accounting_evidence_exists(endpoints)          ║
+    # ╚══════════════════════════════════════════════════════════════════╝
+
+    if DEMO_MODE:
+        result["bmc_endpoints_tested"] = 1
+        result["tests"] = {
+            "ipmi_disabled": {"passed": True, "message": "Demo: IPMI disabled"},
+            "redfish_tls_enabled": {"passed": True, "message": "Demo: Redfish HTTPS/TLS enabled"},
+            "redfish_plain_http_disabled": {"passed": True, "message": "Demo: plain HTTP rejected"},
+            "redfish_authentication_required": {"passed": True, "message": "Demo: unauthenticated Redfish rejected"},
+            "redfish_authorization_enforced": {"passed": True, "message": "Demo: role authorization enforced"},
+            "redfish_accounting_enabled": {"passed": True, "message": "Demo: Redfish audit evidence present"},
+        }
+        result["success"] = True
+    else:
+        result["error"] = "Not implemented - replace with your platform's BMC protocol security test"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -143,6 +143,7 @@ Validations use `sinfo`/`srun` directly: partitions, GPU allocation, job schedul
 | Step | Phase | Script | What It Tests |
 |------|-------|--------|---------------|
 | `bmc_tenant_isolation` | test | `providers/my-isv/scripts/security/bmc_isolation_test.py` | BMC/IPMI/Redfish unreachable from tenant network |
+| `bmc_protocol_security` | test | `providers/my-isv/scripts/security/bmc_protocol_security_test.py` | CNP10-01: IPMI disabled; Redfish over TLS with AAA |
 | `api_endpoint_isolation` | test | `providers/my-isv/scripts/security/api_endpoint_test.py` | API endpoints not publicly accessible |
 | `sa_credential_test` | test | `providers/my-isv/scripts/security/sa_credential_test.py` | Service account long-lived credential auth |
 | `oidc_user_auth_test` | test | `providers/my-isv/scripts/security/oidc_user_auth_test.py` | OIDC issuer metadata and protected endpoint token acceptance/rejection |

--- a/isvctl/configs/suites/security.yaml
+++ b/isvctl/configs/suites/security.yaml
@@ -10,8 +10,8 @@
 
 # Security Validation - Canonical Contract
 #
-# Validations-only contract for infrastructure security hardening (SEC*
-# requirements). Provider configs import this file and supply their own
+# Validations-only contract for infrastructure security hardening
+# requirements. Provider configs import this file and supply their own
 # commands (steps + scripts).
 #
 # This file defines WHAT to validate, not HOW to run it. Each validation
@@ -48,6 +48,11 @@ tests:
       checks:
         BmcTenantIsolationCheck:
           step: bmc_tenant_isolation
+
+    bmc_protocol_security:
+      checks:
+        BmcProtocolSecurityCheck:
+          step: bmc_protocol_security
 
     api_security:
       checks:

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -443,6 +443,99 @@ def test_bmc_management_network_main_emits_sec12_01_contract(
     }
 
 
+def test_bmc_protocol_security_reports_no_customer_bmc_surface() -> None:
+    """AWS BMC protocol check emits all CNP10-01 keys for the no-surface case."""
+    module = _load_security_script("bmc_protocol_security_test.py")
+
+    result = module._aws_no_customer_bmc_result("us-west-2")
+
+    assert result["success"] is True
+    assert result["bmc_endpoints_tested"] == 0
+    assert result["bmc_protocol_surface"] == "none"
+    assert set(result["tests"]) == {
+        "ipmi_disabled",
+        "redfish_tls_enabled",
+        "redfish_plain_http_disabled",
+        "redfish_authentication_required",
+        "redfish_authorization_enforced",
+        "redfish_accounting_enabled",
+    }
+    assert all(test["passed"] is True for test in result["tests"].values())
+    assert "do not receive customer-accessible IPMI or Redfish" in result["evidence"]
+
+
+class FakeStsClient:
+    """Small fake for STS GetCallerIdentity."""
+
+    def __init__(self, error: Exception | None = None) -> None:
+        """Store an optional error returned by get_caller_identity."""
+        self.error = error
+
+    def get_caller_identity(self) -> dict[str, str]:
+        """Return a fake caller identity or raise the configured error."""
+        if self.error:
+            raise self.error
+        return {"Account": "123456789012", "Arn": "arn:aws:iam::123456789012:user/test", "UserId": "test"}
+
+
+def _patch_sts_client(
+    monkeypatch: pytest.MonkeyPatch,
+    module: ModuleType,
+    sts: FakeStsClient,
+    *,
+    expected_region: str,
+) -> None:
+    """Patch boto3.client to return a fake STS client."""
+
+    def fake_client(service_name: str, region_name: str | None = None) -> FakeStsClient:
+        """Return the fake STS client for STS requests."""
+        assert service_name == "sts"
+        assert region_name == expected_region
+        return sts
+
+    monkeypatch.setattr(module.boto3, "client", fake_client)
+
+
+def test_bmc_protocol_security_main_outputs_json(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """AWS BMC protocol script prints the provider-agnostic JSON contract."""
+    module = _load_security_script("bmc_protocol_security_test.py")
+    monkeypatch.setattr(module.sys, "argv", ["bmc_protocol_security_test.py", "--region", "eu-west-1"])
+    _patch_sts_client(monkeypatch, module, FakeStsClient(), expected_region="eu-west-1")
+
+    exit_code = module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["success"] is True
+    assert payload["region"] == "eu-west-1"
+    assert payload["test_name"] == "bmc_protocol_security"
+    assert payload["tests"]["ipmi_disabled"]["passed"] is True
+
+
+def test_bmc_protocol_security_main_reports_sts_probe_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """AWS BMC protocol script fails closed when the STS probe fails."""
+    module = _load_security_script("bmc_protocol_security_test.py")
+    monkeypatch.setattr(module.sys, "argv", ["bmc_protocol_security_test.py", "--region", "eu-west-1"])
+    _patch_sts_client(monkeypatch, module, FakeStsClient(RuntimeError("sts unavailable")), expected_region="eu-west-1")
+
+    exit_code = module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert payload["platform"] == "security"
+    assert payload["test_name"] == "bmc_protocol_security"
+    assert payload["region"] == "eu-west-1"
+    assert "sts unavailable" in payload["evidence"]
+    assert all(test["passed"] is False for test in payload["tests"].values())
+
+
 class FakeIamTags:
     """Small fake for IAM list_user_tags responses."""
 

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -16,7 +16,7 @@ Validations are organized by category:
 - instance: VM/EC2 instance validations
 - network: VPC, subnet, security group validations
 - iam: Access key, tenant, and service account validations
-- security: BMC isolation, API endpoint isolation, infrastructure hardening
+- security: BMC isolation, BMC protocol posture, API endpoint isolation, infrastructure hardening
 
 All validations are also available via step_assertions for backward compatibility.
 """
@@ -92,6 +92,7 @@ from isvtest.validations.nim import (
 from isvtest.validations.security import (
     ApiEndpointIsolationCheck,
     BmcManagementNetworkCheck,
+    BmcProtocolSecurityCheck,
     BmcTenantIsolationCheck,
     ConsoleRbacCheck,
     MfaEnforcedCheck,
@@ -105,6 +106,7 @@ __all__ = [
     "AccessKeyRejectedCheck",
     "ApiEndpointIsolationCheck",
     "BmcManagementNetworkCheck",
+    "BmcProtocolSecurityCheck",
     "BmcTenantIsolationCheck",
     "ByoipCheck",
     "CloudInitCheck",

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -10,8 +10,9 @@
 
 """Security validations for infrastructure hardening.
 
-Validations for BMC isolation, API endpoint exposure, MFA enforcement,
-console RBAC, tenant isolation, and other platform security requirements (SEC* test IDs).
+Validations for BMC isolation, BMC protocol posture, API endpoint exposure,
+MFA enforcement, tenant isolation, console RBAC, and other platform security
+requirements (SEC* test IDs).
 """
 
 from typing import ClassVar
@@ -82,6 +83,42 @@ class BmcTenantIsolationCheck(BaseValidation):
             return
         bmc_count = self.config.get("step_output", {}).get("bmc_endpoints_tested", "N/A")
         self.set_passed(f"BMC interfaces unreachable from tenant network ({bmc_count} endpoints tested)")
+
+
+class BmcProtocolSecurityCheck(BaseValidation):
+    """Validate BMC management protocols enforce CNP10-01 controls.
+
+    Verifies the management protocol posture for BMC endpoints:
+    IPMI must be disabled, Redfish must require TLS and authentication,
+    role authorization must be enforced, and AAA/accounting evidence must
+    be present.
+
+    Config:
+        step_output: The step output to check
+
+    Step output:
+        tests: dict with ipmi_disabled, redfish_tls_enabled,
+               redfish_plain_http_disabled, redfish_authentication_required,
+               redfish_authorization_enforced, redfish_accounting_enabled
+    """
+
+    description: ClassVar[str] = "Check BMC protocol security posture"
+    markers: ClassVar[list[str]] = ["security", "network"]
+
+    def run(self) -> None:
+        """Validate required BMC protocol security probe results."""
+        required = [
+            "ipmi_disabled",
+            "redfish_tls_enabled",
+            "redfish_plain_http_disabled",
+            "redfish_authentication_required",
+            "redfish_authorization_enforced",
+            "redfish_accounting_enabled",
+        ]
+        if not check_required_tests(self, required, "BMC protocol security tests failed"):
+            return
+        bmc_count = self.config.get("step_output", {}).get("bmc_endpoints_tested", "N/A")
+        self.set_passed(f"BMC protocol security posture verified ({bmc_count} endpoints tested)")
 
 
 class MfaEnforcedCheck(BaseValidation):

--- a/isvtest/tests/test_security.py
+++ b/isvtest/tests/test_security.py
@@ -8,7 +8,7 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
-"""Tests for security validation classes."""
+"""Tests for security validations."""
 
 from __future__ import annotations
 
@@ -16,9 +16,19 @@ from typing import Any
 
 from isvtest.validations.security import (
     BmcManagementNetworkCheck,
+    BmcProtocolSecurityCheck,
     MfaEnforcedCheck,
     OidcUserAuthCheck,
 )
+
+REQUIRED_BMC_PROTOCOL_TESTS = [
+    "ipmi_disabled",
+    "redfish_tls_enabled",
+    "redfish_plain_http_disabled",
+    "redfish_authentication_required",
+    "redfish_authorization_enforced",
+    "redfish_accounting_enabled",
+]
 
 OIDC_REQUIRED_TESTS = {
     "valid_token_accepted": {"passed": True},
@@ -113,6 +123,59 @@ class TestBmcManagementNetworkCheck:
 
         assert result["passed"] is False
         assert "tests" in result["error"]
+
+
+def _bmc_protocol_config(
+    tests: dict[str, dict[str, Any]] | None = None,
+    *,
+    bmc_endpoints_tested: int = 1,
+) -> dict[str, Any]:
+    """Build a BMC protocol validation config."""
+    default_tests = {name: {"passed": True, "message": f"{name} passed"} for name in REQUIRED_BMC_PROTOCOL_TESTS}
+    return {
+        "step_output": {
+            "bmc_endpoints_tested": bmc_endpoints_tested,
+            "tests": tests if tests is not None else default_tests,
+        },
+    }
+
+
+def test_bmc_protocol_security_check_passes_with_required_tests() -> None:
+    """BmcProtocolSecurityCheck passes when every required probe passed."""
+    validation = BmcProtocolSecurityCheck(config=_bmc_protocol_config())
+
+    result = validation.execute()
+
+    assert result["passed"] is True
+    assert "BMC protocol security posture verified (1 endpoints tested)" in result["output"]
+
+
+def test_bmc_protocol_security_check_reports_failed_and_missing_tests() -> None:
+    """BmcProtocolSecurityCheck reports both failed and missing probes."""
+    tests = {
+        name: {"passed": True}
+        for name in REQUIRED_BMC_PROTOCOL_TESTS
+        if name not in {"redfish_tls_enabled", "redfish_accounting_enabled"}
+    }
+    tests["redfish_tls_enabled"] = {"passed": False, "error": "certificate expired"}
+    validation = BmcProtocolSecurityCheck(config=_bmc_protocol_config(tests))
+
+    result = validation.execute()
+
+    assert result["passed"] is False
+    assert "BMC protocol security tests failed" in result["error"]
+    assert "redfish_tls_enabled: certificate expired" in result["error"]
+    assert "redfish_accounting_enabled: test not found" in result["error"]
+
+
+def test_bmc_protocol_security_check_preserves_empty_tests_map() -> None:
+    """BmcProtocolSecurityCheck fails when an explicit empty tests map is provided."""
+    validation = BmcProtocolSecurityCheck(config=_bmc_protocol_config({}))
+
+    result = validation.execute()
+
+    assert result["passed"] is False
+    assert result["error"] == "No 'tests' in step output"
 
 
 class TestMfaEnforcedCheck:


### PR DESCRIPTION
## Summary

Adds CNP10-01 coverage to the security suite for verifying BMC management protocol posture: IPMI is disabled, Redfish requires TLS, and AAA (authentication, authorization, accounting) is enforced.

## Changes

- Adds `BmcProtocolSecurityCheck` and security suite wiring for the `bmc_protocol_security` step.
- Adds AWS reference coverage emitting the CNP10-01 contract — AWS EC2/EKS tenants do not receive customer-accessible IPMI or Redfish BMC endpoints, so the script reports the managed-plane posture as evidence.
- Adds my-isv scaffold/demo output for the BMC protocol security contract.
- Adds focused validation, AWS provider script, and catalog tests covering the six required probe keys (`ipmi_disabled`, `redfish_tls_enabled`, `redfish_plain_http_disabled`, `redfish_authentication_required`, `redfish_authorization_enforced`, `redfish_accounting_enabled`).

## Validation

- [x] `make test` — all unit tests pass
- [x] `make demo-test` — my-isv security demo passes end-to-end including the new `bmc_protocol_security` step
- [x] `uvx ruff check` on changed validation, provider script, and test files

Closes #260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BMC protocol security validation with checks for IPMI and Redfish configuration.

* **Documentation**
  * Extended security validation documentation to include BMC protocol security coverage and CNP10-01 compliance references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->