### PR TITLE
feat: add serial console retention validation (CNP06-02 - M5 P0)

### DIFF
--- a/isvctl/configs/providers/aws/config/bare_metal.yaml
+++ b/isvctl/configs/providers/aws/config/bare_metal.yaml
@@ -294,6 +294,14 @@ tests:
 
   # Overrides only - all other validations inherited from ../bare_metal.yaml
   validations:
+    # AWS EC2 GetConsoleOutput can validate current console access, but it does
+    # not prove historical one-month retention. Override the canonical BM group
+    # until an external serial-console archive integration is wired in.
+    serial_console:
+      step: serial_console
+      checks:
+        - SerialConsoleCheck: {}
+
     # GPU stress - AWS metal has 8 GPUs
     gpu_stress:
       step: describe_instance

--- a/isvctl/configs/providers/aws/scripts/bare_metal/docs/aws-bm.md
+++ b/isvctl/configs/providers/aws/scripts/bare_metal/docs/aws-bm.md
@@ -66,7 +66,7 @@ uv run isvctl test run -f isvctl/configs/providers/aws/config/bare_metal.yaml --
 | 2 | `list_instances` | test | `providers/aws/scripts/vm/list_instances.py` | List instances in VPC (reuses VM script) |
 | 3 | `verify_tags` | test | `providers/aws/scripts/bare_metal/describe_tags.py` | Verify instance tags (Name, CreatedBy) |
 | 4 | `topology_placement` | test | `providers/aws/scripts/bare_metal/topology_placement.py` | Validate placement group support |
-| 5 | `serial_console` | test | `providers/aws/scripts/bare_metal/serial_console.py` | Retrieve serial console output |
+| 5 | `serial_console` | test | `providers/aws/scripts/bare_metal/serial_console.py` | Retrieve serial console output; retention proof requires an external log archive |
 | 6 | `verify_image` | test | `providers/aws/scripts/image-registry/verify_image_installed.py` | Verify OS image installed on BM |
 | 7 | `verify_config` | test | `providers/aws/scripts/image-registry/verify_config_installable.py` | Verify install config can provision BM |
 | 8 | `stop_instance` | test | `providers/aws/scripts/bare_metal/stop_instance.py` | Power off node, verify stopped state |
@@ -85,6 +85,12 @@ BM provisioning from OS images. Step 13 (`reinstall_instance`) is skipped by def
 root volume replacement is slow on AWS metal (~30-45 min).
 
 ## Validations
+
+`SerialConsoleRetentionCheck` requires evidence from a historical serial console
+log archive. The AWS config currently overrides the canonical bare-metal suite
+to run only `SerialConsoleCheck` because EC2 `GetConsoleOutput` does not prove
+one-month retention by itself. Add an external archive integration before
+re-enabling the retention check for AWS.
 
 | Validation Group | Check | Step | Description |
 |------------------|-------|------|-------------|

--- a/isvctl/configs/providers/aws/scripts/common/serial_console.py
+++ b/isvctl/configs/providers/aws/scripts/common/serial_console.py
@@ -21,6 +21,9 @@ from typing import Any
 
 from botocore.exceptions import ClientError
 
+RETENTION_EVIDENCE_LIMITATION = "EC2 GetConsoleOutput does not prove one-month log retention"
+SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED = 30
+
 
 def check_serial_access(ec2: Any) -> dict[str, Any]:
     """Check if EC2 serial console access is enabled for the account."""
@@ -76,6 +79,12 @@ def run_serial_console_check(ec2: Any, instance_id: str, platform: str) -> tuple
         "instance_id": instance_id,
         "console_available": False,
         "serial_access_enabled": False,
+        "console_log_queryable": False,
+        "retention_days_required": SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED,
+        "retention_days_configured": 0,
+        "oldest_queryable_log_age_days": 0,
+        "query_result_count": 0,
+        "retention_evidence": RETENTION_EVIDENCE_LIMITATION,
     }
 
     try:

--- a/isvctl/configs/providers/my-isv/scripts/README.md
+++ b/isvctl/configs/providers/my-isv/scripts/README.md
@@ -100,6 +100,12 @@ read specific keys (`instance_id`, `state`, `public_ip`, etc.). The AWS
 reference implementation is the source of truth for what "correct" output
 looks like.
 
+For bare-metal serial console validation, the scaffold must also prove that
+historical console logs are queryable for the required retention window. Emit
+`console_log_queryable`, `retention_days_configured`,
+`oldest_queryable_log_age_days`, `query_result_count`, and `retention_evidence`
+from a real serial console log archive or retention policy query.
+
 ## See also
 
 - [`config/`](../config/) - the YAML wiring that invokes these scripts

--- a/isvctl/configs/providers/my-isv/scripts/bare_metal/serial_console.py
+++ b/isvctl/configs/providers/my-isv/scripts/bare_metal/serial_console.py
@@ -22,7 +22,13 @@ Required JSON output fields:
     "console_available": true,
     "serial_access_enabled": true,
     "output_length": 4096,
-    "output_snippet": "... last 500 chars ..."
+    "output_snippet": "... last 500 chars ...",
+    "console_log_queryable": true,
+    "retention_days_required": 30,
+    "retention_days_configured": 30,
+    "oldest_queryable_log_age_days": 30,
+    "query_result_count": 1,
+    "retention_evidence": "provider serial console log archive"
   }
 
 Usage:
@@ -39,6 +45,7 @@ from typing import Any
 
 # ISVCTL_DEMO_MODE=1 enables demo-success output (used by `make demo-test`).
 DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED = 30
 
 
 def main() -> int:
@@ -54,6 +61,12 @@ def main() -> int:
         "instance_id": args.instance_id,
         "console_available": False,
         "serial_access_enabled": False,
+        "console_log_queryable": False,
+        "retention_days_required": SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED,
+        "retention_days_configured": 0,
+        "oldest_queryable_log_age_days": 0,
+        "query_result_count": 0,
+        "retention_evidence": "",
     }
 
     # TODO: Replace with your platform's serial console implementation
@@ -63,6 +76,11 @@ def main() -> int:
         result["serial_access_enabled"] = True
         result["output_length"] = 4096
         result["output_snippet"] = "... demo serial console output snippet ..."
+        result["console_log_queryable"] = True
+        result["retention_days_configured"] = SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED
+        result["oldest_queryable_log_age_days"] = SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED
+        result["query_result_count"] = 1
+        result["retention_evidence"] = "demo serial console log archive"
         result["success"] = True
     else:
         result["error"] = "Not implemented - replace with your platform's serial console logic"

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -81,7 +81,7 @@ For the domain / script-count / AWS-reference overview see the
 | `list_instances` | test | `providers/my-isv/scripts/vm/list_instances.py` | Reuses VM script |
 | `verify_tags` | test | `providers/my-isv/scripts/bare_metal/describe_tags.py` | `instance_id`, `tags`, `tag_count` |
 | `topology_placement` | test | `providers/my-isv/scripts/bare_metal/topology_placement.py` | `placement_supported`, `operations` |
-| `serial_console` | test | `providers/my-isv/scripts/bare_metal/serial_console.py` | `console_available`, `serial_access_enabled` |
+| `serial_console` | test | `providers/my-isv/scripts/bare_metal/serial_console.py` | `console_available`, `serial_access_enabled`, `console_log_queryable`, `retention_days_required`, `retention_days_configured`, `oldest_queryable_log_age_days`, `query_result_count`, `retention_evidence` |
 | `stop_instance` | test | `providers/my-isv/scripts/bare_metal/stop_instance.py` | `instance_id`, `state`, `stop_initiated` |
 | `start_instance` | test | `providers/my-isv/scripts/bare_metal/start_instance.py` | `instance_id`, `state`, `public_ip`, `ssh_ready` |
 | `reboot_instance` | test | `providers/my-isv/scripts/bare_metal/reboot_instance.py` | `reboot_initiated`, `ssh_ready`, `uptime_seconds` |

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -71,6 +71,7 @@ tests:
       step: serial_console
       checks:
         SerialConsoleCheck: {}
+        SerialConsoleRetentionCheck: {}
 
     cloud_init:
       step: launch_instance

--- a/isvctl/tests/test_aws_serial_console_scripts.py
+++ b/isvctl/tests/test_aws_serial_console_scripts.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Tests for serial-console retention output contracts."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+AWS_COMMON_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "common"
+MY_ISV_BM_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "my-isv" / "scripts" / "bare_metal"
+
+
+def _load_aws_common_script(script_name: str) -> ModuleType:
+    """Load an AWS common script as a module for direct helper testing."""
+    return _load_script(AWS_COMMON_SCRIPTS / script_name)
+
+
+def _load_script(script_path: Path) -> ModuleType:
+    """Load a provider script as a module for direct constant/helper testing."""
+    spec = importlib.util.spec_from_file_location(f"test_{script_path.stem}", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeSerialConsoleEc2:
+    """Fake EC2 client for serial-console helper tests."""
+
+    def get_serial_console_access_status(self) -> dict[str, bool]:
+        """Return enabled serial-console account status."""
+        return {"SerialConsoleAccessEnabled": True}
+
+    def get_console_output(self, InstanceId: str, Latest: bool) -> dict[str, str]:
+        """Return a current console output sample."""
+        return {
+            "Output": f"boot output for {InstanceId}",
+            "Timestamp": "2026-04-01T00:00:00Z",
+        }
+
+
+def test_aws_serial_console_helper_emits_retention_fields() -> None:
+    """AWS helper must include the provider-agnostic retention contract fields."""
+    module = _load_aws_common_script("serial_console.py")
+    required_days = getattr(module, "SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED")
+
+    result, exit_code = module.run_serial_console_check(FakeSerialConsoleEc2(), "i-abc123", platform="bm")
+
+    assert exit_code == 0
+    assert result["success"] is True
+    assert result["console_available"] is True
+    assert result["serial_access_enabled"] is True
+    assert result["console_log_queryable"] is False
+    assert result["retention_days_required"] == required_days
+    assert result["retention_days_configured"] == 0
+    assert result["oldest_queryable_log_age_days"] == 0
+    assert result["query_result_count"] == 0
+    assert "does not prove one-month log retention" in result["retention_evidence"]
+
+
+def test_aws_serial_console_helper_does_not_claim_retention_proof() -> None:
+    """Current EC2 console output availability is not historical retention proof."""
+    module = _load_aws_common_script("serial_console.py")
+
+    result, _ = module.run_serial_console_check(FakeSerialConsoleEc2(), "i-abc123", platform="bm")
+
+    assert result["console_log_queryable"] is False
+    assert result["retention_days_configured"] < result["retention_days_required"]
+    assert result["oldest_queryable_log_age_days"] < result["retention_days_required"]
+    assert result["query_result_count"] == 0
+
+
+def test_my_isv_bare_metal_demo_emits_passing_retention_evidence() -> None:
+    """my-isv demo mode should demonstrate the complete retention contract."""
+    script = MY_ISV_BM_SCRIPTS / "serial_console.py"
+    module = _load_script(script)
+    required_days = getattr(module, "SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED")
+    env = os.environ | {"ISVCTL_DEMO_MODE": "1"}
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--instance-id",
+            "bm-demo-1",
+            "--region",
+            "demo-region",
+        ],
+        capture_output=True,
+        env=env,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    result: dict[str, Any] = json.loads(completed.stdout)
+    assert result["success"] is True
+    assert result["instance_id"] == "bm-demo-1"
+    assert result["console_log_queryable"] is True
+    assert result["retention_days_required"] == required_days
+    assert result["retention_days_configured"] == required_days
+    assert result["oldest_queryable_log_age_days"] == required_days
+    assert result["query_result_count"] == 1
+    assert result["retention_evidence"] == "demo serial console log archive"

--- a/isvctl/tests/test_merger.py
+++ b/isvctl/tests/test_merger.py
@@ -413,6 +413,13 @@ class TestImportEndToEnd:
         assert "k8s_workloads" in validations
         assert result["tests"]["platform"] == "kubernetes"
 
+    def test_aws_bare_metal_overrides_serial_console_retention_check(self) -> None:
+        """AWS BM must not inherit the retention check until archive evidence exists."""
+        result = merge_yaml_files([self.CONFIGS_DIR / "providers" / "aws" / "config" / "bare_metal.yaml"])
+
+        checks = result["tests"]["validations"]["serial_console"]["checks"]
+        assert checks == [{"SerialConsoleCheck": {}}]
+
     def test_microk8s_inherits_k8s_validations(self) -> None:
         """providers/microk8s.yaml imports suites/k8s.yaml and adds overrides."""
         result = merge_yaml_files([self.CONFIGS_DIR / "providers" / "microk8s.yaml"])

--- a/isvtest/src/isvtest/validations/instance.py
+++ b/isvtest/src/isvtest/validations/instance.py
@@ -18,6 +18,8 @@ from typing import ClassVar
 from isvtest.core.validation import BaseValidation
 from isvtest.validations.generic import check_operations_passed
 
+SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED = 30
+
 
 class InstanceStateCheck(BaseValidation):
     """Validate instance state.
@@ -454,6 +456,80 @@ class SerialConsoleCheck(BaseValidation):
             )
 
         self.set_passed(f"Serial console available for {instance_id} ({', '.join(details)})")
+
+
+class SerialConsoleRetentionCheck(BaseValidation):
+    """Validate serial console logs are queryable for the required retention window.
+
+    Config:
+        step_output: The serial_console step output
+        retention_days_required: Minimum retention window in days
+            (default: SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED)
+
+    Step output:
+        instance_id: Instance identifier
+        console_log_queryable: Whether historical serial console logs were queryable
+        retention_days_configured: Provider-configured retention window in days
+        oldest_queryable_log_age_days: Oldest retained/queryable log age in days
+        query_result_count: Number of records returned by the retention query
+        retention_evidence: Human-readable evidence source
+    """
+
+    description: ClassVar[str] = "Check serial console log retention and queryability"
+    markers: ClassVar[list[str]] = ["bare_metal"]
+
+    def run(self) -> None:
+        """Validate serial-console retention evidence from step output."""
+        step_output = self.config.get("step_output", {})
+
+        def fail(message: str) -> None:
+            """Fail this validation with a consistent error message."""
+            self.set_failed(message)
+
+        instance_id = step_output.get("instance_id")
+        if not instance_id:
+            fail("No 'instance_id' in step output")
+            return
+
+        required_days = self.config.get("retention_days_required", SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED)
+
+        if step_output.get("console_log_queryable") is not True:
+            fail(
+                f"Serial console logs are not queryable for {instance_id} "
+                f"(console_log_queryable={step_output.get('console_log_queryable')!r})"
+            )
+            return
+
+        configured_days = step_output.get("retention_days_configured", 0)
+        if configured_days < required_days:
+            fail(
+                f"Serial console log retention for {instance_id} is {configured_days} day(s), "
+                f"below required {required_days}"
+            )
+            return
+
+        oldest_days = step_output.get("oldest_queryable_log_age_days", 0)
+        if oldest_days < required_days:
+            fail(
+                f"Oldest queryable serial console log for {instance_id} is {oldest_days} day(s), "
+                f"below required {required_days}"
+            )
+            return
+
+        if step_output.get("query_result_count", 0) <= 0:
+            fail(f"Serial console log query for {instance_id} returned no records")
+            return
+
+        evidence = step_output.get("retention_evidence")
+        if not evidence:
+            fail(f"No 'retention_evidence' for instance {instance_id}")
+            return
+
+        self.set_passed(
+            f"Serial console logs queryable for {instance_id} "
+            f"(required={required_days}d, configured={configured_days}d, "
+            f"oldest={oldest_days}d, evidence={evidence})"
+        )
 
 
 class TopologyPlacementCheck(BaseValidation):

--- a/isvtest/tests/test_instance.py
+++ b/isvtest/tests/test_instance.py
@@ -14,7 +14,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from isvtest.validations.instance import InstanceRebootCheck
+from isvtest.validations.instance import (
+    SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED,
+    InstanceRebootCheck,
+    SerialConsoleRetentionCheck,
+)
 
 
 def _reboot_output(**overrides: Any) -> dict[str, Any]:
@@ -26,6 +30,21 @@ def _reboot_output(**overrides: Any) -> dict[str, Any]:
         "ssh_ready": True,
         "uptime_seconds": 45.2,
         "reboot_confirmed": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def _retention_output(**overrides: Any) -> dict[str, Any]:
+    """Build a minimal passing serial-console retention step_output."""
+    base: dict[str, Any] = {
+        "instance_id": "bm-abc123",
+        "console_log_queryable": True,
+        "retention_days_required": SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED,
+        "retention_days_configured": SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED,
+        "oldest_queryable_log_age_days": SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED,
+        "query_result_count": 1,
+        "retention_evidence": "test-log-archive:bm-abc123",
     }
     base.update(overrides)
     return base
@@ -90,3 +109,78 @@ class TestInstanceRebootCheck:
         result = v.execute()
         assert result["passed"] is False
         assert "reboot may not have occurred" in result["error"]
+
+
+class TestSerialConsoleRetentionCheck:
+    """Tests for one-month serial console retention evidence validation."""
+
+    def test_passes_with_complete_retention_evidence(self) -> None:
+        """Happy path: queryable logs satisfy the required retention window."""
+        v = SerialConsoleRetentionCheck(
+            config={
+                "step_output": _retention_output(),
+                "retention_days_required": SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED,
+            }
+        )
+        result = v.execute()
+        assert result["passed"] is True
+        assert "bm-abc123" in result["output"]
+        assert f"configured={SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED}d" in result["output"]
+        assert "test-log-archive:bm-abc123" in result["output"]
+
+    def test_fails_when_instance_id_is_missing(self) -> None:
+        """The provider output must identify the node being checked."""
+        out = _retention_output()
+        del out["instance_id"]
+        v = SerialConsoleRetentionCheck(config={"step_output": out})
+        result = v.execute()
+        assert result["passed"] is False
+        assert "No 'instance_id'" in result["error"]
+
+    def test_fails_when_console_logs_are_not_queryable(self) -> None:
+        """A provider must prove historical logs can be queried."""
+        v = SerialConsoleRetentionCheck(config={"step_output": _retention_output(console_log_queryable=False)})
+        result = v.execute()
+        assert result["passed"] is False
+        assert "not queryable" in result["error"]
+
+    def test_fails_when_configured_retention_is_below_required(self) -> None:
+        """Configured retention must meet the required minimum."""
+        v = SerialConsoleRetentionCheck(
+            config={
+                "step_output": _retention_output(retention_days_configured=14),
+                "retention_days_required": SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED,
+            }
+        )
+        result = v.execute()
+        assert result["passed"] is False
+        assert f"below required {SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED}" in result["error"]
+
+    def test_fails_when_oldest_queryable_age_is_below_required(self) -> None:
+        """The returned evidence must cover the full retention window."""
+        v = SerialConsoleRetentionCheck(
+            config={
+                "step_output": _retention_output(oldest_queryable_log_age_days=7),
+                "retention_days_required": SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED,
+            }
+        )
+        result = v.execute()
+        assert result["passed"] is False
+        assert "Oldest queryable serial console log" in result["error"]
+        assert f"below required {SERIAL_CONSOLE_RETENTION_DAYS_REQUIRED}" in result["error"]
+
+    def test_fails_when_query_returns_no_records(self) -> None:
+        """A configured retention policy alone is insufficient without query results."""
+        v = SerialConsoleRetentionCheck(config={"step_output": _retention_output(query_result_count=0)})
+        result = v.execute()
+        assert result["passed"] is False
+        assert "returned no records" in result["error"]
+
+    def test_fails_when_retention_evidence_is_missing(self) -> None:
+        """Passing retention fields still require an evidence source."""
+        out = _retention_output()
+        del out["retention_evidence"]
+        v = SerialConsoleRetentionCheck(config={"step_output": out})
+        result = v.execute()
+        assert result["passed"] is False
+        assert "No 'retention_evidence'" in result["error"]


### PR DESCRIPTION
## Summary

Adds CNP06-02 coverage to the bare-metal suite for verifying that serial console output is logged and queryable for at least one month of history.

## Changes

- Adds `SerialConsoleRetentionCheck` for validating serial console log retention fields, including retention enablement, required retention days, oldest queryable log age, and evidence text.
- Wires the new retention validation into the canonical bare-metal `serial_console` step.
- Adds AWS reference handling and documentation: AWS exposes point-in-time EC2 serial console output rather than a one-month queryable history, so the AWS provider intentionally disables this assertion with provider-specific evidence.
- Extends the my-isv scaffold/demo serial console output and README with the new retention contract.
- Adds focused validation, AWS provider script, and suite merge tests for the serial console retention path.

## Validation

- [x] `uv run pytest isvtest/tests/test_instance.py isvctl/tests/test_aws_serial_console_scripts.py isvctl/tests/test_merger.py` — 64 passed
- [x] `uvx ruff check isvtest/src/isvtest/validations/instance.py isvtest/tests/test_instance.py isvctl/tests/test_aws_serial_console_scripts.py isvctl/tests/test_merger.py isvctl/configs/providers/aws/scripts/common/serial_console.py isvctl/configs/providers/my-isv/scripts/bare_metal/serial_console.py` — all checks passed
- [x] `make demo-test` — my-isv demo suite passes, including bare-metal `SerialConsoleRetentionCheck`

Closes #258


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added serial-console retention validation (30-day requirement) and expanded step output with queryability, retention metrics, evidence and limitation text.

* **Configuration**
  * AWS bare-metal now overrides the canonical serial-console suite to run only the console availability check until an external archive integration is provided.

* **Documentation**
  * Clarified retention evidence requirements, limitations, and the expected output schema.

* **Tests**
  * Added unit and integration tests covering retention outputs, demo mode, and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->