### PR TITLE
feat: add BMC bastion access validation (SEC12-03 - M5 P0)

### DIFF
--- a/isvctl/configs/providers/aws/config/security.yaml
+++ b/isvctl/configs/providers/aws/config/security.yaml
@@ -22,10 +22,19 @@
 #   1. BMC Management Network - Verify BMC management is dedicated/restricted
 #   2. BMC Tenant Isolation   - Verify BMC/IPMI/Redfish unreachable from VPC
 #   3. BMC Protocol Security  - Verify CNP10-01 BMC protocol posture
-#   4. API Endpoint Isolation - Verify management APIs are not publicly exposed
-#   5. MFA Enforcement        - Verify admin interfaces (UI, CLI, API) require MFA
-#   6. SA Credential Auth     - Verify IAM user + long-lived access key auth
-#   7. OIDC User Auth         - Probe configured OIDC-protected platform endpoint (SEC01-01)
+#   4. BMC Bastion Access     - Verify BMC reachable only via hardened bastion
+#   5. API Endpoint Isolation - Verify management APIs are not publicly exposed
+#   6. MFA Enforcement        - Verify admin interfaces (UI, CLI, API) require MFA
+#   7. SA Credential Auth     - Verify IAM user + long-lived access key auth
+#   8. OIDC User Auth         - Probe configured OIDC-protected platform endpoint (SEC01-01)
+#
+# Note: SEC12-* (BMC) tests cannot be fully validated on AWS because the
+# Nitro/hypervisor BMC plane is provider-hidden. The references inspect the
+# customer-visible boundary (tenant CIDRs, route tables, NACLs, SG rules) and
+# pass with a "provider_hidden" marker when no customer-tagged BMC resources
+# are present. Self-managed NCPs running their own BMC fabric should tag
+# resources with bmc/ipmi/redfish/oob/out-of-band to enable strict
+# enforcement.
 
 import:
   - ../../../suites/security.yaml
@@ -64,28 +73,35 @@ commands:
         args: ["--region", "{{region}}"]
         timeout: 60
 
-      # Test 4: API Endpoint Isolation (~15s)
+      # Test 4: BMC Bastion Access (~10s)
+      - name: bmc_bastion_access
+        phase: test
+        command: "python3 ../scripts/security/bmc_bastion_access_test.py"
+        args: ["--region", "{{region}}"]
+        timeout: 60
+
+      # Test 5: API Endpoint Isolation (~15s)
       - name: api_endpoint_isolation
         phase: test
         command: "python3 ../scripts/security/api_endpoint_test.py"
         args: ["--region", "{{region}}"]
         timeout: 60
 
-      # Test 5: MFA Enforcement (~10s)
+      # Test 6: MFA Enforcement (~10s)
       - name: mfa_enforcement
         phase: test
         command: "python3 ../scripts/security/mfa_enforcement_test.py"
         args: ["--region", "{{region}}"]
         timeout: 60
 
-      # Test 6: Service Account Credential Auth (~30s, includes IAM propagation wait)
+      # Test 7: Service Account Credential Auth (~30s, includes IAM propagation wait)
       - name: sa_credential_test
         phase: test
         command: "python3 ../scripts/security/sa_credential_test.py"
         args: ["--region", "{{region}}"]
         timeout: 120
 
-      # Test 7: OIDC User Authentication
+      # Test 8: OIDC User Authentication
       # Requires a real issuer, audience, protected target endpoint, and token
       # fixtures. Non-sensitive endpoint settings can come from tests.settings
       # below; token fixtures are read by the script from OIDC_*_TOKEN env vars

--- a/isvctl/configs/providers/aws/scripts/security/bmc_bastion_access_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/bmc_bastion_access_test.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Verify BMC is reachable only via a hardened bastion (AWS reference).
+
+In AWS, the Nitro/hypervisor BMC plane is provider-owned and is not exposed
+to customer VPCs, so this test cannot fully validate SEC12-03 on AWS. The
+reference exercises the customer-visible side of the contract:
+
+  1. ``bastion_identifiable`` - at least one resource is tagged as a
+     bastion/jumphost when a customer-visible BMC management network exists.
+  2. ``management_ingress_via_bastion_only`` - security groups protecting
+     resources tagged as BMC management only accept ingress from the bastion
+     SG (no ``0.0.0.0/0`` on management ports).
+  3. ``no_direct_public_route`` - subnets tagged as BMC management have no
+     route to an internet gateway and do not auto-assign public IPs.
+  4. ``bastion_hardened`` - the bastion's own SG does not allow ``0.0.0.0/0``
+     on SSH (port 22).
+
+When no BMC management network is found in the account (the typical AWS
+case, since BMC is provider-hidden), each subtest passes with a
+``provider_hidden`` marker so the validation is non-spurious. Self-managed
+NCPs running their own BMC fabric should tag their resources with
+``bmc/ipmi/redfish/oob/out-of-band`` to enable strict enforcement.
+
+Usage:
+    python bmc_bastion_access_test.py --region us-west-2
+
+Output JSON:
+  {
+    "success": true,
+    "platform": "security",
+    "test_name": "bmc_bastion_access",
+    "management_networks_checked": 0,
+    "tests": {
+      "bastion_identifiable":              {"passed": true},
+      "management_ingress_via_bastion_only": {"passed": true},
+      "no_direct_public_route":            {"passed": true},
+      "bastion_hardened":                  {"passed": true}
+    }
+  }
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Any
+
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+
+import boto3
+from common.errors import handle_aws_errors
+
+# Word-boundary matchers reuse the alphanumeric lookarounds from
+# bmc_management_network_test.py so underscore- and hyphen-delimited tag
+# values are matched while substrings like "submarine-bmcollege" are not.
+_MANAGEMENT_TAG_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9])(?:bmc|ipmi|redfish|oob|out[-_]?of[-_]?band)(?![A-Za-z0-9])",
+    re.IGNORECASE,
+)
+_BASTION_TAG_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9])(?:bastion|jump[-_]?host|jumpbox)(?![A-Za-z0-9])",
+    re.IGNORECASE,
+)
+
+# Common management ingress ports to scrutinize for world-open rules.
+_MANAGEMENT_PORTS = (22, 443, 623)
+_PUBLIC_CIDRS = ("0.0.0.0/0", "::/0")
+
+
+def _collect_paginated(ec2: Any, operation_name: str, result_key: str, **kwargs: Any) -> list[dict[str, Any]]:
+    """Collect all items for a paginated EC2 describe operation."""
+    paginator = ec2.get_paginator(operation_name)
+    items: list[dict[str, Any]] = []
+    for page in paginator.paginate(**kwargs):
+        items.extend(page.get(result_key, []))
+    return items
+
+
+def _tag_text(resource: dict[str, Any]) -> str:
+    """Return a single string of all key=value tags for regex matching."""
+    return " ".join(f"{tag.get('Key', '')}={tag.get('Value', '')}" for tag in resource.get("Tags", []))
+
+
+def _is_management_resource(resource: dict[str, Any]) -> bool:
+    """Return True when a resource tag identifies it as a BMC management resource."""
+    return bool(_MANAGEMENT_TAG_PATTERN.search(_tag_text(resource)))
+
+
+def _is_bastion_resource(resource: dict[str, Any]) -> bool:
+    """Return True when a resource tag identifies it as a bastion/jumphost."""
+    return bool(_BASTION_TAG_PATTERN.search(_tag_text(resource)))
+
+
+def _rule_covers_port(rule: dict[str, Any], port: int) -> bool:
+    """Return True when a SG rule's port range covers the given TCP/UDP port."""
+    from_port = rule.get("FromPort")
+    to_port = rule.get("ToPort")
+    if from_port is None or to_port is None:
+        # AWS represents "all ports" as missing FromPort/ToPort.
+        return rule.get("IpProtocol") in ("-1", -1)
+    return from_port <= port <= to_port
+
+
+def _rule_has_public_source(rule: dict[str, Any]) -> bool:
+    """Return True when a SG rule allows ingress from a public CIDR."""
+    for ip_range in rule.get("IpRanges", []):
+        if ip_range.get("CidrIp") in _PUBLIC_CIDRS:
+            return True
+    for ipv6_range in rule.get("Ipv6Ranges", []):
+        if ipv6_range.get("CidrIpv6") in _PUBLIC_CIDRS:
+            return True
+    return False
+
+
+def _provider_hidden(test_name: str) -> dict[str, Any]:
+    """Return a passing subtest result for hyperscalers that hide BMC from tenants."""
+    return {
+        "passed": True,
+        "provider_hidden": True,
+        "message": (
+            f"{test_name}: no customer-visible BMC management network in this account; "
+            "BMC plane is provider-owned. Self-managed NCPs should tag resources with "
+            "bmc/ipmi/redfish/oob/out-of-band to enable strict enforcement."
+        ),
+    }
+
+
+def _check_bastion_identifiable(bastion_sgs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Verify at least one SG is tagged as a bastion/jumphost."""
+    if not bastion_sgs:
+        return {
+            "passed": False,
+            "error": (
+                "No bastion/jumphost-tagged security group found; tag at least one "
+                "SG with bastion/jumphost to designate the management entry point"
+            ),
+        }
+    return {
+        "passed": True,
+        "bastion_security_groups": [sg.get("GroupId") for sg in bastion_sgs],
+        "message": f"{len(bastion_sgs)} bastion-tagged security group(s) identified",
+    }
+
+
+def _check_management_ingress_via_bastion_only(
+    management_sgs: list[dict[str, Any]],
+    bastion_sg_ids: set[str],
+) -> dict[str, Any]:
+    """Verify BMC-tagged SGs only accept ingress from the bastion SG."""
+    for sg in management_sgs:
+        for rule in sg.get("IpPermissions", []):
+            on_management_port = any(_rule_covers_port(rule, port) for port in _MANAGEMENT_PORTS)
+            if not on_management_port:
+                continue
+            if _rule_has_public_source(rule):
+                return {
+                    "passed": False,
+                    "security_group_id": sg.get("GroupId"),
+                    "error": (
+                        f"BMC management SG {sg.get('GroupId')} allows ingress from a public CIDR "
+                        f"on a management port (rule={rule.get('IpProtocol')} "
+                        f"{rule.get('FromPort')}-{rule.get('ToPort')})"
+                    ),
+                }
+            referenced_sg_ids = {pair.get("GroupId") for pair in rule.get("UserIdGroupPairs", [])}
+            non_bastion_refs = referenced_sg_ids - bastion_sg_ids - {None}
+            has_explicit_cidr = bool(rule.get("IpRanges") or rule.get("Ipv6Ranges"))
+            if not referenced_sg_ids and not has_explicit_cidr:
+                continue
+            if non_bastion_refs or has_explicit_cidr:
+                return {
+                    "passed": False,
+                    "security_group_id": sg.get("GroupId"),
+                    "error": (
+                        f"BMC management SG {sg.get('GroupId')} accepts ingress from sources "
+                        f"other than the designated bastion SG(s) "
+                        f"(non_bastion_sg_refs={sorted(s for s in non_bastion_refs if s)}, "
+                        f"explicit_cidr={has_explicit_cidr})"
+                    ),
+                }
+    return {
+        "passed": True,
+        "management_security_groups_checked": len(management_sgs),
+        "message": (f"Ingress to {len(management_sgs)} BMC management SG(s) is restricted to bastion SG(s)"),
+    }
+
+
+def _route_targets_internet_gateway(route: dict[str, Any]) -> bool:
+    """Return True when a route forwards to an internet gateway."""
+    gateway_id = route.get("GatewayId") or ""
+    return gateway_id.startswith("igw-")
+
+
+def _check_no_direct_public_route(
+    ec2: Any,
+    management_subnets: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Verify BMC management subnets have no public route or auto-assign public IP."""
+    if not management_subnets:
+        return {
+            "passed": True,
+            "subnets_checked": 0,
+            "message": "No BMC management subnets in scope",
+        }
+
+    for subnet in management_subnets:
+        if subnet.get("MapPublicIpOnLaunch"):
+            return {
+                "passed": False,
+                "subnet_id": subnet.get("SubnetId"),
+                "error": (f"BMC management subnet {subnet.get('SubnetId')} has MapPublicIpOnLaunch enabled"),
+            }
+
+    subnet_ids = [s["SubnetId"] for s in management_subnets if s.get("SubnetId")]
+    route_tables = _collect_paginated(
+        ec2,
+        "describe_route_tables",
+        "RouteTables",
+        Filters=[{"Name": "association.subnet-id", "Values": subnet_ids}],
+    )
+    for route_table in route_tables:
+        for route in route_table.get("Routes", []):
+            destination = route.get("DestinationCidrBlock") or route.get("DestinationIpv6CidrBlock") or ""
+            if destination in _PUBLIC_CIDRS and _route_targets_internet_gateway(route):
+                return {
+                    "passed": False,
+                    "route_table_id": route_table.get("RouteTableId"),
+                    "error": (
+                        f"BMC management route table {route_table.get('RouteTableId')} "
+                        f"forwards {destination} to an internet gateway"
+                    ),
+                }
+
+    return {
+        "passed": True,
+        "subnets_checked": len(management_subnets),
+        "route_tables_checked": len(route_tables),
+        "message": (
+            f"No internet-gateway routes from {len(management_subnets)} BMC management "
+            f"subnet(s) across {len(route_tables)} route table(s)"
+        ),
+    }
+
+
+def _check_bastion_hardened(bastion_sgs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Verify bastion SGs do not allow 0.0.0.0/0 on SSH."""
+    if not bastion_sgs:
+        return {
+            "passed": False,
+            "error": "No bastion-tagged security group found; cannot evaluate hardening",
+        }
+
+    for sg in bastion_sgs:
+        for rule in sg.get("IpPermissions", []):
+            if not _rule_covers_port(rule, 22):
+                continue
+            if _rule_has_public_source(rule):
+                return {
+                    "passed": False,
+                    "security_group_id": sg.get("GroupId"),
+                    "error": (f"Bastion SG {sg.get('GroupId')} allows SSH from a public CIDR (0.0.0.0/0 or ::/0)"),
+                }
+
+    return {
+        "passed": True,
+        "bastion_security_groups_checked": len(bastion_sgs),
+        "message": (f"{len(bastion_sgs)} bastion SG(s) restrict SSH ingress to non-public CIDRs"),
+    }
+
+
+@handle_aws_errors
+def main() -> int:
+    """Run BMC bastion-access checks and emit JSON result."""
+    parser = argparse.ArgumentParser(description="BMC bastion access test")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--vpc-id", help="Restrict scan to a single VPC (optional)")
+    args = parser.parse_args()
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+
+    sg_filters: list[dict[str, Any]] = []
+    subnet_filters: list[dict[str, Any]] = []
+    if args.vpc_id:
+        sg_filters.append({"Name": "vpc-id", "Values": [args.vpc_id]})
+        subnet_filters.append({"Name": "vpc-id", "Values": [args.vpc_id]})
+
+    security_groups = _collect_paginated(ec2, "describe_security_groups", "SecurityGroups", Filters=sg_filters)
+    subnets = _collect_paginated(ec2, "describe_subnets", "Subnets", Filters=subnet_filters)
+
+    management_sgs = [sg for sg in security_groups if _is_management_resource(sg)]
+    bastion_sgs = [sg for sg in security_groups if _is_bastion_resource(sg)]
+    management_subnets = [s for s in subnets if _is_management_resource(s)]
+    bastion_sg_ids = {sg["GroupId"] for sg in bastion_sgs if sg.get("GroupId")}
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "security",
+        "test_name": "bmc_bastion_access",
+        "management_networks_checked": len(management_sgs) + len(management_subnets),
+        "bastion_security_groups": sorted(bastion_sg_ids),
+        "tests": {},
+    }
+
+    no_management_resources = not management_sgs and not management_subnets
+    if no_management_resources:
+        # Hyperscaler reality: BMC is provider-hidden. Pass each subtest with a
+        # marker so the validation contract is satisfied without false-positive
+        # signal. The contract still fails for self-managed NCPs that tag their
+        # BMC fabric.
+        for subtest in (
+            "bastion_identifiable",
+            "management_ingress_via_bastion_only",
+            "no_direct_public_route",
+            "bastion_hardened",
+        ):
+            result["tests"][subtest] = _provider_hidden(subtest)
+    else:
+        result["tests"]["bastion_identifiable"] = _check_bastion_identifiable(bastion_sgs)
+        result["tests"]["management_ingress_via_bastion_only"] = _check_management_ingress_via_bastion_only(
+            management_sgs, bastion_sg_ids
+        )
+        result["tests"]["no_direct_public_route"] = _check_no_direct_public_route(ec2, management_subnets)
+        result["tests"]["bastion_hardened"] = _check_bastion_hardened(bastion_sgs)
+
+    result["success"] = all(test.get("passed") for test in result["tests"].values())
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/aws/scripts/security/bmc_bastion_access_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/bmc_bastion_access_test.py
@@ -176,9 +176,10 @@ def _check_management_ingress_via_bastion_only(
             referenced_sg_ids = {pair.get("GroupId") for pair in rule.get("UserIdGroupPairs", [])}
             non_bastion_refs = referenced_sg_ids - bastion_sg_ids - {None}
             has_explicit_cidr = bool(rule.get("IpRanges") or rule.get("Ipv6Ranges"))
-            if not referenced_sg_ids and not has_explicit_cidr:
+            has_prefix_list = bool(rule.get("PrefixListIds"))
+            if not referenced_sg_ids and not has_explicit_cidr and not has_prefix_list:
                 continue
-            if non_bastion_refs or has_explicit_cidr:
+            if non_bastion_refs or has_explicit_cidr or has_prefix_list:
                 return {
                     "passed": False,
                     "security_group_id": sg.get("GroupId"),
@@ -186,7 +187,7 @@ def _check_management_ingress_via_bastion_only(
                         f"BMC management SG {sg.get('GroupId')} accepts ingress from sources "
                         f"other than the designated bastion SG(s) "
                         f"(non_bastion_sg_refs={sorted(s for s in non_bastion_refs if s)}, "
-                        f"explicit_cidr={has_explicit_cidr})"
+                        f"explicit_cidr={has_explicit_cidr}, prefix_list={has_prefix_list})"
                     ),
                 }
     return {
@@ -229,6 +230,32 @@ def _check_no_direct_public_route(
         "RouteTables",
         Filters=[{"Name": "association.subnet-id", "Values": subnet_ids}],
     )
+    explicit_subnet_ids = {
+        association.get("SubnetId")
+        for route_table in route_tables
+        for association in route_table.get("Associations", [])
+        if association.get("SubnetId")
+    }
+    main_route_table_vpc_ids = sorted(
+        {
+            subnet.get("VpcId")
+            for subnet in management_subnets
+            if subnet.get("VpcId") and subnet.get("SubnetId") not in explicit_subnet_ids
+        }
+    )
+    for vpc_id in main_route_table_vpc_ids:
+        route_tables.extend(
+            _collect_paginated(
+                ec2,
+                "describe_route_tables",
+                "RouteTables",
+                Filters=[
+                    {"Name": "vpc-id", "Values": [vpc_id]},
+                    {"Name": "association.main", "Values": ["true"]},
+                ],
+            )
+        )
+
     for route_table in route_tables:
         for route in route_table.get("Routes", []):
             destination = route.get("DestinationCidrBlock") or route.get("DestinationIpv6CidrBlock") or ""

--- a/isvctl/configs/providers/my-isv/config/security.yaml
+++ b/isvctl/configs/providers/my-isv/config/security.yaml
@@ -18,6 +18,7 @@
 # Coverage:
 #   SEC12-01: BMC management network (BmcManagementNetworkCheck)
 #   SEC12-02: BMC tenant isolation (BmcTenantIsolationCheck)
+#   SEC12-03: BMC bastion access (BmcBastionAccessCheck)
 #   CNP10-01: BMC protocol security (BmcProtocolSecurityCheck)
 #   SEC14-01: API endpoint isolation (ApiEndpointIsolationCheck)
 #   SEC07-01: MFA enforcement (MfaEnforcedCheck)
@@ -57,6 +58,12 @@ commands:
       - name: bmc_protocol_security
         phase: test
         command: "python ../scripts/security/bmc_protocol_security_test.py"
+        args: ["--region", "{{region}}"]
+        timeout: 60
+
+      - name: bmc_bastion_access
+        phase: test
+        command: "python ../scripts/security/bmc_bastion_access_test.py"
         args: ["--region", "{{region}}"]
         timeout: 60
 

--- a/isvctl/configs/providers/my-isv/scripts/security/bmc_bastion_access_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/security/bmc_bastion_access_test.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""BMC bastion-access test - TEMPLATE (replace with your implementation).
+
+Verifies that BMC/IPMI/Redfish management is reachable only through a
+hardened bastion (jumphost), and that direct public/corporate-network
+access is blocked.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "security",
+    "test_name": "bmc_bastion_access",
+    "management_networks_checked": 1,
+    "tests": {
+      "bastion_identifiable": {"passed": true},
+      "management_ingress_via_bastion_only": {"passed": true},
+      "no_direct_public_route": {"passed": true},
+      "bastion_hardened": {"passed": true}
+    }
+  }
+
+Usage:
+    python bmc_bastion_access_test.py --region <region>
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+
+
+def main() -> int:
+    """Run the BMC bastion-access template and emit structured JSON."""
+    parser = argparse.ArgumentParser(description="BMC bastion-access test (template)")
+    parser.add_argument("--region", required=True, help="Cloud region")
+    _args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "security",
+        "test_name": "bmc_bastion_access",
+        "management_networks_checked": 0,
+        "tests": {
+            "bastion_identifiable": {"passed": False},
+            "management_ingress_via_bastion_only": {"passed": False},
+            "no_direct_public_route": {"passed": False},
+            "bastion_hardened": {"passed": False},
+        },
+    }
+
+    # ╔══════════════════════════════════════════════════════════════════╗
+    # ║  TODO: Replace this block with your platform's SEC12-03 BMC      ║
+    # ║  bastion-access validation.                                      ║
+    # ║                                                                  ║
+    # ║  Example (pseudocode):                                           ║
+    # ║    bastion = lookup_bastion_host(region)                         ║
+    # ║    assert bastion is not None                                    ║
+    # ║    assert bmc_ingress_only_from(bastion)                         ║
+    # ║    assert no_public_route_to_bmc_subnets()                       ║
+    # ║    assert bastion_ssh_not_open_to_world()                        ║
+    # ╚══════════════════════════════════════════════════════════════════╝
+
+    if DEMO_MODE:
+        result["management_networks_checked"] = 1
+        result["tests"] = {
+            "bastion_identifiable": {"passed": True},
+            "management_ingress_via_bastion_only": {"passed": True},
+            "no_direct_public_route": {"passed": True},
+            "bastion_hardened": {"passed": True},
+        }
+        result["success"] = True
+    else:
+        result["error"] = "Not implemented - replace with your platform's BMC bastion-access test"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/security.yaml
+++ b/isvctl/configs/suites/security.yaml
@@ -54,6 +54,11 @@ tests:
         BmcProtocolSecurityCheck:
           step: bmc_protocol_security
 
+    bmc_bastion_access:
+      checks:
+        BmcBastionAccessCheck:
+          step: bmc_bastion_access
+
     api_security:
       checks:
         ApiEndpointIsolationCheck:

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -536,6 +536,308 @@ def test_bmc_protocol_security_main_reports_sts_probe_failure(
     assert all(test["passed"] is False for test in payload["tests"].values())
 
 
+class FakeBastionEc2:
+    """Fake EC2 client for BMC bastion-access checks."""
+
+    def __init__(
+        self,
+        *,
+        security_groups: list[dict[str, Any]] | None = None,
+        subnets: list[dict[str, Any]] | None = None,
+        route_tables: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Initialize paginated EC2 responses."""
+        self.paginators = {
+            "describe_security_groups": FakeEc2Paginator(
+                [{"SecurityGroups": security_groups if security_groups is not None else []}]
+            ),
+            "describe_subnets": FakeEc2Paginator([{"Subnets": subnets if subnets is not None else []}]),
+            "describe_route_tables": FakeEc2Paginator([{"RouteTables": route_tables or []}]),
+        }
+
+    def get_paginator(self, operation_name: str) -> FakeEc2Paginator:
+        """Return a fake paginator for the requested EC2 operation."""
+        return self.paginators[operation_name]
+
+
+def test_bmc_bastion_access_provider_hidden_when_no_management_resources(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """SEC12-03 passes with provider_hidden markers when no BMC resources are tagged."""
+    module = _load_security_script("bmc_bastion_access_test.py")
+    ec2 = FakeBastionEc2()
+
+    def fake_client(service_name: str, **_: Any) -> FakeBastionEc2:
+        """Return the fake EC2 client."""
+        assert service_name == "ec2"
+        return ec2
+
+    monkeypatch.setattr(module.boto3, "client", fake_client)
+    monkeypatch.setattr(module.sys, "argv", ["bmc_bastion_access_test.py", "--region", "us-west-2"])
+
+    exit_code = module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["success"] is True
+    assert payload["test_name"] == "bmc_bastion_access"
+    for subtest in (
+        "bastion_identifiable",
+        "management_ingress_via_bastion_only",
+        "no_direct_public_route",
+        "bastion_hardened",
+    ):
+        assert payload["tests"][subtest]["passed"] is True
+        assert payload["tests"][subtest]["provider_hidden"] is True
+
+
+def test_bmc_bastion_access_fails_when_bmc_tagged_but_no_bastion(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When a BMC-tagged resource exists but no bastion is tagged, bastion_identifiable fails."""
+    module = _load_security_script("bmc_bastion_access_test.py")
+    ec2 = FakeBastionEc2(
+        security_groups=[
+            {
+                "GroupId": "sg-bmc",
+                "Tags": [{"Key": "Role", "Value": "bmc-network"}],
+                "IpPermissions": [],
+            },
+        ],
+    )
+
+    def fake_client(service_name: str, **_: Any) -> FakeBastionEc2:
+        """Return the fake EC2 client."""
+        assert service_name == "ec2"
+        return ec2
+
+    monkeypatch.setattr(module.boto3, "client", fake_client)
+    monkeypatch.setattr(module.sys, "argv", ["bmc_bastion_access_test.py", "--region", "us-west-2"])
+
+    exit_code = module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert payload["tests"]["bastion_identifiable"]["passed"] is False
+    assert payload["tests"]["bastion_hardened"]["passed"] is False
+
+
+def test_bmc_bastion_access_detects_world_open_management_ingress() -> None:
+    """SEC12-03 fails when a BMC-tagged SG accepts ingress from 0.0.0.0/0 on a management port."""
+    module = _load_security_script("bmc_bastion_access_test.py")
+    management_sgs = [
+        {
+            "GroupId": "sg-bmc",
+            "Tags": [{"Key": "Role", "Value": "bmc-network"}],
+            "IpPermissions": [
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 22,
+                    "ToPort": 22,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        }
+    ]
+    bastion_sgs = [
+        {
+            "GroupId": "sg-bastion",
+            "Tags": [{"Key": "Role", "Value": "bastion"}],
+            "IpPermissions": [],
+        }
+    ]
+    bastion_ids = {sg["GroupId"] for sg in bastion_sgs}
+
+    result = module._check_management_ingress_via_bastion_only(management_sgs, bastion_ids)
+
+    assert result["passed"] is False
+    assert "sg-bmc" in result["error"]
+    assert "public CIDR" in result["error"]
+
+
+def test_bmc_bastion_access_accepts_bastion_sg_referenced_ingress() -> None:
+    """Ingress from the bastion SG (UserIdGroupPairs) is acceptable."""
+    module = _load_security_script("bmc_bastion_access_test.py")
+    management_sgs = [
+        {
+            "GroupId": "sg-bmc",
+            "Tags": [{"Key": "Role", "Value": "bmc-network"}],
+            "IpPermissions": [
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 22,
+                    "ToPort": 22,
+                    "UserIdGroupPairs": [{"GroupId": "sg-bastion"}],
+                }
+            ],
+        }
+    ]
+    bastion_ids = {"sg-bastion"}
+
+    result = module._check_management_ingress_via_bastion_only(management_sgs, bastion_ids)
+
+    assert result["passed"] is True
+
+
+def test_bmc_bastion_access_rejects_explicit_cidr_ingress() -> None:
+    """Even a non-public CIDR on a management SG fails; ingress must come via bastion SG ref."""
+    module = _load_security_script("bmc_bastion_access_test.py")
+    management_sgs = [
+        {
+            "GroupId": "sg-bmc",
+            "Tags": [{"Key": "Role", "Value": "bmc-network"}],
+            "IpPermissions": [
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 22,
+                    "ToPort": 22,
+                    "IpRanges": [{"CidrIp": "10.99.0.0/24"}],
+                }
+            ],
+        }
+    ]
+
+    result = module._check_management_ingress_via_bastion_only(management_sgs, set())
+
+    assert result["passed"] is False
+    assert "explicit_cidr=True" in result["error"]
+
+
+def test_bmc_bastion_access_detects_igw_route_from_management_subnet() -> None:
+    """SEC12-03 fails when a BMC-tagged subnet has a 0.0.0.0/0 -> igw route."""
+    module = _load_security_script("bmc_bastion_access_test.py")
+    management_subnets = [
+        {
+            "SubnetId": "subnet-bmc",
+            "MapPublicIpOnLaunch": False,
+            "Tags": [{"Key": "Role", "Value": "bmc-management"}],
+        }
+    ]
+    ec2 = FakeBastionEc2(
+        route_tables=[
+            {
+                "RouteTableId": "rtb-bmc",
+                "Routes": [{"DestinationCidrBlock": "0.0.0.0/0", "GatewayId": "igw-12345"}],
+            }
+        ]
+    )
+
+    result = module._check_no_direct_public_route(ec2, management_subnets)
+
+    assert result["passed"] is False
+    assert "rtb-bmc" in result["error"]
+
+
+def test_bmc_bastion_access_detects_map_public_ip() -> None:
+    """SEC12-03 fails when a BMC-tagged subnet auto-assigns public IPs."""
+    module = _load_security_script("bmc_bastion_access_test.py")
+    management_subnets = [
+        {
+            "SubnetId": "subnet-bmc",
+            "MapPublicIpOnLaunch": True,
+            "Tags": [{"Key": "Role", "Value": "bmc-management"}],
+        }
+    ]
+    ec2 = FakeBastionEc2()
+
+    result = module._check_no_direct_public_route(ec2, management_subnets)
+
+    assert result["passed"] is False
+    assert "MapPublicIpOnLaunch" in result["error"]
+
+
+def test_bmc_bastion_access_detects_world_open_bastion_ssh() -> None:
+    """SEC12-03 fails when the bastion SG itself allows SSH from 0.0.0.0/0."""
+    module = _load_security_script("bmc_bastion_access_test.py")
+    bastion_sgs = [
+        {
+            "GroupId": "sg-bastion",
+            "Tags": [{"Key": "Role", "Value": "bastion"}],
+            "IpPermissions": [
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 22,
+                    "ToPort": 22,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        }
+    ]
+
+    result = module._check_bastion_hardened(bastion_sgs)
+
+    assert result["passed"] is False
+    assert "sg-bastion" in result["error"]
+
+
+def test_bmc_bastion_access_main_emits_sec12_03_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Successful AWS reference run emits the SEC12-03 validation contract."""
+    module = _load_security_script("bmc_bastion_access_test.py")
+    bastion_sg = {
+        "GroupId": "sg-bastion",
+        "Tags": [{"Key": "Role", "Value": "jumphost"}],
+        "IpPermissions": [
+            {
+                "IpProtocol": "tcp",
+                "FromPort": 22,
+                "ToPort": 22,
+                "IpRanges": [{"CidrIp": "10.0.0.0/16"}],
+            }
+        ],
+    }
+    bmc_sg = {
+        "GroupId": "sg-bmc",
+        "Tags": [{"Key": "Role", "Value": "bmc-network"}],
+        "IpPermissions": [
+            {
+                "IpProtocol": "tcp",
+                "FromPort": 22,
+                "ToPort": 22,
+                "UserIdGroupPairs": [{"GroupId": "sg-bastion"}],
+            }
+        ],
+    }
+    bmc_subnet = {
+        "SubnetId": "subnet-bmc",
+        "MapPublicIpOnLaunch": False,
+        "Tags": [{"Key": "Role", "Value": "bmc-management"}],
+    }
+    ec2 = FakeBastionEc2(
+        security_groups=[bastion_sg, bmc_sg],
+        subnets=[bmc_subnet],
+        route_tables=[{"RouteTableId": "rtb-bmc-private", "Routes": []}],
+    )
+
+    def fake_client(service_name: str, **_: Any) -> FakeBastionEc2:
+        """Return the fake EC2 client."""
+        assert service_name == "ec2"
+        return ec2
+
+    monkeypatch.setattr(module.boto3, "client", fake_client)
+    monkeypatch.setattr(module.sys, "argv", ["bmc_bastion_access_test.py", "--region", "us-west-2"])
+
+    exit_code = module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["success"] is True
+    assert payload["test_name"] == "bmc_bastion_access"
+    assert set(payload["tests"]) == {
+        "bastion_identifiable",
+        "management_ingress_via_bastion_only",
+        "no_direct_public_route",
+        "bastion_hardened",
+    }
+    for subtest in payload["tests"].values():
+        assert subtest["passed"] is True
+
+
 class FakeIamTags:
     """Small fake for IAM list_user_tags responses."""
 

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -560,6 +560,44 @@ class FakeBastionEc2:
         return self.paginators[operation_name]
 
 
+class FakeBastionRouteTablePaginator:
+    """Fake route-table paginator that varies responses by route-table association filter."""
+
+    def __init__(
+        self,
+        *,
+        explicit_route_tables: list[dict[str, Any]] | None = None,
+        main_route_tables: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Store route tables returned for explicit subnet and main associations."""
+        self.explicit_route_tables = explicit_route_tables or []
+        self.main_route_tables = main_route_tables or []
+        self.calls: list[dict[str, Any]] = []
+
+    def paginate(self, **kwargs: Any) -> list[dict[str, Any]]:
+        """Return route tables based on the requested association filter."""
+        self.calls.append(kwargs)
+        filter_names = {filter_config["Name"] for filter_config in kwargs.get("Filters", [])}
+        if "association.main" in filter_names:
+            return [{"RouteTables": self.main_route_tables}]
+        if "association.subnet-id" in filter_names:
+            return [{"RouteTables": self.explicit_route_tables}]
+        return [{"RouteTables": []}]
+
+
+class FakeMainRouteBastionEc2:
+    """Fake EC2 client for BMC bastion route-table association checks."""
+
+    def __init__(self, paginator: FakeBastionRouteTablePaginator) -> None:
+        """Store the route-table paginator."""
+        self.route_table_paginator = paginator
+
+    def get_paginator(self, operation_name: str) -> FakeBastionRouteTablePaginator:
+        """Return the fake route-table paginator."""
+        assert operation_name == "describe_route_tables"
+        return self.route_table_paginator
+
+
 def test_bmc_bastion_access_provider_hidden_when_no_management_resources(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -706,6 +744,30 @@ def test_bmc_bastion_access_rejects_explicit_cidr_ingress() -> None:
     assert "explicit_cidr=True" in result["error"]
 
 
+def test_bmc_bastion_access_rejects_prefix_list_ingress() -> None:
+    """Prefix-list ingress is not bastion SG ingress and must fail SEC12-03."""
+    module = _load_security_script("bmc_bastion_access_test.py")
+    management_sgs = [
+        {
+            "GroupId": "sg-bmc",
+            "Tags": [{"Key": "Role", "Value": "bmc-network"}],
+            "IpPermissions": [
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 22,
+                    "ToPort": 22,
+                    "PrefixListIds": [{"PrefixListId": "pl-corporate"}],
+                }
+            ],
+        }
+    ]
+
+    result = module._check_management_ingress_via_bastion_only(management_sgs, {"sg-bastion"})
+
+    assert result["passed"] is False
+    assert "prefix_list=True" in result["error"]
+
+
 def test_bmc_bastion_access_detects_igw_route_from_management_subnet() -> None:
     """SEC12-03 fails when a BMC-tagged subnet has a 0.0.0.0/0 -> igw route."""
     module = _load_security_script("bmc_bastion_access_test.py")
@@ -729,6 +791,43 @@ def test_bmc_bastion_access_detects_igw_route_from_management_subnet() -> None:
 
     assert result["passed"] is False
     assert "rtb-bmc" in result["error"]
+
+
+def test_bmc_bastion_access_detects_igw_route_from_main_route_table() -> None:
+    """SEC12-03 checks the VPC main route table when a BMC subnet has no explicit association."""
+    module = _load_security_script("bmc_bastion_access_test.py")
+    management_subnets = [
+        {
+            "SubnetId": "subnet-bmc",
+            "VpcId": "vpc-bmc",
+            "MapPublicIpOnLaunch": False,
+            "Tags": [{"Key": "Role", "Value": "bmc-management"}],
+        }
+    ]
+    paginator = FakeBastionRouteTablePaginator(
+        main_route_tables=[
+            {
+                "RouteTableId": "rtb-main-public",
+                "Associations": [{"Main": True, "RouteTableAssociationId": "rtbassoc-main"}],
+                "Routes": [{"DestinationCidrBlock": "0.0.0.0/0", "GatewayId": "igw-12345"}],
+            }
+        ]
+    )
+    ec2 = FakeMainRouteBastionEc2(paginator)
+
+    result = module._check_no_direct_public_route(ec2, management_subnets)
+
+    assert result["passed"] is False
+    assert "rtb-main-public" in result["error"]
+    assert paginator.calls == [
+        {"Filters": [{"Name": "association.subnet-id", "Values": ["subnet-bmc"]}]},
+        {
+            "Filters": [
+                {"Name": "vpc-id", "Values": ["vpc-bmc"]},
+                {"Name": "association.main", "Values": ["true"]},
+            ]
+        },
+    ]
 
 
 def test_bmc_bastion_access_detects_map_public_ip() -> None:

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -91,6 +91,7 @@ from isvtest.validations.nim import (
 )
 from isvtest.validations.security import (
     ApiEndpointIsolationCheck,
+    BmcBastionAccessCheck,
     BmcManagementNetworkCheck,
     BmcProtocolSecurityCheck,
     BmcTenantIsolationCheck,
@@ -105,6 +106,7 @@ __all__ = [
     "AccessKeyDisabledCheck",
     "AccessKeyRejectedCheck",
     "ApiEndpointIsolationCheck",
+    "BmcBastionAccessCheck",
     "BmcManagementNetworkCheck",
     "BmcProtocolSecurityCheck",
     "BmcTenantIsolationCheck",

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -121,6 +121,45 @@ class BmcProtocolSecurityCheck(BaseValidation):
         self.set_passed(f"BMC protocol security posture verified ({bmc_count} endpoints tested)")
 
 
+class BmcBastionAccessCheck(BaseValidation):
+    """Validate BMC is only accessible via a hardened bastion.
+
+    Verifies that out-of-band management interfaces (BMC/IPMI/Redfish) accept
+    ingress only through a designated bastion/jumphost, that the bastion
+    itself is hardened (no world-open SSH), and that BMC-tagged subnets have
+    no direct route to the public internet.
+
+    Hyperscalers that hide the BMC plane from customers (e.g. AWS) cannot
+    fully exercise this check; the AWS reference reports each subtest as
+    passed with a ``provider_hidden`` note when no customer-visible BMC
+    network is present. Self-managed NCPs running their own BMC fabric
+    should report concrete pass/fail per subtest.
+
+    Config:
+        step_output: The step output to check
+
+    Step output:
+        tests: dict with bastion_identifiable, management_ingress_via_bastion_only,
+               no_direct_public_route, bastion_hardened
+    """
+
+    description: ClassVar[str] = "Check BMC reachable only via hardened bastion"
+    markers: ClassVar[list[str]] = ["security", "network"]
+
+    def run(self) -> None:
+        """Validate required BMC bastion-access results from step output."""
+        required = [
+            "bastion_identifiable",
+            "management_ingress_via_bastion_only",
+            "no_direct_public_route",
+            "bastion_hardened",
+        ]
+        if not check_required_tests(self, required, "BMC bastion access tests failed"):
+            return
+        endpoints = self.config.get("step_output", {}).get("management_networks_checked", "N/A")
+        self.set_passed(f"BMC reachable only via hardened bastion ({endpoints} networks checked)")
+
+
 class MfaEnforcedCheck(BaseValidation):
     """Validate all administrative interfaces are protected by MFA.
 

--- a/isvtest/tests/test_catalog.py
+++ b/isvtest/tests/test_catalog.py
@@ -78,6 +78,7 @@ class TestBuildCatalog:
 
         assert by_name["SgCrudCheck"]["platforms"] == ["NETWORK"]
         assert by_name["BmcTenantIsolationCheck"]["platforms"] == ["SECURITY"]
+        assert by_name["BmcBastionAccessCheck"]["platforms"] == ["SECURITY"]
         assert by_name["ServiceAccountCredentialCheck"]["platforms"] == ["SECURITY"]
         assert by_name["ConsoleRbacCheck"]["platforms"] == ["VM"]
         assert by_name["OidcUserAuthCheck"]["platforms"] == ["SECURITY"]

--- a/isvtest/tests/test_security.py
+++ b/isvtest/tests/test_security.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from typing import Any
 
 from isvtest.validations.security import (
+    BmcBastionAccessCheck,
     BmcManagementNetworkCheck,
     BmcProtocolSecurityCheck,
     MfaEnforcedCheck,
@@ -176,6 +177,72 @@ def test_bmc_protocol_security_check_preserves_empty_tests_map() -> None:
 
     assert result["passed"] is False
     assert result["error"] == "No 'tests' in step output"
+
+
+def _bastion_access_config(tests: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    """Build a minimal BMC bastion-access validation config."""
+    return {
+        "step_output": {
+            "success": True,
+            "platform": "security",
+            "test_name": "bmc_bastion_access",
+            "management_networks_checked": 1,
+            "tests": tests,
+        }
+    }
+
+
+class TestBmcBastionAccessCheck:
+    """Tests for SEC12-03 BMC bastion-access validation."""
+
+    def test_all_required_tests_pass(self) -> None:
+        """Pass when all SEC12-03 contract checks passed."""
+        tests = {
+            "bastion_identifiable": {"passed": True},
+            "management_ingress_via_bastion_only": {"passed": True},
+            "no_direct_public_route": {"passed": True},
+            "bastion_hardened": {"passed": True},
+        }
+
+        result = BmcBastionAccessCheck(config=_bastion_access_config(tests)).execute()
+
+        assert result["passed"] is True
+        assert "BMC reachable only via hardened bastion" in result["output"]
+
+    def test_failed_bastion_hardened_reports_contract_key(self) -> None:
+        """Fail with the specific contract key when bastion hardening fails."""
+        tests = {
+            "bastion_identifiable": {"passed": True},
+            "management_ingress_via_bastion_only": {"passed": True},
+            "no_direct_public_route": {"passed": True},
+            "bastion_hardened": {"passed": False, "error": "SSH open to 0.0.0.0/0"},
+        }
+
+        result = BmcBastionAccessCheck(config=_bastion_access_config(tests)).execute()
+
+        assert result["passed"] is False
+        assert "bastion_hardened" in result["error"]
+        assert "0.0.0.0/0" in result["error"]
+
+    def test_missing_required_key_fails(self) -> None:
+        """Fail when one of the four required contract keys is absent."""
+        tests = {
+            "bastion_identifiable": {"passed": True},
+            "management_ingress_via_bastion_only": {"passed": True},
+            "no_direct_public_route": {"passed": True},
+        }
+
+        result = BmcBastionAccessCheck(config=_bastion_access_config(tests)).execute()
+
+        assert result["passed"] is False
+        assert "bastion_hardened" in result["error"]
+
+    def test_missing_tests_fails(self) -> None:
+        """Fail when the step output does not include contract tests."""
+        result = BmcBastionAccessCheck(config={"step_output": {}}).execute()
+
+        assert result["passed"] is False
+        assert "tests" in result["error"]
 
 
 class TestMfaEnforcedCheck:


### PR DESCRIPTION
## Summary

Adds `BmcBastionAccessCheck` (SEC12-03) verifying BMC is reachable only via a hardened bastion (jumphost) and that direct public/corporate-network access is blocked.

- `BmcBastionAccessCheck` with 4 subtests: `bastion_identifiable`, `management_ingress_via_bastion_only`, `no_direct_public_route`, `bastion_hardened`
- AWS boto3 reference: tag-driven discovery of BMC management resources and bastion SGs (word-boundary regex matching the SEC12-01 pattern); checks SG ingress, subnet routing (no IGW route, no `MapPublicIpOnLaunch`), and bastion SSH hardening
- AWS limitation: the Nitro/hypervisor BMC plane is provider-hidden, so when no customer-tagged BMC resources exist the four subtests pass with a `provider_hidden` marker. Self-managed NCPs running their own BMC fabric should tag resources with `bmc/ipmi/redfish/oob/out-of-band` to enable strict enforcement.
- my-isv scaffold stub with `DEMO_MODE`
- Suite + provider configs, unit tests, catalog assertion

Verified on AWS (`ncp-isv-lab`) and `make demo-test`.

Closes #308

## Test plan

- [x] `make lint` (ruff, ruff-format, yamlfmt, SPDX) — clean
- [x] `make test` — 579 passed, 124 deselected
- [x] `make demo-test` — green; new `bmc_bastion_access` step runs end-to-end via `BmcBastionAccessCheck`
- [x] Live AWS run: `AWS_PROFILE=ncp-isv-lab uv run isvctl test run -f isvctl/configs/providers/aws/config/security.yaml` — green; `bmc_bastion_access` enters provider-hidden path (`0 networks checked`) since the lab account has no BMC-tagged resources, which is the expected hyperscaler behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a BMC bastion-access security validation (SEC12-03) to verify management-plane access is restricted to hardened bastion hosts and wired into provider/security test steps.

* **Documentation**
  * Clarified AWS provider limitations for BMC checks, introduced a provider-hidden marker, and documented expected out-of-band tagging for strict enforcement.

* **Tests**
  * Added comprehensive unit and end-to-end tests covering bastion, subnet, route and security-group hardening scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->