### PR TITLE
feat: add customer-managed key security validation (SEC09-04 - M5 P0)

### DIFF
--- a/isvctl/configs/providers/aws/README.md
+++ b/isvctl/configs/providers/aws/README.md
@@ -13,7 +13,7 @@ Provider configs that wire the [provider-agnostic test suites](../../suites/READ
 | [`config/eks.yaml`](config/eks.yaml) | Kubernetes GPU cluster (nodes, GPU operator, workloads) | [AWS EKS Guide](scripts/eks/docs/aws-eks.md) |
 | [`config/control-plane.yaml`](config/control-plane.yaml) | API health, access keys, tenant lifecycle | [AWS Control Plane Guide](scripts/control-plane/docs/aws-control-plane.md) |
 | [`config/image-registry.yaml`](config/image-registry.yaml) | Image upload, CRUD, VM launch, install config | [AWS Image Registry Guide](scripts/image-registry/docs/aws-image-registry.md) |
-| [`config/security.yaml`](config/security.yaml) | BMC isolation, BMC protocol security, API endpoint isolation, SA credential auth | - |
+| [`config/security.yaml`](config/security.yaml) | BMC isolation, BMC protocol security, API endpoint isolation, BYOK, SA credential auth | - |
 
 ## Quick Start
 

--- a/isvctl/configs/providers/aws/config/security.yaml
+++ b/isvctl/configs/providers/aws/config/security.yaml
@@ -25,8 +25,9 @@
 #   4. BMC Bastion Access     - Verify BMC reachable only via hardened bastion
 #   5. API Endpoint Isolation - Verify management APIs are not publicly exposed
 #   6. MFA Enforcement        - Verify admin interfaces (UI, CLI, API) require MFA
-#   7. SA Credential Auth     - Verify IAM user + long-lived access key auth
-#   8. OIDC User Auth         - Probe configured OIDC-protected platform endpoint (SEC01-01)
+#   7. Customer Managed Key   - Verify customer-managed key encryption (SEC09-04)
+#   8. SA Credential Auth     - Verify IAM user + long-lived access key auth
+#   9. OIDC User Auth         - Probe configured OIDC-protected platform endpoint (SEC01-01)
 #
 # Note: SEC12-* (BMC) tests cannot be fully validated on AWS because the
 # Nitro/hypervisor BMC plane is provider-hidden. The references inspect the
@@ -94,14 +95,24 @@ commands:
         args: ["--region", "{{region}}"]
         timeout: 60
 
-      # Test 7: Service Account Credential Auth (~30s, includes IAM propagation wait)
+      # Test 7: Customer Managed Key / BYOK (~30s)
+      - name: customer_managed_key_test
+        phase: test
+        command: "python3 ../scripts/security/customer_managed_key_test.py"
+        args:
+          - "--region"
+          - "{{region}}"
+          - "--key-id={{customer_managed_key_id}}"
+        timeout: 120
+
+      # Test 8: Service Account Credential Auth (~30s, includes IAM propagation wait)
       - name: sa_credential_test
         phase: test
         command: "python3 ../scripts/security/sa_credential_test.py"
         args: ["--region", "{{region}}"]
         timeout: 120
 
-      # Test 8: OIDC User Authentication
+      # Test 9: OIDC User Authentication
       # Requires a real issuer, audience, protected target endpoint, and token
       # fixtures. Non-sensitive endpoint settings can come from tests.settings
       # below; token fixtures are read by the script from OIDC_*_TOKEN env vars
@@ -139,3 +150,4 @@ tests:
     oidc_issuer_url: "{{env.OIDC_ISSUER_URL | default('', true)}}"
     oidc_audience: "{{env.OIDC_AUDIENCE | default('', true)}}"
     oidc_target_url: "{{env.OIDC_TARGET_URL | default('', true)}}"
+    customer_managed_key_id: "{{env.AWS_KMS_KEY_ID | default('', true)}}"

--- a/isvctl/configs/providers/aws/scripts/security/customer_managed_key_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/customer_managed_key_test.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Verify customer-managed key / BYOK support (AWS reference).
+
+The check accepts an existing KMS key via ``--key-id`` or creates a tagged
+temporary customer-managed KMS key. It verifies KMS metadata, performs an
+encrypt/decrypt roundtrip, creates a small encrypted EBS volume with the key,
+then cleans up the temporary volume and any key it created.
+
+Usage:
+    python customer_managed_key_test.py --region us-west-2
+    python customer_managed_key_test.py --region us-west-2 --key-id <kms-key-id-or-arn>
+
+Output JSON:
+  {
+    "success": true,
+    "platform": "security",
+    "test_name": "customer_managed_key_test",
+    "key_id": "1234abcd-...",
+    "key_arn": "arn:aws:kms:...",
+    "encrypted_resource_id": "vol-...",
+    "encrypted_resource_kms_key_id": "arn:aws:kms:...",
+    "tests": { ... }
+  }
+"""
+
+import argparse
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import boto3
+from botocore.exceptions import ClientError, WaiterError
+from common.errors import handle_aws_errors
+
+REQUIRED_TESTS = [
+    "customer_managed_key_available",
+    "key_manager_is_customer",
+    "encrypt_decrypt_roundtrip",
+    "resource_encrypted_with_customer_key",
+    "provider_managed_key_not_used",
+]
+
+
+def _normalize_optional_key_id(key_id: str | None) -> str | None:
+    """Return a stripped key id, treating empty template values as absent."""
+    if key_id is None:
+        return None
+    stripped = key_id.strip()
+    return stripped or None
+
+
+def _failed_tests(error: str) -> dict[str, dict[str, Any]]:
+    """Build a failure result for every required BYOK probe."""
+    return {name: {"passed": False, "error": error} for name in REQUIRED_TESTS}
+
+
+def _base_result(region: str) -> dict[str, Any]:
+    """Build the common result payload."""
+    return {
+        "success": False,
+        "platform": "security",
+        "test_name": "customer_managed_key_test",
+        "region": region,
+        "key_id": "",
+        "key_arn": "",
+        "key_manager": "",
+        "encrypted_resource_id": "",
+        "encrypted_resource_kms_key_id": "",
+        "tests": _failed_tests("Validation not executed"),
+    }
+
+
+def _create_customer_managed_key(kms: Any, region: str) -> dict[str, Any]:
+    """Create a tagged temporary symmetric KMS key and return its metadata."""
+    name = f"isv-byok-test-{uuid.uuid4().hex[:8]}"
+    response = kms.create_key(
+        Description=f"Temporary ISV BYOK validation key in {region}",
+        KeyUsage="ENCRYPT_DECRYPT",
+        Origin="AWS_KMS",
+        Tags=[
+            {"TagKey": "CreatedBy", "TagValue": "isvtest"},
+            {"TagKey": "Name", "TagValue": name},
+        ],
+    )
+    return response["KeyMetadata"]
+
+
+def _check_customer_managed_key_available(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Verify the KMS key exists, is enabled, and supports encryption."""
+    key_state = metadata.get("KeyState")
+    if key_state != "Enabled":
+        return {"passed": False, "error": f"KMS key is not enabled (KeyState={key_state!r})"}
+
+    key_usage = metadata.get("KeyUsage")
+    if key_usage != "ENCRYPT_DECRYPT":
+        return {"passed": False, "error": f"KMS key does not support encrypt/decrypt (KeyUsage={key_usage!r})"}
+
+    return {"passed": True, "message": f"KMS key {metadata.get('KeyId')} is enabled for encrypt/decrypt"}
+
+
+def _check_key_manager_is_customer(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Verify KMS reports the key as customer-managed."""
+    key_manager = metadata.get("KeyManager")
+    if key_manager != "CUSTOMER":
+        return {"passed": False, "error": f"KMS key is not customer-managed (KeyManager={key_manager!r})"}
+    return {"passed": True, "message": "KMS KeyManager is CUSTOMER"}
+
+
+def _check_provider_managed_key_not_used(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Verify the selected key is not an AWS-managed provider default."""
+    key_manager = metadata.get("KeyManager")
+    if key_manager == "AWS":
+        return {"passed": False, "error": "AWS-managed KMS key selected instead of a customer-managed key"}
+    if key_manager != "CUSTOMER":
+        return {"passed": False, "error": f"Unexpected KMS KeyManager={key_manager!r}"}
+    return {"passed": True, "message": "Provider-managed default key was not used"}
+
+
+def _check_encrypt_decrypt_roundtrip(kms: Any, key_id: str) -> dict[str, Any]:
+    """Encrypt and decrypt a small payload with the selected KMS key."""
+    plaintext = b"isv-customer-managed-key-validation"
+    try:
+        encrypted = kms.encrypt(KeyId=key_id, Plaintext=plaintext)
+        decrypted = kms.decrypt(KeyId=key_id, CiphertextBlob=encrypted["CiphertextBlob"])
+    except ClientError as e:
+        return {"passed": False, "error": str(e)}
+
+    if decrypted.get("Plaintext") != plaintext:
+        return {"passed": False, "error": "KMS decrypt plaintext did not match original payload"}
+
+    return {"passed": True, "message": "KMS encrypt/decrypt roundtrip succeeded"}
+
+
+def _select_availability_zone(ec2: Any) -> str:
+    """Return the first available AZ in the region."""
+    response = ec2.describe_availability_zones(Filters=[{"Name": "state", "Values": ["available"]}])
+    for zone in response.get("AvailabilityZones", []):
+        opt_in_status = zone.get("OptInStatus", "opt-in-not-required")
+        if opt_in_status in {"opt-in-not-required", "opted-in"}:
+            return zone["ZoneName"]
+    msg = "No available availability zone found for encrypted volume test"
+    raise RuntimeError(msg)
+
+
+def _kms_key_matches(actual_key_id: str | None, metadata: dict[str, Any]) -> bool:
+    """Return True when an EC2 KmsKeyId refers to the selected KMS key."""
+    if not actual_key_id:
+        return False
+
+    expected_values = {value for value in (metadata.get("Arn"), metadata.get("KeyId")) if value}
+    if actual_key_id in expected_values:
+        return True
+
+    key_id = metadata.get("KeyId")
+    return bool(key_id and actual_key_id.endswith(f":key/{key_id}"))
+
+
+def _check_resource_encrypted_with_customer_key(
+    ec2: Any,
+    key_metadata: dict[str, Any],
+    availability_zone: str,
+) -> dict[str, Any]:
+    """Create a small encrypted EBS volume and verify its KMS key id."""
+    volume_id = ""
+    try:
+        response = ec2.create_volume(
+            AvailabilityZone=availability_zone,
+            Size=1,
+            VolumeType="gp3",
+            Encrypted=True,
+            KmsKeyId=key_metadata.get("Arn") or key_metadata["KeyId"],
+            TagSpecifications=[
+                {
+                    "ResourceType": "volume",
+                    "Tags": [
+                        {"Key": "CreatedBy", "Value": "isvtest"},
+                        {"Key": "Name", "Value": "isv-byok-test-volume"},
+                    ],
+                }
+            ],
+        )
+        volume_id = response["VolumeId"]
+
+        waiter = ec2.get_waiter("volume_available")
+        waiter.wait(VolumeIds=[volume_id], WaiterConfig={"Delay": 2, "MaxAttempts": 30})
+
+        volume = ec2.describe_volumes(VolumeIds=[volume_id])["Volumes"][0]
+        actual_key_id = volume.get("KmsKeyId") or response.get("KmsKeyId")
+        if volume.get("Encrypted") is not True:
+            return {"passed": False, "volume_id": volume_id, "error": f"EBS volume {volume_id} is not encrypted"}
+        if not _kms_key_matches(actual_key_id, key_metadata):
+            return {
+                "passed": False,
+                "volume_id": volume_id,
+                "kms_key_id": actual_key_id,
+                "error": f"EBS volume {volume_id} uses unexpected KMS key {actual_key_id!r}",
+            }
+
+        return {
+            "passed": True,
+            "volume_id": volume_id,
+            "kms_key_id": actual_key_id,
+            "message": f"EBS volume {volume_id} encrypted with customer-managed key",
+        }
+    except (ClientError, WaiterError) as e:
+        return {"passed": False, "volume_id": volume_id, "error": str(e)}
+    except Exception as e:
+        return {"passed": False, "volume_id": volume_id, "error": str(e)}
+
+
+def _delete_test_volume(ec2: Any, volume_id: str) -> list[str]:
+    """Delete a temporary EBS volume and return cleanup errors."""
+    try:
+        ec2.delete_volume(VolumeId=volume_id)
+    except ClientError as e:
+        return [f"delete volume {volume_id}: {e}"]
+    return []
+
+
+def _schedule_key_deletion(kms: Any, key_id: str) -> list[str]:
+    """Schedule a temporary KMS key for deletion and return cleanup errors."""
+    try:
+        kms.schedule_key_deletion(KeyId=key_id, PendingWindowInDays=7)
+    except ClientError as e:
+        return [f"schedule key deletion {key_id}: {e}"]
+    return []
+
+
+def _run_customer_managed_key_test(
+    kms: Any,
+    ec2: Any,
+    region: str,
+    key_id: str | None = None,
+) -> dict[str, Any]:
+    """Run the BYOK checks with injected AWS clients."""
+    result = _base_result(region)
+    owned_key = False
+    cleanup_key_id = ""
+    volume_id = ""
+
+    try:
+        if key_id:
+            key_metadata = kms.describe_key(KeyId=key_id)["KeyMetadata"]
+        else:
+            key_metadata = _create_customer_managed_key(kms, region)
+            owned_key = True
+
+        cleanup_key_id = key_metadata.get("KeyId", "")
+        result["key_id"] = cleanup_key_id
+        result["key_arn"] = key_metadata.get("Arn", "")
+        result["key_manager"] = key_metadata.get("KeyManager", "")
+
+        result["tests"] = {
+            "customer_managed_key_available": _check_customer_managed_key_available(key_metadata),
+            "key_manager_is_customer": _check_key_manager_is_customer(key_metadata),
+            "encrypt_decrypt_roundtrip": {
+                "passed": False,
+                "error": "Skipped because key is not an enabled customer-managed key",
+            },
+            "resource_encrypted_with_customer_key": {
+                "passed": False,
+                "error": "Skipped because key is not an enabled customer-managed key",
+            },
+            "provider_managed_key_not_used": _check_provider_managed_key_not_used(key_metadata),
+        }
+
+        can_use_key = (
+            result["tests"]["customer_managed_key_available"]["passed"]
+            and result["tests"]["key_manager_is_customer"]["passed"]
+            and result["tests"]["provider_managed_key_not_used"]["passed"]
+        )
+        if can_use_key:
+            result["tests"]["encrypt_decrypt_roundtrip"] = _check_encrypt_decrypt_roundtrip(kms, cleanup_key_id)
+            try:
+                availability_zone = _select_availability_zone(ec2)
+                volume_result = _check_resource_encrypted_with_customer_key(ec2, key_metadata, availability_zone)
+            except Exception as e:
+                volume_result = {"passed": False, "volume_id": volume_id, "error": str(e)}
+            result["tests"]["resource_encrypted_with_customer_key"] = volume_result
+            volume_id = volume_result.get("volume_id", "")
+            result["encrypted_resource_id"] = volume_id
+            result["encrypted_resource_kms_key_id"] = volume_result.get("kms_key_id", "")
+
+        result["success"] = all(test.get("passed") for test in result["tests"].values())
+    except Exception as e:
+        result["error"] = str(e)
+        result["tests"] = _failed_tests(str(e))
+    finally:
+        cleanup_errors: list[str] = []
+        if volume_id:
+            cleanup_errors.extend(_delete_test_volume(ec2, volume_id))
+        if owned_key and cleanup_key_id:
+            cleanup_errors.extend(_schedule_key_deletion(kms, cleanup_key_id))
+
+        if cleanup_errors:
+            result["cleanup_errors"] = cleanup_errors
+            cleanup_error = f"Cleanup failed: {'; '.join(cleanup_errors)}"
+            result["error"] = f"{result['error']}; {cleanup_error}" if result.get("error") else cleanup_error
+            result["success"] = False
+
+    return result
+
+
+@handle_aws_errors
+def main() -> int:
+    """Run customer-managed key checks and emit JSON result."""
+    parser = argparse.ArgumentParser(description="Customer-managed key / BYOK test")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--key-id", default=os.environ.get("AWS_KMS_KEY_ID", ""), help="Existing KMS key id or ARN")
+    args = parser.parse_args()
+
+    kms = boto3.client("kms", region_name=args.region)
+    ec2 = boto3.client("ec2", region_name=args.region)
+    result = _run_customer_managed_key_test(kms, ec2, args.region, _normalize_optional_key_id(args.key_id))
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/my-isv/README.md
+++ b/isvctl/configs/providers/my-isv/README.md
@@ -18,7 +18,7 @@ exercises.
 | [`config/bare_metal.yaml`](config/bare_metal.yaml) | BMaaS lifecycle (launch -> topology -> serial -> power-cycle -> teardown) | [`scripts/bare_metal/`](scripts/bare_metal/) |
 | [`config/network.yaml`](config/network.yaml) | VPC CRUD, subnets, isolation, SG, connectivity, traffic, DDI, fabric metadata | [`scripts/network/`](scripts/network/) |
 | [`config/image-registry.yaml`](config/image-registry.yaml) | Image upload, CRUD, VM launch, install config, BMaaS install | [`scripts/image-registry/`](scripts/image-registry/) |
-| [`config/security.yaml`](config/security.yaml) | BMC isolation, BMC protocol security, API endpoint isolation, SA credential auth | [`scripts/security/`](scripts/security/) |
+| [`config/security.yaml`](config/security.yaml) | BMC isolation, BMC protocol security, API endpoint isolation, BYOK, SA credential auth | [`scripts/security/`](scripts/security/) |
 
 ## Coverage note
 

--- a/isvctl/configs/providers/my-isv/config/security.yaml
+++ b/isvctl/configs/providers/my-isv/config/security.yaml
@@ -22,6 +22,7 @@
 #   CNP10-01: BMC protocol security (BmcProtocolSecurityCheck)
 #   SEC14-01: API endpoint isolation (ApiEndpointIsolationCheck)
 #   SEC07-01: MFA enforcement (MfaEnforcedCheck)
+#   SEC09-04: Customer-managed keys / BYOK (CustomerManagedKeyCheck)
 #   SEC03-01: Service account credentials (ServiceAccountCredentialCheck)
 #   SEC01-01: OIDC user authentication (OidcUserAuthCheck)
 #
@@ -76,6 +77,12 @@ commands:
       - name: mfa_enforcement
         phase: test
         command: "python ../scripts/security/mfa_enforcement_test.py"
+        args: ["--region", "{{region}}"]
+        timeout: 60
+
+      - name: customer_managed_key_test
+        phase: test
+        command: "python ../scripts/security/customer_managed_key_test.py"
         args: ["--region", "{{region}}"]
         timeout: 60
 

--- a/isvctl/configs/providers/my-isv/scripts/README.md
+++ b/isvctl/configs/providers/my-isv/scripts/README.md
@@ -34,7 +34,7 @@ the TODOs.
 | `bare_metal/` | 12 | [`suites/bare_metal.yaml`](../../../suites/bare_metal.yaml) | [`config/bare_metal.yaml`](../config/bare_metal.yaml) | [`providers/aws/scripts/bare_metal/`](../../aws/scripts/bare_metal/) |
 | `network/` | 18 | [`suites/network.yaml`](../../../suites/network.yaml) | [`config/network.yaml`](../config/network.yaml) | [`providers/aws/scripts/network/`](../../aws/scripts/network/) |
 | `image-registry/` | 7 | [`suites/image-registry.yaml`](../../../suites/image-registry.yaml) | [`config/image-registry.yaml`](../config/image-registry.yaml) | [`providers/aws/scripts/image-registry/`](../../aws/scripts/image-registry/) |
-| `security/` | 5 | [`suites/security.yaml`](../../../suites/security.yaml) | [`config/security.yaml`](../config/security.yaml) | [`providers/aws/scripts/security/`](../../aws/scripts/security/) |
+| `security/` | 9 | [`suites/security.yaml`](../../../suites/security.yaml) | [`config/security.yaml`](../config/security.yaml) | [`providers/aws/scripts/security/`](../../aws/scripts/security/) |
 | `k8s/` | 9 shell | [`suites/k8s.yaml`](../../../suites/k8s.yaml) | - | [`providers/aws/scripts/eks/`](../../aws/scripts/eks/) |
 | `slurm/` | 2 shell | [`suites/slurm.yaml`](../../../suites/slurm.yaml) | - | - |
 

--- a/isvctl/configs/providers/my-isv/scripts/security/customer_managed_key_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/security/customer_managed_key_test.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Customer-managed key / BYOK encryption test - TEMPLATE.
+
+Verifies that the platform supports customer-managed keys and that a
+provider resource can be encrypted with a customer-owned key instead of a
+provider-managed default key. This covers the SEC09-04 requirement.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "security",
+    "test_name": "customer_managed_key_test",
+    "key_id": "cmk-123",
+    "key_arn": "my-isv:kms:region:tenant:key/cmk-123",
+    "encrypted_resource_id": "volume-123",
+    "encrypted_resource_kms_key_id": "cmk-123",
+    "tests": {
+      "customer_managed_key_available": {"passed": true},
+      "key_manager_is_customer": {"passed": true},
+      "encrypt_decrypt_roundtrip": {"passed": true},
+      "resource_encrypted_with_customer_key": {"passed": true},
+      "provider_managed_key_not_used": {"passed": true}
+    }
+  }
+
+Usage:
+    python customer_managed_key_test.py --region <region>
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+
+
+def main() -> int:
+    """Customer-managed key test (template) and emit structured JSON result."""
+    parser = argparse.ArgumentParser(description="Customer-managed key / BYOK test (template)")
+    parser.add_argument("--region", required=True, help="Cloud region")
+    _args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "security",
+        "test_name": "customer_managed_key_test",
+        "key_id": "",
+        "key_arn": "",
+        "encrypted_resource_id": "",
+        "encrypted_resource_kms_key_id": "",
+        "tests": {
+            "customer_managed_key_available": {"passed": False},
+            "key_manager_is_customer": {"passed": False},
+            "encrypt_decrypt_roundtrip": {"passed": False},
+            "resource_encrypted_with_customer_key": {"passed": False},
+            "provider_managed_key_not_used": {"passed": False},
+        },
+    }
+
+    # ╔══════════════════════════════════════════════════════════════════╗
+    # ║  TODO: Replace this block with your platform's BYOK              ║
+    # ║  implementation.                                                 ║
+    # ║                                                                  ║
+    # ║  Example (pseudocode):                                           ║
+    # ║    key = create_or_lookup_customer_managed_key(                  ║
+    # ║        region=args.region                                        ║
+    # ║    )                                                             ║
+    # ║    metadata = describe_key(key.id)                               ║
+    # ║    tests = result["tests"]                                       ║
+    # ║    tests["customer_managed_key_available"]["passed"] = (         ║
+    # ║        key.enabled                                               ║
+    # ║    )                                                             ║
+    # ║    tests["key_manager_is_customer"]["passed"] = (                ║
+    # ║        metadata.owner == "customer"                              ║
+    # ║    )                                                             ║
+    # ║    ciphertext = encrypt_with_key(key.id, b"isv-validation")      ║
+    # ║    plaintext = decrypt_with_key(key.id, ciphertext)              ║
+    # ║    tests["encrypt_decrypt_roundtrip"]["passed"] = (              ║
+    # ║        plaintext == b"isv-validation"                            ║
+    # ║    )                                                             ║
+    # ║    resource = create_small_encrypted_resource(key_id=key.id)     ║
+    # ║    tests["resource_encrypted_with_customer_key"]["passed"] = (   ║
+    # ║        resource.key_id == key.id                                 ║
+    # ║    )                                                             ║
+    # ║    tests["provider_managed_key_not_used"]["passed"] = (          ║
+    # ║        resource.key_owner == "customer"                          ║
+    # ║    )                                                             ║
+    # ║    cleanup(resource)                                             ║
+    # ╚══════════════════════════════════════════════════════════════════╝
+
+    if DEMO_MODE:
+        result["key_id"] = "my-isv-cmk-demo"
+        result["key_arn"] = "my-isv:kms:my-isv-region-1:tenant:key/my-isv-cmk-demo"
+        result["encrypted_resource_id"] = "my-isv-encrypted-volume-demo"
+        result["encrypted_resource_kms_key_id"] = "my-isv-cmk-demo"
+        result["tests"] = {
+            "customer_managed_key_available": {"passed": True},
+            "key_manager_is_customer": {"passed": True},
+            "encrypt_decrypt_roundtrip": {"passed": True},
+            "resource_encrypted_with_customer_key": {"passed": True},
+            "provider_managed_key_not_used": {"passed": True},
+        }
+        result["success"] = True
+    else:
+        result["error"] = "Not implemented - replace with your platform's customer-managed key test"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -144,9 +144,12 @@ Validations use `sinfo`/`srun` directly: partitions, GPU allocation, job schedul
 
 | Step | Phase | Script | What It Tests |
 |------|-------|--------|---------------|
+| `bmc_management_network` | test | `providers/my-isv/scripts/security/bmc_management_network_test.py` | BMC management network is dedicated and restricted |
 | `bmc_tenant_isolation` | test | `providers/my-isv/scripts/security/bmc_isolation_test.py` | BMC/IPMI/Redfish unreachable from tenant network |
 | `bmc_protocol_security` | test | `providers/my-isv/scripts/security/bmc_protocol_security_test.py` | CNP10-01: IPMI disabled; Redfish over TLS with AAA |
 | `api_endpoint_isolation` | test | `providers/my-isv/scripts/security/api_endpoint_test.py` | API endpoints not publicly accessible |
+| `mfa_enforcement` | test | `providers/my-isv/scripts/security/mfa_enforcement_test.py` | Administrative UI, CLI, and API access require MFA |
+| `customer_managed_key_test` | test | `providers/my-isv/scripts/security/customer_managed_key_test.py` | SEC09-04: Customer-managed key / BYOK encryption |
 | `sa_credential_test` | test | `providers/my-isv/scripts/security/sa_credential_test.py` | Service account long-lived credential auth |
 | `oidc_user_auth_test` | test | `providers/my-isv/scripts/security/oidc_user_auth_test.py` | OIDC issuer metadata and protected endpoint token acceptance/rejection |
 | `teardown` | teardown | `providers/my-isv/scripts/security/teardown.py` | Cleanup test resources |

--- a/isvctl/configs/suites/security.yaml
+++ b/isvctl/configs/suites/security.yaml
@@ -69,6 +69,11 @@ tests:
         MfaEnforcedCheck:
           step: mfa_enforcement
 
+    customer_managed_key:
+      checks:
+        CustomerManagedKeyCheck:
+          step: customer_managed_key_test
+
     service_account_auth:
       checks:
         ServiceAccountCredentialCheck:

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -22,7 +22,7 @@ from typing import Any
 from urllib.error import HTTPError
 
 import pytest
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, WaiterError
 
 ISVCTL_ROOT = Path(__file__).resolve().parents[1]
 AWS_SECURITY_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "security"
@@ -1115,6 +1115,246 @@ def test_teardown_main_fails_when_owned_user_cleanup_fails(
     assert payload["resources_failed"][0]["username"] == "isv-sa-test-leftover"
     assert len(payload["resources_failed"][0]["errors"]) == 2
     assert iam.delete_user_called is True
+
+
+@pytest.fixture(scope="module")
+def byok_module() -> ModuleType:
+    """Load the customer-managed key script as a module."""
+    return _load_security_script("customer_managed_key_test.py")
+
+
+class FakeByokWaiter:
+    """Fake EC2 waiter for encrypted volume tests."""
+
+    def __init__(self, error: Exception | None = None) -> None:
+        """Initialize wait call tracking."""
+        self.calls: list[dict[str, Any]] = []
+        self.error = error
+
+    def wait(self, **kwargs: Any) -> None:
+        """Record waiter arguments."""
+        self.calls.append(kwargs)
+        if self.error:
+            raise self.error
+
+
+class FakeByokKms:
+    """Fake KMS client for customer-managed key tests."""
+
+    def __init__(
+        self,
+        *,
+        key_manager: str = "CUSTOMER",
+        plaintext_mismatch: bool = False,
+        encrypt_error: ClientError | None = None,
+    ) -> None:
+        """Initialize fake KMS behavior."""
+        self.key_metadata = {
+            "KeyId": "cmk-123",
+            "Arn": "arn:aws:kms:us-west-2:123456789012:key/cmk-123",
+            "KeyManager": key_manager,
+            "KeyState": "Enabled",
+            "KeyUsage": "ENCRYPT_DECRYPT",
+        }
+        self.plaintext_mismatch = plaintext_mismatch
+        self.encrypt_error = encrypt_error
+        self.created_keys: list[dict[str, Any]] = []
+        self.scheduled_deletions: list[dict[str, Any]] = []
+
+    def create_key(self, **kwargs: Any) -> dict[str, dict[str, Any]]:
+        """Create a fake customer-managed key."""
+        self.created_keys.append(kwargs)
+        return {"KeyMetadata": self.key_metadata}
+
+    def describe_key(self, KeyId: str) -> dict[str, dict[str, Any]]:
+        """Return fake KMS key metadata."""
+        assert KeyId in {"cmk-123", self.key_metadata["Arn"], "alias/aws/ebs"}
+        return {"KeyMetadata": self.key_metadata}
+
+    def encrypt(self, KeyId: str, Plaintext: bytes) -> dict[str, bytes]:
+        """Return fake ciphertext or raise the configured error."""
+        assert KeyId == "cmk-123"
+        if self.encrypt_error:
+            raise self.encrypt_error
+        return {"CiphertextBlob": b"ciphertext:" + Plaintext}
+
+    def decrypt(self, KeyId: str, CiphertextBlob: bytes) -> dict[str, bytes]:
+        """Return the decrypted fake plaintext."""
+        assert KeyId == "cmk-123"
+        assert CiphertextBlob.startswith(b"ciphertext:")
+        if self.plaintext_mismatch:
+            return {"Plaintext": b"wrong"}
+        return {"Plaintext": CiphertextBlob.removeprefix(b"ciphertext:")}
+
+    def schedule_key_deletion(self, **kwargs: Any) -> None:
+        """Record a scheduled key deletion request."""
+        self.scheduled_deletions.append(kwargs)
+
+
+class FakeByokEc2:
+    """Fake EC2 client for encrypted EBS volume tests."""
+
+    def __init__(
+        self,
+        *,
+        kms_key_id: str | None = None,
+        encrypted: bool = True,
+        waiter_error: Exception | None = None,
+        describe_error: Exception | None = None,
+    ) -> None:
+        """Initialize fake EC2 behavior."""
+        self.kms_key_id = kms_key_id or "arn:aws:kms:us-west-2:123456789012:key/cmk-123"
+        self.encrypted = encrypted
+        self.describe_error = describe_error
+        self.created_volumes: list[dict[str, Any]] = []
+        self.deleted_volumes: list[str] = []
+        self.waiter = FakeByokWaiter(waiter_error)
+
+    def describe_availability_zones(self, **kwargs: Any) -> dict[str, list[dict[str, str]]]:
+        """Return one available AZ."""
+        assert kwargs == {"Filters": [{"Name": "state", "Values": ["available"]}]}
+        return {"AvailabilityZones": [{"ZoneName": "us-west-2a", "OptInStatus": "opt-in-not-required"}]}
+
+    def create_volume(self, **kwargs: Any) -> dict[str, Any]:
+        """Create a fake encrypted volume."""
+        self.created_volumes.append(kwargs)
+        return {
+            "VolumeId": "vol-byok-123",
+            "Encrypted": self.encrypted,
+            "KmsKeyId": self.kms_key_id,
+        }
+
+    def get_waiter(self, waiter_name: str) -> FakeByokWaiter:
+        """Return a fake waiter."""
+        assert waiter_name == "volume_available"
+        return self.waiter
+
+    def describe_volumes(self, VolumeIds: list[str]) -> dict[str, list[dict[str, Any]]]:
+        """Return the fake volume description."""
+        assert VolumeIds == ["vol-byok-123"]
+        if self.describe_error:
+            raise self.describe_error
+        return {
+            "Volumes": [
+                {
+                    "VolumeId": "vol-byok-123",
+                    "Encrypted": self.encrypted,
+                    "KmsKeyId": self.kms_key_id,
+                }
+            ]
+        }
+
+    def delete_volume(self, VolumeId: str) -> None:
+        """Record fake volume deletion."""
+        self.deleted_volumes.append(VolumeId)
+
+
+def test_byok_existing_customer_managed_key_path(byok_module: ModuleType) -> None:
+    """Existing customer-managed KMS key path passes all SEC09-04 probes."""
+    kms = FakeByokKms()
+    ec2 = FakeByokEc2()
+
+    result = byok_module._run_customer_managed_key_test(kms, ec2, "us-west-2", "cmk-123")
+
+    assert result["success"] is True
+    assert result["key_id"] == "cmk-123"
+    assert result["encrypted_resource_id"] == "vol-byok-123"
+    assert all(test["passed"] for test in result["tests"].values())
+    assert ec2.deleted_volumes == ["vol-byok-123"]
+    assert kms.scheduled_deletions == []
+
+
+def test_byok_rejects_aws_managed_key(byok_module: ModuleType) -> None:
+    """AWS-managed KMS keys fail the customer-managed-key contract."""
+    kms = FakeByokKms(key_manager="AWS")
+    ec2 = FakeByokEc2()
+
+    result = byok_module._run_customer_managed_key_test(kms, ec2, "us-west-2", "alias/aws/ebs")
+
+    assert result["success"] is False
+    assert result["tests"]["customer_managed_key_available"]["passed"] is True
+    assert result["tests"]["key_manager_is_customer"]["passed"] is False
+    assert result["tests"]["provider_managed_key_not_used"]["passed"] is False
+    assert ec2.created_volumes == []
+
+
+def test_byok_encrypt_decrypt_roundtrip_success_and_failure(byok_module: ModuleType) -> None:
+    """KMS encrypt/decrypt roundtrip reports success and plaintext mismatch failure."""
+    success = byok_module._check_encrypt_decrypt_roundtrip(FakeByokKms(), "cmk-123")
+    mismatch = byok_module._check_encrypt_decrypt_roundtrip(FakeByokKms(plaintext_mismatch=True), "cmk-123")
+    aws_error = byok_module._check_encrypt_decrypt_roundtrip(
+        FakeByokKms(encrypt_error=_client_error("Encrypt")),
+        "cmk-123",
+    )
+
+    assert success["passed"] is True
+    assert mismatch["passed"] is False
+    assert "did not match" in mismatch["error"]
+    assert aws_error["passed"] is False
+    assert "denied" in aws_error["error"]
+
+
+def test_byok_ebs_volume_kms_key_verification(byok_module: ModuleType) -> None:
+    """Encrypted EBS volume verification checks the reported KmsKeyId."""
+    key_metadata = FakeByokKms().key_metadata
+
+    success = byok_module._check_resource_encrypted_with_customer_key(FakeByokEc2(), key_metadata, "us-west-2a")
+    mismatch = byok_module._check_resource_encrypted_with_customer_key(
+        FakeByokEc2(kms_key_id="arn:aws:kms:us-west-2:123456789012:key/other"),
+        key_metadata,
+        "us-west-2a",
+    )
+
+    assert success["passed"] is True
+    assert success["volume_id"] == "vol-byok-123"
+    assert mismatch["passed"] is False
+    assert "unexpected KMS key" in mismatch["error"]
+
+
+def test_byok_deletes_volume_when_ebs_waiter_fails(byok_module: ModuleType) -> None:
+    """EBS waiter failures preserve the volume id so final cleanup can delete it."""
+    waiter_error = WaiterError(
+        name="VolumeAvailable",
+        reason="Max attempts exceeded",
+        last_response={"Volumes": [{"VolumeId": "vol-byok-123", "State": "creating"}]},
+    )
+    kms = FakeByokKms()
+    ec2 = FakeByokEc2(waiter_error=waiter_error)
+
+    result = byok_module._run_customer_managed_key_test(kms, ec2, "us-west-2", "cmk-123")
+
+    assert result["success"] is False
+    assert result["encrypted_resource_id"] == "vol-byok-123"
+    assert result["tests"]["resource_encrypted_with_customer_key"]["passed"] is False
+    assert result["tests"]["resource_encrypted_with_customer_key"]["volume_id"] == "vol-byok-123"
+    assert ec2.deleted_volumes == ["vol-byok-123"]
+
+
+def test_byok_deletes_volume_when_ebs_verification_raises_unexpected_error(byok_module: ModuleType) -> None:
+    """Unexpected EBS verification errors preserve the volume id for cleanup."""
+    kms = FakeByokKms()
+    ec2 = FakeByokEc2(describe_error=RuntimeError("describe failed"))
+
+    result = byok_module._run_customer_managed_key_test(kms, ec2, "us-west-2", "cmk-123")
+
+    assert result["success"] is False
+    assert result["encrypted_resource_id"] == "vol-byok-123"
+    assert result["tests"]["resource_encrypted_with_customer_key"]["volume_id"] == "vol-byok-123"
+    assert "describe failed" in result["tests"]["resource_encrypted_with_customer_key"]["error"]
+    assert ec2.deleted_volumes == ["vol-byok-123"]
+
+
+def test_byok_owned_temporary_key_and_volume_are_cleaned_up(byok_module: ModuleType) -> None:
+    """Temporary KMS keys are scheduled for deletion and test volumes are deleted."""
+    kms = FakeByokKms()
+    ec2 = FakeByokEc2()
+
+    result = byok_module._run_customer_managed_key_test(kms, ec2, "us-west-2")
+
+    assert result["success"] is True
+    assert kms.created_keys
+    assert kms.scheduled_deletions == [{"KeyId": "cmk-123", "PendingWindowInDays": 7}]
+    assert ec2.deleted_volumes == ["vol-byok-123"]
 
 
 @pytest.fixture(scope="module")

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -98,6 +98,7 @@ from isvtest.validations.security import (
     BmcProtocolSecurityCheck,
     BmcTenantIsolationCheck,
     ConsoleRbacCheck,
+    CustomerManagedKeyCheck,
     MfaEnforcedCheck,
     OidcUserAuthCheck,
 )
@@ -119,6 +120,7 @@ __all__ = [
     "ConsoleRbacCheck",
     "ContainerRuntimeCheck",
     "CpuInfoCheck",
+    "CustomerManagedKeyCheck",
     "DhcpIpManagementCheck",
     "DriverCheck",
     "FieldExistsCheck",

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -192,6 +192,69 @@ class MfaEnforcedCheck(BaseValidation):
         self.set_passed(f"Admin interfaces protected by MFA ({interfaces} interfaces checked)")
 
 
+class CustomerManagedKeyCheck(BaseValidation):
+    """Validate resources can be encrypted with customer-managed keys.
+
+    Verifies that the platform exposes customer-managed key support, the
+    reported key is customer-owned rather than provider-managed, encryption
+    and decryption work with that key, and a provider resource is encrypted
+    with that exact customer-managed key.
+
+    Config:
+        step_output: The step output to check
+
+    Step output:
+        key_id or key_arn: Non-empty customer-managed key evidence
+        encrypted_resource_id or resource_id: Non-empty encrypted resource evidence
+        tests: dict with customer_managed_key_available,
+               key_manager_is_customer, encrypt_decrypt_roundtrip,
+               resource_encrypted_with_customer_key,
+               provider_managed_key_not_used
+    """
+
+    description: ClassVar[str] = "Check BYOK/customer-managed key encryption support"
+    markers: ClassVar[list[str]] = ["security", "workload", "slow"]
+
+    def run(self) -> None:
+        """Validate required BYOK/customer-managed key results from step output."""
+        required = [
+            "customer_managed_key_available",
+            "key_manager_is_customer",
+            "encrypt_decrypt_roundtrip",
+            "resource_encrypted_with_customer_key",
+            "provider_managed_key_not_used",
+        ]
+        if not check_required_tests(self, required, "Customer-managed key tests failed"):
+            return
+
+        step_output = self.config.get("step_output", {})
+        key_evidence = next(
+            (
+                value.strip()
+                for value in (step_output.get("key_id"), step_output.get("key_arn"))
+                if isinstance(value, str) and value.strip()
+            ),
+            "",
+        )
+        if not key_evidence:
+            self.set_failed("Customer-managed key output missing non-empty key evidence")
+            return
+
+        resource_evidence = next(
+            (
+                value.strip()
+                for value in (step_output.get("encrypted_resource_id"), step_output.get("resource_id"))
+                if isinstance(value, str) and value.strip()
+            ),
+            "",
+        )
+        if not resource_evidence:
+            self.set_failed("Customer-managed key output missing non-empty encrypted resource evidence")
+            return
+
+        self.set_passed(f"Customer-managed key encryption verified (key={key_evidence}, resource={resource_evidence})")
+
+
 class ApiEndpointIsolationCheck(BaseValidation):
     """Validate no public internet access to API endpoints by default.
 

--- a/isvtest/tests/test_security.py
+++ b/isvtest/tests/test_security.py
@@ -12,12 +12,14 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any
 
 from isvtest.validations.security import (
     BmcBastionAccessCheck,
     BmcManagementNetworkCheck,
     BmcProtocolSecurityCheck,
+    CustomerManagedKeyCheck,
     MfaEnforcedCheck,
     OidcUserAuthCheck,
 )
@@ -39,6 +41,14 @@ OIDC_REQUIRED_TESTS = {
     "expired_token_rejected": {"passed": True},
     "missing_required_claim_rejected": {"passed": True},
     "discovery_and_jwks_reachable": {"passed": True},
+}
+
+BYOK_REQUIRED_TESTS = {
+    "customer_managed_key_available": {"passed": True},
+    "key_manager_is_customer": {"passed": True},
+    "encrypt_decrypt_roundtrip": {"passed": True},
+    "resource_encrypted_with_customer_key": {"passed": True},
+    "provider_managed_key_not_used": {"passed": True},
 }
 
 
@@ -314,6 +324,110 @@ class TestMfaEnforcedCheck:
         result = v.execute()
         assert result["passed"] is True
         assert "7 interfaces checked" in result["output"]
+
+
+def _byok_step_output(**overrides: Any) -> dict[str, Any]:
+    """Return a valid BYOK step output with optional overrides."""
+    output: dict[str, Any] = {
+        "success": True,
+        "platform": "security",
+        "test_name": "customer_managed_key_test",
+        "key_id": "cmk-test-123",
+        "key_arn": "arn:provider:kms:region:tenant:key/cmk-test-123",
+        "encrypted_resource_id": "volume-test-123",
+        "encrypted_resource_kms_key_id": "cmk-test-123",
+        "tests": deepcopy(BYOK_REQUIRED_TESTS),
+    }
+    output.update(overrides)
+    return output
+
+
+def test_customer_managed_key_check_passes_with_required_evidence() -> None:
+    """CustomerManagedKeyCheck passes with all required BYOK checks and evidence."""
+    check = CustomerManagedKeyCheck(config={"step_output": _byok_step_output()})
+
+    result = check.execute()
+
+    assert result["passed"] is True
+    assert "Customer-managed key encryption verified" in result["output"]
+    assert "cmk-test-123" in result["output"]
+
+
+def test_byok_step_output_returns_independent_tests() -> None:
+    """BYOK step output helper returns independent nested test data."""
+    first = _byok_step_output()
+    second = _byok_step_output()
+
+    first["tests"]["customer_managed_key_available"]["passed"] = False
+
+    assert second["tests"]["customer_managed_key_available"]["passed"] is True
+    assert BYOK_REQUIRED_TESTS["customer_managed_key_available"]["passed"] is True
+
+
+def test_customer_managed_key_check_fails_when_required_check_fails() -> None:
+    """CustomerManagedKeyCheck fails with the specific failed BYOK probe."""
+    tests = dict(BYOK_REQUIRED_TESTS)
+    tests["provider_managed_key_not_used"] = {"passed": False, "error": "AWS-managed key selected"}
+    check = CustomerManagedKeyCheck(config={"step_output": _byok_step_output(tests=tests)})
+
+    result = check.execute()
+
+    assert result["passed"] is False
+    assert "provider_managed_key_not_used" in result["error"]
+    assert "AWS-managed key selected" in result["error"]
+
+
+def test_customer_managed_key_check_fails_when_required_check_missing() -> None:
+    """CustomerManagedKeyCheck fails when a required BYOK probe is missing."""
+    tests = {
+        name: result for name, result in BYOK_REQUIRED_TESTS.items() if name != "resource_encrypted_with_customer_key"
+    }
+    check = CustomerManagedKeyCheck(config={"step_output": _byok_step_output(tests=tests)})
+
+    result = check.execute()
+
+    assert result["passed"] is False
+    assert "resource_encrypted_with_customer_key" in result["error"]
+
+
+def test_customer_managed_key_check_fails_without_key_evidence() -> None:
+    """CustomerManagedKeyCheck fails when no key evidence is reported."""
+    check = CustomerManagedKeyCheck(config={"step_output": _byok_step_output(key_id="", key_arn="")})
+
+    result = check.execute()
+
+    assert result["passed"] is False
+    assert "key evidence" in result["error"]
+
+
+def test_customer_managed_key_check_fails_without_resource_evidence() -> None:
+    """CustomerManagedKeyCheck fails when no encrypted resource evidence is reported."""
+    check = CustomerManagedKeyCheck(config={"step_output": _byok_step_output(encrypted_resource_id="", resource_id="")})
+
+    result = check.execute()
+
+    assert result["passed"] is False
+    assert "encrypted resource evidence" in result["error"]
+
+
+def test_customer_managed_key_check_falls_back_from_blank_evidence() -> None:
+    """CustomerManagedKeyCheck falls back when preferred evidence fields are blank."""
+    check = CustomerManagedKeyCheck(
+        config={
+            "step_output": _byok_step_output(
+                key_id="   ",
+                key_arn="  arn:provider:kms:region:tenant:key/fallback-key  ",
+                encrypted_resource_id="   ",
+                resource_id="  volume-fallback-123  ",
+            )
+        }
+    )
+
+    result = check.execute()
+
+    assert result["passed"] is True
+    assert "fallback-key" in result["output"]
+    assert "volume-fallback-123" in result["output"]
 
 
 def _oidc_step_output(**overrides: Any) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Adds SEC09-04 coverage to the security suite for verifying Customer Managed Keys (BYOK): customer-managed key availability, customer ownership, encrypt/decrypt roundtrip, and proof that a test resource is encrypted with the customer-managed key instead of a provider-managed default.

## Changes

- Adds `CustomerManagedKeyCheck` and security suite wiring for the `customer_managed_key_test` step.
- Adds AWS reference coverage for existing or temporary KMS customer-managed keys, KMS encrypt/decrypt, encrypted EBS volume verification, and cleanup after success or waiter failures.
- Adds my-isv scaffold/demo output for the BYOK contract.
- Updates provider and suite documentation/catalog wiring for SEC09-04.
- Adds focused validation, AWS provider script, and stub contract tests covering the required BYOK probe keys (`customer_managed_key_available`, `key_manager_is_customer`, `encrypt_decrypt_roundtrip`, `resource_encrypted_with_customer_key`, `provider_managed_key_not_used`).

## Validation

- [x] `uv run pytest isvtest/tests/test_security.py isvctl/tests/test_aws_security_scripts.py isvctl/tests/test_stub_contracts.py` - 219 passed
- [x] `make demo-test` - my-isv demo configs pass end-to-end including `customer_managed_key_test`
- [x] `uvx ruff check` on changed validation, provider script, and test files

Closes #304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customer-managed key (BYOK) validation and test steps across providers, exposing runtime probes for key ownership, encrypt/decrypt roundtrips, encrypted-resource verification, and cleanup; new validation is available to suites.

* **Documentation**
  * Updated provider, suite, and scripts docs to list BYOK coverage and the new security test step.

* **Tests**
  * Added integration and unit tests covering BYOK probe behaviors, volume verification, cleanup handling, and success/failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->