### PR TITLE
fix(security): skip OIDC validation when not configured

### DIFF
--- a/isvctl/configs/providers/aws/scripts/security/oidc_user_auth_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/oidc_user_auth_test.py
@@ -16,9 +16,10 @@ endpoint. It fetches the platform issuer's real discovery document and JWKS,
 checks that a supplied valid JWT chains to that issuer/audience, then sends
 valid and invalid bearer tokens to the configured target endpoint.
 
-The step is intentionally fail-closed. If no real issuer, audience, target
-endpoint, or valid test token is configured, it reports failure rather than
-simulating an OIDC provider locally.
+The step is intentionally fail-closed: it never simulates an OIDC provider
+locally. When no real issuer, audience, target endpoint, or valid test token
+is configured, it emits a structured ``skipped`` result (exit 0) so the
+orchestrator and validation can skip the check rather than fabricate a pass.
 
 Usage:
     OIDC_VALID_TOKEN=... \\
@@ -764,9 +765,11 @@ def main() -> int:
 
         missing = _missing_config_errors(args.issuer_url, args.audience, args.target_url, valid_token)
         if missing:
-            error = "OIDC validation not configured; missing " + ", ".join(missing)
-            result["error"] = error
-            result["tests"] = _not_executed_probes(error)
+            result["success"] = True
+            result["skipped"] = True
+            result["skip_reason"] = "OIDC validation not configured; missing " + ", ".join(missing)
+            print(json.dumps(result, indent=2))
+            return 0
         else:
             result["tests"] = run_probes(
                 args.issuer_url,

--- a/isvctl/configs/providers/aws/scripts/security/oidc_user_auth_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/oidc_user_auth_test.py
@@ -768,6 +768,7 @@ def main() -> int:
             result["success"] = True
             result["skipped"] = True
             result["skip_reason"] = "OIDC validation not configured; missing " + ", ".join(missing)
+            result["endpoints_tested"] = 0
             print(json.dumps(result, indent=2))
             return 0
         else:

--- a/isvctl/src/isvctl/orchestrator/step_executor.py
+++ b/isvctl/src/isvctl/orchestrator/step_executor.py
@@ -252,7 +252,7 @@ class StepExecutor:
                     logger.warning(f"Step {step.name} failed (best-effort mode, continuing)")
                     results.success = False
                 else:
-                    logger.error(f"Step {step.name} failed, stopping execution")
+                    logger.error(f"Step {step.name} failed; skipping remaining steps in this phase")
                     results.success = False
                     break
 

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -1845,6 +1845,40 @@ def test_oidc_main_emits_skip_with_inline_empty_config_args(
     assert payload["tests"] == {}
 
 
+def test_oidc_main_skip_resets_endpoints_tested_when_only_target_url_set(
+    oidc_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A partially-configured run still reports endpoints_tested=0 on skip."""
+    for env_var in (
+        "OIDC_ISSUER_URL",
+        "OIDC_AUDIENCE",
+        "OIDC_TARGET_URL",
+        "OIDC_VALID_TOKEN",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.setattr(
+        oidc_module.sys,
+        "argv",
+        [
+            "oidc_user_auth_test.py",
+            "--region",
+            "us-west-2",
+            "--target-url",
+            "https://api.example/protected",
+        ],
+    )
+
+    exit_code = oidc_module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["skipped"] is True
+    assert payload["target_url"] == "https://api.example/protected"
+    assert payload["endpoints_tested"] == 0
+
+
 def test_oidc_main_fails_when_probes_fail(
     oidc_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -1781,12 +1781,12 @@ def test_oidc_main_emits_success_json(
     assert all(p["passed"] for p in payload["tests"].values())
 
 
-def test_oidc_main_fails_closed_without_real_configuration(
+def test_oidc_main_emits_skip_when_unconfigured(
     oidc_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """main() must not pass with the default unconfigured OIDC settings."""
+    """main() emits a structured skip (exit 0) when no OIDC inputs are provided."""
     for env_var in (
         "OIDC_ISSUER_URL",
         "OIDC_AUDIENCE",
@@ -1799,19 +1799,21 @@ def test_oidc_main_fails_closed_without_real_configuration(
     exit_code = oidc_module.main()
     payload = json.loads(capsys.readouterr().out)
 
-    assert exit_code == 1
-    assert payload["success"] is False
+    assert exit_code == 0
+    assert payload["success"] is True
+    assert payload["skipped"] is True
     assert payload["endpoints_tested"] == 0
-    assert "OIDC validation not configured" in payload["error"]
-    assert all(not probe["passed"] for probe in payload["tests"].values())
+    assert "OIDC validation not configured" in payload["skip_reason"]
+    assert payload["tests"] == {}
+    assert "error" not in payload
 
 
-def test_oidc_main_fails_closed_with_inline_empty_config_args(
+def test_oidc_main_emits_skip_with_inline_empty_config_args(
     oidc_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Inline empty args reach the script and produce structured fail-closed JSON."""
+    """Inline empty args still produce a structured skip rather than a failure."""
     for env_var in (
         "OIDC_ISSUER_URL",
         "OIDC_AUDIENCE",
@@ -1835,11 +1837,12 @@ def test_oidc_main_fails_closed_with_inline_empty_config_args(
     exit_code = oidc_module.main()
     payload = json.loads(capsys.readouterr().out)
 
-    assert exit_code == 1
-    assert payload["success"] is False
+    assert exit_code == 0
+    assert payload["success"] is True
+    assert payload["skipped"] is True
     assert payload["endpoints_tested"] == 0
-    assert "OIDC validation not configured" in payload["error"]
-    assert all(not probe["passed"] for probe in payload["tests"].values())
+    assert "OIDC validation not configured" in payload["skip_reason"]
+    assert payload["tests"] == {}
 
 
 def test_oidc_main_fails_when_probes_fail(

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -17,6 +17,8 @@ requirements (SEC* test IDs).
 
 from typing import ClassVar
 
+import pytest
+
 from isvtest.core.validation import BaseValidation, check_required_tests
 
 
@@ -371,6 +373,10 @@ class OidcUserAuthCheck(BaseValidation):
 
     def run(self) -> None:
         """Validate required OIDC token verification probe results from step output."""
+        step_output = self.config.get("step_output", {})
+        if step_output.get("skipped") is True:
+            pytest.skip(step_output.get("skip_reason") or "OIDC validation skipped (not configured)")
+
         required = [
             "valid_token_accepted",
             "bad_signature_rejected",
@@ -383,7 +389,6 @@ class OidcUserAuthCheck(BaseValidation):
         if not check_required_tests(self, required, "OIDC user auth tests failed"):
             return
 
-        step_output = self.config.get("step_output", {})
         for field in ("issuer_url", "audience", "target_url"):
             value = step_output.get(field)
             if not isinstance(value, str) or not value.strip():

--- a/isvtest/tests/test_security.py
+++ b/isvtest/tests/test_security.py
@@ -477,14 +477,16 @@ def test_oidc_user_auth_check_requires_endpoint_probe_count() -> None:
 
 
 def test_oidc_user_auth_check_skips_when_step_marks_skipped() -> None:
-    """OidcUserAuthCheck pytest.skips when the step output flags itself as skipped."""
+    """OidcUserAuthCheck pytest.skips through both run() and execute() when flagged."""
     step_output = {
         "success": True,
         "skipped": True,
         "skip_reason": "OIDC validation not configured; missing --issuer-url or OIDC_ISSUER_URL",
         "tests": {},
     }
-    check = OidcUserAuthCheck(config={"step_output": step_output})
 
     with pytest.raises(pytest.skip.Exception, match="OIDC validation not configured"):
-        check.run()
+        OidcUserAuthCheck(config={"step_output": step_output}).run()
+
+    with pytest.raises(pytest.skip.Exception, match="OIDC validation not configured"):
+        OidcUserAuthCheck(config={"step_output": step_output}).execute()

--- a/isvtest/tests/test_security.py
+++ b/isvtest/tests/test_security.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any
 
+import pytest
+
 from isvtest.validations.security import (
     BmcBastionAccessCheck,
     BmcManagementNetworkCheck,
@@ -472,3 +474,17 @@ def test_oidc_user_auth_check_requires_endpoint_probe_count() -> None:
 
     assert result["passed"] is False
     assert "did not probe any platform endpoint" in result["error"]
+
+
+def test_oidc_user_auth_check_skips_when_step_marks_skipped() -> None:
+    """OidcUserAuthCheck pytest.skips when the step output flags itself as skipped."""
+    step_output = {
+        "success": True,
+        "skipped": True,
+        "skip_reason": "OIDC validation not configured; missing --issuer-url or OIDC_ISSUER_URL",
+        "tests": {},
+    }
+    check = OidcUserAuthCheck(config={"step_output": step_output})
+
+    with pytest.raises(pytest.skip.Exception, match="OIDC validation not configured"):
+        check.run()


### PR DESCRIPTION
## Summary

The AWS security suite has been failing in any environment without a real OIDC IdP since SEC01-01 landed in #379, because the OIDC step is fail-closed and no env in the repo provides the required issuer/audience/target/token. This PR makes "not configured" a structured skip instead of a failure, so the AWS reference is green out of the box and only fails when a configured OIDC stack misbehaves.

- `oidc_user_auth_test.py`: when issuer/audience/target/token are missing, exit 0 with `skipped: true, skip_reason: ...` instead of exit 1 with synthetic per-probe failures. Configured runs unchanged.
- `OidcUserAuthCheck`: `pytest.skip(skip_reason)` when the step output flags itself as skipped, matching the pattern in `nim.py` / `host.py`.
- `step_executor.py`: reword the misleading `"stopping execution"` log line — only the current phase's remaining steps are skipped, teardown still runs.

## Test plan

- [x] `pytest isvtest/tests isvctl/tests` → 1160 passed
- [x] `make lint`, `make demo-test` → green
- [x] Live `isvctl test run -f providers/aws/config/security.yaml` → `[PASS] All phases completed successfully`, OIDC clearly marked `SKIPPED` in the summary

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OIDC user authentication validation now reports "skipped" (with a skip reason and zero endpoints tested) when required configuration is missing, instead of marking the run as failed.
  * Clarified messaging to state that remaining steps in the current phase are skipped when a step fails in standard mode.

* **Tests**
  * Added tests to cover OIDC validation skip behavior, including partially configured inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->