### PR TITLE
feat: add short-lived credentials validation (SEC02-01 - M5 P0)

### DIFF
--- a/isvctl/configs/providers/aws/config/security.yaml
+++ b/isvctl/configs/providers/aws/config/security.yaml
@@ -28,6 +28,7 @@
 #   7. Customer Managed Key   - Verify customer-managed key encryption (SEC09-04)
 #   8. SA Credential Auth     - Verify IAM user + long-lived access key auth
 #   9. OIDC User Auth         - Probe configured OIDC-protected platform endpoint (SEC01-01)
+#  10. Short-Lived Credentials - Verify STS issues node + workload creds with bounded TTL (SEC02-01)
 #
 # Note: SEC12-* (BMC) tests cannot be fully validated on AWS because the
 # Nitro/hypervisor BMC plane is provider-hidden. The references inspect the
@@ -134,6 +135,21 @@ commands:
           - "--missing-required-claim-token"
         timeout: 60
 
+      # Test 10: Short-Lived Credentials (SEC02-01)
+      # Probes sts:GetSessionToken (node-equivalent) and sts:GetFederationToken
+      # (workload-equivalent) and asserts each returned credential has a finite
+      # TTL within the configured upper bound. Emits a structured skip when
+      # the calling principal is itself a session/role and neither API is
+      # available.
+      - name: short_lived_credentials_test
+        phase: test
+        command: "python3 ../scripts/security/short_lived_credentials_test.py"
+        args:
+          - "--region"
+          - "{{region}}"
+          - "--max-ttl-seconds={{short_lived_credentials_max_ttl_seconds}}"
+        timeout: 60
+
       # Teardown: Clean up leftover test IAM users
       - name: teardown
         phase: teardown
@@ -151,3 +167,4 @@ tests:
     oidc_audience: "{{env.OIDC_AUDIENCE | default('', true)}}"
     oidc_target_url: "{{env.OIDC_TARGET_URL | default('', true)}}"
     customer_managed_key_id: "{{env.AWS_KMS_KEY_ID | default('', true)}}"
+    short_lived_credentials_max_ttl_seconds: "{{env.SEC02_MAX_TTL_SECONDS | default('43200', true)}}"

--- a/isvctl/configs/providers/aws/config/security.yaml
+++ b/isvctl/configs/providers/aws/config/security.yaml
@@ -155,7 +155,9 @@ commands:
           - "--region"
           - "{{region}}"
           - "--max-ttl-seconds={{short_lived_credentials_max_ttl_seconds}}"
-        timeout: 60
+        # Same envelope as sa_credential_test: provisions an IAM user and
+        # waits on IAM->STS propagation (worst case ~46s of backoff).
+        timeout: 120
 
       # Teardown: Clean up leftover test IAM users
       - name: teardown

--- a/isvctl/configs/providers/aws/config/security.yaml
+++ b/isvctl/configs/providers/aws/config/security.yaml
@@ -136,11 +136,18 @@ commands:
         timeout: 60
 
       # Test 10: Short-Lived Credentials (SEC02-01)
-      # Probes sts:GetSessionToken (node-equivalent) and sts:GetFederationToken
-      # (workload-equivalent) and asserts each returned credential has a finite
-      # TTL within the configured upper bound. Emits a structured skip when
-      # the calling principal is itself a session/role and neither API is
-      # available.
+      # Self-contained: provisions a fresh IAM user with an inline policy
+      # granting just sts:GetSessionToken + sts:GetFederationToken, mints
+      # an access key, probes both APIs to assert each returned credential
+      # has a finite TTL within the configured upper bound, then cleans
+      # the user up in a finally block. Works from assumed-role/SSO
+      # orchestrator principals because the probes run as the freshly
+      # provisioned IAM user, not as the caller.
+      #
+      # Orchestrator principal needs:
+      #   iam:CreateUser, iam:PutUserPolicy, iam:CreateAccessKey,
+      #   iam:DeleteUserPolicy, iam:DeleteAccessKey, iam:DeleteUser
+      # When those are missing the step emits a structured skip.
       - name: short_lived_credentials_test
         phase: test
         command: "python3 ../scripts/security/short_lived_credentials_test.py"

--- a/isvctl/configs/providers/aws/scripts/security/short_lived_credentials_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/short_lived_credentials_test.py
@@ -83,7 +83,9 @@ from common.errors import handle_aws_errors
 DEFAULT_MAX_TTL_SECONDS = 43200  # 12h - DGXC SEC02 upper bound for short-lived creds
 NODE_METHOD = "sts:GetSessionToken"
 WORKLOAD_METHOD = "sts:GetFederationToken"
-WORKLOAD_FEDERATION_NAME = "isv-sec02-workload"
+# Federation Name + IAM username share a per-run suffix so CloudTrail /
+# IAM Access Analyzer events from the same probe correlate cleanly.
+WORKLOAD_FEDERATION_PREFIX = "isv-sec02-workload-"
 TEST_USER_PREFIX = "isv-sec02-test-"
 INLINE_POLICY_NAME = "isv-sec02-sts-allow"
 DENY_ALL_POLICY = json.dumps(
@@ -217,10 +219,10 @@ def _probe_node_credential(sts: Any) -> datetime | None:
     return None
 
 
-def _probe_workload_credential(sts: Any) -> datetime | None:
+def _probe_workload_credential(sts: Any, federation_name: str) -> datetime | None:
     """Call sts:GetFederationToken with a deny-all session policy."""
     response = sts.get_federation_token(
-        Name=WORKLOAD_FEDERATION_NAME,
+        Name=federation_name,
         Policy=DENY_ALL_POLICY,
     )
     return response.get("Credentials", {}).get("Expiration")
@@ -249,7 +251,9 @@ def main() -> int:
     # cleanup helper can roll back whatever did succeed when any step
     # raises (e.g. CreateUser succeeds but PutUserPolicy hits LimitExceeded
     # or AccessDenied -> the user was created and must be deleted).
-    username = f"{TEST_USER_PREFIX}{uuid.uuid4().hex[:8]}"
+    run_suffix = uuid.uuid4().hex[:8]
+    username = f"{TEST_USER_PREFIX}{run_suffix}"
+    federation_name = f"{WORKLOAD_FEDERATION_PREFIX}{run_suffix}"
     access_key_id: str | None = None
     secret_key: str | None = None
     user_created = False
@@ -272,7 +276,7 @@ def main() -> int:
             print(
                 json.dumps(
                     _skipped_result(
-                        f"cannot provision SEC02 test IAM user ({code}); "
+                        f"cannot provision SEC02 test IAM user: {exc}; "
                         "orchestrator principal needs iam:CreateUser, iam:PutUserPolicy, "
                         "iam:CreateAccessKey (and matching delete permissions for cleanup)"
                     ),
@@ -318,10 +322,9 @@ def main() -> int:
         )
 
         try:
-            workload_expiration = _probe_workload_credential(sts)
+            workload_expiration = _probe_workload_credential(sts, federation_name)
         except ClientError as exc:
-            code = exc.response.get("Error", {}).get("Code", "")
-            error_msg = f"{WORKLOAD_METHOD} failed ({code})"
+            error_msg = f"{WORKLOAD_METHOD} failed: {exc}"
             result["tests"]["workload_credential_has_expiry"]["error"] = error_msg
             result["tests"]["workload_credential_ttl_within_bound"]["error"] = error_msg
         else:

--- a/isvctl/configs/providers/aws/scripts/security/short_lived_credentials_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/short_lived_credentials_test.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Verify the platform issues short-lived credentials to nodes and workloads (SEC02-01).
+
+This AWS reference probes two STS issuance paths whose response shape
+mirrors the node and workload identity flows the requirement targets, and
+asserts each returned credential carries a finite expiry that does not
+exceed a configured upper bound:
+
+* Node-equivalent: ``sts:GetSessionToken`` -- the API a long-lived IAM
+  user uses to mint short-lived session credentials, equivalent in shape
+  to the credentials an EC2 instance receives via instance metadata.
+* Workload-equivalent: ``sts:GetFederationToken`` (with a deny-all session
+  policy) -- the API used to issue short-lived credentials to an external
+  workload identity, equivalent in shape to the credentials an
+  IRSA-enabled pod receives.
+
+When the calling principal is itself an assumed-role session, neither API
+is available, and the step emits a structured ``skipped`` result (exit 0)
+so the orchestrator and validation can skip the check rather than
+fabricate a pass.
+
+Usage:
+    python short_lived_credentials_test.py --region us-west-2
+
+Output JSON:
+  {
+    "success": true,
+    "platform": "security",
+    "test_name": "short_lived_credentials_test",
+    "node_credential_method": "sts:GetSessionToken",
+    "workload_credential_method": "sts:GetFederationToken",
+    "node_credential_ttl_seconds": 43197,
+    "workload_credential_ttl_seconds": 43197,
+    "max_ttl_seconds": 43200,
+    "tests": {
+      "node_credential_has_expiry":           {"passed": true},
+      "node_credential_ttl_within_bound":     {"passed": true},
+      "workload_credential_has_expiry":       {"passed": true},
+      "workload_credential_ttl_within_bound": {"passed": true}
+    }
+  }
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import boto3
+from botocore.exceptions import ClientError
+from common.errors import handle_aws_errors
+
+DEFAULT_MAX_TTL_SECONDS = 43200  # 12h - DGXC SEC02 upper bound for short-lived creds
+NODE_METHOD = "sts:GetSessionToken"
+WORKLOAD_METHOD = "sts:GetFederationToken"
+WORKLOAD_FEDERATION_NAME = "isv-sec02-workload"
+DENY_ALL_POLICY = json.dumps(
+    {
+        "Version": "2012-10-17",
+        "Statement": [{"Effect": "Deny", "Action": "*", "Resource": "*"}],
+    }
+)
+# AWS error codes that mean "this principal cannot call the STS issuance API",
+# which is operational signal (not a SEC02 failure) -> skip the step.
+SKIPPABLE_STS_ERRORS = frozenset(
+    {
+        "AccessDenied",
+        "InvalidClientTokenId",
+        "ValidationError",
+    }
+)
+
+
+def _ttl_seconds(expiration: datetime) -> int:
+    """Return seconds until ``expiration``, treating naive datetimes as UTC."""
+    if expiration.tzinfo is None:
+        expiration = expiration.replace(tzinfo=UTC)
+    now = datetime.now(UTC)
+    return int((expiration - now).total_seconds())
+
+
+def _skipped_result(reason: str) -> dict[str, Any]:
+    """Return a structured top-level skip payload for the validation."""
+    return {
+        "success": True,
+        "platform": "security",
+        "test_name": "short_lived_credentials_test",
+        "skipped": True,
+        "skip_reason": reason,
+        "tests": {},
+    }
+
+
+def _record_credential(
+    result: dict[str, Any],
+    *,
+    expiry_key: str,
+    ttl_key: str,
+    ttl_field: str,
+    expiration: datetime | None,
+    max_ttl_seconds: int,
+) -> None:
+    """Update ``result`` with expiry + TTL probe outcomes for one credential."""
+    if expiration is None:
+        result["tests"][expiry_key]["error"] = "Credentials.Expiration missing in STS response"
+        result["tests"][ttl_key]["error"] = "no expiry returned -- TTL bound cannot be evaluated"
+        return
+    result["tests"][expiry_key]["passed"] = True
+    ttl = _ttl_seconds(expiration)
+    result[ttl_field] = ttl
+    if 0 < ttl <= max_ttl_seconds:
+        result["tests"][ttl_key]["passed"] = True
+    else:
+        result["tests"][ttl_key]["error"] = f"TTL {ttl}s outside (0, {max_ttl_seconds}s] bound"
+
+
+def _probe_node_credential(sts: Any) -> tuple[datetime | None, str | None]:
+    """Call sts:GetSessionToken and return (expiration, skip_reason)."""
+    try:
+        response = sts.get_session_token()
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in SKIPPABLE_STS_ERRORS:
+            return None, (
+                f"{NODE_METHOD} not available with current principal ({code}); "
+                f"AWS short-lived credential validation requires IAM user credentials"
+            )
+        raise
+    expiration = response.get("Credentials", {}).get("Expiration")
+    return expiration, None
+
+
+def _probe_workload_credential(sts: Any) -> tuple[datetime | None, str | None]:
+    """Call sts:GetFederationToken (deny-all policy) and return (expiration, error_msg)."""
+    try:
+        response = sts.get_federation_token(
+            Name=WORKLOAD_FEDERATION_NAME,
+            Policy=DENY_ALL_POLICY,
+        )
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in SKIPPABLE_STS_ERRORS:
+            return None, f"{WORKLOAD_METHOD} not available ({code})"
+        raise
+    expiration = response.get("Credentials", {}).get("Expiration")
+    return expiration, None
+
+
+@handle_aws_errors
+def main() -> int:
+    """Run the short-lived credentials probes and emit JSON result."""
+    parser = argparse.ArgumentParser(description="Short-lived credentials test (SEC02-01)")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument(
+        "--max-ttl-seconds",
+        type=int,
+        default=DEFAULT_MAX_TTL_SECONDS,
+        help=f"Upper bound on credential TTL (default: {DEFAULT_MAX_TTL_SECONDS})",
+    )
+    args = parser.parse_args()
+
+    if args.max_ttl_seconds < 1:
+        print(json.dumps(_skipped_result("--max-ttl-seconds must be a positive integer"), indent=2))
+        return 0
+
+    sts = boto3.client("sts", region_name=args.region)
+
+    node_expiration, skip_reason = _probe_node_credential(sts)
+    if skip_reason is not None:
+        print(json.dumps(_skipped_result(skip_reason), indent=2, default=str))
+        return 0
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "security",
+        "test_name": "short_lived_credentials_test",
+        "node_credential_method": NODE_METHOD,
+        "workload_credential_method": WORKLOAD_METHOD,
+        "node_credential_ttl_seconds": 0,
+        "workload_credential_ttl_seconds": 0,
+        "max_ttl_seconds": args.max_ttl_seconds,
+        "tests": {
+            "node_credential_has_expiry": {"passed": False},
+            "node_credential_ttl_within_bound": {"passed": False},
+            "workload_credential_has_expiry": {"passed": False},
+            "workload_credential_ttl_within_bound": {"passed": False},
+        },
+    }
+
+    _record_credential(
+        result,
+        expiry_key="node_credential_has_expiry",
+        ttl_key="node_credential_ttl_within_bound",
+        ttl_field="node_credential_ttl_seconds",
+        expiration=node_expiration,
+        max_ttl_seconds=args.max_ttl_seconds,
+    )
+
+    workload_expiration, workload_error = _probe_workload_credential(sts)
+    if workload_error is not None:
+        result["tests"]["workload_credential_has_expiry"]["error"] = workload_error
+        result["tests"]["workload_credential_ttl_within_bound"]["error"] = workload_error
+    else:
+        _record_credential(
+            result,
+            expiry_key="workload_credential_has_expiry",
+            ttl_key="workload_credential_ttl_within_bound",
+            ttl_field="workload_credential_ttl_seconds",
+            expiration=workload_expiration,
+            max_ttl_seconds=args.max_ttl_seconds,
+        )
+
+    result["success"] = all(probe["passed"] for probe in result["tests"].values())
+    print(json.dumps(result, indent=2, default=str))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/aws/scripts/security/short_lived_credentials_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/short_lived_credentials_test.py
@@ -11,10 +11,17 @@
 
 """Verify the platform issues short-lived credentials to nodes and workloads (SEC02-01).
 
-This AWS reference probes two STS issuance paths whose response shape
-mirrors the node and workload identity flows the requirement targets, and
-asserts each returned credential carries a finite expiry that does not
-exceed a configured upper bound:
+This AWS reference is self-contained (mirrors ``sa_credential_test.py``):
+it provisions a fresh IAM user with an inline policy granting just the two
+STS issuance APIs we probe, mints an access key, runs the probes against
+that user, and cleans the user up in a ``finally`` block. This means the
+test runs successfully even when the orchestrator principal is itself an
+assumed-role/SSO session - those callers cannot invoke
+``sts:GetSessionToken``/``sts:GetFederationToken`` directly, but they can
+``iam:CreateUser`` and let the test impersonate a fresh IAM user.
+
+Two STS issuance paths are probed; their response shape mirrors the node
+and workload identity flows the requirement targets:
 
 * Node-equivalent: ``sts:GetSessionToken`` -- the API a long-lived IAM
   user uses to mint short-lived session credentials, equivalent in shape
@@ -24,10 +31,16 @@ exceed a configured upper bound:
   workload identity, equivalent in shape to the credentials an
   IRSA-enabled pod receives.
 
-When the calling principal is itself an assumed-role session, neither API
-is available, and the step emits a structured ``skipped`` result (exit 0)
-so the orchestrator and validation can skip the check rather than
-fabricate a pass.
+Each probe asserts the returned credential carries a finite expiry that
+does not exceed a configured upper bound.
+
+When the orchestrator principal cannot provision the test IAM user (e.g.
+read-only credentials), the script emits a structured ``skipped`` payload
+(exit 0) so the validation can skip rather than fabricate a pass.
+
+Required orchestrator-principal IAM permissions:
+    iam:CreateUser, iam:PutUserPolicy, iam:CreateAccessKey,
+    iam:DeleteUserPolicy, iam:DeleteAccessKey, iam:DeleteUser
 
 Usage:
     python short_lived_credentials_test.py --region us-west-2
@@ -55,6 +68,8 @@ import argparse
 import json
 import os
 import sys
+import time
+import uuid
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -69,21 +84,36 @@ DEFAULT_MAX_TTL_SECONDS = 43200  # 12h - DGXC SEC02 upper bound for short-lived 
 NODE_METHOD = "sts:GetSessionToken"
 WORKLOAD_METHOD = "sts:GetFederationToken"
 WORKLOAD_FEDERATION_NAME = "isv-sec02-workload"
+TEST_USER_PREFIX = "isv-sec02-test-"
+INLINE_POLICY_NAME = "isv-sec02-sts-allow"
 DENY_ALL_POLICY = json.dumps(
     {
         "Version": "2012-10-17",
         "Statement": [{"Effect": "Deny", "Action": "*", "Resource": "*"}],
     }
 )
-# AWS error codes that mean "this principal cannot call the STS issuance API",
-# which is operational signal (not a SEC02 failure) -> skip the step.
-SKIPPABLE_STS_ERRORS = frozenset(
+INLINE_STS_POLICY = json.dumps(
     {
-        "AccessDenied",
-        "InvalidClientTokenId",
-        "ValidationError",
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": ["sts:GetSessionToken", "sts:GetFederationToken"],
+                "Resource": "*",
+            }
+        ],
     }
 )
+# AWS error codes that mean the orchestrator principal cannot provision
+# the test IAM user, which is operational signal (not a SEC02 failure)
+# -> emit a structured skip.
+SKIPPABLE_SETUP_ERRORS = frozenset({"AccessDenied", "UnauthorizedOperation"})
+
+# IAM is eventually consistent: a freshly created access key may take
+# 15-30s to propagate to STS. Mirror sa_credential_test.py's retry
+# pattern: exponential backoff capped at 8s, 8 attempts (~46s worst case).
+STS_PROPAGATION_MAX_ATTEMPTS = 8
+STS_PROPAGATION_BACKOFF_CAP = 8
 
 
 def _ttl_seconds(expiration: datetime) -> int:
@@ -129,41 +159,100 @@ def _record_credential(
         result["tests"][ttl_key]["error"] = f"TTL {ttl}s outside (0, {max_ttl_seconds}s] bound"
 
 
-def _probe_node_credential(sts: Any) -> tuple[datetime | None, str | None]:
-    """Call sts:GetSessionToken and return (expiration, skip_reason)."""
-    try:
-        response = sts.get_session_token()
-    except ClientError as exc:
-        code = exc.response.get("Error", {}).get("Code", "")
-        if code in SKIPPABLE_STS_ERRORS:
-            return None, (
-                f"{NODE_METHOD} not available with current principal ({code}); "
-                f"AWS short-lived credential validation requires IAM user credentials"
-            )
-        raise
-    expiration = response.get("Credentials", {}).get("Expiration")
-    return expiration, None
+def _setup_test_user(iam: Any) -> tuple[str, str, str]:
+    """Create test IAM user + inline policy + access key.
+
+    Returns:
+        Tuple of (username, access_key_id, secret_access_key).
+    """
+    username = f"{TEST_USER_PREFIX}{uuid.uuid4().hex[:8]}"
+    iam.create_user(
+        UserName=username,
+        Tags=[{"Key": "CreatedBy", "Value": "isvtest"}],
+    )
+    iam.put_user_policy(
+        UserName=username,
+        PolicyName=INLINE_POLICY_NAME,
+        PolicyDocument=INLINE_STS_POLICY,
+    )
+    response = iam.create_access_key(UserName=username)
+    return (
+        username,
+        response["AccessKey"]["AccessKeyId"],
+        response["AccessKey"]["SecretAccessKey"],
+    )
 
 
-def _probe_workload_credential(sts: Any) -> tuple[datetime | None, str | None]:
-    """Call sts:GetFederationToken (deny-all policy) and return (expiration, error_msg)."""
-    try:
-        response = sts.get_federation_token(
-            Name=WORKLOAD_FEDERATION_NAME,
-            Policy=DENY_ALL_POLICY,
-        )
-    except ClientError as exc:
-        code = exc.response.get("Error", {}).get("Code", "")
-        if code in SKIPPABLE_STS_ERRORS:
-            return None, f"{WORKLOAD_METHOD} not available ({code})"
-        raise
-    expiration = response.get("Credentials", {}).get("Expiration")
-    return expiration, None
+def _cleanup_test_user(
+    iam: Any,
+    username: str | None,
+    access_key_id: str | None,
+    user_created: bool,
+) -> list[str]:
+    """Best-effort delete of the test IAM user's policy, access key, and user.
+
+    Each step is attempted independently so a failure in one does not
+    block the others. ``NoSuchEntity`` is treated as success (already gone).
+    """
+    cleanup_errors: list[str] = []
+    if not username:
+        return cleanup_errors
+
+    if user_created:
+        try:
+            iam.delete_user_policy(UserName=username, PolicyName=INLINE_POLICY_NAME)
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") != "NoSuchEntity":
+                cleanup_errors.append(f"delete inline policy {INLINE_POLICY_NAME} for {username}: {e}")
+
+    if access_key_id:
+        try:
+            iam.delete_access_key(UserName=username, AccessKeyId=access_key_id)
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") != "NoSuchEntity":
+                cleanup_errors.append(f"delete access key {access_key_id} for {username}: {e}")
+
+    if user_created:
+        try:
+            iam.delete_user(UserName=username)
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") != "NoSuchEntity":
+                cleanup_errors.append(f"delete user {username}: {e}")
+
+    return cleanup_errors
+
+
+def _probe_node_credential(sts: Any) -> datetime | None:
+    """Call sts:GetSessionToken with retries for IAM eventual consistency.
+
+    Raises ``ClientError`` if all retry attempts are exhausted or the
+    error is not retryable.
+    """
+    for attempt in range(STS_PROPAGATION_MAX_ATTEMPTS):
+        try:
+            response = sts.get_session_token()
+            return response.get("Credentials", {}).get("Expiration")
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if code == "InvalidClientTokenId" and attempt < STS_PROPAGATION_MAX_ATTEMPTS - 1:
+                time.sleep(min(2 ** (attempt + 1), STS_PROPAGATION_BACKOFF_CAP))
+                continue
+            raise
+    return None
+
+
+def _probe_workload_credential(sts: Any) -> datetime | None:
+    """Call sts:GetFederationToken with a deny-all session policy."""
+    response = sts.get_federation_token(
+        Name=WORKLOAD_FEDERATION_NAME,
+        Policy=DENY_ALL_POLICY,
+    )
+    return response.get("Credentials", {}).get("Expiration")
 
 
 @handle_aws_errors
 def main() -> int:
-    """Run the short-lived credentials probes and emit JSON result."""
+    """Provision a test IAM user, probe STS issuance, emit JSON, clean up."""
     parser = argparse.ArgumentParser(description="Short-lived credentials test (SEC02-01)")
     parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
     parser.add_argument(
@@ -178,12 +267,33 @@ def main() -> int:
         print(json.dumps(_skipped_result("--max-ttl-seconds must be a positive integer"), indent=2))
         return 0
 
-    sts = boto3.client("sts", region_name=args.region)
+    iam = boto3.client("iam", region_name=args.region)
 
-    node_expiration, skip_reason = _probe_node_credential(sts)
-    if skip_reason is not None:
-        print(json.dumps(_skipped_result(skip_reason), indent=2, default=str))
-        return 0
+    username: str | None = None
+    access_key_id: str | None = None
+    secret_key: str | None = None
+    user_created = False
+
+    try:
+        username, access_key_id, secret_key = _setup_test_user(iam)
+        user_created = True
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in SKIPPABLE_SETUP_ERRORS:
+            _cleanup_test_user(iam, username, access_key_id, user_created)
+            print(
+                json.dumps(
+                    _skipped_result(
+                        f"cannot provision SEC02 test IAM user ({code}); "
+                        "orchestrator principal needs iam:CreateUser, iam:PutUserPolicy, "
+                        "iam:CreateAccessKey (and matching delete permissions for cleanup)"
+                    ),
+                    indent=2,
+                )
+            )
+            return 0
+        _cleanup_test_user(iam, username, access_key_id, user_created)
+        raise
 
     result: dict[str, Any] = {
         "success": False,
@@ -202,30 +312,51 @@ def main() -> int:
         },
     }
 
-    _record_credential(
-        result,
-        expiry_key="node_credential_has_expiry",
-        ttl_key="node_credential_ttl_within_bound",
-        ttl_field="node_credential_ttl_seconds",
-        expiration=node_expiration,
-        max_ttl_seconds=args.max_ttl_seconds,
-    )
+    try:
+        sts = boto3.client(
+            "sts",
+            region_name=args.region,
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_key,
+        )
 
-    workload_expiration, workload_error = _probe_workload_credential(sts)
-    if workload_error is not None:
-        result["tests"]["workload_credential_has_expiry"]["error"] = workload_error
-        result["tests"]["workload_credential_ttl_within_bound"]["error"] = workload_error
-    else:
+        node_expiration = _probe_node_credential(sts)
         _record_credential(
             result,
-            expiry_key="workload_credential_has_expiry",
-            ttl_key="workload_credential_ttl_within_bound",
-            ttl_field="workload_credential_ttl_seconds",
-            expiration=workload_expiration,
+            expiry_key="node_credential_has_expiry",
+            ttl_key="node_credential_ttl_within_bound",
+            ttl_field="node_credential_ttl_seconds",
+            expiration=node_expiration,
             max_ttl_seconds=args.max_ttl_seconds,
         )
 
-    result["success"] = all(probe["passed"] for probe in result["tests"].values())
+        try:
+            workload_expiration = _probe_workload_credential(sts)
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            error_msg = f"{WORKLOAD_METHOD} failed ({code})"
+            result["tests"]["workload_credential_has_expiry"]["error"] = error_msg
+            result["tests"]["workload_credential_ttl_within_bound"]["error"] = error_msg
+        else:
+            _record_credential(
+                result,
+                expiry_key="workload_credential_has_expiry",
+                ttl_key="workload_credential_ttl_within_bound",
+                ttl_field="workload_credential_ttl_seconds",
+                expiration=workload_expiration,
+                max_ttl_seconds=args.max_ttl_seconds,
+            )
+
+        result["success"] = all(probe["passed"] for probe in result["tests"].values())
+    finally:
+        cleanup_errors = _cleanup_test_user(iam, username, access_key_id, user_created)
+        if cleanup_errors:
+            result["cleanup_errors"] = cleanup_errors
+            cleanup_msg = f"Cleanup failed: {'; '.join(cleanup_errors)}"
+            existing = result.get("error")
+            result["error"] = f"{existing}; {cleanup_msg}" if existing else cleanup_msg
+            result["success"] = False
+
     print(json.dumps(result, indent=2, default=str))
     return 0 if result["success"] else 1
 

--- a/isvctl/configs/providers/aws/scripts/security/short_lived_credentials_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/short_lived_credentials_test.py
@@ -271,7 +271,25 @@ def main() -> int:
         secret_key = response["AccessKey"]["SecretAccessKey"]
     except ClientError as exc:
         code = exc.response.get("Error", {}).get("Code", "")
-        _cleanup_test_user(iam, username, access_key_id, user_created)
+        cleanup_errors = _cleanup_test_user(iam, username, access_key_id, user_created)
+        if cleanup_errors:
+            # Even if the setup error itself is skippable, a failed cleanup
+            # means we leaked IAM state. Surface as a hard failure so the
+            # run is not reported as a clean skip.
+            print(
+                json.dumps(
+                    {
+                        "success": False,
+                        "platform": "security",
+                        "test_name": "short_lived_credentials_test",
+                        "error": f"setup failed: {exc}; cleanup failed: {'; '.join(cleanup_errors)}",
+                        "cleanup_errors": cleanup_errors,
+                        "tests": {},
+                    },
+                    indent=2,
+                )
+            )
+            return 1
         if code in SKIPPABLE_SETUP_ERRORS:
             print(
                 json.dumps(

--- a/isvctl/configs/providers/aws/scripts/security/short_lived_credentials_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/short_lived_credentials_test.py
@@ -159,30 +159,6 @@ def _record_credential(
         result["tests"][ttl_key]["error"] = f"TTL {ttl}s outside (0, {max_ttl_seconds}s] bound"
 
 
-def _setup_test_user(iam: Any) -> tuple[str, str, str]:
-    """Create test IAM user + inline policy + access key.
-
-    Returns:
-        Tuple of (username, access_key_id, secret_access_key).
-    """
-    username = f"{TEST_USER_PREFIX}{uuid.uuid4().hex[:8]}"
-    iam.create_user(
-        UserName=username,
-        Tags=[{"Key": "CreatedBy", "Value": "isvtest"}],
-    )
-    iam.put_user_policy(
-        UserName=username,
-        PolicyName=INLINE_POLICY_NAME,
-        PolicyDocument=INLINE_STS_POLICY,
-    )
-    response = iam.create_access_key(UserName=username)
-    return (
-        username,
-        response["AccessKey"]["AccessKeyId"],
-        response["AccessKey"]["SecretAccessKey"],
-    )
-
-
 def _cleanup_test_user(
     iam: Any,
     username: str | None,
@@ -269,18 +245,30 @@ def main() -> int:
 
     iam = boto3.client("iam", region_name=args.region)
 
-    username: str | None = None
+    # Setup runs as three separate IAM calls. Track partial state so the
+    # cleanup helper can roll back whatever did succeed when any step
+    # raises (e.g. CreateUser succeeds but PutUserPolicy hits LimitExceeded
+    # or AccessDenied -> the user was created and must be deleted).
+    username = f"{TEST_USER_PREFIX}{uuid.uuid4().hex[:8]}"
     access_key_id: str | None = None
     secret_key: str | None = None
     user_created = False
 
     try:
-        username, access_key_id, secret_key = _setup_test_user(iam)
+        iam.create_user(UserName=username, Tags=[{"Key": "CreatedBy", "Value": "isvtest"}])
         user_created = True
+        iam.put_user_policy(
+            UserName=username,
+            PolicyName=INLINE_POLICY_NAME,
+            PolicyDocument=INLINE_STS_POLICY,
+        )
+        response = iam.create_access_key(UserName=username)
+        access_key_id = response["AccessKey"]["AccessKeyId"]
+        secret_key = response["AccessKey"]["SecretAccessKey"]
     except ClientError as exc:
         code = exc.response.get("Error", {}).get("Code", "")
+        _cleanup_test_user(iam, username, access_key_id, user_created)
         if code in SKIPPABLE_SETUP_ERRORS:
-            _cleanup_test_user(iam, username, access_key_id, user_created)
             print(
                 json.dumps(
                     _skipped_result(
@@ -292,7 +280,6 @@ def main() -> int:
                 )
             )
             return 0
-        _cleanup_test_user(iam, username, access_key_id, user_created)
         raise
 
     result: dict[str, Any] = {

--- a/isvctl/configs/providers/aws/scripts/security/teardown.py
+++ b/isvctl/configs/providers/aws/scripts/security/teardown.py
@@ -12,8 +12,12 @@
 """Security test teardown (AWS reference).
 
 Each individual test script handles its own cleanup.  This teardown
-step is a safety net that scans for leftover isv-sa-test-* IAM users
-created by the SA credential test.
+step is a safety net that scans for leftover IAM users created by
+security test scripts:
+
+* ``isv-sa-test-*``     - sa_credential_test.py
+* ``isv-sec02-test-*``  - short_lived_credentials_test.py (has an inline
+                          policy that must be deleted before the user)
 
 Usage:
     python teardown.py --region us-west-2
@@ -31,6 +35,8 @@ sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
 import boto3
 from botocore.exceptions import ClientError
 from common.errors import handle_aws_errors
+
+OWNED_USER_PREFIXES: tuple[str, ...] = ("isv-sa-test-", "isv-sec02-test-")
 
 
 def _user_has_isvtest_tag(iam: Any, username: str) -> bool:
@@ -50,9 +56,15 @@ def _user_has_isvtest_tag(iam: Any, username: str) -> bool:
 
 
 def _cleanup_owned_user(iam: Any, username: str) -> list[str]:
-    """Delete one owned IAM user and its access keys, returning cleanup errors."""
+    """Delete one owned IAM user, its access keys, and any inline policies.
+
+    Inline policies must be detached before ``DeleteUser`` succeeds; SEC02
+    test users carry one. SA-credential test users have no inline policies,
+    so the inline-policy pass is a no-op for them.
+    """
     cleanup_errors: list[str] = []
     keys: list[dict[str, Any]] = []
+    inline_policies: list[str] = []
 
     try:
         keys = iam.list_access_keys(UserName=username)["AccessKeyMetadata"]
@@ -65,6 +77,17 @@ def _cleanup_owned_user(iam: Any, username: str) -> list[str]:
             iam.delete_access_key(UserName=username, AccessKeyId=access_key_id)
         except ClientError as e:
             cleanup_errors.append(f"delete access key {access_key_id} for {username}: {e}")
+
+    try:
+        inline_policies = iam.list_user_policies(UserName=username).get("PolicyNames", [])
+    except ClientError as e:
+        cleanup_errors.append(f"list inline policies for {username}: {e}")
+
+    for policy_name in inline_policies:
+        try:
+            iam.delete_user_policy(UserName=username, PolicyName=policy_name)
+        except ClientError as e:
+            cleanup_errors.append(f"delete inline policy {policy_name} for {username}: {e}")
 
     try:
         iam.delete_user(UserName=username)
@@ -104,7 +127,7 @@ def main() -> int:
         for page in paginator.paginate():
             for user in page["Users"]:
                 name = user["UserName"]
-                if not name.startswith("isv-sa-test-"):
+                if not name.startswith(OWNED_USER_PREFIXES):
                     continue
                 if not _user_has_isvtest_tag(iam, name):
                     skipped_unowned += 1

--- a/isvctl/configs/providers/my-isv/config/security.yaml
+++ b/isvctl/configs/providers/my-isv/config/security.yaml
@@ -25,6 +25,7 @@
 #   SEC09-04: Customer-managed keys / BYOK (CustomerManagedKeyCheck)
 #   SEC03-01: Service account credentials (ServiceAccountCredentialCheck)
 #   SEC01-01: OIDC user authentication (OidcUserAuthCheck)
+#   SEC02-01: Short-lived credentials/tokens (ShortLivedCredentialsCheck)
 #
 # Usage:
 #   uv run isvctl test run -f isvctl/configs/providers/my-isv/config/security.yaml
@@ -95,6 +96,12 @@ commands:
       - name: oidc_user_auth_test
         phase: test
         command: "python ../scripts/security/oidc_user_auth_test.py"
+        args: ["--region", "{{region}}"]
+        timeout: 60
+
+      - name: short_lived_credentials_test
+        phase: test
+        command: "python ../scripts/security/short_lived_credentials_test.py"
         args: ["--region", "{{region}}"]
         timeout: 60
 

--- a/isvctl/configs/providers/my-isv/scripts/README.md
+++ b/isvctl/configs/providers/my-isv/scripts/README.md
@@ -34,7 +34,7 @@ the TODOs.
 | `bare_metal/` | 12 | [`suites/bare_metal.yaml`](../../../suites/bare_metal.yaml) | [`config/bare_metal.yaml`](../config/bare_metal.yaml) | [`providers/aws/scripts/bare_metal/`](../../aws/scripts/bare_metal/) |
 | `network/` | 18 | [`suites/network.yaml`](../../../suites/network.yaml) | [`config/network.yaml`](../config/network.yaml) | [`providers/aws/scripts/network/`](../../aws/scripts/network/) |
 | `image-registry/` | 7 | [`suites/image-registry.yaml`](../../../suites/image-registry.yaml) | [`config/image-registry.yaml`](../config/image-registry.yaml) | [`providers/aws/scripts/image-registry/`](../../aws/scripts/image-registry/) |
-| `security/` | 9 | [`suites/security.yaml`](../../../suites/security.yaml) | [`config/security.yaml`](../config/security.yaml) | [`providers/aws/scripts/security/`](../../aws/scripts/security/) |
+| `security/` | 10 | [`suites/security.yaml`](../../../suites/security.yaml) | [`config/security.yaml`](../config/security.yaml) | [`providers/aws/scripts/security/`](../../aws/scripts/security/) |
 | `k8s/` | 9 shell | [`suites/k8s.yaml`](../../../suites/k8s.yaml) | - | [`providers/aws/scripts/eks/`](../../aws/scripts/eks/) |
 | `slurm/` | 2 shell | [`suites/slurm.yaml`](../../../suites/slurm.yaml) | - | - |
 

--- a/isvctl/configs/providers/my-isv/scripts/security/short_lived_credentials_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/security/short_lived_credentials_test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Short-lived credentials test - TEMPLATE (replace with your platform implementation).
+
+Verifies that workloads and nodes receive credentials with a finite expiry
+that does not exceed a configured upper bound. Covers SEC02-01.
+
+The validation expects two distinct issuance surfaces to be probed:
+
+  * Node-side: credentials a host/instance role acquires from the platform
+    identity service.
+  * Workload-side: credentials an in-cluster workload acquires through the
+    workload identity flow.
+
+When neither issuance path is available in the current environment the
+script may emit a structured ``skipped`` payload (top-level
+``skipped: true`` plus a ``skip_reason``) and exit 0; the validation will
+treat that as a clean skip rather than a failure.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "security",
+    "test_name": "short_lived_credentials_test",
+    "node_credential_method": "<short label, e.g. instance-metadata role>",
+    "workload_credential_method": "<short label, e.g. workload-identity>",
+    "node_credential_ttl_seconds": <int>,
+    "workload_credential_ttl_seconds": <int>,
+    "max_ttl_seconds": <int>,
+    "tests": {
+      "node_credential_has_expiry":           {"passed": true},
+      "node_credential_ttl_within_bound":     {"passed": true},
+      "workload_credential_has_expiry":       {"passed": true},
+      "workload_credential_ttl_within_bound": {"passed": true}
+    }
+  }
+
+Usage:
+    python short_lived_credentials_test.py --region <region>
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+DEFAULT_MAX_TTL_SECONDS = 43200  # 12h upper bound
+
+
+def main() -> int:
+    """Short-lived credentials test (template) and emit structured JSON result."""
+    parser = argparse.ArgumentParser(description="Short-lived credentials test (template)")
+    parser.add_argument("--region", required=True, help="Cloud region")
+    parser.add_argument(
+        "--max-ttl-seconds",
+        type=int,
+        default=DEFAULT_MAX_TTL_SECONDS,
+        help="Upper bound on credential TTL (default: 43200 = 12h)",
+    )
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "security",
+        "test_name": "short_lived_credentials_test",
+        "node_credential_method": "",
+        "workload_credential_method": "",
+        "node_credential_ttl_seconds": 0,
+        "workload_credential_ttl_seconds": 0,
+        "max_ttl_seconds": args.max_ttl_seconds,
+        "tests": {
+            "node_credential_has_expiry": {"passed": False},
+            "node_credential_ttl_within_bound": {"passed": False},
+            "workload_credential_has_expiry": {"passed": False},
+            "workload_credential_ttl_within_bound": {"passed": False},
+        },
+    }
+
+    # ╔══════════════════════════════════════════════════════════════════╗
+    # ║  TODO: Replace this block with your platform's short-lived       ║
+    # ║  credentials test.                                               ║
+    # ║                                                                  ║
+    # ║  Example (pseudocode):                                           ║
+    # ║    node_creds = mint_node_credentials(region)                    ║
+    # ║    assert node_creds.expires_at is not None                      ║
+    # ║    node_ttl = (node_creds.expires_at - now()).total_seconds()    ║
+    # ║    assert 0 < node_ttl <= max_ttl_seconds                        ║
+    # ║                                                                  ║
+    # ║    wl_creds = mint_workload_credentials(region)                  ║
+    # ║    assert wl_creds.expires_at is not None                        ║
+    # ║    wl_ttl = (wl_creds.expires_at - now()).total_seconds()        ║
+    # ║    assert 0 < wl_ttl <= max_ttl_seconds                          ║
+    # ║                                                                  ║
+    # ║  If neither issuance path can be exercised in this environment,  ║
+    # ║  emit ``skipped: true`` plus a ``skip_reason`` and exit 0.       ║
+    # ╚══════════════════════════════════════════════════════════════════╝
+
+    if DEMO_MODE:
+        result["node_credential_method"] = "instance-role-token"
+        result["workload_credential_method"] = "workload-identity-token"
+        result["node_credential_ttl_seconds"] = 3600
+        result["workload_credential_ttl_seconds"] = 3600
+        result["tests"] = {
+            "node_credential_has_expiry": {"passed": True},
+            "node_credential_ttl_within_bound": {"passed": True},
+            "workload_credential_has_expiry": {"passed": True},
+            "workload_credential_ttl_within_bound": {"passed": True},
+        }
+        result["success"] = True
+    else:
+        result["error"] = "Not implemented - replace with your platform's short-lived credentials test"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -152,6 +152,7 @@ Validations use `sinfo`/`srun` directly: partitions, GPU allocation, job schedul
 | `customer_managed_key_test` | test | `providers/my-isv/scripts/security/customer_managed_key_test.py` | SEC09-04: Customer-managed key / BYOK encryption |
 | `sa_credential_test` | test | `providers/my-isv/scripts/security/sa_credential_test.py` | Service account long-lived credential auth |
 | `oidc_user_auth_test` | test | `providers/my-isv/scripts/security/oidc_user_auth_test.py` | OIDC issuer metadata and protected endpoint token acceptance/rejection |
+| `short_lived_credentials_test` | test | `providers/my-isv/scripts/security/short_lived_credentials_test.py` | SEC02-01: workloads and nodes receive credentials with finite, bounded TTL |
 | `teardown` | teardown | `providers/my-isv/scripts/security/teardown.py` | Cleanup test resources |
 
 ## Related Documentation

--- a/isvctl/configs/suites/security.yaml
+++ b/isvctl/configs/suites/security.yaml
@@ -84,6 +84,11 @@ tests:
         OidcUserAuthCheck:
           step: oidc_user_auth_test
 
+    short_lived_credentials:
+      checks:
+        ShortLivedCredentialsCheck:
+          step: short_lived_credentials_test
+
     teardown_checks:
       step: teardown
       checks:

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -1084,6 +1084,11 @@ class FakeTeardownIam:
         assert AccessKeyId == "AKIA_LEFTOVER"
         raise _client_error("DeleteAccessKey")
 
+    def list_user_policies(self, UserName: str) -> dict[str, list[str]]:
+        """Return no inline policies for the legacy sa_credential test user."""
+        assert UserName == "isv-sa-test-leftover"
+        return {"PolicyNames": []}
+
     def delete_user(self, UserName: str) -> None:
         """Fail user deletion after access key deletion failed."""
         assert UserName == "isv-sa-test-leftover"
@@ -1114,8 +1119,66 @@ def test_teardown_main_fails_when_owned_user_cleanup_fails(
     assert payload["success"] is False
     assert payload["resources_cleaned"] == 0
     assert payload["resources_failed"][0]["username"] == "isv-sa-test-leftover"
+    # Two failure paths now plus a list_inline_policies success: keep
+    # the existing two-failure assertion but allow the inline-policy
+    # listing call to succeed silently.
     assert len(payload["resources_failed"][0]["errors"]) == 2
     assert iam.delete_user_called is True
+
+
+class FakeSec02CleanupIam:
+    """Fake IAM client exercising teardown's inline-policy cleanup path for SEC02 users."""
+
+    def __init__(self) -> None:
+        """Initialize call tracking."""
+        self.deleted_keys: list[tuple[str, str]] = []
+        self.deleted_policies: list[tuple[str, str]] = []
+        self.deleted_users: list[str] = []
+
+    def list_access_keys(self, UserName: str) -> dict[str, list[dict[str, str]]]:
+        """Return one fake access key."""
+        assert UserName.startswith("isv-sec02-test-")
+        return {"AccessKeyMetadata": [{"AccessKeyId": "AKIA_SEC02"}]}
+
+    def delete_access_key(self, UserName: str, AccessKeyId: str) -> None:
+        """Record access key deletion."""
+        self.deleted_keys.append((UserName, AccessKeyId))
+
+    def list_user_policies(self, UserName: str) -> dict[str, list[str]]:
+        """Return one inline policy attached to the SEC02 user."""
+        assert UserName.startswith("isv-sec02-test-")
+        return {"PolicyNames": ["isv-sec02-sts-allow"]}
+
+    def delete_user_policy(self, UserName: str, PolicyName: str) -> None:
+        """Record inline policy deletion."""
+        self.deleted_policies.append((UserName, PolicyName))
+
+    def delete_user(self, UserName: str) -> None:
+        """Record user deletion."""
+        self.deleted_users.append(UserName)
+
+
+def test_teardown_cleanup_owned_user_deletes_inline_policy_for_sec02_users() -> None:
+    """`_cleanup_owned_user` must detach inline policies before deleting SEC02 users."""
+    module = _load_security_script("teardown.py")
+    iam = FakeSec02CleanupIam()
+
+    cleanup_errors = module._cleanup_owned_user(iam, "isv-sec02-test-abcd1234")
+
+    assert cleanup_errors == []
+    assert iam.deleted_keys == [("isv-sec02-test-abcd1234", "AKIA_SEC02")]
+    assert iam.deleted_policies == [("isv-sec02-test-abcd1234", "isv-sec02-sts-allow")]
+    assert iam.deleted_users == ["isv-sec02-test-abcd1234"]
+
+
+def test_teardown_owned_user_prefixes_cover_security_test_scripts() -> None:
+    """The teardown sweep must recognize both sa_credential and short-lived test users."""
+    module = _load_security_script("teardown.py")
+
+    assert "isv-sa-test-".startswith("isv-sa-test-")
+    assert "isv-sec02-test-foo".startswith(module.OWNED_USER_PREFIXES)
+    assert "isv-sa-test-bar".startswith(module.OWNED_USER_PREFIXES)
+    assert not "isv-network-test-baz".startswith(module.OWNED_USER_PREFIXES)
 
 
 @pytest.fixture(scope="module")
@@ -2012,32 +2075,102 @@ def short_lived_module() -> ModuleType:
     return _load_security_script("short_lived_credentials_test.py")
 
 
+class FakeShortLivedIam:
+    """Fake IAM client tracking SEC02 user provisioning + cleanup calls."""
+
+    def __init__(
+        self,
+        *,
+        create_user_error: ClientError | None = None,
+        put_user_policy_error: ClientError | None = None,
+        create_access_key_error: ClientError | None = None,
+        delete_user_policy_error: ClientError | None = None,
+        delete_access_key_error: ClientError | None = None,
+        delete_user_error: ClientError | None = None,
+    ) -> None:
+        """Configure optional per-call failures."""
+        self.create_user_error = create_user_error
+        self.put_user_policy_error = put_user_policy_error
+        self.create_access_key_error = create_access_key_error
+        self.delete_user_policy_error = delete_user_policy_error
+        self.delete_access_key_error = delete_access_key_error
+        self.delete_user_error = delete_user_error
+        self.created_users: list[dict[str, Any]] = []
+        self.put_policies: list[dict[str, str]] = []
+        self.deleted_policies: list[tuple[str, str]] = []
+        self.deleted_keys: list[tuple[str, str]] = []
+        self.deleted_users: list[str] = []
+
+    def create_user(self, UserName: str, Tags: list[dict[str, str]]) -> dict[str, dict[str, str]]:
+        """Create a fake IAM user, recording the call."""
+        if self.create_user_error is not None:
+            raise self.create_user_error
+        assert UserName.startswith("isv-sec02-test-")
+        assert {"Key": "CreatedBy", "Value": "isvtest"} in Tags
+        self.created_users.append({"UserName": UserName, "Tags": Tags})
+        return {"User": {"UserName": UserName, "Arn": f"arn:aws:iam::123:user/{UserName}"}}
+
+    def put_user_policy(self, UserName: str, PolicyName: str, PolicyDocument: str) -> None:
+        """Attach a fake inline policy to the test user."""
+        if self.put_user_policy_error is not None:
+            raise self.put_user_policy_error
+        assert UserName.startswith("isv-sec02-test-")
+        self.put_policies.append({"UserName": UserName, "PolicyName": PolicyName, "PolicyDocument": PolicyDocument})
+
+    def create_access_key(self, UserName: str) -> dict[str, dict[str, str]]:
+        """Return fake access key material for the test user."""
+        if self.create_access_key_error is not None:
+            raise self.create_access_key_error
+        assert UserName.startswith("isv-sec02-test-")
+        return {"AccessKey": {"AccessKeyId": "AKIA_FAKE", "SecretAccessKey": "secret_fake"}}
+
+    def delete_user_policy(self, UserName: str, PolicyName: str) -> None:
+        """Detach the inline policy, recording the call."""
+        if self.delete_user_policy_error is not None:
+            raise self.delete_user_policy_error
+        self.deleted_policies.append((UserName, PolicyName))
+
+    def delete_access_key(self, UserName: str, AccessKeyId: str) -> None:
+        """Delete the test user's access key, recording the call."""
+        if self.delete_access_key_error is not None:
+            raise self.delete_access_key_error
+        self.deleted_keys.append((UserName, AccessKeyId))
+
+    def delete_user(self, UserName: str) -> None:
+        """Delete the test user, recording the call."""
+        if self.delete_user_error is not None:
+            raise self.delete_user_error
+        self.deleted_users.append(UserName)
+
+
 class FakeShortLivedSts:
-    """Minimal STS fake supporting GetSessionToken / GetFederationToken."""
+    """Fake STS client supporting GetSessionToken / GetFederationToken with optional retry sequencing."""
 
     def __init__(
         self,
         *,
         session_expiration: Any = None,
-        session_error: ClientError | None = None,
+        session_errors: list[ClientError] | None = None,
         federation_expiration: Any = None,
         federation_error: ClientError | None = None,
         omit_session_expiration: bool = False,
         omit_federation_expiration: bool = False,
     ) -> None:
-        """Configure fake STS responses or errors per API."""
+        """Configure fake STS responses, optional retry-error sequence on session, and per-probe expirations."""
         self.session_expiration = session_expiration
-        self.session_error = session_error
+        self.session_errors: list[ClientError] = list(session_errors) if session_errors else []
         self.federation_expiration = federation_expiration
         self.federation_error = federation_error
         self.omit_session_expiration = omit_session_expiration
         self.omit_federation_expiration = omit_federation_expiration
         self.federation_calls: list[dict[str, str]] = []
+        self.session_call_count = 0
 
     def get_session_token(self) -> dict[str, dict[str, Any]]:
-        """Return fake GetSessionToken response or raise the configured error."""
-        if self.session_error is not None:
-            raise self.session_error
+        """Return fake GetSessionToken response, popping a queued error on each call."""
+        self.session_call_count += 1
+        if self.session_errors:
+            raise self.session_errors.pop(0)
         creds: dict[str, Any] = {
             "AccessKeyId": "ASIA_FAKE",
             "SecretAccessKey": "secret",
@@ -2062,20 +2195,35 @@ class FakeShortLivedSts:
         return {"Credentials": creds}
 
 
-def _patch_short_lived_sts(
+def _patch_short_lived_clients(
     monkeypatch: pytest.MonkeyPatch,
     module: ModuleType,
+    *,
+    iam: FakeShortLivedIam,
     sts: FakeShortLivedSts,
 ) -> None:
-    """Patch boto3.client to return the supplied fake STS client."""
+    """Patch boto3.client to return fakes for iam and sts, and zero out the IAM-propagation sleep."""
 
-    def fake_client(service_name: str, region_name: str | None = None) -> FakeShortLivedSts:
-        """Return the fake STS client for sts requests."""
-        assert service_name == "sts"
-        assert region_name == "us-west-2"
-        return sts
+    def fake_client(service_name: str, **kwargs: Any) -> FakeShortLivedIam | FakeShortLivedSts:
+        """Return the matching fake client for iam/sts."""
+        if service_name == "iam":
+            return iam
+        if service_name == "sts":
+            return sts
+        msg = f"unexpected service: {service_name}"
+        raise AssertionError(msg)
 
     monkeypatch.setattr(module.boto3, "client", fake_client)
+    monkeypatch.setattr(module.time, "sleep", lambda _: None)
+
+
+def _set_short_lived_argv(monkeypatch: pytest.MonkeyPatch, module: ModuleType, *extra_args: str) -> None:
+    """Set sys.argv for the short-lived credentials script with optional extra args."""
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        ["short_lived_credentials_test.py", "--region", "us-west-2", *extra_args],
+    )
 
 
 def test_short_lived_credentials_main_passes_with_bounded_ttls(
@@ -2083,20 +2231,17 @@ def test_short_lived_credentials_main_passes_with_bounded_ttls(
     capsys: pytest.CaptureFixture[str],
     short_lived_module: ModuleType,
 ) -> None:
-    """Both probes pass when STS returns bounded TTLs on session and federation creds."""
+    """Both probes pass when STS returns bounded TTLs, and the test user is cleaned up."""
     from datetime import datetime, timedelta
 
     now = datetime.now(UTC)
+    iam = FakeShortLivedIam()
     sts = FakeShortLivedSts(
         session_expiration=now + timedelta(seconds=3600),
         federation_expiration=now + timedelta(seconds=3600),
     )
-    _patch_short_lived_sts(monkeypatch, short_lived_module, sts)
-    monkeypatch.setattr(
-        short_lived_module.sys,
-        "argv",
-        ["short_lived_credentials_test.py", "--region", "us-west-2"],
-    )
+    _patch_short_lived_clients(monkeypatch, short_lived_module, iam=iam, sts=sts)
+    _set_short_lived_argv(monkeypatch, short_lived_module)
 
     exit_code = short_lived_module.main()
     payload = json.loads(capsys.readouterr().out)
@@ -2110,11 +2255,24 @@ def test_short_lived_credentials_main_passes_with_bounded_ttls(
     assert 0 < payload["workload_credential_ttl_seconds"] <= 3600
     for probe in payload["tests"].values():
         assert probe["passed"] is True
+
+    assert len(iam.created_users) == 1
+    username = iam.created_users[0]["UserName"]
+    assert iam.put_policies == [
+        {
+            "UserName": username,
+            "PolicyName": short_lived_module.INLINE_POLICY_NAME,
+            "PolicyDocument": short_lived_module.INLINE_STS_POLICY,
+        }
+    ]
+    assert iam.deleted_policies == [(username, short_lived_module.INLINE_POLICY_NAME)]
+    assert iam.deleted_keys == [(username, "AKIA_FAKE")]
+    assert iam.deleted_users == [username]
     assert sts.federation_calls == [
         {
             "Name": short_lived_module.WORKLOAD_FEDERATION_NAME,
             "Policy": short_lived_module.DENY_ALL_POLICY,
-        },
+        }
     ]
 
 
@@ -2123,26 +2281,17 @@ def test_short_lived_credentials_main_fails_when_node_ttl_exceeds_bound(
     capsys: pytest.CaptureFixture[str],
     short_lived_module: ModuleType,
 ) -> None:
-    """Node TTL above the configured bound fails the within-bound probe."""
+    """Node TTL above the configured bound fails the within-bound probe and still cleans up."""
     from datetime import datetime, timedelta
 
     now = datetime.now(UTC)
+    iam = FakeShortLivedIam()
     sts = FakeShortLivedSts(
         session_expiration=now + timedelta(seconds=7200),
         federation_expiration=now + timedelta(seconds=1800),
     )
-    _patch_short_lived_sts(monkeypatch, short_lived_module, sts)
-    monkeypatch.setattr(
-        short_lived_module.sys,
-        "argv",
-        [
-            "short_lived_credentials_test.py",
-            "--region",
-            "us-west-2",
-            "--max-ttl-seconds",
-            "3600",
-        ],
-    )
+    _patch_short_lived_clients(monkeypatch, short_lived_module, iam=iam, sts=sts)
+    _set_short_lived_argv(monkeypatch, short_lived_module, "--max-ttl-seconds", "3600")
 
     exit_code = short_lived_module.main()
     payload = json.loads(capsys.readouterr().out)
@@ -2153,21 +2302,19 @@ def test_short_lived_credentials_main_fails_when_node_ttl_exceeds_bound(
     assert payload["tests"]["node_credential_ttl_within_bound"]["passed"] is False
     assert "outside" in payload["tests"]["node_credential_ttl_within_bound"]["error"]
     assert payload["tests"]["workload_credential_ttl_within_bound"]["passed"] is True
+    assert iam.deleted_users  # cleanup still ran on probe failure
 
 
-def test_short_lived_credentials_main_skips_when_get_session_token_denied(
+def test_short_lived_credentials_main_skips_when_create_user_denied(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
     short_lived_module: ModuleType,
 ) -> None:
-    """Assumed-role principal that cannot call GetSessionToken yields a clean skip."""
-    sts = FakeShortLivedSts(session_error=_client_error("GetSessionToken", code="AccessDenied"))
-    _patch_short_lived_sts(monkeypatch, short_lived_module, sts)
-    monkeypatch.setattr(
-        short_lived_module.sys,
-        "argv",
-        ["short_lived_credentials_test.py", "--region", "us-west-2"],
-    )
+    """Orchestrator principal lacking iam:CreateUser yields a clean skip and never probes STS."""
+    iam = FakeShortLivedIam(create_user_error=_client_error("CreateUser", code="AccessDenied"))
+    sts = FakeShortLivedSts()
+    _patch_short_lived_clients(monkeypatch, short_lived_module, iam=iam, sts=sts)
+    _set_short_lived_argv(monkeypatch, short_lived_module)
 
     exit_code = short_lived_module.main()
     payload = json.loads(capsys.readouterr().out)
@@ -2176,23 +2323,55 @@ def test_short_lived_credentials_main_skips_when_get_session_token_denied(
     assert payload["success"] is True
     assert payload["skipped"] is True
     assert "AccessDenied" in payload["skip_reason"]
+    assert "iam:CreateUser" in payload["skip_reason"]
     assert payload["tests"] == {}
+    assert sts.session_call_count == 0
     assert sts.federation_calls == []
+    assert iam.deleted_users == []  # nothing was created
 
 
-def test_short_lived_credentials_main_unhandled_sts_error_fails(
+def test_short_lived_credentials_main_retries_node_probe_on_eventual_consistency(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
     short_lived_module: ModuleType,
 ) -> None:
-    """Unexpected STS errors are not silently skipped; main() returns 1 via the AWS error handler."""
-    sts = FakeShortLivedSts(session_error=_client_error("GetSessionToken", code="ServiceUnavailable"))
-    _patch_short_lived_sts(monkeypatch, short_lived_module, sts)
-    monkeypatch.setattr(
-        short_lived_module.sys,
-        "argv",
-        ["short_lived_credentials_test.py", "--region", "us-west-2"],
+    """A burst of InvalidClientTokenId errors is retried until STS sees the new key."""
+    from datetime import datetime, timedelta
+
+    now = datetime.now(UTC)
+    iam = FakeShortLivedIam()
+    sts = FakeShortLivedSts(
+        session_expiration=now + timedelta(seconds=3600),
+        federation_expiration=now + timedelta(seconds=3600),
+        session_errors=[
+            _client_error("GetSessionToken", code="InvalidClientTokenId"),
+            _client_error("GetSessionToken", code="InvalidClientTokenId"),
+        ],
     )
+    _patch_short_lived_clients(monkeypatch, short_lived_module, iam=iam, sts=sts)
+    _set_short_lived_argv(monkeypatch, short_lived_module)
+
+    exit_code = short_lived_module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["success"] is True
+    assert sts.session_call_count == 3  # two failures plus one success
+    assert iam.deleted_users  # cleanup still ran
+
+
+def test_short_lived_credentials_main_unhandled_node_error_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    short_lived_module: ModuleType,
+) -> None:
+    """Non-retryable STS errors on the node probe surface as a failure (not a skip)."""
+    iam = FakeShortLivedIam()
+    sts = FakeShortLivedSts(
+        session_errors=[_client_error("GetSessionToken", code="ServiceUnavailable")],
+    )
+    _patch_short_lived_clients(monkeypatch, short_lived_module, iam=iam, sts=sts)
+    _set_short_lived_argv(monkeypatch, short_lived_module)
 
     exit_code = short_lived_module.main()
     payload = json.loads(capsys.readouterr().out)
@@ -2200,27 +2379,25 @@ def test_short_lived_credentials_main_unhandled_sts_error_fails(
     assert exit_code == 1
     assert payload["success"] is False
     assert payload.get("skipped") is not True
+    assert iam.deleted_users  # cleanup still ran via the decorator-caught path
 
 
-def test_short_lived_credentials_main_marks_workload_failed_when_federation_denied(
+def test_short_lived_credentials_main_records_workload_error_and_keeps_node_pass(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
     short_lived_module: ModuleType,
 ) -> None:
-    """Node still passes when only GetFederationToken is denied; workload fails."""
+    """A workload-side STS error is captured per-probe; node probe still passes."""
     from datetime import datetime, timedelta
 
     now = datetime.now(UTC)
+    iam = FakeShortLivedIam()
     sts = FakeShortLivedSts(
         session_expiration=now + timedelta(seconds=3600),
         federation_error=_client_error("GetFederationToken", code="AccessDenied"),
     )
-    _patch_short_lived_sts(monkeypatch, short_lived_module, sts)
-    monkeypatch.setattr(
-        short_lived_module.sys,
-        "argv",
-        ["short_lived_credentials_test.py", "--region", "us-west-2"],
-    )
+    _patch_short_lived_clients(monkeypatch, short_lived_module, iam=iam, sts=sts)
+    _set_short_lived_argv(monkeypatch, short_lived_module)
 
     exit_code = short_lived_module.main()
     payload = json.loads(capsys.readouterr().out)
@@ -2232,6 +2409,7 @@ def test_short_lived_credentials_main_marks_workload_failed_when_federation_deni
     assert payload["tests"]["node_credential_ttl_within_bound"]["passed"] is True
     assert payload["tests"]["workload_credential_has_expiry"]["passed"] is False
     assert "AccessDenied" in payload["tests"]["workload_credential_has_expiry"]["error"]
+    assert iam.deleted_users  # cleanup ran
 
 
 def test_short_lived_credentials_main_handles_missing_expiration(
@@ -2239,20 +2417,17 @@ def test_short_lived_credentials_main_handles_missing_expiration(
     capsys: pytest.CaptureFixture[str],
     short_lived_module: ModuleType,
 ) -> None:
-    """Missing Credentials.Expiration in either response surfaces as a probe error."""
+    """Missing Credentials.Expiration in either response surfaces as a per-probe error."""
     from datetime import datetime, timedelta
 
     now = datetime.now(UTC)
+    iam = FakeShortLivedIam()
     sts = FakeShortLivedSts(
         omit_session_expiration=True,
         federation_expiration=now + timedelta(seconds=1800),
     )
-    _patch_short_lived_sts(monkeypatch, short_lived_module, sts)
-    monkeypatch.setattr(
-        short_lived_module.sys,
-        "argv",
-        ["short_lived_credentials_test.py", "--region", "us-west-2"],
-    )
+    _patch_short_lived_clients(monkeypatch, short_lived_module, iam=iam, sts=sts)
+    _set_short_lived_argv(monkeypatch, short_lived_module)
 
     exit_code = short_lived_module.main()
     payload = json.loads(capsys.readouterr().out)
@@ -2264,25 +2439,43 @@ def test_short_lived_credentials_main_handles_missing_expiration(
     assert payload["tests"]["workload_credential_has_expiry"]["passed"] is True
 
 
+def test_short_lived_credentials_main_records_cleanup_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    short_lived_module: ModuleType,
+) -> None:
+    """Successful probes are reported failed when IAM cleanup fails."""
+    from datetime import datetime, timedelta
+
+    now = datetime.now(UTC)
+    iam = FakeShortLivedIam(delete_user_error=_client_error("DeleteUser", code="ServiceUnavailable"))
+    sts = FakeShortLivedSts(
+        session_expiration=now + timedelta(seconds=3600),
+        federation_expiration=now + timedelta(seconds=3600),
+    )
+    _patch_short_lived_clients(monkeypatch, short_lived_module, iam=iam, sts=sts)
+    _set_short_lived_argv(monkeypatch, short_lived_module)
+
+    exit_code = short_lived_module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert "cleanup_errors" in payload
+    assert any("delete user" in err for err in payload["cleanup_errors"])
+    assert "Cleanup failed" in payload["error"]
+
+
 def test_short_lived_credentials_main_skips_for_non_positive_max_ttl(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
     short_lived_module: ModuleType,
 ) -> None:
-    """A non-positive --max-ttl-seconds yields a clean skip rather than a hard fail."""
+    """A non-positive --max-ttl-seconds yields a clean skip rather than a hard fail or any AWS calls."""
+    iam = FakeShortLivedIam()
     sts = FakeShortLivedSts()
-    _patch_short_lived_sts(monkeypatch, short_lived_module, sts)
-    monkeypatch.setattr(
-        short_lived_module.sys,
-        "argv",
-        [
-            "short_lived_credentials_test.py",
-            "--region",
-            "us-west-2",
-            "--max-ttl-seconds",
-            "0",
-        ],
-    )
+    _patch_short_lived_clients(monkeypatch, short_lived_module, iam=iam, sts=sts)
+    _set_short_lived_argv(monkeypatch, short_lived_module, "--max-ttl-seconds", "0")
 
     exit_code = short_lived_module.main()
     payload = json.loads(capsys.readouterr().out)
@@ -2290,3 +2483,16 @@ def test_short_lived_credentials_main_skips_for_non_positive_max_ttl(
     assert exit_code == 0
     assert payload["skipped"] is True
     assert "positive integer" in payload["skip_reason"]
+    assert iam.created_users == []
+    assert sts.session_call_count == 0
+
+
+def test_short_lived_credentials_cleanup_handles_partial_setup(
+    short_lived_module: ModuleType,
+) -> None:
+    """_cleanup_test_user is no-op for an unset username and skips inline policy when user_created is False."""
+    iam = FakeShortLivedIam()
+    assert short_lived_module._cleanup_test_user(iam, None, None, False) == []
+    assert short_lived_module._cleanup_test_user(iam, "isv-sec02-test-xyz", None, False) == []
+    assert iam.deleted_policies == []
+    assert iam.deleted_users == []

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+from datetime import UTC
 from email.message import Message
 from pathlib import Path
 from types import ModuleType
@@ -1998,3 +1999,294 @@ def test_oidc_verify_handles_aud_list(oidc_module: ModuleType) -> None:
 
     ok, _ = oidc_module._verify_jwt(token, jwks, "iss", "isv-validation", now=now)
     assert ok
+
+
+# ===========================================================================
+# Short-lived credentials (SEC02-01) tests
+# ===========================================================================
+
+
+@pytest.fixture(scope="module")
+def short_lived_module() -> ModuleType:
+    """Load the short-lived credentials script as a module."""
+    return _load_security_script("short_lived_credentials_test.py")
+
+
+class FakeShortLivedSts:
+    """Minimal STS fake supporting GetSessionToken / GetFederationToken."""
+
+    def __init__(
+        self,
+        *,
+        session_expiration: Any = None,
+        session_error: ClientError | None = None,
+        federation_expiration: Any = None,
+        federation_error: ClientError | None = None,
+        omit_session_expiration: bool = False,
+        omit_federation_expiration: bool = False,
+    ) -> None:
+        """Configure fake STS responses or errors per API."""
+        self.session_expiration = session_expiration
+        self.session_error = session_error
+        self.federation_expiration = federation_expiration
+        self.federation_error = federation_error
+        self.omit_session_expiration = omit_session_expiration
+        self.omit_federation_expiration = omit_federation_expiration
+        self.federation_calls: list[dict[str, str]] = []
+
+    def get_session_token(self) -> dict[str, dict[str, Any]]:
+        """Return fake GetSessionToken response or raise the configured error."""
+        if self.session_error is not None:
+            raise self.session_error
+        creds: dict[str, Any] = {
+            "AccessKeyId": "ASIA_FAKE",
+            "SecretAccessKey": "secret",
+            "SessionToken": "session",
+        }
+        if not self.omit_session_expiration:
+            creds["Expiration"] = self.session_expiration
+        return {"Credentials": creds}
+
+    def get_federation_token(self, **kwargs: Any) -> dict[str, dict[str, Any]]:
+        """Return fake GetFederationToken response or raise the configured error."""
+        self.federation_calls.append(kwargs)
+        if self.federation_error is not None:
+            raise self.federation_error
+        creds: dict[str, Any] = {
+            "AccessKeyId": "ASIA_FED_FAKE",
+            "SecretAccessKey": "secret",
+            "SessionToken": "session",
+        }
+        if not self.omit_federation_expiration:
+            creds["Expiration"] = self.federation_expiration
+        return {"Credentials": creds}
+
+
+def _patch_short_lived_sts(
+    monkeypatch: pytest.MonkeyPatch,
+    module: ModuleType,
+    sts: FakeShortLivedSts,
+) -> None:
+    """Patch boto3.client to return the supplied fake STS client."""
+
+    def fake_client(service_name: str, region_name: str | None = None) -> FakeShortLivedSts:
+        """Return the fake STS client for sts requests."""
+        assert service_name == "sts"
+        assert region_name == "us-west-2"
+        return sts
+
+    monkeypatch.setattr(module.boto3, "client", fake_client)
+
+
+def test_short_lived_credentials_main_passes_with_bounded_ttls(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    short_lived_module: ModuleType,
+) -> None:
+    """Both probes pass when STS returns bounded TTLs on session and federation creds."""
+    from datetime import datetime, timedelta
+
+    now = datetime.now(UTC)
+    sts = FakeShortLivedSts(
+        session_expiration=now + timedelta(seconds=3600),
+        federation_expiration=now + timedelta(seconds=3600),
+    )
+    _patch_short_lived_sts(monkeypatch, short_lived_module, sts)
+    monkeypatch.setattr(
+        short_lived_module.sys,
+        "argv",
+        ["short_lived_credentials_test.py", "--region", "us-west-2"],
+    )
+
+    exit_code = short_lived_module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["success"] is True
+    assert payload["max_ttl_seconds"] == 43200
+    assert payload["node_credential_method"] == "sts:GetSessionToken"
+    assert payload["workload_credential_method"] == "sts:GetFederationToken"
+    assert 0 < payload["node_credential_ttl_seconds"] <= 3600
+    assert 0 < payload["workload_credential_ttl_seconds"] <= 3600
+    for probe in payload["tests"].values():
+        assert probe["passed"] is True
+    assert sts.federation_calls == [
+        {
+            "Name": short_lived_module.WORKLOAD_FEDERATION_NAME,
+            "Policy": short_lived_module.DENY_ALL_POLICY,
+        },
+    ]
+
+
+def test_short_lived_credentials_main_fails_when_node_ttl_exceeds_bound(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    short_lived_module: ModuleType,
+) -> None:
+    """Node TTL above the configured bound fails the within-bound probe."""
+    from datetime import datetime, timedelta
+
+    now = datetime.now(UTC)
+    sts = FakeShortLivedSts(
+        session_expiration=now + timedelta(seconds=7200),
+        federation_expiration=now + timedelta(seconds=1800),
+    )
+    _patch_short_lived_sts(monkeypatch, short_lived_module, sts)
+    monkeypatch.setattr(
+        short_lived_module.sys,
+        "argv",
+        [
+            "short_lived_credentials_test.py",
+            "--region",
+            "us-west-2",
+            "--max-ttl-seconds",
+            "3600",
+        ],
+    )
+
+    exit_code = short_lived_module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert payload["tests"]["node_credential_has_expiry"]["passed"] is True
+    assert payload["tests"]["node_credential_ttl_within_bound"]["passed"] is False
+    assert "outside" in payload["tests"]["node_credential_ttl_within_bound"]["error"]
+    assert payload["tests"]["workload_credential_ttl_within_bound"]["passed"] is True
+
+
+def test_short_lived_credentials_main_skips_when_get_session_token_denied(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    short_lived_module: ModuleType,
+) -> None:
+    """Assumed-role principal that cannot call GetSessionToken yields a clean skip."""
+    sts = FakeShortLivedSts(session_error=_client_error("GetSessionToken", code="AccessDenied"))
+    _patch_short_lived_sts(monkeypatch, short_lived_module, sts)
+    monkeypatch.setattr(
+        short_lived_module.sys,
+        "argv",
+        ["short_lived_credentials_test.py", "--region", "us-west-2"],
+    )
+
+    exit_code = short_lived_module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["success"] is True
+    assert payload["skipped"] is True
+    assert "AccessDenied" in payload["skip_reason"]
+    assert payload["tests"] == {}
+    assert sts.federation_calls == []
+
+
+def test_short_lived_credentials_main_unhandled_sts_error_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    short_lived_module: ModuleType,
+) -> None:
+    """Unexpected STS errors are not silently skipped; main() returns 1 via the AWS error handler."""
+    sts = FakeShortLivedSts(session_error=_client_error("GetSessionToken", code="ServiceUnavailable"))
+    _patch_short_lived_sts(monkeypatch, short_lived_module, sts)
+    monkeypatch.setattr(
+        short_lived_module.sys,
+        "argv",
+        ["short_lived_credentials_test.py", "--region", "us-west-2"],
+    )
+
+    exit_code = short_lived_module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert payload.get("skipped") is not True
+
+
+def test_short_lived_credentials_main_marks_workload_failed_when_federation_denied(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    short_lived_module: ModuleType,
+) -> None:
+    """Node still passes when only GetFederationToken is denied; workload fails."""
+    from datetime import datetime, timedelta
+
+    now = datetime.now(UTC)
+    sts = FakeShortLivedSts(
+        session_expiration=now + timedelta(seconds=3600),
+        federation_error=_client_error("GetFederationToken", code="AccessDenied"),
+    )
+    _patch_short_lived_sts(monkeypatch, short_lived_module, sts)
+    monkeypatch.setattr(
+        short_lived_module.sys,
+        "argv",
+        ["short_lived_credentials_test.py", "--region", "us-west-2"],
+    )
+
+    exit_code = short_lived_module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert payload.get("skipped") is not True
+    assert payload["tests"]["node_credential_has_expiry"]["passed"] is True
+    assert payload["tests"]["node_credential_ttl_within_bound"]["passed"] is True
+    assert payload["tests"]["workload_credential_has_expiry"]["passed"] is False
+    assert "AccessDenied" in payload["tests"]["workload_credential_has_expiry"]["error"]
+
+
+def test_short_lived_credentials_main_handles_missing_expiration(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    short_lived_module: ModuleType,
+) -> None:
+    """Missing Credentials.Expiration in either response surfaces as a probe error."""
+    from datetime import datetime, timedelta
+
+    now = datetime.now(UTC)
+    sts = FakeShortLivedSts(
+        omit_session_expiration=True,
+        federation_expiration=now + timedelta(seconds=1800),
+    )
+    _patch_short_lived_sts(monkeypatch, short_lived_module, sts)
+    monkeypatch.setattr(
+        short_lived_module.sys,
+        "argv",
+        ["short_lived_credentials_test.py", "--region", "us-west-2"],
+    )
+
+    exit_code = short_lived_module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert payload["tests"]["node_credential_has_expiry"]["passed"] is False
+    assert "Expiration missing" in payload["tests"]["node_credential_has_expiry"]["error"]
+    assert payload["tests"]["workload_credential_has_expiry"]["passed"] is True
+
+
+def test_short_lived_credentials_main_skips_for_non_positive_max_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    short_lived_module: ModuleType,
+) -> None:
+    """A non-positive --max-ttl-seconds yields a clean skip rather than a hard fail."""
+    sts = FakeShortLivedSts()
+    _patch_short_lived_sts(monkeypatch, short_lived_module, sts)
+    monkeypatch.setattr(
+        short_lived_module.sys,
+        "argv",
+        [
+            "short_lived_credentials_test.py",
+            "--region",
+            "us-west-2",
+            "--max-ttl-seconds",
+            "0",
+        ],
+    )
+
+    exit_code = short_lived_module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["skipped"] is True
+    assert "positive integer" in payload["skip_reason"]

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -2268,12 +2268,15 @@ def test_short_lived_credentials_main_passes_with_bounded_ttls(
     assert iam.deleted_policies == [(username, short_lived_module.INLINE_POLICY_NAME)]
     assert iam.deleted_keys == [(username, "AKIA_FAKE")]
     assert iam.deleted_users == [username]
-    assert sts.federation_calls == [
-        {
-            "Name": short_lived_module.WORKLOAD_FEDERATION_NAME,
-            "Policy": short_lived_module.DENY_ALL_POLICY,
-        }
-    ]
+    assert len(sts.federation_calls) == 1
+    federation_name = sts.federation_calls[0]["Name"]
+    assert federation_name.startswith(short_lived_module.WORKLOAD_FEDERATION_PREFIX)
+    # Federation Name shares the per-run uuid suffix with the IAM username
+    # so CloudTrail events from the same probe correlate.
+    assert federation_name.removeprefix(short_lived_module.WORKLOAD_FEDERATION_PREFIX) == username.removeprefix(
+        short_lived_module.TEST_USER_PREFIX
+    )
+    assert sts.federation_calls[0]["Policy"] == short_lived_module.DENY_ALL_POLICY
 
 
 def test_short_lived_credentials_main_fails_when_node_ttl_exceeds_bound(
@@ -2311,7 +2314,11 @@ def test_short_lived_credentials_main_skips_when_create_user_denied(
     short_lived_module: ModuleType,
 ) -> None:
     """Orchestrator principal lacking iam:CreateUser yields a clean skip and never probes STS."""
-    iam = FakeShortLivedIam(create_user_error=_client_error("CreateUser", code="AccessDenied"))
+    iam = FakeShortLivedIam(
+        create_user_error=_client_error(
+            "CreateUser", code="AccessDenied", message="not authorized to perform iam:CreateUser"
+        ),
+    )
     sts = FakeShortLivedSts()
     _patch_short_lived_clients(monkeypatch, short_lived_module, iam=iam, sts=sts)
     _set_short_lived_argv(monkeypatch, short_lived_module)
@@ -2322,8 +2329,12 @@ def test_short_lived_credentials_main_skips_when_create_user_denied(
     assert exit_code == 0
     assert payload["success"] is True
     assert payload["skipped"] is True
+    # Skip reason includes the failing operation name, AWS error code, and
+    # the underlying message so operators don't need to re-run with debug
+    # to figure out what was denied.
+    assert "CreateUser" in payload["skip_reason"]
     assert "AccessDenied" in payload["skip_reason"]
-    assert "iam:CreateUser" in payload["skip_reason"]
+    assert "not authorized to perform iam:CreateUser" in payload["skip_reason"]
     assert payload["tests"] == {}
     assert sts.session_call_count == 0
     assert sts.federation_calls == []
@@ -2381,9 +2392,13 @@ def test_short_lived_credentials_main_skips_and_cleans_up_when_put_user_policy_d
     capsys: pytest.CaptureFixture[str],
     short_lived_module: ModuleType,
 ) -> None:
-    """Skip path on a partial-setup AccessDenied still deletes the user that was created."""
+    """Skip path on a partial-setup AccessDenied still deletes the user and surfaces the AWS message."""
     iam = FakeShortLivedIam(
-        put_user_policy_error=_client_error("PutUserPolicy", code="AccessDenied"),
+        put_user_policy_error=_client_error(
+            "PutUserPolicy",
+            code="AccessDenied",
+            message="not authorized to perform iam:PutUserPolicy",
+        ),
     )
     sts = FakeShortLivedSts()
     _patch_short_lived_clients(monkeypatch, short_lived_module, iam=iam, sts=sts)
@@ -2394,8 +2409,9 @@ def test_short_lived_credentials_main_skips_and_cleans_up_when_put_user_policy_d
 
     assert exit_code == 0
     assert payload["skipped"] is True
+    assert "PutUserPolicy" in payload["skip_reason"]
     assert "AccessDenied" in payload["skip_reason"]
-    assert "iam:PutUserPolicy" in payload["skip_reason"]
+    assert "not authorized to perform iam:PutUserPolicy" in payload["skip_reason"]
     assert len(iam.created_users) == 1
     assert iam.deleted_users == [iam.created_users[0]["UserName"]]
 
@@ -2457,14 +2473,18 @@ def test_short_lived_credentials_main_records_workload_error_and_keeps_node_pass
     capsys: pytest.CaptureFixture[str],
     short_lived_module: ModuleType,
 ) -> None:
-    """A workload-side STS error is captured per-probe; node probe still passes."""
+    """A workload-side STS error is captured per-probe with op + code + message; node probe still passes."""
     from datetime import datetime, timedelta
 
     now = datetime.now(UTC)
     iam = FakeShortLivedIam()
     sts = FakeShortLivedSts(
         session_expiration=now + timedelta(seconds=3600),
-        federation_error=_client_error("GetFederationToken", code="AccessDenied"),
+        federation_error=_client_error(
+            "GetFederationToken",
+            code="AccessDenied",
+            message="not authorized to perform sts:GetFederationToken",
+        ),
     )
     _patch_short_lived_clients(monkeypatch, short_lived_module, iam=iam, sts=sts)
     _set_short_lived_argv(monkeypatch, short_lived_module)
@@ -2478,7 +2498,10 @@ def test_short_lived_credentials_main_records_workload_error_and_keeps_node_pass
     assert payload["tests"]["node_credential_has_expiry"]["passed"] is True
     assert payload["tests"]["node_credential_ttl_within_bound"]["passed"] is True
     assert payload["tests"]["workload_credential_has_expiry"]["passed"] is False
-    assert "AccessDenied" in payload["tests"]["workload_credential_has_expiry"]["error"]
+    workload_error = payload["tests"]["workload_credential_has_expiry"]["error"]
+    assert "GetFederationToken" in workload_error
+    assert "AccessDenied" in workload_error
+    assert "not authorized to perform sts:GetFederationToken" in workload_error
     assert iam.deleted_users  # cleanup ran
 
 

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -2330,6 +2330,76 @@ def test_short_lived_credentials_main_skips_when_create_user_denied(
     assert iam.deleted_users == []  # nothing was created
 
 
+def test_short_lived_credentials_main_cleans_up_when_put_user_policy_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    short_lived_module: ModuleType,
+) -> None:
+    """Non-skippable failure on PutUserPolicy must still delete the user that was just created."""
+    iam = FakeShortLivedIam(
+        put_user_policy_error=_client_error("PutUserPolicy", code="LimitExceeded"),
+    )
+    sts = FakeShortLivedSts()
+    _patch_short_lived_clients(monkeypatch, short_lived_module, iam=iam, sts=sts)
+    _set_short_lived_argv(monkeypatch, short_lived_module)
+
+    exit_code = short_lived_module.main()
+
+    assert exit_code == 1
+    assert len(iam.created_users) == 1
+    username = iam.created_users[0]["UserName"]
+    assert iam.deleted_users == [username]
+    assert sts.session_call_count == 0  # no probes attempted
+    assert sts.federation_calls == []
+
+
+def test_short_lived_credentials_main_cleans_up_when_create_access_key_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    short_lived_module: ModuleType,
+) -> None:
+    """Non-skippable failure on CreateAccessKey must still detach inline policy and delete the user."""
+    iam = FakeShortLivedIam(
+        create_access_key_error=_client_error("CreateAccessKey", code="LimitExceeded"),
+    )
+    sts = FakeShortLivedSts()
+    _patch_short_lived_clients(monkeypatch, short_lived_module, iam=iam, sts=sts)
+    _set_short_lived_argv(monkeypatch, short_lived_module)
+
+    exit_code = short_lived_module.main()
+
+    assert exit_code == 1
+    assert len(iam.created_users) == 1
+    username = iam.created_users[0]["UserName"]
+    assert iam.deleted_policies == [(username, short_lived_module.INLINE_POLICY_NAME)]
+    assert iam.deleted_users == [username]
+    assert sts.session_call_count == 0
+
+
+def test_short_lived_credentials_main_skips_and_cleans_up_when_put_user_policy_denied(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    short_lived_module: ModuleType,
+) -> None:
+    """Skip path on a partial-setup AccessDenied still deletes the user that was created."""
+    iam = FakeShortLivedIam(
+        put_user_policy_error=_client_error("PutUserPolicy", code="AccessDenied"),
+    )
+    sts = FakeShortLivedSts()
+    _patch_short_lived_clients(monkeypatch, short_lived_module, iam=iam, sts=sts)
+    _set_short_lived_argv(monkeypatch, short_lived_module)
+
+    exit_code = short_lived_module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["skipped"] is True
+    assert "AccessDenied" in payload["skip_reason"]
+    assert "iam:PutUserPolicy" in payload["skip_reason"]
+    assert len(iam.created_users) == 1
+    assert iam.deleted_users == [iam.created_users[0]["UserName"]]
+
+
 def test_short_lived_credentials_main_retries_node_probe_on_eventual_consistency(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -1134,28 +1134,37 @@ class FakeSec02CleanupIam:
         self.deleted_keys: list[tuple[str, str]] = []
         self.deleted_policies: list[tuple[str, str]] = []
         self.deleted_users: list[str] = []
+        # Ordered call log so tests can lock in the relative order of
+        # delete_user_policy vs delete_user (the inline policy must be
+        # detached first or DeleteUser fails with DeleteConflict on AWS).
+        self.call_sequence: list[str] = []
 
     def list_access_keys(self, UserName: str) -> dict[str, list[dict[str, str]]]:
         """Return one fake access key."""
         assert UserName.startswith("isv-sec02-test-")
+        self.call_sequence.append(f"list_access_keys:{UserName}")
         return {"AccessKeyMetadata": [{"AccessKeyId": "AKIA_SEC02"}]}
 
     def delete_access_key(self, UserName: str, AccessKeyId: str) -> None:
         """Record access key deletion."""
         self.deleted_keys.append((UserName, AccessKeyId))
+        self.call_sequence.append(f"delete_access_key:{UserName}:{AccessKeyId}")
 
     def list_user_policies(self, UserName: str) -> dict[str, list[str]]:
         """Return one inline policy attached to the SEC02 user."""
         assert UserName.startswith("isv-sec02-test-")
+        self.call_sequence.append(f"list_user_policies:{UserName}")
         return {"PolicyNames": ["isv-sec02-sts-allow"]}
 
     def delete_user_policy(self, UserName: str, PolicyName: str) -> None:
         """Record inline policy deletion."""
         self.deleted_policies.append((UserName, PolicyName))
+        self.call_sequence.append(f"delete_user_policy:{UserName}:{PolicyName}")
 
     def delete_user(self, UserName: str) -> None:
         """Record user deletion."""
         self.deleted_users.append(UserName)
+        self.call_sequence.append(f"delete_user:{UserName}")
 
 
 def test_teardown_cleanup_owned_user_deletes_inline_policy_for_sec02_users() -> None:
@@ -1169,6 +1178,11 @@ def test_teardown_cleanup_owned_user_deletes_inline_policy_for_sec02_users() -> 
     assert iam.deleted_keys == [("isv-sec02-test-abcd1234", "AKIA_SEC02")]
     assert iam.deleted_policies == [("isv-sec02-test-abcd1234", "isv-sec02-sts-allow")]
     assert iam.deleted_users == ["isv-sec02-test-abcd1234"]
+    # Order matters: AWS DeleteUser fails with DeleteConflict if an inline
+    # policy is still attached. Lock in policy-before-user.
+    policy_idx = iam.call_sequence.index("delete_user_policy:isv-sec02-test-abcd1234:isv-sec02-sts-allow")
+    user_idx = iam.call_sequence.index("delete_user:isv-sec02-test-abcd1234")
+    assert policy_idx < user_idx
 
 
 def test_teardown_owned_user_prefixes_cover_security_test_scripts() -> None:
@@ -2412,6 +2426,36 @@ def test_short_lived_credentials_main_skips_and_cleans_up_when_put_user_policy_d
     assert "not authorized to perform iam:PutUserPolicy" in payload["skip_reason"]
     assert len(iam.created_users) == 1
     assert iam.deleted_users == [iam.created_users[0]["UserName"]]
+
+
+def test_short_lived_credentials_main_fails_when_skip_path_cleanup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    short_lived_module: ModuleType,
+) -> None:
+    """Skip-eligible setup error + cleanup failure must surface as a hard failure, never a clean skip.
+
+    Otherwise we'd report ``skipped: true`` while leaving an IAM user
+    behind in the account.
+    """
+    iam = FakeShortLivedIam(
+        put_user_policy_error=_client_error("PutUserPolicy", code="AccessDenied"),
+        delete_user_error=_client_error("DeleteUser", code="ServiceUnavailable"),
+    )
+    sts = FakeShortLivedSts()
+    _patch_short_lived_clients(monkeypatch, short_lived_module, iam=iam, sts=sts)
+    _set_short_lived_argv(monkeypatch, short_lived_module)
+
+    exit_code = short_lived_module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert payload.get("skipped") is not True
+    assert "cleanup_errors" in payload
+    assert "setup failed" in payload["error"]
+    assert "cleanup failed" in payload["error"]
+    assert any("delete user" in err for err in payload["cleanup_errors"])
 
 
 def test_short_lived_credentials_main_retries_node_probe_on_eventual_consistency(

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -2154,7 +2154,6 @@ class FakeShortLivedSts:
         federation_expiration: Any = None,
         federation_error: ClientError | None = None,
         omit_session_expiration: bool = False,
-        omit_federation_expiration: bool = False,
     ) -> None:
         """Configure fake STS responses, optional retry-error sequence on session, and per-probe expirations."""
         self.session_expiration = session_expiration
@@ -2162,7 +2161,6 @@ class FakeShortLivedSts:
         self.federation_expiration = federation_expiration
         self.federation_error = federation_error
         self.omit_session_expiration = omit_session_expiration
-        self.omit_federation_expiration = omit_federation_expiration
         self.federation_calls: list[dict[str, str]] = []
         self.session_call_count = 0
 
@@ -2185,14 +2183,14 @@ class FakeShortLivedSts:
         self.federation_calls.append(kwargs)
         if self.federation_error is not None:
             raise self.federation_error
-        creds: dict[str, Any] = {
-            "AccessKeyId": "ASIA_FED_FAKE",
-            "SecretAccessKey": "secret",
-            "SessionToken": "session",
+        return {
+            "Credentials": {
+                "AccessKeyId": "ASIA_FED_FAKE",
+                "SecretAccessKey": "secret",
+                "SessionToken": "session",
+                "Expiration": self.federation_expiration,
+            },
         }
-        if not self.omit_federation_expiration:
-            creds["Expiration"] = self.federation_expiration
-        return {"Credentials": creds}
 
 
 def _patch_short_lived_clients(

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -101,6 +101,7 @@ from isvtest.validations.security import (
     CustomerManagedKeyCheck,
     MfaEnforcedCheck,
     OidcUserAuthCheck,
+    ShortLivedCredentialsCheck,
 )
 
 __all__ = [
@@ -155,6 +156,7 @@ __all__ = [
     "SgServiceScopingCheck",
     "SgSubnetScopingCheck",
     "SgWorkloadScopingCheck",
+    "ShortLivedCredentialsCheck",
     "StableIdentifierCheck",
     "StablePrivateIpCheck",
     "StepSuccessCheck",

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -403,3 +403,79 @@ class OidcUserAuthCheck(BaseValidation):
         issuer = step_output["issuer_url"]
         target_url = step_output["target_url"]
         self.set_passed(f"OIDC user auth verified (issuer={issuer}, target={target_url})")
+
+
+class ShortLivedCredentialsCheck(BaseValidation):
+    """Validate workloads and nodes receive short-lived credentials/tokens.
+
+    Verifies that the platform issues credentials with a finite expiry on
+    both surfaces SEC02-01 cares about:
+
+    * Node-side: credentials a host/instance role acquires from the
+      platform identity service (AWS reference: ``sts:GetSessionToken``;
+      mirrors instance-metadata role chaining on EC2).
+    * Workload-side: credentials an in-cluster workload acquires through
+      the workload identity flow (AWS reference: ``sts:GetFederationToken``
+      with a deny-all session policy; mirrors IRSA on EKS / GKE Workload
+      Identity / AKS Workload Identity in shape).
+
+    The validation also enforces an upper TTL bound so "short-lived" is
+    enforced numerically, not just by virtue of an ``Expiration`` field
+    being present.
+
+    Like ``OidcUserAuthCheck``, the step may emit a structured top-level
+    ``skipped`` payload when no real issuance path is available (e.g. the
+    AWS reference cannot probe ``sts:GetSessionToken`` from an assumed-role
+    session). In that case the validation skips rather than fabricates a
+    pass.
+
+    Config:
+        step_output: The step output to check
+
+    Step output:
+        node_credential_ttl_seconds: Positive integer
+        workload_credential_ttl_seconds: Positive integer
+        max_ttl_seconds: Positive integer (configured upper bound)
+        tests: dict with node_credential_has_expiry,
+               node_credential_ttl_within_bound,
+               workload_credential_has_expiry,
+               workload_credential_ttl_within_bound
+    """
+
+    description: ClassVar[str] = "Check workloads and nodes receive credentials with finite, bounded TTL"
+    markers: ClassVar[list[str]] = ["security", "iam"]
+
+    def run(self) -> None:
+        """Validate required short-lived credentials results from step output."""
+        step_output = self.config.get("step_output", {})
+        if step_output.get("skipped") is True:
+            pytest.skip(step_output.get("skip_reason") or "Short-lived credentials validation skipped (not configured)")
+
+        required = [
+            "node_credential_has_expiry",
+            "node_credential_ttl_within_bound",
+            "workload_credential_has_expiry",
+            "workload_credential_ttl_within_bound",
+        ]
+        if not check_required_tests(self, required, "Short-lived credentials tests failed"):
+            return
+
+        max_ttl = step_output.get("max_ttl_seconds")
+        if type(max_ttl) is not int or max_ttl < 1:
+            self.set_failed("Short-lived credentials output missing positive int 'max_ttl_seconds'")
+            return
+
+        for field in ("node_credential_ttl_seconds", "workload_credential_ttl_seconds"):
+            value = step_output.get(field)
+            if type(value) is not int or value < 1:
+                self.set_failed(f"Short-lived credentials output missing positive int '{field}'")
+                return
+            if value > max_ttl:
+                self.set_failed(f"{field}={value}s exceeds max_ttl_seconds={max_ttl}s")
+                return
+
+        node_ttl = step_output["node_credential_ttl_seconds"]
+        workload_ttl = step_output["workload_credential_ttl_seconds"]
+        self.set_passed(
+            f"Short-lived credentials verified (node TTL={node_ttl}s, workload TTL={workload_ttl}s, bound={max_ttl}s)"
+        )

--- a/isvtest/tests/test_catalog.py
+++ b/isvtest/tests/test_catalog.py
@@ -87,17 +87,51 @@ class TestBuildCatalog:
             assert "." in entry["module"]
             assert entry["module"].startswith("isvtest.")
 
-    def test_platforms_come_from_suites_before_filter_markers(self) -> None:
-        """Test that feature markers do not add extra platform ownership."""
-        catalog = build_catalog(released_only=False)
-        by_name = {entry["name"]: entry for entry in catalog}
+    def test_suite_membership_overrides_marker_platforms(self) -> None:
+        """Regression: feature markers must not add extra platform ownership.
 
-        assert by_name["SgCrudCheck"]["platforms"] == ["NETWORK"]
-        assert by_name["BmcTenantIsolationCheck"]["platforms"] == ["SECURITY"]
-        assert by_name["BmcBastionAccessCheck"]["platforms"] == ["SECURITY"]
-        assert by_name["ServiceAccountCredentialCheck"]["platforms"] == ["SECURITY"]
-        assert by_name["ConsoleRbacCheck"]["platforms"] == ["VM"]
-        assert by_name["OidcUserAuthCheck"]["platforms"] == ["SECURITY"]
+        A check can carry markers like ``["security", "network"]`` for pytest
+        filtering AND appear in a single suite YAML (e.g. ``security.yaml``).
+        ``_build_platform_map`` must use the suite as the source of truth and
+        skip marker-derived platform inference in that case - otherwise the
+        UI shows phantom platform badges.
+
+        DO NOT add per-check asserts to this test. It is a property test
+        that already covers every check in the catalog. If a new validation
+        breaks the invariant, the failure message names it.
+        """
+        from isvtest.catalog import (
+            MARKER_TO_PLATFORM,
+            PLATFORM_CONFIGS,
+            _extract_checks_from_config,
+            _find_configs_dir,
+        )
+
+        configs_dir = _find_configs_dir()
+        assert configs_dir is not None, "isvctl/configs/ not found"
+
+        suite_platforms: dict[str, set[str]] = {}
+        for platform, files in PLATFORM_CONFIGS.items():
+            for relpath in files:
+                for name in _extract_checks_from_config(configs_dir / relpath):
+                    suite_platforms.setdefault(name, set()).add(platform)
+
+        for entry in build_catalog():
+            name = entry["name"]
+            if name not in suite_platforms:
+                continue
+            marker_platforms = {MARKER_TO_PLATFORM[m] for m in entry["markers"] if m in MARKER_TO_PLATFORM}
+            expected = suite_platforms[name]
+            actual = set(entry["platforms"])
+            phantom = (marker_platforms - expected) & actual
+            assert not phantom, (
+                f"{name}: marker-derived platforms {sorted(phantom)} leaked "
+                f"into catalog; expected exactly {sorted(expected)}, "
+                f"got {sorted(actual)}"
+            )
+            assert actual == expected, (
+                f"{name}: platforms should equal suite assignment {sorted(expected)}, got {sorted(actual)}"
+            )
 
 
 class TestGetCatalogVersion:

--- a/isvtest/tests/test_security.py
+++ b/isvtest/tests/test_security.py
@@ -24,6 +24,7 @@ from isvtest.validations.security import (
     CustomerManagedKeyCheck,
     MfaEnforcedCheck,
     OidcUserAuthCheck,
+    ShortLivedCredentialsCheck,
 )
 
 REQUIRED_BMC_PROTOCOL_TESTS = [
@@ -490,3 +491,107 @@ def test_oidc_user_auth_check_skips_when_step_marks_skipped() -> None:
 
     with pytest.raises(pytest.skip.Exception, match="OIDC validation not configured"):
         OidcUserAuthCheck(config={"step_output": step_output}).execute()
+
+
+SHORT_LIVED_REQUIRED_TESTS = {
+    "node_credential_has_expiry": {"passed": True},
+    "node_credential_ttl_within_bound": {"passed": True},
+    "workload_credential_has_expiry": {"passed": True},
+    "workload_credential_ttl_within_bound": {"passed": True},
+}
+
+
+def _short_lived_step_output(**overrides: Any) -> dict[str, Any]:
+    """Return a valid short-lived credentials step output with optional overrides."""
+    output: dict[str, Any] = {
+        "success": True,
+        "platform": "security",
+        "test_name": "short_lived_credentials_test",
+        "node_credential_method": "sts:GetSessionToken",
+        "workload_credential_method": "sts:GetFederationToken",
+        "node_credential_ttl_seconds": 3600,
+        "workload_credential_ttl_seconds": 3600,
+        "max_ttl_seconds": 43200,
+        "tests": deepcopy(SHORT_LIVED_REQUIRED_TESTS),
+    }
+    output.update(overrides)
+    return output
+
+
+def test_short_lived_credentials_check_passes_with_bounded_ttls() -> None:
+    """ShortLivedCredentialsCheck passes when both TTLs sit within the configured bound."""
+    check = ShortLivedCredentialsCheck(config={"step_output": _short_lived_step_output()})
+
+    result = check.execute()
+
+    assert result["passed"] is True
+    assert "node TTL=3600s" in result["output"]
+    assert "workload TTL=3600s" in result["output"]
+    assert "bound=43200s" in result["output"]
+
+
+def test_short_lived_credentials_check_fails_when_required_probe_missing() -> None:
+    """ShortLivedCredentialsCheck reports the missing contract probe by name."""
+    tests = {
+        name: result
+        for name, result in SHORT_LIVED_REQUIRED_TESTS.items()
+        if name != "workload_credential_ttl_within_bound"
+    }
+    check = ShortLivedCredentialsCheck(config={"step_output": _short_lived_step_output(tests=tests)})
+
+    result = check.execute()
+
+    assert result["passed"] is False
+    assert "workload_credential_ttl_within_bound" in result["error"]
+
+
+def test_short_lived_credentials_check_fails_when_node_ttl_exceeds_bound() -> None:
+    """ShortLivedCredentialsCheck fails when the node TTL is over the configured bound."""
+    check = ShortLivedCredentialsCheck(
+        config={"step_output": _short_lived_step_output(node_credential_ttl_seconds=99999)},
+    )
+
+    result = check.execute()
+
+    assert result["passed"] is False
+    assert "node_credential_ttl_seconds=99999s exceeds max_ttl_seconds=43200s" in result["error"]
+
+
+def test_short_lived_credentials_check_fails_when_workload_ttl_zero() -> None:
+    """ShortLivedCredentialsCheck rejects non-positive TTL values."""
+    check = ShortLivedCredentialsCheck(
+        config={"step_output": _short_lived_step_output(workload_credential_ttl_seconds=0)},
+    )
+
+    result = check.execute()
+
+    assert result["passed"] is False
+    assert "workload_credential_ttl_seconds" in result["error"]
+
+
+def test_short_lived_credentials_check_fails_when_max_ttl_missing() -> None:
+    """ShortLivedCredentialsCheck fails when max_ttl_seconds is missing or non-positive."""
+    check = ShortLivedCredentialsCheck(
+        config={"step_output": _short_lived_step_output(max_ttl_seconds=0)},
+    )
+
+    result = check.execute()
+
+    assert result["passed"] is False
+    assert "max_ttl_seconds" in result["error"]
+
+
+def test_short_lived_credentials_check_skips_when_step_marks_skipped() -> None:
+    """ShortLivedCredentialsCheck pytest.skips through both run() and execute() when flagged."""
+    step_output = {
+        "success": True,
+        "skipped": True,
+        "skip_reason": "sts:GetSessionToken not available with current principal (AccessDenied)",
+        "tests": {},
+    }
+
+    with pytest.raises(pytest.skip.Exception, match="GetSessionToken not available"):
+        ShortLivedCredentialsCheck(config={"step_output": step_output}).run()
+
+    with pytest.raises(pytest.skip.Exception, match="GetSessionToken not available"):
+        ShortLivedCredentialsCheck(config={"step_output": step_output}).execute()


### PR DESCRIPTION
## Summary

Adds SEC02-01 coverage to the security suite for verifying that workloads and nodes receive credentials with a finite, bounded TTL.

## Changes

- Adds `ShortLivedCredentialsCheck` and security suite wiring.
- Adds AWS reference that provisions a fresh `isv-sec02-test-<uuid>` IAM  user with an inline policy granting just `sts:GetSessionToken` and  `sts:GetFederationToken`, mints an access key, runs both probes as that  user, then cleans up in a `finally` block. Self-contained so SSO /  assumed-role orchestrator principals can run it (the original
  `GetSessionToken` direct-probe approach skipped on those callers  because AWS only accepts those APIs from IAM-user creds).
- Extends the security teardown safety net: `OWNED_USER_PREFIXES` now  covers `isv-sec02-test-*` and `_cleanup_owned_user` lists+deletes  inline policies before `DeleteUser` (no-op for SA-credential users).
- Adds the my-isv security scaffold/demo stub with a cloud-agnostic TODO  and `DEMO_MODE` dummy success.
- Adds focused validation, AWS provider script, and stub contract tests.

## Validation

- [x] `pytest isvtest/tests isvctl/tests` - 1193 passed
- [x] `make lint`
- [x] `make demo-test`
- [x] Live `isvctl test run -f providers/aws/config/security.yaml` against an SSO profile - `[PASS] All phases completed successfully`, `ShortLivedCredentialsCheck: PASSED` with TTL=43199s within the 43200s bound.

## Test Plan

- Manual AWS smoke test on an SSO orchestrator profile, confirming the  IAM user is provisioned, both STS probes return bounded-TTL  credentials, and the user + inline policy + access key are deleted on exit.

Closes #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SEC02-01 short-lived credentials validation for node and workload credential TTLs with configurable max TTL (default 43,200s) and provider/demo implementations.

* **Bug Fixes**
  * Teardown now cleans up inline user policies and recognizes additional test user prefixes to avoid leftover resources.

* **Tests**
  * Added comprehensive unit and integration tests covering pass, fail, skip, retry, and cleanup scenarios.

* **Documentation**
  * Updated security suite and scripts README to include the new check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->