### PR TITLE
feat: add tenant isolation validation (SEC11-01)

### DIFF
--- a/.cursor/rules/python-standards.mdc
+++ b/.cursor/rules/python-standards.mdc
@@ -20,6 +20,18 @@ alwaysApply: false
 - Return types must be explicitly specified for all functions
 - Maintain existing comments when modifying files
 
+## Imports
+
+- Place all imports at the top of the file
+- Defer imports inside functions only with a one-line comment giving the reason (import cycle, lazy expensive dep, side effects)
+- If a function-local import is from a module that's already imported at the top of the file, fold it into the top-level import (the deferred form is a stale leftover, not load-bearing)
+
+## Line Length
+
+- Code: respect `[tool.ruff] line-length` (120)
+- Comments and docstrings: wrap at ~100 for readability (prose at 120 reads as a wall)
+- `E501` is ignored in this repo, so the linter won't catch long comments — apply both limits at authoring time
+
 ## Testing Requirements
 
 - Use pytest exclusively (no unittest)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,13 @@ Entry point: `isvreporter/src/isvreporter/main.py` (Typer).
 jumphost (`remote/transfer.py`) → `install.sh` on target → `isvctl test run` with
 forwarded env vars → optional isvreporter upload.
 
+## Files agents must not edit
+
+- `isvtest/src/isvtest/released_tests.json` - release-gating manifest owned
+  by the release process (bumped via `chore: update package versions`). New
+  checks ship unreleased and land here in a separate release commit, not in
+  feature PRs.
+
 ## Directory Layout
 
 - Workspace root `pyproject.toml` defines members; each package has its own

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,9 @@ forwarded env vars → optional isvreporter upload.
 - `isvtest/src/isvtest/released_tests.json` - release-gating manifest owned
   by the release process (bumped via `chore: update package versions`). New
   checks ship unreleased and land here in a separate release commit, not in
-  feature PRs.
+  feature PRs. To exercise an unreleased check end-to-end against a config,
+  run with `ISVTEST_INCLUDE_UNRELEASED=1` (the orchestrator otherwise logs
+  `Skipping unreleased validation '<Name>'` and the new check is a no-op).
 
 ## Directory Layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,14 @@ uv run isvctl test run -f isvctl/configs/providers/k3s.yaml
 
 See the [Local Development Guide](docs/guides/local-development.md) for MicroK8s, Minikube, and k3s setup.
 
+### Validating an Unreleased Test Locally
+
+New validations are gated by `released_tests.json` until the next release
+bump. To exercise a new check end-to-end before that, set
+`ISVTEST_INCLUDE_UNRELEASED=1` (see [Releasing](#releasing) for the full
+workflow). Without it the orchestrator logs `Skipping unreleased validation
+'<Name>'` and the check is a no-op.
+
 ## Pull Request Process
 
 1. **Fork** the [upstream repository](https://github.com/NVIDIA/ISV-NCP-Validation-Suite) and create a branch from `main`.

--- a/isvctl/configs/providers/aws/config/security.yaml
+++ b/isvctl/configs/providers/aws/config/security.yaml
@@ -182,12 +182,15 @@ commands:
         args: ["--region", "{{region}}"]
         timeout: 600
 
-      # Teardown: Clean up leftover test IAM users
+      # Teardown: Safety-net sweep for leftover IAM users + SEC11 fixture.
+      # 300s budget covers worst-case instance-terminated waiter
+      # (5s delay * 60 attempts) plus VPC dependency unwinding when a
+      # prior run died mid-fixture.
       - name: teardown
         phase: teardown
         command: "python3 ../scripts/security/teardown.py"
         args: ["--region", "{{region}}"]
-        timeout: 60
+        timeout: 300
 
 tests:
   cluster_name: "aws-security-validation"

--- a/isvctl/configs/providers/aws/config/security.yaml
+++ b/isvctl/configs/providers/aws/config/security.yaml
@@ -29,6 +29,7 @@
 #   8. SA Credential Auth     - Verify IAM user + long-lived access key auth
 #   9. OIDC User Auth         - Probe configured OIDC-protected platform endpoint (SEC01-01)
 #  10. Short-Lived Credentials - Verify STS issues node + workload creds with bounded TTL (SEC02-01)
+#  11. Tenant Isolation       - Verify hard tenant isolation across network/data/compute/storage (SEC11-01)
 #
 # Note: SEC12-* (BMC) tests cannot be fully validated on AWS because the
 # Nitro/hypervisor BMC plane is provider-hidden. The references inspect the
@@ -158,6 +159,28 @@ commands:
         # Same envelope as sa_credential_test: provisions an IAM user and
         # waits on IAM->STS propagation (worst case ~46s of backoff).
         timeout: 120
+
+      # Test 11: Tenant Isolation (SEC11-01)
+      # Self-contained: provisions two ephemeral tenants (each with VPC,
+      # IAM user with scoped inline policy, KMS CMK, S3 bucket, t3.micro
+      # EC2, and EBS volume) and runs cross-tenant negative probes from
+      # tenant A's IAM creds against tenant B's resources, asserting
+      # AccessDenied across network/data/compute/storage surfaces. Tears
+      # the fixture down in a finally block.
+      #
+      # Orchestrator principal needs ec2:*, iam:CreateUser/PutUserPolicy/
+      # CreateAccessKey/Delete*, kms:CreateKey/CreateAlias/Schedule*,
+      # s3:CreateBucket/PutBucketTagging/DeleteBucket, plus matching
+      # describe perms. When those are missing the step emits a
+      # structured skip.
+      #
+      # Setup launches two t3.micro instances + waits for instance
+      # termination during teardown (~60s end-to-end on a warm region).
+      - name: tenant_isolation_test
+        phase: test
+        command: "python3 ../scripts/security/tenant_isolation_test.py"
+        args: ["--region", "{{region}}"]
+        timeout: 600
 
       # Teardown: Clean up leftover test IAM users
       - name: teardown

--- a/isvctl/configs/providers/aws/scripts/security/teardown.py
+++ b/isvctl/configs/providers/aws/scripts/security/teardown.py
@@ -41,7 +41,7 @@ from typing import Any
 sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
 
 import boto3
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, WaiterError
 from common.errors import delete_with_retry, handle_aws_errors
 
 OWNED_USER_PREFIXES: tuple[str, ...] = ("isv-sa-test-", "isv-sec02-test-", "isv-sec11-test-")
@@ -139,12 +139,19 @@ def _cleanup_sec11_instances(ec2: Any) -> list[str]:
 
     try:
         ec2.terminate_instances(InstanceIds=instance_ids)
+    except ClientError as e:
+        errors.append(f"terminate instances {instance_ids}: {e}")
+        return errors
+    try:
         ec2.get_waiter("instance_terminated").wait(
             InstanceIds=instance_ids,
             WaiterConfig={"Delay": 5, "MaxAttempts": 60},
         )
-    except ClientError as e:
-        errors.append(f"terminate instances {instance_ids}: {e}")
+    except (ClientError, WaiterError) as e:
+        # ``pending`` is a terminal failure for the InstanceTerminated
+        # waiter; happens when a previous run died mid-launch. Volume
+        # delete is retry-driven downstream, so log and move on.
+        errors.append(f"wait terminated {instance_ids}: {e}")
     return errors
 
 

--- a/isvctl/configs/providers/aws/scripts/security/teardown.py
+++ b/isvctl/configs/providers/aws/scripts/security/teardown.py
@@ -11,13 +11,21 @@
 
 """Security test teardown (AWS reference).
 
-Each individual test script handles its own cleanup.  This teardown
-step is a safety net that scans for leftover IAM users created by
-security test scripts:
+Each individual test script handles its own cleanup. This teardown step
+is a safety net that scans for leftover resources that owned-prefix
+test scripts may have leaked on a hard crash:
 
-* ``isv-sa-test-*``     - sa_credential_test.py
-* ``isv-sec02-test-*``  - short_lived_credentials_test.py (has an inline
-                          policy that must be deleted before the user)
+* IAM users
+    * ``isv-sa-test-*``     - sa_credential_test.py
+    * ``isv-sec02-test-*``  - short_lived_credentials_test.py
+    * ``isv-sec11-test-*``  - tenant_isolation_test.py
+* SEC11 fixture (``isv-sec11-test-*`` prefix + ``CreatedBy=isvtest`` tag):
+    * EC2 instances, EBS volumes, security groups, subnets, VPCs
+    * KMS aliases (and the keys they target)
+    * S3 buckets
+
+All deletes go through ``delete_with_retry`` so a transient throttling
+or endpoint reset does not leak resources on the next loop iteration.
 
 Usage:
     python teardown.py --region us-west-2
@@ -34,9 +42,17 @@ sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
 
 import boto3
 from botocore.exceptions import ClientError
-from common.errors import handle_aws_errors
+from common.errors import delete_with_retry, handle_aws_errors
 
-OWNED_USER_PREFIXES: tuple[str, ...] = ("isv-sa-test-", "isv-sec02-test-")
+OWNED_USER_PREFIXES: tuple[str, ...] = ("isv-sa-test-", "isv-sec02-test-", "isv-sec11-test-")
+
+# SEC11 tenant-isolation fixture prefix. Used to scope EC2/KMS/S3 sweeps
+# so we never touch resources outside the suite's namespace.
+SEC11_PREFIX = "isv-sec11-test-"
+SEC11_KMS_ALIAS_PREFIX = f"alias/{SEC11_PREFIX}"
+ISVTEST_TAG_FILTER = [
+    {"Name": "tag:CreatedBy", "Values": ["isvtest"]},
+]
 
 
 def _user_has_isvtest_tag(iam: Any, username: str) -> bool:
@@ -59,8 +75,8 @@ def _cleanup_owned_user(iam: Any, username: str) -> list[str]:
     """Delete one owned IAM user, its access keys, and any inline policies.
 
     Inline policies must be detached before ``DeleteUser`` succeeds; SEC02
-    test users carry one. SA-credential test users have no inline policies,
-    so the inline-policy pass is a no-op for them.
+    and SEC11 test users carry one. SA-credential test users have no
+    inline policies, so the inline-policy pass is a no-op for them.
     """
     cleanup_errors: list[str] = []
     keys: list[dict[str, Any]] = []
@@ -97,6 +113,190 @@ def _cleanup_owned_user(iam: Any, username: str) -> list[str]:
     return cleanup_errors
 
 
+def _resource_has_sec11_name(tags: list[dict[str, str]] | None) -> bool:
+    """Return True if the EC2 ``Tags`` contain a Name with the SEC11 prefix."""
+    if not tags:
+        return False
+    return any(t.get("Key") == "Name" and (t.get("Value") or "").startswith(SEC11_PREFIX) for t in tags)
+
+
+def _cleanup_sec11_instances(ec2: Any) -> list[str]:
+    """Terminate any leftover SEC11 EC2 instances and wait for the terminated state."""
+    errors: list[str] = []
+    instance_ids: list[str] = []
+    paginator = ec2.get_paginator("describe_instances")
+    for page in paginator.paginate(Filters=ISVTEST_TAG_FILTER):
+        for reservation in page.get("Reservations", []):
+            for instance in reservation.get("Instances", []):
+                if instance.get("State", {}).get("Name") == "terminated":
+                    continue
+                if not _resource_has_sec11_name(instance.get("Tags")):
+                    continue
+                instance_ids.append(instance["InstanceId"])
+
+    if not instance_ids:
+        return errors
+
+    try:
+        ec2.terminate_instances(InstanceIds=instance_ids)
+        ec2.get_waiter("instance_terminated").wait(
+            InstanceIds=instance_ids,
+            WaiterConfig={"Delay": 5, "MaxAttempts": 60},
+        )
+    except ClientError as e:
+        errors.append(f"terminate instances {instance_ids}: {e}")
+    return errors
+
+
+def _cleanup_sec11_volumes(ec2: Any) -> list[str]:
+    """Delete leftover SEC11 EBS volumes (must run AFTER instance termination)."""
+    errors: list[str] = []
+    paginator = ec2.get_paginator("describe_volumes")
+    for page in paginator.paginate(Filters=ISVTEST_TAG_FILTER):
+        for volume in page.get("Volumes", []):
+            if not _resource_has_sec11_name(volume.get("Tags")):
+                continue
+            volume_id = volume["VolumeId"]
+            if not delete_with_retry(
+                ec2.delete_volume,
+                VolumeId=volume_id,
+                resource_desc=f"volume {volume_id}",
+            ):
+                errors.append(f"delete volume {volume_id} failed")
+    return errors
+
+
+def _cleanup_sec11_vpcs(ec2: Any) -> list[str]:
+    """Delete leftover SEC11 VPCs and their dependencies (security groups, subnets)."""
+    errors: list[str] = []
+    vpcs = ec2.describe_vpcs(Filters=ISVTEST_TAG_FILTER).get("Vpcs", [])
+    for vpc in vpcs:
+        if not _resource_has_sec11_name(vpc.get("Tags")):
+            continue
+        vpc_id = vpc["VpcId"]
+
+        # Security groups (skip the default SG which cannot be deleted).
+        sgs = ec2.describe_security_groups(Filters=[{"Name": "vpc-id", "Values": [vpc_id]}]).get("SecurityGroups", [])
+        for sg in sgs:
+            if sg.get("GroupName") == "default":
+                continue
+            if not delete_with_retry(
+                ec2.delete_security_group,
+                GroupId=sg["GroupId"],
+                resource_desc=f"security group {sg['GroupId']}",
+            ):
+                errors.append(f"delete security group {sg['GroupId']} failed")
+
+        # Subnets.
+        subnets = ec2.describe_subnets(Filters=[{"Name": "vpc-id", "Values": [vpc_id]}]).get("Subnets", [])
+        for subnet in subnets:
+            if not delete_with_retry(
+                ec2.delete_subnet,
+                SubnetId=subnet["SubnetId"],
+                resource_desc=f"subnet {subnet['SubnetId']}",
+            ):
+                errors.append(f"delete subnet {subnet['SubnetId']} failed")
+
+        if not delete_with_retry(
+            ec2.delete_vpc,
+            VpcId=vpc_id,
+            resource_desc=f"VPC {vpc_id}",
+        ):
+            errors.append(f"delete VPC {vpc_id} failed")
+    return errors
+
+
+def _cleanup_sec11_kms(kms: Any) -> list[str]:
+    """Schedule SEC11 KMS keys for deletion and remove their aliases."""
+    errors: list[str] = []
+    paginator = kms.get_paginator("list_aliases")
+    for page in paginator.paginate():
+        for alias in page.get("Aliases", []):
+            alias_name = alias.get("AliasName", "")
+            if not alias_name.startswith(SEC11_KMS_ALIAS_PREFIX):
+                continue
+            target_key = alias.get("TargetKeyId")
+            try:
+                kms.delete_alias(AliasName=alias_name)
+            except ClientError as e:
+                if e.response.get("Error", {}).get("Code") != "NotFoundException":
+                    errors.append(f"delete kms alias {alias_name}: {e}")
+            if target_key:
+                try:
+                    kms.schedule_key_deletion(KeyId=target_key, PendingWindowInDays=7)
+                except ClientError as e:
+                    code = e.response.get("Error", {}).get("Code", "")
+                    if code not in {"NotFoundException", "KMSInvalidStateException"}:
+                        # KMSInvalidStateException = key is already pending deletion.
+                        errors.append(f"schedule kms key {target_key} deletion: {e}")
+    return errors
+
+
+def _cleanup_sec11_buckets(s3: Any) -> list[str]:
+    """Empty and delete leftover SEC11 S3 buckets."""
+    errors: list[str] = []
+    try:
+        buckets = s3.list_buckets().get("Buckets", [])
+    except ClientError as e:
+        return [f"list_buckets: {e}"]
+
+    for bucket in buckets:
+        name = bucket.get("Name", "")
+        if not name.startswith(SEC11_PREFIX):
+            continue
+        # Verified-ownership check: only delete buckets carrying our tag.
+        try:
+            tagging = s3.get_bucket_tagging(Bucket=name)
+            tags = {t["Key"]: t["Value"] for t in tagging.get("TagSet", [])}
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") == "NoSuchTagSet":
+                tags = {}
+            else:
+                errors.append(f"get_bucket_tagging {name}: {e}")
+                continue
+        if tags.get("CreatedBy") != "isvtest":
+            continue
+
+        try:
+            paginator = s3.get_paginator("list_object_versions")
+            for page in paginator.paginate(Bucket=name):
+                to_delete = [
+                    {"Key": v["Key"], "VersionId": v["VersionId"]}
+                    for v in (page.get("Versions") or []) + (page.get("DeleteMarkers") or [])
+                ]
+                if to_delete:
+                    s3.delete_objects(Bucket=name, Delete={"Objects": to_delete, "Quiet": True})
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") not in {"NoSuchBucket"}:
+                errors.append(f"empty bucket {name}: {e}")
+
+        if not delete_with_retry(s3.delete_bucket, Bucket=name, resource_desc=f"S3 bucket {name}"):
+            errors.append(f"delete bucket {name} failed")
+    return errors
+
+
+def _sweep_iam_users(iam: Any) -> tuple[int, int, list[dict[str, Any]]]:
+    """Sweep IAM users matching ``OWNED_USER_PREFIXES`` and tagged ``CreatedBy=isvtest``."""
+    cleaned = 0
+    skipped_unowned = 0
+    failed_resources: list[dict[str, Any]] = []
+    paginator = iam.get_paginator("list_users")
+    for page in paginator.paginate():
+        for user in page["Users"]:
+            name = user["UserName"]
+            if not name.startswith(OWNED_USER_PREFIXES):
+                continue
+            if not _user_has_isvtest_tag(iam, name):
+                skipped_unowned += 1
+                continue
+            cleanup_errors = _cleanup_owned_user(iam, name)
+            if cleanup_errors:
+                failed_resources.append({"username": name, "errors": cleanup_errors})
+            else:
+                cleaned += 1
+    return cleaned, skipped_unowned, failed_resources
+
+
 @handle_aws_errors
 def main() -> int:
     """Clean up leftover security test resources created by isvtest."""
@@ -118,38 +318,53 @@ def main() -> int:
         return 0
 
     iam = boto3.client("iam", region_name=args.region)
+    ec2 = boto3.client("ec2", region_name=args.region)
+    kms = boto3.client("kms", region_name=args.region)
+    s3 = boto3.client("s3", region_name=args.region)
+
+    sec11_errors: list[str] = []
+
+    # Order matters: instances first (so volumes can be deleted), then
+    # volumes, then VPCs (which need empty subnets/SGs).
+    try:
+        sec11_errors.extend(_cleanup_sec11_instances(ec2))
+        sec11_errors.extend(_cleanup_sec11_volumes(ec2))
+        sec11_errors.extend(_cleanup_sec11_vpcs(ec2))
+        sec11_errors.extend(_cleanup_sec11_kms(kms))
+        sec11_errors.extend(_cleanup_sec11_buckets(s3))
+    except ClientError as e:
+        sec11_errors.append(str(e))
+
     cleaned = 0
     skipped_unowned = 0
     failed_resources: list[dict[str, Any]] = []
-
     try:
-        paginator = iam.get_paginator("list_users")
-        for page in paginator.paginate():
-            for user in page["Users"]:
-                name = user["UserName"]
-                if not name.startswith(OWNED_USER_PREFIXES):
-                    continue
-                if not _user_has_isvtest_tag(iam, name):
-                    skipped_unowned += 1
-                    continue
-                cleanup_errors = _cleanup_owned_user(iam, name)
-                if cleanup_errors:
-                    failed_resources.append({"username": name, "errors": cleanup_errors})
-                else:
-                    cleaned += 1
-
-        result["resources_cleaned"] = cleaned
-        result["resources_skipped_unowned"] = skipped_unowned
-        if failed_resources:
-            result["success"] = False
-            result["resources_failed"] = failed_resources
-            result["error"] = f"Failed to clean up {len(failed_resources)} owned IAM user(s): " + "; ".join(
-                f"{item['username']}: {', '.join(item['errors'])}" for item in failed_resources
-            )
-        else:
-            result["success"] = True
+        cleaned, skipped_unowned, failed_resources = _sweep_iam_users(iam)
     except ClientError as e:
         result["error"] = str(e)
+
+    result["resources_cleaned"] = cleaned
+    result["resources_skipped_unowned"] = skipped_unowned
+    if sec11_errors:
+        result["sec11_cleanup_errors"] = sec11_errors
+    if failed_resources:
+        result["resources_failed"] = failed_resources
+
+    if failed_resources or sec11_errors:
+        result["success"] = False
+        existing_error = result.get("error", "")
+        msgs: list[str] = []
+        if failed_resources:
+            msgs.append(
+                f"Failed to clean up {len(failed_resources)} owned IAM user(s): "
+                + "; ".join(f"{item['username']}: {', '.join(item['errors'])}" for item in failed_resources)
+            )
+        if sec11_errors:
+            msgs.append("SEC11 sweep errors: " + "; ".join(sec11_errors))
+        combined = "; ".join(msgs)
+        result["error"] = f"{existing_error}; {combined}" if existing_error else combined
+    elif "error" not in result:
+        result["success"] = True
 
     print(json.dumps(result, indent=2))
     return 0 if result["success"] else 1

--- a/isvctl/configs/providers/aws/scripts/security/tenant_isolation_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/tenant_isolation_test.py
@@ -1,0 +1,873 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Verify hard tenant isolation across network/data/compute/storage (SEC11-01).
+
+Self-contained AWS reference. Provisions two ephemeral "tenants" in a try /
+finally block, where each tenant = (VPC + subnet + SG, IAM user with an
+inline policy scoped to its own resources, KMS CMK, S3 bucket, t3.micro EC2
+instance, 1 GiB EBS volume), then runs four cross-tenant negative probes
+from tenant A's IAM creds against tenant B's resources, asserting each is
+denied:
+
+  * network_isolated: no VPC peering between A and B and no route from
+    A's route tables targeting B's CIDR (orchestrator describe; mirrors
+    bmc_isolation_test.py's config-plane check).
+  * data_isolated: tenant A's IAM principal denied ``kms:Encrypt`` on
+    tenant B's CMK and ``s3:GetObject`` on tenant B's bucket.
+  * compute_isolated: tenant A denied ``ec2:StopInstances`` (DryRun) and
+    ``ssm:StartSession`` against tenant B's instance.
+  * storage_isolated: tenant A denied ``ec2:CreateSnapshot`` (DryRun) and
+    ``ec2:AttachVolume`` (DryRun) against tenant B's volume.
+
+Per-tenant resources share an ``isv-sec11-test-<suffix>`` prefix and the
+``CreatedBy=isvtest`` tag so the security teardown sweep can clean up
+anything this script leaks on a hard crash.
+
+Physical isolation (bare-metal) and IB switch-fabric isolation are out of
+scope for this test (covered by SDN04-04/05).
+
+Usage:
+    python tenant_isolation_test.py --region us-west-2
+
+Output JSON:
+  {
+    "success": true,
+    "platform": "security",
+    "test_name": "tenant_isolation_test",
+    "tenant_a_id": "isv-sec11-test-aaaa1111",
+    "tenant_b_id": "isv-sec11-test-bbbb2222",
+    "tests": {
+      "network_isolated": {"passed": true, "message": "..."},
+      "data_isolated":    {"passed": true, "probes": [...]},
+      "compute_isolated": {"passed": true, "probes": [...]},
+      "storage_isolated": {"passed": true, "probes": [...]}
+    }
+  }
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import boto3
+from botocore.exceptions import ClientError
+from common.errors import delete_with_retry, handle_aws_errors
+
+TEST_NAME = "tenant_isolation_test"
+TENANT_PREFIX = "isv-sec11-test-"
+INLINE_POLICY_NAME = "isv-sec11-tenant-scope"
+TENANT_A_CIDR = "10.94.0.0/24"
+TENANT_B_CIDR = "10.95.0.0/24"
+INSTANCE_TYPE = "t3.micro"
+VOLUME_SIZE_GIB = 1
+
+# AWS error codes from setup that signal the orchestrator principal cannot
+# provision the test fixture; surface as a structured skip rather than a
+# SEC11-01 failure.
+SKIPPABLE_SETUP_ERRORS = frozenset({"AccessDenied", "UnauthorizedOperation"})
+
+# IAM is eventually consistent: a freshly created access key may take
+# 15-30s to propagate. Mirror short_lived_credentials_test.py's pattern.
+IAM_PROPAGATION_MAX_ATTEMPTS = 8
+IAM_PROPAGATION_BACKOFF_CAP = 8
+
+# Error codes that mean the probe was correctly denied. UnauthorizedOperation
+# is what EC2 returns for DryRun calls when IAM denies; AccessDenied is the
+# generic deny for KMS, S3, SSM, IAM-scoped actions.
+DENY_CODES = frozenset({"AccessDenied", "AccessDeniedException", "UnauthorizedOperation", "Forbidden"})
+
+# Error code returned by EC2 when DryRun=True succeeds (i.e. IAM allowed it
+# but the action was not performed). Treated as "probe was NOT denied", so
+# the cross-tenant probe FAILS.
+DRY_RUN_ALLOWED_CODE = "DryRunOperation"
+
+
+@dataclass
+class Tenant:
+    """Per-tenant resources created during setup, used during probes and teardown."""
+
+    suffix: str
+    cidr: str
+    vpc_id: str = ""
+    subnet_id: str = ""
+    sg_id: str = ""
+    iam_user_arn: str = ""
+    access_key_id: str = ""
+    secret_key: str = ""
+    kms_key_id: str = ""
+    kms_key_arn: str = ""
+    s3_bucket: str = ""
+    instance_id: str = ""
+    volume_id: str = ""
+    created: dict[str, bool] = field(default_factory=dict)
+
+    @property
+    def name(self) -> str:
+        """Return the canonical ``isv-sec11-test-<suffix>`` identifier."""
+        return f"{TENANT_PREFIX}{self.suffix}"
+
+
+# -- Setup helpers --------------------------------------------------------
+
+
+def _scoped_policy_document(tenant: Tenant) -> str:
+    """IAM policy granting tenant A's user actions only on its OWN resources.
+
+    Cross-tenant probes against tenant B's resources fall outside this
+    allow-list and hit IAM's default deny -- which is exactly what
+    SEC11-01 wants to see. The test does not actually require A to be
+    able to act on A's own resources; granting these actions is
+    sanity-only so the inline policy is a realistic tenant scope rather
+    than an empty deny-all.
+    """
+    instance_arn = f"arn:aws:ec2:*:*:instance/{tenant.instance_id}"
+    volume_arn = f"arn:aws:ec2:*:*:volume/{tenant.volume_id}"
+    return json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "AllowOwnKms",
+                    "Effect": "Allow",
+                    "Action": ["kms:Encrypt", "kms:Decrypt", "kms:DescribeKey"],
+                    "Resource": [tenant.kms_key_arn],
+                },
+                {
+                    "Sid": "AllowOwnBucket",
+                    "Effect": "Allow",
+                    "Action": ["s3:GetObject", "s3:PutObject", "s3:ListBucket"],
+                    "Resource": [
+                        f"arn:aws:s3:::{tenant.s3_bucket}",
+                        f"arn:aws:s3:::{tenant.s3_bucket}/*",
+                    ],
+                },
+                {
+                    "Sid": "AllowOwnInstance",
+                    "Effect": "Allow",
+                    "Action": ["ec2:StopInstances", "ec2:StartInstances", "ssm:StartSession"],
+                    "Resource": [instance_arn],
+                },
+                {
+                    "Sid": "AllowOwnVolumeAndAttach",
+                    "Effect": "Allow",
+                    "Action": ["ec2:CreateSnapshot", "ec2:AttachVolume", "ec2:DetachVolume"],
+                    "Resource": [volume_arn, instance_arn],
+                },
+            ],
+        }
+    )
+
+
+def _isvtest_tags(name: str) -> list[dict[str, str]]:
+    """Standard ``CreatedBy=isvtest`` + ``Name`` tag pair for EC2 resources."""
+    return [
+        {"Key": "CreatedBy", "Value": "isvtest"},
+        {"Key": "Name", "Value": name},
+    ]
+
+
+def _create_vpc_and_subnet(ec2: Any, tenant: Tenant) -> None:
+    """Create VPC, subnet, default SG; populate ``tenant`` in place."""
+    vpc = ec2.create_vpc(CidrBlock=tenant.cidr)
+    tenant.vpc_id = vpc["Vpc"]["VpcId"]
+    tenant.created["vpc"] = True
+    ec2.create_tags(Resources=[tenant.vpc_id], Tags=_isvtest_tags(tenant.name))
+    ec2.get_waiter("vpc_available").wait(VpcIds=[tenant.vpc_id])
+
+    az = ec2.describe_availability_zones(Filters=[{"Name": "state", "Values": ["available"]}])["AvailabilityZones"][0][
+        "ZoneName"
+    ]
+    subnet = ec2.create_subnet(VpcId=tenant.vpc_id, CidrBlock=tenant.cidr, AvailabilityZone=az)
+    tenant.subnet_id = subnet["Subnet"]["SubnetId"]
+    tenant.created["subnet"] = True
+    ec2.create_tags(Resources=[tenant.subnet_id], Tags=_isvtest_tags(tenant.name))
+
+    sg = ec2.create_security_group(
+        GroupName=f"{tenant.name}-sg",
+        Description=f"SEC11-01 tenant isolation test SG for {tenant.name}",
+        VpcId=tenant.vpc_id,
+    )
+    tenant.sg_id = sg["GroupId"]
+    tenant.created["sg"] = True
+    ec2.create_tags(Resources=[tenant.sg_id], Tags=_isvtest_tags(tenant.name))
+
+
+def _get_amazon_linux_ami(ec2: Any) -> str:
+    """Return latest Amazon Linux 2023 x86_64 AMI id (or AL2 fallback)."""
+    response = ec2.describe_images(
+        Owners=["amazon"],
+        Filters=[
+            {"Name": "name", "Values": ["al2023-ami-*-x86_64"]},
+            {"Name": "state", "Values": ["available"]},
+            {"Name": "architecture", "Values": ["x86_64"]},
+        ],
+    )
+    images = sorted(response.get("Images", []), key=lambda x: x["CreationDate"], reverse=True)
+    if not images:
+        # Fallback to AL2 if AL2023 unavailable in this partition.
+        response = ec2.describe_images(
+            Owners=["amazon"],
+            Filters=[
+                {"Name": "name", "Values": ["amzn2-ami-hvm-*-x86_64-gp2"]},
+                {"Name": "state", "Values": ["available"]},
+            ],
+        )
+        images = sorted(response.get("Images", []), key=lambda x: x["CreationDate"], reverse=True)
+    if not images:
+        msg = "No Amazon Linux AMI found for tenant fixture"
+        raise RuntimeError(msg)
+    return images[0]["ImageId"]
+
+
+def _launch_instance(ec2: Any, tenant: Tenant, ami_id: str) -> None:
+    """Launch a single t3.micro into tenant's subnet (no key pair, no user data)."""
+    response = ec2.run_instances(
+        ImageId=ami_id,
+        InstanceType=INSTANCE_TYPE,
+        MinCount=1,
+        MaxCount=1,
+        SubnetId=tenant.subnet_id,
+        SecurityGroupIds=[tenant.sg_id],
+        TagSpecifications=[{"ResourceType": "instance", "Tags": _isvtest_tags(tenant.name)}],
+    )
+    tenant.instance_id = response["Instances"][0]["InstanceId"]
+    tenant.created["instance"] = True
+
+
+def _create_volume(ec2: Any, tenant: Tenant) -> None:
+    """Create a 1 GiB gp3 EBS volume in the tenant's AZ."""
+    az = ec2.describe_subnets(SubnetIds=[tenant.subnet_id])["Subnets"][0]["AvailabilityZone"]
+    response = ec2.create_volume(
+        AvailabilityZone=az,
+        Size=VOLUME_SIZE_GIB,
+        VolumeType="gp3",
+        TagSpecifications=[{"ResourceType": "volume", "Tags": _isvtest_tags(tenant.name)}],
+    )
+    tenant.volume_id = response["VolumeId"]
+    tenant.created["volume"] = True
+    ec2.get_waiter("volume_available").wait(
+        VolumeIds=[tenant.volume_id],
+        WaiterConfig={"Delay": 2, "MaxAttempts": 30},
+    )
+
+
+def _create_kms_key(kms: Any, tenant: Tenant) -> None:
+    """Create a tagged symmetric customer-managed KMS key for the tenant."""
+    response = kms.create_key(
+        Description=f"SEC11-01 tenant isolation test key for {tenant.name}",
+        KeyUsage="ENCRYPT_DECRYPT",
+        Origin="AWS_KMS",
+        Tags=[
+            {"TagKey": "CreatedBy", "TagValue": "isvtest"},
+            {"TagKey": "Name", "TagValue": tenant.name},
+        ],
+    )
+    tenant.kms_key_id = response["KeyMetadata"]["KeyId"]
+    tenant.kms_key_arn = response["KeyMetadata"]["Arn"]
+    tenant.created["kms_key"] = True
+    # Attach a friendly alias so teardown's prefix sweep can find orphaned
+    # keys without scanning the whole region.
+    kms.create_alias(AliasName=f"alias/{tenant.name}", TargetKeyId=tenant.kms_key_id)
+    tenant.created["kms_alias"] = True
+
+
+def _create_s3_bucket(s3: Any, tenant: Tenant, region: str) -> None:
+    """Create a tagged S3 bucket. us-east-1 must NOT pass LocationConstraint."""
+    bucket = f"{tenant.name}-{uuid.uuid4().hex[:6]}"
+    create_kwargs: dict[str, Any] = {"Bucket": bucket}
+    if region != "us-east-1":
+        create_kwargs["CreateBucketConfiguration"] = {"LocationConstraint": region}
+    s3.create_bucket(**create_kwargs)
+    tenant.s3_bucket = bucket
+    tenant.created["s3"] = True
+    s3.put_bucket_tagging(
+        Bucket=bucket,
+        Tagging={"TagSet": [{"Key": "CreatedBy", "Value": "isvtest"}, {"Key": "Name", "Value": tenant.name}]},
+    )
+
+
+def _create_iam_user(iam: Any, tenant: Tenant) -> None:
+    """Create the tenant's IAM user with a scoped inline policy + access key."""
+    response = iam.create_user(
+        UserName=tenant.name,
+        Tags=[{"Key": "CreatedBy", "Value": "isvtest"}, {"Key": "Tenant", "Value": tenant.name}],
+    )
+    tenant.iam_user_arn = response["User"]["Arn"]
+    tenant.created["iam_user"] = True
+
+    iam.put_user_policy(
+        UserName=tenant.name,
+        PolicyName=INLINE_POLICY_NAME,
+        PolicyDocument=_scoped_policy_document(tenant),
+    )
+    tenant.created["iam_policy"] = True
+
+    key_response = iam.create_access_key(UserName=tenant.name)
+    tenant.access_key_id = key_response["AccessKey"]["AccessKeyId"]
+    tenant.secret_key = key_response["AccessKey"]["SecretAccessKey"]
+    tenant.created["iam_access_key"] = True
+
+
+def _provision_tenant(
+    *,
+    ec2: Any,
+    iam: Any,
+    kms: Any,
+    s3: Any,
+    region: str,
+    suffix: str,
+    cidr: str,
+    ami_id: str,
+) -> Tenant:
+    """Provision the full per-tenant fixture. Caller invokes ``_teardown_tenant`` from finally."""
+    tenant = Tenant(suffix=suffix, cidr=cidr)
+    _create_vpc_and_subnet(ec2, tenant)
+    _create_s3_bucket(s3, tenant, region)
+    _create_kms_key(kms, tenant)
+    _launch_instance(ec2, tenant, ami_id)
+    _create_volume(ec2, tenant)
+    # IAM user must be created last: its inline policy ARNs reference the
+    # KMS key, S3 bucket, instance, and volume created above.
+    _create_iam_user(iam, tenant)
+    return tenant
+
+
+# -- Teardown -------------------------------------------------------------
+
+
+def _teardown_tenant(
+    *,
+    ec2: Any,
+    iam: Any,
+    kms: Any,
+    s3: Any,
+    tenant: Tenant,
+) -> list[str]:
+    """Best-effort teardown of every resource the setup helpers created.
+
+    Each step is independent so a transient failure on one resource does
+    not leak the rest.
+    """
+    errors: list[str] = []
+
+    if tenant.created.get("instance") and tenant.instance_id:
+        try:
+            ec2.terminate_instances(InstanceIds=[tenant.instance_id])
+            ec2.get_waiter("instance_terminated").wait(
+                InstanceIds=[tenant.instance_id],
+                WaiterConfig={"Delay": 5, "MaxAttempts": 60},
+            )
+        except ClientError as e:
+            errors.append(f"terminate instance {tenant.instance_id}: {e}")
+
+    if tenant.created.get("volume") and tenant.volume_id:
+        if not delete_with_retry(
+            ec2.delete_volume,
+            VolumeId=tenant.volume_id,
+            resource_desc=f"volume {tenant.volume_id}",
+        ):
+            errors.append(f"delete volume {tenant.volume_id} failed")
+
+    if tenant.created.get("iam_access_key") and tenant.access_key_id:
+        try:
+            iam.delete_access_key(UserName=tenant.name, AccessKeyId=tenant.access_key_id)
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") != "NoSuchEntity":
+                errors.append(f"delete access key for {tenant.name}: {e}")
+
+    if tenant.created.get("iam_policy"):
+        try:
+            iam.delete_user_policy(UserName=tenant.name, PolicyName=INLINE_POLICY_NAME)
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") != "NoSuchEntity":
+                errors.append(f"delete inline policy for {tenant.name}: {e}")
+
+    if tenant.created.get("iam_user"):
+        try:
+            iam.delete_user(UserName=tenant.name)
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") != "NoSuchEntity":
+                errors.append(f"delete user {tenant.name}: {e}")
+
+    if tenant.created.get("kms_alias"):
+        try:
+            kms.delete_alias(AliasName=f"alias/{tenant.name}")
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") != "NotFoundException":
+                errors.append(f"delete kms alias {tenant.name}: {e}")
+
+    if tenant.created.get("kms_key") and tenant.kms_key_id:
+        try:
+            kms.schedule_key_deletion(KeyId=tenant.kms_key_id, PendingWindowInDays=7)
+        except ClientError as e:
+            errors.append(f"schedule kms key deletion for {tenant.kms_key_id}: {e}")
+
+    if tenant.created.get("s3") and tenant.s3_bucket:
+        errors.extend(_empty_and_delete_bucket(s3, tenant.s3_bucket))
+
+    if tenant.created.get("sg") and tenant.sg_id:
+        if not delete_with_retry(
+            ec2.delete_security_group,
+            GroupId=tenant.sg_id,
+            resource_desc=f"security group {tenant.sg_id}",
+        ):
+            errors.append(f"delete security group {tenant.sg_id} failed")
+
+    if tenant.created.get("subnet") and tenant.subnet_id:
+        if not delete_with_retry(
+            ec2.delete_subnet,
+            SubnetId=tenant.subnet_id,
+            resource_desc=f"subnet {tenant.subnet_id}",
+        ):
+            errors.append(f"delete subnet {tenant.subnet_id} failed")
+
+    if tenant.created.get("vpc") and tenant.vpc_id:
+        if not delete_with_retry(
+            ec2.delete_vpc,
+            VpcId=tenant.vpc_id,
+            resource_desc=f"VPC {tenant.vpc_id}",
+        ):
+            errors.append(f"delete VPC {tenant.vpc_id} failed")
+
+    return errors
+
+
+def _empty_and_delete_bucket(s3: Any, bucket: str) -> list[str]:
+    """Empty an S3 bucket (objects + versions + delete markers) then delete it."""
+    errors: list[str] = []
+    try:
+        paginator = s3.get_paginator("list_object_versions")
+        for page in paginator.paginate(Bucket=bucket):
+            to_delete = [
+                {"Key": v["Key"], "VersionId": v["VersionId"]}
+                for v in (page.get("Versions") or []) + (page.get("DeleteMarkers") or [])
+            ]
+            if to_delete:
+                s3.delete_objects(Bucket=bucket, Delete={"Objects": to_delete, "Quiet": True})
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") not in {"NoSuchBucket"}:
+            errors.append(f"empty bucket {bucket}: {e}")
+
+    if not delete_with_retry(s3.delete_bucket, Bucket=bucket, resource_desc=f"S3 bucket {bucket}"):
+        errors.append(f"delete bucket {bucket} failed")
+    return errors
+
+
+# -- Probe helpers --------------------------------------------------------
+
+
+def _is_denied(exc: ClientError) -> bool:
+    """Return True when the AWS ClientError represents an authorization deny."""
+    code = exc.response.get("Error", {}).get("Code", "")
+    return code in DENY_CODES
+
+
+def _classify_dry_run(exc: ClientError) -> str:
+    """Classify an EC2 DryRun ClientError as ``denied``, ``allowed``, or ``other``."""
+    code = exc.response.get("Error", {}).get("Code", "")
+    if code in DENY_CODES:
+        return "denied"
+    if code == DRY_RUN_ALLOWED_CODE:
+        return "allowed"
+    return "other"
+
+
+def _wait_for_iam_propagation(sts_a: Any) -> None:
+    """Block until tenant A's STS client can call GetCallerIdentity (or give up)."""
+    for attempt in range(IAM_PROPAGATION_MAX_ATTEMPTS):
+        try:
+            sts_a.get_caller_identity()
+            return
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if code == "InvalidClientTokenId" and attempt < IAM_PROPAGATION_MAX_ATTEMPTS - 1:
+                time.sleep(min(2 ** (attempt + 1), IAM_PROPAGATION_BACKOFF_CAP))
+                continue
+            raise
+
+
+def _build_tenant_clients(tenant: Tenant, region: str) -> dict[str, Any]:
+    """Return boto3 clients authenticated as ``tenant`` (used for negative probes)."""
+    common = {
+        "region_name": region,
+        "aws_access_key_id": tenant.access_key_id,
+        "aws_secret_access_key": tenant.secret_key,
+    }
+    return {
+        "ec2": boto3.client("ec2", **common),
+        "kms": boto3.client("kms", **common),
+        "s3": boto3.client("s3", **common),
+        "ssm": boto3.client("ssm", **common),
+        "sts": boto3.client("sts", **common),
+    }
+
+
+# -- Probes ---------------------------------------------------------------
+
+
+def _probe_network_isolation(orchestrator_ec2: Any, tenant_a: Tenant, tenant_b: Tenant) -> dict[str, Any]:
+    """Verify no peering and no shared route between tenant A's and B's VPCs.
+
+    This is a config-plane check (mirrors bmc_isolation_test.py): in AWS,
+    two freshly created VPCs are unreachable to each other unless a
+    peering connection or transit gateway is wired in. We assert no such
+    plumbing exists.
+    """
+    peerings = orchestrator_ec2.describe_vpc_peering_connections(
+        Filters=[
+            {"Name": "accepter-vpc-info.vpc-id", "Values": [tenant_a.vpc_id, tenant_b.vpc_id]},
+            {"Name": "requester-vpc-info.vpc-id", "Values": [tenant_a.vpc_id, tenant_b.vpc_id]},
+        ]
+    ).get("VpcPeeringConnections", [])
+    cross_peerings = [
+        p for p in peerings if p.get("Status", {}).get("Code") in {"active", "pending-acceptance", "provisioning"}
+    ]
+    if cross_peerings:
+        return {
+            "passed": False,
+            "error": f"VPC peering exists between tenant A ({tenant_a.vpc_id}) and tenant B ({tenant_b.vpc_id})",
+        }
+
+    tenant_b_cidrs = {tenant_b.cidr}
+    a_route_tables = orchestrator_ec2.describe_route_tables(
+        Filters=[{"Name": "vpc-id", "Values": [tenant_a.vpc_id]}]
+    ).get("RouteTables", [])
+    for rt in a_route_tables:
+        for route in rt.get("Routes", []):
+            if route.get("DestinationCidrBlock") in tenant_b_cidrs:
+                return {
+                    "passed": False,
+                    "error": (
+                        f"Route to tenant B CIDR {route['DestinationCidrBlock']} found in "
+                        f"{rt['RouteTableId']} for tenant A VPC {tenant_a.vpc_id}"
+                    ),
+                }
+
+    return {
+        "passed": True,
+        "message": (
+            f"No peering or shared route between tenant A VPC {tenant_a.vpc_id} ({tenant_a.cidr}) "
+            f"and tenant B VPC {tenant_b.vpc_id} ({tenant_b.cidr})"
+        ),
+    }
+
+
+def _probe_data_isolation(clients_a: dict[str, Any], tenant_b: Tenant) -> dict[str, Any]:
+    """Tenant A's IAM principal must be denied kms:Encrypt on B's CMK and s3:GetObject on B's bucket."""
+    probes: list[dict[str, Any]] = []
+
+    try:
+        clients_a["kms"].encrypt(KeyId=tenant_b.kms_key_arn, Plaintext=b"sec11-cross-tenant")
+    except ClientError as exc:
+        probes.append(
+            {
+                "name": "kms_encrypt_denied",
+                "passed": _is_denied(exc),
+                "code": exc.response.get("Error", {}).get("Code", ""),
+            }
+        )
+    else:
+        probes.append({"name": "kms_encrypt_denied", "passed": False, "error": "kms:Encrypt unexpectedly succeeded"})
+
+    try:
+        clients_a["s3"].get_object(Bucket=tenant_b.s3_bucket, Key="probe-key")
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        # NoSuchKey would mean ListBucket was implicitly granted (it is not),
+        # so any "not denied" outcome here is a real failure.
+        probes.append(
+            {
+                "name": "s3_get_object_denied",
+                "passed": _is_denied(exc),
+                "code": code,
+            }
+        )
+    else:
+        probes.append({"name": "s3_get_object_denied", "passed": False, "error": "s3:GetObject unexpectedly succeeded"})
+
+    passed = all(p["passed"] for p in probes)
+    return {
+        "passed": passed,
+        "probes": probes,
+        **(
+            {"error": "; ".join(p.get("error", p.get("code", "")) for p in probes if not p["passed"])}
+            if not passed
+            else {}
+        ),
+    }
+
+
+def _probe_compute_isolation(clients_a: dict[str, Any], tenant_b: Tenant) -> dict[str, Any]:
+    """Tenant A must be denied ec2:StopInstances (DryRun) and ssm:StartSession against B's instance."""
+    probes: list[dict[str, Any]] = []
+
+    try:
+        clients_a["ec2"].stop_instances(InstanceIds=[tenant_b.instance_id], DryRun=True)
+    except ClientError as exc:
+        verdict = _classify_dry_run(exc)
+        probes.append(
+            {
+                "name": "ec2_stop_instances_denied",
+                "passed": verdict == "denied",
+                "code": exc.response.get("Error", {}).get("Code", ""),
+            }
+        )
+    else:
+        # No exception means EC2 silently returned without DryRunOperation,
+        # which AWS does not do for DryRun=True; treat defensively as fail.
+        probes.append(
+            {
+                "name": "ec2_stop_instances_denied",
+                "passed": False,
+                "error": "ec2:StopInstances DryRun returned no error (unexpected)",
+            }
+        )
+
+    try:
+        clients_a["ssm"].start_session(Target=tenant_b.instance_id)
+    except ClientError as exc:
+        probes.append(
+            {
+                "name": "ssm_start_session_denied",
+                "passed": _is_denied(exc),
+                "code": exc.response.get("Error", {}).get("Code", ""),
+            }
+        )
+    else:
+        probes.append(
+            {"name": "ssm_start_session_denied", "passed": False, "error": "ssm:StartSession unexpectedly succeeded"}
+        )
+
+    passed = all(p["passed"] for p in probes)
+    return {
+        "passed": passed,
+        "probes": probes,
+        **(
+            {"error": "; ".join(p.get("error", p.get("code", "")) for p in probes if not p["passed"])}
+            if not passed
+            else {}
+        ),
+    }
+
+
+def _probe_storage_isolation(clients_a: dict[str, Any], tenant_a: Tenant, tenant_b: Tenant) -> dict[str, Any]:
+    """Tenant A must be denied ec2:CreateSnapshot (DryRun) and ec2:AttachVolume (DryRun) against B's volume."""
+    probes: list[dict[str, Any]] = []
+
+    try:
+        clients_a["ec2"].create_snapshot(VolumeId=tenant_b.volume_id, DryRun=True)
+    except ClientError as exc:
+        verdict = _classify_dry_run(exc)
+        probes.append(
+            {
+                "name": "ec2_create_snapshot_denied",
+                "passed": verdict == "denied",
+                "code": exc.response.get("Error", {}).get("Code", ""),
+            }
+        )
+    else:
+        probes.append(
+            {
+                "name": "ec2_create_snapshot_denied",
+                "passed": False,
+                "error": "ec2:CreateSnapshot DryRun returned no error (unexpected)",
+            }
+        )
+
+    # AttachVolume requires (volume, instance) ARN pair; we use tenant A's
+    # own instance as the attach target so the only deny axis is the
+    # foreign volume ARN.
+    try:
+        clients_a["ec2"].attach_volume(
+            VolumeId=tenant_b.volume_id,
+            InstanceId=tenant_a.instance_id,
+            Device="/dev/sdf",
+            DryRun=True,
+        )
+    except ClientError as exc:
+        verdict = _classify_dry_run(exc)
+        probes.append(
+            {
+                "name": "ec2_attach_volume_denied",
+                "passed": verdict == "denied",
+                "code": exc.response.get("Error", {}).get("Code", ""),
+            }
+        )
+    else:
+        probes.append(
+            {
+                "name": "ec2_attach_volume_denied",
+                "passed": False,
+                "error": "ec2:AttachVolume DryRun returned no error (unexpected)",
+            }
+        )
+
+    passed = all(p["passed"] for p in probes)
+    return {
+        "passed": passed,
+        "probes": probes,
+        **(
+            {"error": "; ".join(p.get("error", p.get("code", "")) for p in probes if not p["passed"])}
+            if not passed
+            else {}
+        ),
+    }
+
+
+# -- Main -----------------------------------------------------------------
+
+
+def _skipped_result(reason: str) -> dict[str, Any]:
+    """Return a structured top-level skip payload (validation will skip rather than fabricate a pass)."""
+    return {
+        "success": True,
+        "platform": "security",
+        "test_name": TEST_NAME,
+        "skipped": True,
+        "skip_reason": reason,
+        "tests": {},
+    }
+
+
+@handle_aws_errors
+def main() -> int:
+    """Provision two tenants, run cross-tenant negative probes, emit JSON, clean up."""
+    parser = argparse.ArgumentParser(description="Tenant isolation test (SEC11-01)")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    args = parser.parse_args()
+    region = args.region
+
+    ec2 = boto3.client("ec2", region_name=region)
+    iam = boto3.client("iam", region_name=region)
+    kms = boto3.client("kms", region_name=region)
+    s3 = boto3.client("s3", region_name=region)
+
+    suffix_a = uuid.uuid4().hex[:8]
+    suffix_b = uuid.uuid4().hex[:8]
+
+    tenant_a: Tenant | None = None
+    tenant_b: Tenant | None = None
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "security",
+        "test_name": TEST_NAME,
+        "region": region,
+        "tenant_a_id": "",
+        "tenant_b_id": "",
+        "tests": {
+            "network_isolated": {"passed": False},
+            "data_isolated": {"passed": False},
+            "compute_isolated": {"passed": False},
+            "storage_isolated": {"passed": False},
+        },
+    }
+
+    try:
+        try:
+            ami_id = _get_amazon_linux_ami(ec2)
+            tenant_a = _provision_tenant(
+                ec2=ec2,
+                iam=iam,
+                kms=kms,
+                s3=s3,
+                region=region,
+                suffix=suffix_a,
+                cidr=TENANT_A_CIDR,
+                ami_id=ami_id,
+            )
+            tenant_b = _provision_tenant(
+                ec2=ec2,
+                iam=iam,
+                kms=kms,
+                s3=s3,
+                region=region,
+                suffix=suffix_b,
+                cidr=TENANT_B_CIDR,
+                ami_id=ami_id,
+            )
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if code in SKIPPABLE_SETUP_ERRORS:
+                # Best-effort cleanup of whatever did get created before reraising as skip.
+                cleanup_errors: list[str] = []
+                if tenant_a is not None:
+                    cleanup_errors.extend(_teardown_tenant(ec2=ec2, iam=iam, kms=kms, s3=s3, tenant=tenant_a))
+                if tenant_b is not None:
+                    cleanup_errors.extend(_teardown_tenant(ec2=ec2, iam=iam, kms=kms, s3=s3, tenant=tenant_b))
+                if cleanup_errors:
+                    print(
+                        json.dumps(
+                            {
+                                "success": False,
+                                "platform": "security",
+                                "test_name": TEST_NAME,
+                                "error": (f"setup failed: {exc}; cleanup left orphans: " + "; ".join(cleanup_errors)),
+                                "cleanup_errors": cleanup_errors,
+                                "tests": {},
+                            },
+                            indent=2,
+                        )
+                    )
+                    return 1
+                print(
+                    json.dumps(
+                        _skipped_result(
+                            f"cannot provision SEC11-01 tenant fixture: {exc}; "
+                            "orchestrator principal needs ec2/iam/kms/s3 create+delete perms "
+                            "(see script docstring)"
+                        ),
+                        indent=2,
+                    )
+                )
+                return 0
+            raise
+
+        result["tenant_a_id"] = tenant_a.name
+        result["tenant_b_id"] = tenant_b.name
+
+        clients_a = _build_tenant_clients(tenant_a, region)
+        _wait_for_iam_propagation(clients_a["sts"])
+
+        result["tests"]["network_isolated"] = _probe_network_isolation(ec2, tenant_a, tenant_b)
+        result["tests"]["data_isolated"] = _probe_data_isolation(clients_a, tenant_b)
+        result["tests"]["compute_isolated"] = _probe_compute_isolation(clients_a, tenant_b)
+        result["tests"]["storage_isolated"] = _probe_storage_isolation(clients_a, tenant_a, tenant_b)
+
+        result["success"] = all(t.get("passed") for t in result["tests"].values())
+    finally:
+        cleanup_errors = []
+        if tenant_a is not None:
+            cleanup_errors.extend(_teardown_tenant(ec2=ec2, iam=iam, kms=kms, s3=s3, tenant=tenant_a))
+        if tenant_b is not None:
+            cleanup_errors.extend(_teardown_tenant(ec2=ec2, iam=iam, kms=kms, s3=s3, tenant=tenant_b))
+        if cleanup_errors:
+            result["cleanup_errors"] = cleanup_errors
+            cleanup_msg = f"Cleanup failed: {'; '.join(cleanup_errors)}"
+            existing = result.get("error")
+            result["error"] = f"{existing}; {cleanup_msg}" if existing else cleanup_msg
+            result["success"] = False
+
+    print(json.dumps(result, indent=2, default=str))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/aws/scripts/security/tenant_isolation_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/tenant_isolation_test.py
@@ -67,8 +67,8 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import boto3
-from botocore.exceptions import ClientError
-from common.errors import delete_with_retry, handle_aws_errors
+from botocore.exceptions import BotoCoreError, ClientError, WaiterError
+from common.errors import classify_aws_error, delete_with_retry, handle_aws_errors
 
 TEST_NAME = "tenant_isolation_test"
 TENANT_PREFIX = "isv-sec11-test-"
@@ -98,6 +98,11 @@ DENY_CODES = frozenset({"AccessDenied", "AccessDeniedException", "UnauthorizedOp
 # the cross-tenant probe FAILS.
 DRY_RUN_ALLOWED_CODE = "DryRunOperation"
 
+# TGW VPC-attachment states that still represent a live cross-VPC bridge.
+# Anything outside this set (deleted, deleting, failed, ...) is a stale
+# attachment that can't carry traffic.
+LIVE_TGW_STATES = frozenset({"available", "pending", "modifying", "initiating", "initiatingRequest", "rollingBack"})
+
 
 @dataclass
 class Tenant:
@@ -107,6 +112,7 @@ class Tenant:
     cidr: str
     vpc_id: str = ""
     subnet_id: str = ""
+    availability_zone: str = ""
     sg_id: str = ""
     iam_user_arn: str = ""
     access_key_id: str = ""
@@ -194,6 +200,7 @@ def _create_vpc_and_subnet(ec2: Any, tenant: Tenant) -> None:
     az = ec2.describe_availability_zones(Filters=[{"Name": "state", "Values": ["available"]}])["AvailabilityZones"][0][
         "ZoneName"
     ]
+    tenant.availability_zone = az
     subnet = ec2.create_subnet(VpcId=tenant.vpc_id, CidrBlock=tenant.cidr, AvailabilityZone=az)
     tenant.subnet_id = subnet["Subnet"]["SubnetId"]
     tenant.created["subnet"] = True
@@ -253,9 +260,8 @@ def _launch_instance(ec2: Any, tenant: Tenant, ami_id: str) -> None:
 
 def _create_volume(ec2: Any, tenant: Tenant) -> None:
     """Create a 1 GiB gp3 EBS volume in the tenant's AZ."""
-    az = ec2.describe_subnets(SubnetIds=[tenant.subnet_id])["Subnets"][0]["AvailabilityZone"]
     response = ec2.create_volume(
-        AvailabilityZone=az,
+        AvailabilityZone=tenant.availability_zone,
         Size=VOLUME_SIZE_GIB,
         VolumeType="gp3",
         TagSpecifications=[{"ResourceType": "volume", "Tags": _isvtest_tags(tenant.name)}],
@@ -290,7 +296,7 @@ def _create_kms_key(kms: Any, tenant: Tenant) -> None:
 
 def _create_s3_bucket(s3: Any, tenant: Tenant, region: str) -> None:
     """Create a tagged S3 bucket. us-east-1 must NOT pass LocationConstraint."""
-    bucket = f"{tenant.name}-{uuid.uuid4().hex[:6]}"
+    bucket = f"{tenant.name}-{uuid.uuid4().hex[:8]}"
     create_kwargs: dict[str, Any] = {"Bucket": bucket}
     if region != "us-east-1":
         create_kwargs["CreateBucketConfiguration"] = {"LocationConstraint": region}
@@ -368,14 +374,23 @@ def _teardown_tenant(
     errors: list[str] = []
 
     if tenant.created.get("instance") and tenant.instance_id:
+        # NB: catch WaiterError too -- the InstanceTerminated waiter treats
+        # "pending" as a terminal failure, which fires when setup raised
+        # before the instance reached running. Letting it propagate would
+        # mask the original error (and skip the rest of cleanup); the
+        # safety-net teardown step picks up any leftover instance.
         try:
             ec2.terminate_instances(InstanceIds=[tenant.instance_id])
-            ec2.get_waiter("instance_terminated").wait(
-                InstanceIds=[tenant.instance_id],
-                WaiterConfig={"Delay": 5, "MaxAttempts": 60},
-            )
         except ClientError as e:
             errors.append(f"terminate instance {tenant.instance_id}: {e}")
+        else:
+            try:
+                ec2.get_waiter("instance_terminated").wait(
+                    InstanceIds=[tenant.instance_id],
+                    WaiterConfig={"Delay": 5, "MaxAttempts": 60},
+                )
+            except (ClientError, WaiterError) as e:
+                errors.append(f"wait terminated {tenant.instance_id}: {e}")
 
     if tenant.created.get("volume") and tenant.volume_id:
         if not delete_with_retry(
@@ -489,6 +504,15 @@ def _classify_dry_run(exc: ClientError) -> str:
     return "other"
 
 
+def _build_probe_result(probes: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate per-probe results into the ``passed`` / ``probes`` / ``error`` envelope."""
+    passed = all(p["passed"] for p in probes)
+    result: dict[str, Any] = {"passed": passed, "probes": probes}
+    if not passed:
+        result["error"] = "; ".join(p.get("error", p.get("code", "")) for p in probes if not p["passed"])
+    return result
+
+
 def _wait_for_iam_propagation(sts_a: Any) -> None:
     """Block until tenant A's STS client can call GetCallerIdentity (or give up)."""
     for attempt in range(IAM_PROPAGATION_MAX_ATTEMPTS):
@@ -523,12 +547,13 @@ def _build_tenant_clients(tenant: Tenant, region: str) -> dict[str, Any]:
 
 
 def _probe_network_isolation(orchestrator_ec2: Any, tenant_a: Tenant, tenant_b: Tenant) -> dict[str, Any]:
-    """Verify no peering and no shared route between tenant A's and B's VPCs.
+    """Verify no peering, TGW attachment, or shared route between tenant A and B.
 
-    This is a config-plane check (mirrors bmc_isolation_test.py): in AWS,
-    two freshly created VPCs are unreachable to each other unless a
-    peering connection or transit gateway is wired in. We assert no such
-    plumbing exists.
+    Config-plane check (mirrors bmc_isolation_test.py): two freshly created
+    VPCs in AWS are unreachable to each other unless cross-VPC plumbing is
+    wired in. We assert none of the three common mechanisms exists --
+    VPC peering, Transit Gateway attachment binding both VPCs, or a route
+    in tenant A's route tables targeting tenant B's CIDR.
     """
     peerings = orchestrator_ec2.describe_vpc_peering_connections(
         Filters=[
@@ -543,6 +568,32 @@ def _probe_network_isolation(orchestrator_ec2: Any, tenant_a: Tenant, tenant_b: 
         return {
             "passed": False,
             "error": f"VPC peering exists between tenant A ({tenant_a.vpc_id}) and tenant B ({tenant_b.vpc_id})",
+        }
+
+    # Transit Gateway: a TGW attached to BOTH VPCs is a separate teleport
+    # mechanism that would route around the peering check above. We
+    # describe attachments for either VPC and flag any TGW that appears
+    # for both.
+    tgw_attachments = orchestrator_ec2.describe_transit_gateway_vpc_attachments(
+        Filters=[{"Name": "vpc-id", "Values": [tenant_a.vpc_id, tenant_b.vpc_id]}]
+    ).get("TransitGatewayVpcAttachments", [])
+    by_tgw: dict[str, set[str]] = {}
+    for att in tgw_attachments:
+        if att.get("State") not in LIVE_TGW_STATES:
+            continue
+        tgw_id = att.get("TransitGatewayId")
+        vpc_id = att.get("VpcId")
+        if not tgw_id or not vpc_id:
+            continue
+        by_tgw.setdefault(tgw_id, set()).add(vpc_id)
+    shared_tgws = [tgw_id for tgw_id, vpcs in by_tgw.items() if {tenant_a.vpc_id, tenant_b.vpc_id}.issubset(vpcs)]
+    if shared_tgws:
+        return {
+            "passed": False,
+            "error": (
+                f"Transit Gateway {shared_tgws[0]} bridges tenant A ({tenant_a.vpc_id}) "
+                f"and tenant B ({tenant_b.vpc_id})"
+            ),
         }
 
     tenant_b_cidrs = {tenant_b.cidr}
@@ -563,8 +614,8 @@ def _probe_network_isolation(orchestrator_ec2: Any, tenant_a: Tenant, tenant_b: 
     return {
         "passed": True,
         "message": (
-            f"No peering or shared route between tenant A VPC {tenant_a.vpc_id} ({tenant_a.cidr}) "
-            f"and tenant B VPC {tenant_b.vpc_id} ({tenant_b.cidr})"
+            f"No peering, transit gateway, or shared route between tenant A VPC {tenant_a.vpc_id} "
+            f"({tenant_a.cidr}) and tenant B VPC {tenant_b.vpc_id} ({tenant_b.cidr})"
         ),
     }
 
@@ -602,16 +653,7 @@ def _probe_data_isolation(clients_a: dict[str, Any], tenant_b: Tenant) -> dict[s
     else:
         probes.append({"name": "s3_get_object_denied", "passed": False, "error": "s3:GetObject unexpectedly succeeded"})
 
-    passed = all(p["passed"] for p in probes)
-    return {
-        "passed": passed,
-        "probes": probes,
-        **(
-            {"error": "; ".join(p.get("error", p.get("code", "")) for p in probes if not p["passed"])}
-            if not passed
-            else {}
-        ),
-    }
+    return _build_probe_result(probes)
 
 
 def _probe_compute_isolation(clients_a: dict[str, Any], tenant_b: Tenant) -> dict[str, Any]:
@@ -655,16 +697,7 @@ def _probe_compute_isolation(clients_a: dict[str, Any], tenant_b: Tenant) -> dic
             {"name": "ssm_start_session_denied", "passed": False, "error": "ssm:StartSession unexpectedly succeeded"}
         )
 
-    passed = all(p["passed"] for p in probes)
-    return {
-        "passed": passed,
-        "probes": probes,
-        **(
-            {"error": "; ".join(p.get("error", p.get("code", "")) for p in probes if not p["passed"])}
-            if not passed
-            else {}
-        ),
-    }
+    return _build_probe_result(probes)
 
 
 def _probe_storage_isolation(clients_a: dict[str, Any], tenant_a: Tenant, tenant_b: Tenant) -> dict[str, Any]:
@@ -719,16 +752,7 @@ def _probe_storage_isolation(clients_a: dict[str, Any], tenant_a: Tenant, tenant
             }
         )
 
-    passed = all(p["passed"] for p in probes)
-    return {
-        "passed": passed,
-        "probes": probes,
-        **(
-            {"error": "; ".join(p.get("error", p.get("code", "")) for p in probes if not p["passed"])}
-            if not passed
-            else {}
-        ),
-    }
+    return _build_probe_result(probes)
 
 
 # -- Main -----------------------------------------------------------------
@@ -780,6 +804,8 @@ def main() -> int:
         },
     }
 
+    skip_payload: dict[str, Any] | None = None
+
     try:
         try:
             ami_id = _get_amazon_linux_ami(ec2)
@@ -805,65 +831,56 @@ def main() -> int:
             )
         except ClientError as exc:
             code = exc.response.get("Error", {}).get("Code", "")
-            if code in SKIPPABLE_SETUP_ERRORS:
-                # Best-effort cleanup of whatever did get created before reraising as skip.
-                cleanup_errors: list[str] = []
-                if tenant_a is not None:
-                    cleanup_errors.extend(_teardown_tenant(ec2=ec2, iam=iam, kms=kms, s3=s3, tenant=tenant_a))
-                if tenant_b is not None:
-                    cleanup_errors.extend(_teardown_tenant(ec2=ec2, iam=iam, kms=kms, s3=s3, tenant=tenant_b))
-                if cleanup_errors:
-                    print(
-                        json.dumps(
-                            {
-                                "success": False,
-                                "platform": "security",
-                                "test_name": TEST_NAME,
-                                "error": (f"setup failed: {exc}; cleanup left orphans: " + "; ".join(cleanup_errors)),
-                                "cleanup_errors": cleanup_errors,
-                                "tests": {},
-                            },
-                            indent=2,
-                        )
-                    )
-                    return 1
-                print(
-                    json.dumps(
-                        _skipped_result(
-                            f"cannot provision SEC11-01 tenant fixture: {exc}; "
-                            "orchestrator principal needs ec2/iam/kms/s3 create+delete perms "
-                            "(see script docstring)"
-                        ),
-                        indent=2,
-                    )
+            if code in SKIPPABLE_SETUP_ERRORS and tenant_a is None and tenant_b is None:
+                # Pure-permission denial with NO partial state -- emit a skip
+                # so the validation pytest.skips rather than fabricating a pass.
+                skip_payload = _skipped_result(
+                    f"cannot provision SEC11-01 tenant fixture: {exc}; "
+                    "orchestrator principal needs ec2/iam/kms/s3 create+delete perms "
+                    "(see script docstring)"
                 )
-                return 0
-            raise
+            else:
+                raise
 
-        result["tenant_a_id"] = tenant_a.name
-        result["tenant_b_id"] = tenant_b.name
+        if tenant_a is not None and tenant_b is not None:
+            result["tenant_a_id"] = tenant_a.name
+            result["tenant_b_id"] = tenant_b.name
 
-        clients_a = _build_tenant_clients(tenant_a, region)
-        _wait_for_iam_propagation(clients_a["sts"])
+            clients_a = _build_tenant_clients(tenant_a, region)
+            _wait_for_iam_propagation(clients_a["sts"])
 
-        result["tests"]["network_isolated"] = _probe_network_isolation(ec2, tenant_a, tenant_b)
-        result["tests"]["data_isolated"] = _probe_data_isolation(clients_a, tenant_b)
-        result["tests"]["compute_isolated"] = _probe_compute_isolation(clients_a, tenant_b)
-        result["tests"]["storage_isolated"] = _probe_storage_isolation(clients_a, tenant_a, tenant_b)
+            result["tests"]["network_isolated"] = _probe_network_isolation(ec2, tenant_a, tenant_b)
+            result["tests"]["data_isolated"] = _probe_data_isolation(clients_a, tenant_b)
+            result["tests"]["compute_isolated"] = _probe_compute_isolation(clients_a, tenant_b)
+            result["tests"]["storage_isolated"] = _probe_storage_isolation(clients_a, tenant_a, tenant_b)
 
-        result["success"] = all(t.get("passed") for t in result["tests"].values())
+            result["success"] = all(t.get("passed") for t in result["tests"].values())
+    except (ClientError, WaiterError, BotoCoreError) as exc:
+        # Capture the FIRST error before cleanup runs, otherwise a downstream
+        # WaiterError from terminating a still-pending instance would mask
+        # the real cause (IAM limit, VPC limit, ResourceLimitExceeded, ...).
+        error_type, error_msg = classify_aws_error(exc)
+        result["error"] = f"[{error_type}] {error_msg}"
+        result["success"] = False
     finally:
-        cleanup_errors = []
-        if tenant_a is not None:
-            cleanup_errors.extend(_teardown_tenant(ec2=ec2, iam=iam, kms=kms, s3=s3, tenant=tenant_a))
-        if tenant_b is not None:
-            cleanup_errors.extend(_teardown_tenant(ec2=ec2, iam=iam, kms=kms, s3=s3, tenant=tenant_b))
+        cleanup_errors: list[str] = []
+        for tenant in (tenant_a, tenant_b):
+            if tenant is None:
+                continue
+            try:
+                cleanup_errors.extend(_teardown_tenant(ec2=ec2, iam=iam, kms=kms, s3=s3, tenant=tenant))
+            except (ClientError, WaiterError, BotoCoreError) as exc:
+                cleanup_errors.append(f"unexpected cleanup error for {tenant.name}: {type(exc).__name__}: {exc}")
         if cleanup_errors:
             result["cleanup_errors"] = cleanup_errors
             cleanup_msg = f"Cleanup failed: {'; '.join(cleanup_errors)}"
             existing = result.get("error")
             result["error"] = f"{existing}; {cleanup_msg}" if existing else cleanup_msg
             result["success"] = False
+
+    if skip_payload is not None and not result.get("cleanup_errors"):
+        print(json.dumps(skip_payload, indent=2))
+        return 0
 
     print(json.dumps(result, indent=2, default=str))
     return 0 if result["success"] else 1

--- a/isvctl/configs/providers/aws/scripts/security/tenant_isolation_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/tenant_isolation_test.py
@@ -338,12 +338,10 @@ def _provision_tenant(
     kms: Any,
     s3: Any,
     region: str,
-    suffix: str,
-    cidr: str,
+    tenant: Tenant,
     ami_id: str,
 ) -> Tenant:
-    """Provision the full per-tenant fixture. Caller invokes ``_teardown_tenant`` from finally."""
-    tenant = Tenant(suffix=suffix, cidr=cidr)
+    """Provision the full per-tenant fixture into a caller-owned resource ledger."""
     _create_vpc_and_subnet(ec2, tenant)
     _create_s3_bucket(s3, tenant, region)
     _create_kms_key(kms, tenant)
@@ -809,29 +807,32 @@ def main() -> int:
     try:
         try:
             ami_id = _get_amazon_linux_ami(ec2)
+            tenant_a = Tenant(suffix=suffix_a, cidr=TENANT_A_CIDR)
             tenant_a = _provision_tenant(
                 ec2=ec2,
                 iam=iam,
                 kms=kms,
                 s3=s3,
                 region=region,
-                suffix=suffix_a,
-                cidr=TENANT_A_CIDR,
+                tenant=tenant_a,
                 ami_id=ami_id,
             )
+            tenant_b = Tenant(suffix=suffix_b, cidr=TENANT_B_CIDR)
             tenant_b = _provision_tenant(
                 ec2=ec2,
                 iam=iam,
                 kms=kms,
                 s3=s3,
                 region=region,
-                suffix=suffix_b,
-                cidr=TENANT_B_CIDR,
+                tenant=tenant_b,
                 ami_id=ami_id,
             )
         except ClientError as exc:
             code = exc.response.get("Error", {}).get("Code", "")
-            if code in SKIPPABLE_SETUP_ERRORS and tenant_a is None and tenant_b is None:
+            partial_resources_created = any(
+                tenant is not None and any(tenant.created.values()) for tenant in (tenant_a, tenant_b)
+            )
+            if code in SKIPPABLE_SETUP_ERRORS and not partial_resources_created:
                 # Pure-permission denial with NO partial state -- emit a skip
                 # so the validation pytest.skips rather than fabricating a pass.
                 skip_payload = _skipped_result(

--- a/isvctl/configs/providers/my-isv/config/security.yaml
+++ b/isvctl/configs/providers/my-isv/config/security.yaml
@@ -26,6 +26,7 @@
 #   SEC03-01: Service account credentials (ServiceAccountCredentialCheck)
 #   SEC01-01: OIDC user authentication (OidcUserAuthCheck)
 #   SEC02-01: Short-lived credentials/tokens (ShortLivedCredentialsCheck)
+#   SEC11-01: Hard tenant isolation across network/data/compute/storage (TenantIsolationCheck)
 #
 # Usage:
 #   uv run isvctl test run -f isvctl/configs/providers/my-isv/config/security.yaml
@@ -102,6 +103,12 @@ commands:
       - name: short_lived_credentials_test
         phase: test
         command: "python ../scripts/security/short_lived_credentials_test.py"
+        args: ["--region", "{{region}}"]
+        timeout: 60
+
+      - name: tenant_isolation_test
+        phase: test
+        command: "python ../scripts/security/tenant_isolation_test.py"
         args: ["--region", "{{region}}"]
         timeout: 60
 

--- a/isvctl/configs/providers/my-isv/scripts/README.md
+++ b/isvctl/configs/providers/my-isv/scripts/README.md
@@ -34,7 +34,7 @@ the TODOs.
 | `bare_metal/` | 12 | [`suites/bare_metal.yaml`](../../../suites/bare_metal.yaml) | [`config/bare_metal.yaml`](../config/bare_metal.yaml) | [`providers/aws/scripts/bare_metal/`](../../aws/scripts/bare_metal/) |
 | `network/` | 18 | [`suites/network.yaml`](../../../suites/network.yaml) | [`config/network.yaml`](../config/network.yaml) | [`providers/aws/scripts/network/`](../../aws/scripts/network/) |
 | `image-registry/` | 7 | [`suites/image-registry.yaml`](../../../suites/image-registry.yaml) | [`config/image-registry.yaml`](../config/image-registry.yaml) | [`providers/aws/scripts/image-registry/`](../../aws/scripts/image-registry/) |
-| `security/` | 10 | [`suites/security.yaml`](../../../suites/security.yaml) | [`config/security.yaml`](../config/security.yaml) | [`providers/aws/scripts/security/`](../../aws/scripts/security/) |
+| `security/` | 11 | [`suites/security.yaml`](../../../suites/security.yaml) | [`config/security.yaml`](../config/security.yaml) | [`providers/aws/scripts/security/`](../../aws/scripts/security/) |
 | `k8s/` | 9 shell | [`suites/k8s.yaml`](../../../suites/k8s.yaml) | - | [`providers/aws/scripts/eks/`](../../aws/scripts/eks/) |
 | `slurm/` | 2 shell | [`suites/slurm.yaml`](../../../suites/slurm.yaml) | - | - |
 

--- a/isvctl/configs/providers/my-isv/scripts/security/tenant_isolation_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/security/tenant_isolation_test.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Tenant isolation test (SEC11-01) - TEMPLATE (replace with your platform implementation).
+
+Verifies hard logical isolation between two tenants across four orthogonal
+surfaces:
+
+  * ``network_isolated``  -- tenant A's network has no route to tenant B
+    (no peering, no shared route, SG/NACL deny).
+  * ``data_isolated``     -- tenant A is denied ``kms:Decrypt`` on tenant
+    B's CMK and ``s3:GetObject`` (or equivalent) on tenant B's bucket.
+  * ``compute_isolated``  -- tenant A is denied ``ec2:*`` /
+    ``ssm:StartSession`` (or equivalent) against tenant B's instance.
+  * ``storage_isolated``  -- tenant A is denied ``ebs:*`` snapshot/attach
+    (or equivalent) against tenant B's volume.
+
+Physical isolation (bare-metal) and switch-fabric isolation are out of
+scope for this test (covered by SDN04-04/05).
+
+Provision two ephemeral tenants in a try / finally and run negative
+probes from tenant A against tenant B's resources, asserting each probe
+is denied (AccessDenied / forbidden / timeout / refused).
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "security",
+    "test_name": "tenant_isolation_test",
+    "tenant_a_id": "<source tenant id>",
+    "tenant_b_id": "<target tenant id>",
+    "tests": {
+      "network_isolated":  {"passed": true},
+      "data_isolated":     {"passed": true},
+      "compute_isolated":  {"passed": true},
+      "storage_isolated":  {"passed": true}
+    }
+  }
+
+Usage:
+    python tenant_isolation_test.py --region <region>
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+
+
+def main() -> int:
+    """Tenant isolation test (template) and emit structured JSON result."""
+    parser = argparse.ArgumentParser(description="Tenant isolation test (template)")
+    parser.add_argument("--region", required=True, help="Cloud region")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "security",
+        "test_name": "tenant_isolation_test",
+        "region": args.region,
+        "tenant_a_id": "",
+        "tenant_b_id": "",
+        "tests": {
+            "network_isolated": {"passed": False},
+            "data_isolated": {"passed": False},
+            "compute_isolated": {"passed": False},
+            "storage_isolated": {"passed": False},
+        },
+    }
+
+    # ╔══════════════════════════════════════════════════════════════════╗
+    # ║  TODO: Replace this block with your platform's tenant isolation  ║
+    # ║  test.                                                           ║
+    # ║                                                                  ║
+    # ║  Pseudocode (adapt to your platform's IAM/network/storage APIs): ║
+    # ║                                                                  ║
+    # ║    tenant_a = provision_tenant("isv-sec11-test-A")               ║
+    # ║    tenant_b = provision_tenant("isv-sec11-test-B")               ║
+    # ║    try:                                                          ║
+    # ║      assert not tenant_a.can_reach(tenant_b.network)             ║
+    # ║      assert not tenant_a.can_decrypt(tenant_b.cmk)               ║
+    # ║      assert not tenant_a.can_get_object(tenant_b.bucket)         ║
+    # ║      assert not tenant_a.can_describe(tenant_b.instance)         ║
+    # ║      assert not tenant_a.can_attach_volume(tenant_b.volume)      ║
+    # ║    finally:                                                      ║
+    # ║      teardown(tenant_a); teardown(tenant_b)                      ║
+    # ║                                                                  ║
+    # ║  Emit one boolean per surface in `tests`. The validation also    ║
+    # ║  requires non-empty ``tenant_a_id`` and ``tenant_b_id``.         ║
+    # ╚══════════════════════════════════════════════════════════════════╝
+
+    if DEMO_MODE:
+        result["tenant_a_id"] = "isv-sec11-test-aaaa1111"
+        result["tenant_b_id"] = "isv-sec11-test-bbbb2222"
+        result["tests"] = {
+            "network_isolated": {"passed": True, "message": "demo: tenant A's VPC has no route to tenant B's VPC"},
+            "data_isolated": {"passed": True, "message": "demo: kms:Decrypt and s3:GetObject denied across tenants"},
+            "compute_isolated": {"passed": True, "message": "demo: ec2:* and ssm:StartSession denied across tenants"},
+            "storage_isolated": {"passed": True, "message": "demo: ebs snapshot/attach denied across tenants"},
+        }
+        result["success"] = True
+    else:
+        result["error"] = "Not implemented - replace with your platform's tenant isolation test"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -153,6 +153,7 @@ Validations use `sinfo`/`srun` directly: partitions, GPU allocation, job schedul
 | `sa_credential_test` | test | `providers/my-isv/scripts/security/sa_credential_test.py` | Service account long-lived credential auth |
 | `oidc_user_auth_test` | test | `providers/my-isv/scripts/security/oidc_user_auth_test.py` | OIDC issuer metadata and protected endpoint token acceptance/rejection |
 | `short_lived_credentials_test` | test | `providers/my-isv/scripts/security/short_lived_credentials_test.py` | SEC02-01: workloads and nodes receive credentials with finite, bounded TTL |
+| `tenant_isolation_test` | test | `providers/my-isv/scripts/security/tenant_isolation_test.py` | SEC11-01: hard tenant isolation across network/data/compute/storage |
 | `teardown` | teardown | `providers/my-isv/scripts/security/teardown.py` | Cleanup test resources |
 
 ## Related Documentation

--- a/isvctl/configs/suites/security.yaml
+++ b/isvctl/configs/suites/security.yaml
@@ -89,6 +89,11 @@ tests:
         ShortLivedCredentialsCheck:
           step: short_lived_credentials_test
 
+    tenant_isolation:
+      checks:
+        TenantIsolationCheck:
+          step: tenant_isolation_test
+
     teardown_checks:
       step: teardown
       checks:

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -1096,6 +1096,31 @@ class FakeTeardownIam:
         raise _client_error("DeleteUser", code="DeleteConflict")
 
 
+class FakeNoSec11Resources:
+    """Trivial AWS client stub used for ec2/kms/s3 when the SEC11 sweep has nothing to find.
+
+    The sweep helpers iterate over describe_* / list_* responses; returning
+    empty pages turns each helper into a no-op without exercising it.
+    """
+
+    def get_paginator(self, _operation_name: str) -> Any:
+        """Return a paginator that yields a single empty page."""
+
+        class _P:
+            def paginate(self, **_kwargs: Any) -> list[dict[str, Any]]:
+                return [{"Reservations": [], "Volumes": [], "Aliases": [], "Versions": [], "DeleteMarkers": []}]
+
+        return _P()
+
+    def describe_vpcs(self, **_kwargs: Any) -> dict[str, list[dict[str, Any]]]:
+        """Return no VPCs."""
+        return {"Vpcs": []}
+
+    def list_buckets(self) -> dict[str, list[dict[str, str]]]:
+        """Return no buckets."""
+        return {"Buckets": []}
+
+
 def test_teardown_main_fails_when_owned_user_cleanup_fails(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -1103,11 +1128,16 @@ def test_teardown_main_fails_when_owned_user_cleanup_fails(
     """Teardown reports failure when owned IAM resources cannot be removed."""
     module = _load_security_script("teardown.py")
     iam = FakeTeardownIam()
+    no_sec11 = FakeNoSec11Resources()
 
-    def fake_client(service_name: str, **kwargs: Any) -> FakeTeardownIam:
-        """Return the fake IAM client."""
-        assert service_name == "iam"
-        return iam
+    def fake_client(service_name: str, **kwargs: Any) -> Any:
+        """Return the fake IAM client; trivial empty stub for SEC11 sweep services."""
+        if service_name == "iam":
+            return iam
+        if service_name in {"ec2", "kms", "s3"}:
+            return no_sec11
+        msg = f"unexpected service: {service_name}"
+        raise AssertionError(msg)
 
     monkeypatch.setattr(module.boto3, "client", fake_client)
     monkeypatch.setattr(module.sys, "argv", ["teardown.py", "--region", "us-west-2"])
@@ -1186,11 +1216,12 @@ def test_teardown_cleanup_owned_user_deletes_inline_policy_for_sec02_users() -> 
 
 
 def test_teardown_owned_user_prefixes_cover_security_test_scripts() -> None:
-    """The teardown sweep must recognize both sa_credential and short-lived test users."""
+    """The teardown sweep must recognize sa_credential, short-lived, and tenant-isolation test users."""
     module = _load_security_script("teardown.py")
 
     assert "isv-sa-test-".startswith("isv-sa-test-")
     assert "isv-sec02-test-foo".startswith(module.OWNED_USER_PREFIXES)
+    assert "isv-sec11-test-foo".startswith(module.OWNED_USER_PREFIXES)
     assert "isv-sa-test-bar".startswith(module.OWNED_USER_PREFIXES)
     assert not "isv-network-test-baz".startswith(module.OWNED_USER_PREFIXES)
 
@@ -2631,3 +2662,448 @@ def test_short_lived_credentials_cleanup_handles_partial_setup(
     assert short_lived_module._cleanup_test_user(iam, "isv-sec02-test-xyz", None, False) == []
     assert iam.deleted_policies == []
     assert iam.deleted_users == []
+
+
+# ===========================================================================
+# Tenant isolation (SEC11-01) tests
+# ===========================================================================
+
+
+@pytest.fixture(scope="module")
+def tenant_isolation_module() -> ModuleType:
+    """Load the tenant-isolation script as a module for direct helper testing."""
+    return _load_security_script("tenant_isolation_test.py")
+
+
+def _make_tenant(module: ModuleType, suffix: str, cidr: str) -> Any:
+    """Build a populated ``Tenant`` instance for probe tests."""
+    return module.Tenant(
+        suffix=suffix,
+        cidr=cidr,
+        vpc_id=f"vpc-{suffix}",
+        subnet_id=f"subnet-{suffix}",
+        sg_id=f"sg-{suffix}",
+        kms_key_id=f"key-{suffix}",
+        kms_key_arn=f"arn:aws:kms:us-west-2:111122223333:key/{suffix}",
+        s3_bucket=f"isv-sec11-test-{suffix}-abc123",
+        instance_id=f"i-{suffix}",
+        volume_id=f"vol-{suffix}",
+    )
+
+
+def test_tenant_isolation_scoped_policy_only_grants_own_arns(tenant_isolation_module: ModuleType) -> None:
+    """The scoped policy must NOT reference the peer tenant's ARNs.
+
+    This is the security-critical invariant: every cross-tenant deny in
+    SEC11-01 hinges on tenant A's policy not granting any access to
+    tenant B's resources.
+    """
+    a = _make_tenant(tenant_isolation_module, "aaaa1111", "10.94.0.0/24")
+    b = _make_tenant(tenant_isolation_module, "bbbb2222", "10.95.0.0/24")
+
+    policy = tenant_isolation_module._scoped_policy_document(a)
+
+    assert a.kms_key_arn in policy
+    assert a.s3_bucket in policy
+    assert a.instance_id in policy
+    assert a.volume_id in policy
+    assert b.kms_key_arn not in policy
+    assert b.s3_bucket not in policy
+    assert b.instance_id not in policy
+    assert b.volume_id not in policy
+
+
+def test_tenant_isolation_classify_dry_run_buckets_codes(tenant_isolation_module: ModuleType) -> None:
+    """``_classify_dry_run`` distinguishes denied / allowed / other AWS error codes."""
+    denied = _client_error("StopInstances", code="UnauthorizedOperation")
+    allowed = _client_error("StopInstances", code="DryRunOperation")
+    other = _client_error("StopInstances", code="InvalidInstanceID.NotFound")
+
+    assert tenant_isolation_module._classify_dry_run(denied) == "denied"
+    assert tenant_isolation_module._classify_dry_run(allowed) == "allowed"
+    assert tenant_isolation_module._classify_dry_run(other) == "other"
+
+
+class FakeOrchestratorEc2:
+    """Fake orchestrator-side EC2 client for ``_probe_network_isolation``."""
+
+    def __init__(
+        self,
+        *,
+        peerings: list[dict[str, Any]] | None = None,
+        route_tables: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Configure peering connections and route tables to return."""
+        self.peerings = peerings or []
+        self.route_tables = route_tables or []
+
+    def describe_vpc_peering_connections(self, **_kwargs: Any) -> dict[str, list[dict[str, Any]]]:
+        """Return configured peering connections."""
+        return {"VpcPeeringConnections": self.peerings}
+
+    def describe_route_tables(self, **_kwargs: Any) -> dict[str, list[dict[str, Any]]]:
+        """Return configured route tables."""
+        return {"RouteTables": self.route_tables}
+
+
+def test_probe_network_isolation_passes_when_no_peering_or_shared_route(
+    tenant_isolation_module: ModuleType,
+) -> None:
+    """Pass when no peering connection and no route to tenant B's CIDR exists."""
+    a = _make_tenant(tenant_isolation_module, "aaaa1111", "10.94.0.0/24")
+    b = _make_tenant(tenant_isolation_module, "bbbb2222", "10.95.0.0/24")
+    ec2 = FakeOrchestratorEc2(
+        route_tables=[
+            {
+                "RouteTableId": "rtb-a",
+                "Routes": [{"DestinationCidrBlock": "10.94.0.0/24", "GatewayId": "local"}],
+            }
+        ],
+    )
+
+    result = tenant_isolation_module._probe_network_isolation(ec2, a, b)
+
+    assert result["passed"] is True
+    assert "No peering" in result["message"]
+
+
+def test_probe_network_isolation_fails_when_active_peering_exists(
+    tenant_isolation_module: ModuleType,
+) -> None:
+    """Fail when an active VPC peering connection links A and B."""
+    a = _make_tenant(tenant_isolation_module, "aaaa1111", "10.94.0.0/24")
+    b = _make_tenant(tenant_isolation_module, "bbbb2222", "10.95.0.0/24")
+    ec2 = FakeOrchestratorEc2(
+        peerings=[{"VpcPeeringConnectionId": "pcx-1", "Status": {"Code": "active"}}],
+    )
+
+    result = tenant_isolation_module._probe_network_isolation(ec2, a, b)
+
+    assert result["passed"] is False
+    assert "VPC peering exists" in result["error"]
+
+
+def test_probe_network_isolation_fails_when_route_to_b_cidr_present(
+    tenant_isolation_module: ModuleType,
+) -> None:
+    """Fail when tenant A's route table has any route to tenant B's CIDR."""
+    a = _make_tenant(tenant_isolation_module, "aaaa1111", "10.94.0.0/24")
+    b = _make_tenant(tenant_isolation_module, "bbbb2222", "10.95.0.0/24")
+    ec2 = FakeOrchestratorEc2(
+        route_tables=[
+            {
+                "RouteTableId": "rtb-a",
+                "Routes": [{"DestinationCidrBlock": "10.95.0.0/24", "GatewayId": "tgw-leak"}],
+            }
+        ],
+    )
+
+    result = tenant_isolation_module._probe_network_isolation(ec2, a, b)
+
+    assert result["passed"] is False
+    assert "Route to tenant B CIDR 10.95.0.0/24" in result["error"]
+
+
+class FakeTenantClient:
+    """Fake AWS service client that raises a configured error on every method."""
+
+    def __init__(self, errors: dict[str, Exception | None]) -> None:
+        """Map method-name -> ClientError (or None to silently succeed)."""
+        self._errors = errors
+
+    def __getattr__(self, name: str) -> Any:
+        """Return a method that raises the configured error or returns ``{}``."""
+        err = self._errors.get(name)
+
+        def _call(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            if err is not None:
+                raise err
+            return {}
+
+        return _call
+
+
+def _denied_clients(tenant_isolation_module: ModuleType) -> dict[str, Any]:
+    """Build per-service fake clients that all return AccessDenied / UnauthorizedOperation."""
+    return {
+        "ec2": FakeTenantClient(
+            {
+                "stop_instances": _client_error("StopInstances", code="UnauthorizedOperation"),
+                "create_snapshot": _client_error("CreateSnapshot", code="UnauthorizedOperation"),
+                "attach_volume": _client_error("AttachVolume", code="UnauthorizedOperation"),
+            }
+        ),
+        "kms": FakeTenantClient({"encrypt": _client_error("Encrypt")}),
+        "s3": FakeTenantClient({"get_object": _client_error("GetObject")}),
+        "ssm": FakeTenantClient({"start_session": _client_error("StartSession")}),
+        "sts": FakeTenantClient({}),
+    }
+
+
+def test_probe_data_isolation_passes_when_kms_and_s3_denied(tenant_isolation_module: ModuleType) -> None:
+    """Pass when both kms:Encrypt and s3:GetObject return AccessDenied."""
+    b = _make_tenant(tenant_isolation_module, "bbbb2222", "10.95.0.0/24")
+    clients = _denied_clients(tenant_isolation_module)
+
+    result = tenant_isolation_module._probe_data_isolation(clients, b)
+
+    assert result["passed"] is True
+    probe_names = {p["name"] for p in result["probes"]}
+    assert probe_names == {"kms_encrypt_denied", "s3_get_object_denied"}
+
+
+def test_probe_data_isolation_fails_when_kms_unexpectedly_succeeds(tenant_isolation_module: ModuleType) -> None:
+    """Fail when kms:Encrypt returns no error (would mean tenant A could decrypt B's data)."""
+    b = _make_tenant(tenant_isolation_module, "bbbb2222", "10.95.0.0/24")
+    clients = _denied_clients(tenant_isolation_module)
+    # Override kms to silently succeed (the disastrous case).
+    clients["kms"] = FakeTenantClient({"encrypt": None})
+
+    result = tenant_isolation_module._probe_data_isolation(clients, b)
+
+    assert result["passed"] is False
+    kms_probe = next(p for p in result["probes"] if p["name"] == "kms_encrypt_denied")
+    assert kms_probe["passed"] is False
+
+
+def test_probe_compute_isolation_passes_when_dryrun_denied_and_ssm_denied(
+    tenant_isolation_module: ModuleType,
+) -> None:
+    """Pass when EC2 DryRun returns UnauthorizedOperation and SSM returns AccessDenied."""
+    b = _make_tenant(tenant_isolation_module, "bbbb2222", "10.95.0.0/24")
+    clients = _denied_clients(tenant_isolation_module)
+
+    result = tenant_isolation_module._probe_compute_isolation(clients, b)
+
+    assert result["passed"] is True
+    assert {p["name"] for p in result["probes"]} == {"ec2_stop_instances_denied", "ssm_start_session_denied"}
+
+
+def test_probe_compute_isolation_fails_when_dryrun_returns_dryrunoperation(
+    tenant_isolation_module: ModuleType,
+) -> None:
+    """Fail when EC2 returns ``DryRunOperation`` (= IAM allowed the call)."""
+    b = _make_tenant(tenant_isolation_module, "bbbb2222", "10.95.0.0/24")
+    clients = _denied_clients(tenant_isolation_module)
+    clients["ec2"] = FakeTenantClient(
+        {
+            "stop_instances": _client_error("StopInstances", code="DryRunOperation"),
+            "create_snapshot": _client_error("CreateSnapshot", code="UnauthorizedOperation"),
+            "attach_volume": _client_error("AttachVolume", code="UnauthorizedOperation"),
+        }
+    )
+
+    result = tenant_isolation_module._probe_compute_isolation(clients, b)
+
+    assert result["passed"] is False
+    stop_probe = next(p for p in result["probes"] if p["name"] == "ec2_stop_instances_denied")
+    assert stop_probe["code"] == "DryRunOperation"
+
+
+def test_probe_storage_isolation_passes_when_dryrun_denies_snapshot_and_attach(
+    tenant_isolation_module: ModuleType,
+) -> None:
+    """Pass when CreateSnapshot and AttachVolume DryRun calls both return UnauthorizedOperation."""
+    a = _make_tenant(tenant_isolation_module, "aaaa1111", "10.94.0.0/24")
+    b = _make_tenant(tenant_isolation_module, "bbbb2222", "10.95.0.0/24")
+    clients = _denied_clients(tenant_isolation_module)
+
+    result = tenant_isolation_module._probe_storage_isolation(clients, a, b)
+
+    assert result["passed"] is True
+    assert {p["name"] for p in result["probes"]} == {"ec2_create_snapshot_denied", "ec2_attach_volume_denied"}
+
+
+# --- teardown SEC11 sweep helpers ----------------------------------------
+
+
+class FakeSec11Ec2:
+    """Fake EC2 client backing the SEC11 teardown sweep helpers."""
+
+    def __init__(
+        self,
+        *,
+        instances: list[dict[str, Any]] | None = None,
+        volumes: list[dict[str, Any]] | None = None,
+        vpcs: list[dict[str, Any]] | None = None,
+        subnets: list[dict[str, Any]] | None = None,
+        sgs: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Configure resources returned by describe_*."""
+        self.instances = instances or []
+        self.volumes = volumes or []
+        self.vpcs = vpcs or []
+        self.subnets = subnets or []
+        self.sgs = sgs or []
+        self.terminated: list[str] = []
+        self.deleted_volumes: list[str] = []
+        self.deleted_vpcs: list[str] = []
+        self.deleted_subnets: list[str] = []
+        self.deleted_sgs: list[str] = []
+
+    def get_paginator(self, operation_name: str) -> Any:
+        """Return a fake paginator that yields a single page from the fixture data."""
+        instances = self.instances
+        volumes = self.volumes
+
+        class _P:
+            def paginate(_self, **_kwargs: Any) -> list[dict[str, Any]]:
+                if operation_name == "describe_instances":
+                    return [{"Reservations": [{"Instances": instances}]}]
+                if operation_name == "describe_volumes":
+                    return [{"Volumes": volumes}]
+                msg = f"unexpected paginator: {operation_name}"
+                raise AssertionError(msg)
+
+        return _P()
+
+    def terminate_instances(self, InstanceIds: list[str]) -> None:
+        """Record terminated instance ids."""
+        self.terminated.extend(InstanceIds)
+
+    def get_waiter(self, _name: str) -> Any:
+        """Return a no-op waiter."""
+
+        class _W:
+            def wait(self, **_kwargs: Any) -> None:
+                return None
+
+        return _W()
+
+    def delete_volume(self, VolumeId: str) -> None:
+        """Record deleted volume id."""
+        self.deleted_volumes.append(VolumeId)
+
+    def describe_vpcs(self, **_kwargs: Any) -> dict[str, Any]:
+        """Return configured VPCs."""
+        return {"Vpcs": self.vpcs}
+
+    def describe_subnets(self, **_kwargs: Any) -> dict[str, Any]:
+        """Return configured subnets."""
+        return {"Subnets": self.subnets}
+
+    def describe_security_groups(self, **_kwargs: Any) -> dict[str, Any]:
+        """Return configured security groups."""
+        return {"SecurityGroups": self.sgs}
+
+    def delete_security_group(self, GroupId: str) -> None:
+        """Record deleted SG id."""
+        self.deleted_sgs.append(GroupId)
+
+    def delete_subnet(self, SubnetId: str) -> None:
+        """Record deleted subnet id."""
+        self.deleted_subnets.append(SubnetId)
+
+    def delete_vpc(self, VpcId: str) -> None:
+        """Record deleted VPC id."""
+        self.deleted_vpcs.append(VpcId)
+
+
+def test_teardown_cleanup_sec11_instances_only_terminates_matching_prefix() -> None:
+    """`_cleanup_sec11_instances` skips non-SEC11 instances and ignores terminated ones."""
+    module = _load_security_script("teardown.py")
+    ec2 = FakeSec11Ec2(
+        instances=[
+            {
+                "InstanceId": "i-keep",
+                "State": {"Name": "running"},
+                "Tags": [{"Key": "Name", "Value": "production-app"}, {"Key": "CreatedBy", "Value": "isvtest"}],
+            },
+            {
+                "InstanceId": "i-sec11-active",
+                "State": {"Name": "running"},
+                "Tags": [
+                    {"Key": "Name", "Value": "isv-sec11-test-aaaa1111"},
+                    {"Key": "CreatedBy", "Value": "isvtest"},
+                ],
+            },
+            {
+                "InstanceId": "i-sec11-already-gone",
+                "State": {"Name": "terminated"},
+                "Tags": [
+                    {"Key": "Name", "Value": "isv-sec11-test-bbbb2222"},
+                    {"Key": "CreatedBy", "Value": "isvtest"},
+                ],
+            },
+        ]
+    )
+
+    errors = module._cleanup_sec11_instances(ec2)
+
+    assert errors == []
+    assert ec2.terminated == ["i-sec11-active"]
+
+
+def test_teardown_cleanup_sec11_buckets_skips_untagged_buckets() -> None:
+    """`_cleanup_sec11_buckets` only deletes buckets whose tag set contains ``CreatedBy=isvtest``."""
+    module = _load_security_script("teardown.py")
+    deleted_buckets: list[str] = []
+
+    class FakeS3:
+        def list_buckets(self) -> dict[str, list[dict[str, str]]]:
+            return {
+                "Buckets": [
+                    {"Name": "isv-sec11-test-aaaa-abcdef"},  # tagged
+                    {"Name": "isv-sec11-test-other-zzzzzz"},  # untagged -> skip
+                    {"Name": "production-bucket"},  # wrong prefix -> skip
+                ]
+            }
+
+        def get_bucket_tagging(self, Bucket: str) -> dict[str, list[dict[str, str]]]:
+            if Bucket == "isv-sec11-test-aaaa-abcdef":
+                return {"TagSet": [{"Key": "CreatedBy", "Value": "isvtest"}]}
+            raise _client_error("GetBucketTagging", code="NoSuchTagSet")
+
+        def get_paginator(self, _operation_name: str) -> Any:
+            class _P:
+                def paginate(_self, **_kwargs: Any) -> list[dict[str, Any]]:
+                    return [{"Versions": [], "DeleteMarkers": []}]
+
+            return _P()
+
+        def delete_bucket(self, Bucket: str) -> None:
+            deleted_buckets.append(Bucket)
+
+    errors = module._cleanup_sec11_buckets(FakeS3())
+
+    assert errors == []
+    assert deleted_buckets == ["isv-sec11-test-aaaa-abcdef"]
+
+
+def test_teardown_cleanup_sec11_kms_deletes_alias_and_schedules_key_deletion() -> None:
+    """`_cleanup_sec11_kms` deletes only ``alias/isv-sec11-test-*`` aliases and schedules their target keys."""
+    module = _load_security_script("teardown.py")
+    deleted_aliases: list[str] = []
+    scheduled_keys: list[str] = []
+
+    class FakeKms:
+        def get_paginator(self, _operation_name: str) -> Any:
+            class _P:
+                def paginate(_self, **_kwargs: Any) -> list[dict[str, Any]]:
+                    return [
+                        {
+                            "Aliases": [
+                                {"AliasName": "alias/production-key", "TargetKeyId": "key-prod"},
+                                {"AliasName": "alias/isv-sec11-test-aaaa1111", "TargetKeyId": "key-sec11-a"},
+                                {"AliasName": "alias/isv-sec11-test-bbbb2222", "TargetKeyId": "key-sec11-b"},
+                            ]
+                        }
+                    ]
+
+            return _P()
+
+        def delete_alias(self, AliasName: str) -> None:
+            deleted_aliases.append(AliasName)
+
+        def schedule_key_deletion(self, KeyId: str, PendingWindowInDays: int) -> None:
+            assert PendingWindowInDays == 7
+            scheduled_keys.append(KeyId)
+
+    errors = module._cleanup_sec11_kms(FakeKms())
+
+    assert errors == []
+    assert deleted_aliases == [
+        "alias/isv-sec11-test-aaaa1111",
+        "alias/isv-sec11-test-bbbb2222",
+    ]
+    assert scheduled_keys == ["key-sec11-a", "key-sec11-b"]

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -2732,10 +2732,12 @@ class FakeOrchestratorEc2:
         *,
         peerings: list[dict[str, Any]] | None = None,
         route_tables: list[dict[str, Any]] | None = None,
+        tgw_attachments: list[dict[str, Any]] | None = None,
     ) -> None:
-        """Configure peering connections and route tables to return."""
+        """Configure peering connections, route tables, and TGW attachments to return."""
         self.peerings = peerings or []
         self.route_tables = route_tables or []
+        self.tgw_attachments = tgw_attachments or []
 
     def describe_vpc_peering_connections(self, **_kwargs: Any) -> dict[str, list[dict[str, Any]]]:
         """Return configured peering connections."""
@@ -2744,6 +2746,10 @@ class FakeOrchestratorEc2:
     def describe_route_tables(self, **_kwargs: Any) -> dict[str, list[dict[str, Any]]]:
         """Return configured route tables."""
         return {"RouteTables": self.route_tables}
+
+    def describe_transit_gateway_vpc_attachments(self, **_kwargs: Any) -> dict[str, list[dict[str, Any]]]:
+        """Return configured Transit Gateway VPC attachments."""
+        return {"TransitGatewayVpcAttachments": self.tgw_attachments}
 
 
 def test_probe_network_isolation_passes_when_no_peering_or_shared_route(
@@ -2765,6 +2771,61 @@ def test_probe_network_isolation_passes_when_no_peering_or_shared_route(
 
     assert result["passed"] is True
     assert "No peering" in result["message"]
+    assert "transit gateway" in result["message"]
+
+
+def test_probe_network_isolation_fails_when_shared_tgw_attachment_exists(
+    tenant_isolation_module: ModuleType,
+) -> None:
+    """Fail when a single Transit Gateway is attached to BOTH tenant VPCs."""
+    a = _make_tenant(tenant_isolation_module, "aaaa1111", "10.94.0.0/24")
+    b = _make_tenant(tenant_isolation_module, "bbbb2222", "10.95.0.0/24")
+    ec2 = FakeOrchestratorEc2(
+        tgw_attachments=[
+            {"TransitGatewayId": "tgw-leak", "VpcId": a.vpc_id, "State": "available"},
+            {"TransitGatewayId": "tgw-leak", "VpcId": b.vpc_id, "State": "available"},
+        ],
+    )
+
+    result = tenant_isolation_module._probe_network_isolation(ec2, a, b)
+
+    assert result["passed"] is False
+    assert "Transit Gateway tgw-leak" in result["error"]
+
+
+def test_probe_network_isolation_passes_when_tgw_attached_to_only_one_vpc(
+    tenant_isolation_module: ModuleType,
+) -> None:
+    """A TGW attached to only one tenant VPC is not a cross-tenant bridge."""
+    a = _make_tenant(tenant_isolation_module, "aaaa1111", "10.94.0.0/24")
+    b = _make_tenant(tenant_isolation_module, "bbbb2222", "10.95.0.0/24")
+    ec2 = FakeOrchestratorEc2(
+        tgw_attachments=[
+            {"TransitGatewayId": "tgw-only-a", "VpcId": a.vpc_id, "State": "available"},
+        ],
+    )
+
+    result = tenant_isolation_module._probe_network_isolation(ec2, a, b)
+
+    assert result["passed"] is True
+
+
+def test_probe_network_isolation_ignores_deleted_tgw_attachment(
+    tenant_isolation_module: ModuleType,
+) -> None:
+    """A TGW attachment in 'deleted' state must not count as a live bridge."""
+    a = _make_tenant(tenant_isolation_module, "aaaa1111", "10.94.0.0/24")
+    b = _make_tenant(tenant_isolation_module, "bbbb2222", "10.95.0.0/24")
+    ec2 = FakeOrchestratorEc2(
+        tgw_attachments=[
+            {"TransitGatewayId": "tgw-stale", "VpcId": a.vpc_id, "State": "deleted"},
+            {"TransitGatewayId": "tgw-stale", "VpcId": b.vpc_id, "State": "deleted"},
+        ],
+    )
+
+    result = tenant_isolation_module._probe_network_isolation(ec2, a, b)
+
+    assert result["passed"] is True
 
 
 def test_probe_network_isolation_fails_when_active_peering_exists(

--- a/isvctl/tests/test_aws_security_scripts.py
+++ b/isvctl/tests/test_aws_security_scripts.py
@@ -2975,6 +2975,57 @@ def test_probe_storage_isolation_passes_when_dryrun_denies_snapshot_and_attach(
     assert {p["name"] for p in result["probes"]} == {"ec2_create_snapshot_denied", "ec2_attach_volume_denied"}
 
 
+def test_tenant_isolation_main_cleans_partial_provision_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tenant_isolation_module: ModuleType,
+) -> None:
+    """A setup failure after partial resource creation still reaches teardown."""
+
+    class FakeUuid:
+        """Deterministic UUID stand-in exposing the ``hex`` attribute used by the script."""
+
+        def __init__(self, value: str) -> None:
+            self.hex = value
+
+    def fake_client(service_name: str, **_kwargs: Any) -> object:
+        """Return an opaque fake client for each AWS service."""
+        if service_name in {"ec2", "iam", "kms", "s3"}:
+            return object()
+        msg = f"unexpected service: {service_name}"
+        raise AssertionError(msg)
+
+    cleanup_calls: list[tuple[str, dict[str, bool], str]] = []
+    suffixes = iter([FakeUuid("aaaa1111ffffffff"), FakeUuid("bbbb2222ffffffff")])
+
+    def fake_provision_tenant(*, tenant: Any, **_kwargs: Any) -> Any:
+        """Simulate a helper failing after creating a resource."""
+        tenant.vpc_id = "vpc-partial"
+        tenant.created["vpc"] = True
+        raise _client_error("CreateUser", code="LimitExceeded", message="setup failed")
+
+    def fake_teardown_tenant(*, tenant: Any, **_kwargs: Any) -> list[str]:
+        """Record the tenant ledger passed to cleanup."""
+        cleanup_calls.append((tenant.name, dict(tenant.created), tenant.vpc_id))
+        return []
+
+    monkeypatch.setattr(tenant_isolation_module.boto3, "client", fake_client)
+    monkeypatch.setattr(tenant_isolation_module.uuid, "uuid4", lambda: next(suffixes))
+    monkeypatch.setattr(tenant_isolation_module.sys, "argv", ["tenant_isolation_test.py", "--region", "us-west-2"])
+    monkeypatch.setattr(tenant_isolation_module, "_get_amazon_linux_ami", lambda _ec2: "ami-test")
+    monkeypatch.setattr(tenant_isolation_module, "_provision_tenant", fake_provision_tenant)
+    monkeypatch.setattr(tenant_isolation_module, "_teardown_tenant", fake_teardown_tenant)
+
+    exit_code = tenant_isolation_module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert payload.get("skipped") is not True
+    assert "setup failed" in payload["error"]
+    assert cleanup_calls == [("isv-sec11-test-aaaa1111", {"vpc": True}, "vpc-partial")]
+
+
 # --- teardown SEC11 sweep helpers ----------------------------------------
 
 

--- a/isvtest/src/isvtest/main.py
+++ b/isvtest/src/isvtest/main.py
@@ -96,7 +96,13 @@ def run_validations_via_pytest(
             # Env override is set: enumerate which configured validations are being included that would
             # otherwise be gated, so it's obvious in the log which unreleased checks are actually running.
             logger.info(f"Including unreleased validations because {INCLUDE_UNRELEASED_ENV} is enabled")
-            manifest = load_released_tests()
+            # Manifest read is for log diffing only; failure must not abort the unreleased run since
+            # that's the path that exists precisely to bypass the gate.
+            try:
+                manifest = load_released_tests()
+            except (FileNotFoundError, ValueError) as exc:
+                logger.warning(f"Could not diff against released_tests.json: {exc}")
+                manifest = set()
             for name in _iter_configured_validation_names(validations):
                 if name not in manifest:
                     logger.info(f"Including unreleased validation '{name}' (not in manifest)")

--- a/isvtest/src/isvtest/main.py
+++ b/isvtest/src/isvtest/main.py
@@ -29,10 +29,20 @@ from isvreporter.version import get_version
 from isvtest.config.loader import ConfigLoader
 from isvtest.core import runners as reframe_runner
 from isvtest.core.logger import setup_logger
-from isvtest.release_manifest import INCLUDE_UNRELEASED_ENV, load_released_test_filter
-from isvtest.tests.test_validations import ADAPTER_HANDLED_CATEGORIES
+from isvtest.release_manifest import INCLUDE_UNRELEASED_ENV, load_released_test_filter, load_released_tests
+from isvtest.tests.test_validations import (
+    ADAPTER_HANDLED_CATEGORIES,
+    clear_validation_results,
+    get_validation_results,
+)
 
 logger = setup_logger()
+
+# Process-level dedup so manifest-gate logs fire once per invocation
+# rather than once per phase (run_validations_via_pytest is called for
+# setup/test/teardown).
+_MANIFEST_GATE_ANNOUNCED = False
+_SKIPPED_UNRELEASED_LOGGED: set[str] = set()
 
 
 def run_validations_via_pytest(
@@ -77,14 +87,31 @@ def run_validations_via_pytest(
         exit_code: 0 if all validations passed, non-zero otherwise.
         validation_results: List of validation result dicts with name, passed, message, category.
     """
-    # Import result storage from test_validations
-    from isvtest.tests.test_validations import clear_validation_results, get_validation_results
-
     # Transform validations into the format expected by test_validations.py
     # The test_validations.py expects a "validations" dict at config root
     released_tests = load_released_test_filter()
-    if released_tests is None:
-        logger.info("Including unreleased validations because %s is enabled", INCLUDE_UNRELEASED_ENV)
+    global _MANIFEST_GATE_ANNOUNCED
+    if not _MANIFEST_GATE_ANNOUNCED:
+        if released_tests is None:
+            # Env override is set: enumerate which configured validations are being included that would
+            # otherwise be gated, so it's obvious in the log which unreleased checks are actually running.
+            logger.info(f"Including unreleased validations because {INCLUDE_UNRELEASED_ENV} is enabled")
+            manifest = load_released_tests()
+            for name in _iter_configured_validation_names(validations):
+                if name not in manifest:
+                    logger.info(f"Including unreleased validation '{name}' (not in manifest)")
+        else:
+            # Env override is not set: announce the gate (with a count of unreleased configured validations)
+            # so it's obvious why newly-added validations may show up as 'Skipping unreleased ...' below.
+            unreleased_count = sum(
+                1 for name in _iter_configured_validation_names(validations) if name not in released_tests
+            )
+            logger.info(
+                f"Release manifest gate active: {unreleased_count} configured validation(s) unreleased "
+                f"(set {INCLUDE_UNRELEASED_ENV}=1 to include them)"
+            )
+        _MANIFEST_GATE_ANNOUNCED = True
+
     transformed_validations = _transform_validations_for_pytest(
         validations,
         step_outputs,
@@ -203,6 +230,30 @@ def run_validations_via_pytest(
             pass
 
 
+def _iter_configured_validation_names(
+    validations: dict[str, list[dict[str, Any]] | dict[str, Any]],
+) -> list[str]:
+    """Return the validation class names referenced by ``validations``.
+
+    Used purely for logging: walks both supported config shapes (group
+    defaults with ``checks`` key, and flat list-of-dicts) and yields the
+    class name of every configured check.
+    """
+    names: list[str] = []
+    for category, category_config in validations.items():
+        if category in ADAPTER_HANDLED_CATEGORIES:
+            continue
+        if isinstance(category_config, dict) and "checks" in category_config:
+            checks_val = category_config.get("checks", {})
+            if isinstance(checks_val, dict):
+                names.extend(checks_val.keys())
+            else:
+                names.extend(n for item in checks_val for n in item)
+        elif isinstance(category_config, list):
+            names.extend(n for item in category_config for n in item)
+    return names
+
+
 def _transform_validations_for_pytest(
     validations: dict[str, list[dict[str, Any]] | dict[str, Any]],
     step_outputs: dict[str, dict[str, Any]],
@@ -270,7 +321,10 @@ def _transform_validations_for_pytest(
 
         for name, params in checks_iter:
             if released_tests is not None and name not in released_tests:
-                logger.info(f"Skipping unreleased validation '{name}' in [{category}]")
+                key = f"{category}:{name}"
+                if key not in _SKIPPED_UNRELEASED_LOGGED:
+                    logger.info(f"Skipping unreleased validation '{name}' in [{category}]")
+                    _SKIPPED_UNRELEASED_LOGGED.add(key)
                 continue
 
             if params is None:

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -102,6 +102,7 @@ from isvtest.validations.security import (
     MfaEnforcedCheck,
     OidcUserAuthCheck,
     ShortLivedCredentialsCheck,
+    TenantIsolationCheck,
 )
 
 __all__ = [
@@ -163,6 +164,7 @@ __all__ = [
     "SubnetConfigCheck",
     "TenantCreatedCheck",
     "TenantInfoCheck",
+    "TenantIsolationCheck",
     "TenantListedCheck",
     "TrafficFlowCheck",
     "VpcCrudCheck",

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -123,6 +123,8 @@ class TenantIsolationCheck(BaseValidation):
     def run(self) -> None:
         """Validate the four tenant-isolation sub-claims from step output."""
         step_output = self.config.get("step_output", {})
+        if step_output.get("skipped") is True:
+            pytest.skip(step_output.get("skip_reason") or "Tenant isolation validation skipped (not configured)")
 
         for field in ("tenant_a_id", "tenant_b_id"):
             value = step_output.get(field)

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -87,6 +87,63 @@ class BmcTenantIsolationCheck(BaseValidation):
         self.set_passed(f"BMC interfaces unreachable from tenant network ({bmc_count} endpoints tested)")
 
 
+class TenantIsolationCheck(BaseValidation):
+    """Validate hard isolation between tenants (SEC11-01).
+
+    Verifies four orthogonal isolation surfaces by inspecting the boolean
+    sub-claims a provider script reports after running cross-tenant
+    negative probes (tenant A's principal acting against tenant B's
+    resources):
+
+    * ``network_isolated``  -- tenant A's network has no route to tenant B's
+      network (no peering, no shared route, SG/NACL deny).
+    * ``data_isolated``     -- tenant A is denied ``kms:Decrypt`` on tenant
+      B's CMK and ``s3:GetObject`` on tenant B's bucket.
+    * ``compute_isolated``  -- tenant A is denied ``ec2:*`` /
+      ``ssm:StartSession`` against tenant B's instance.
+    * ``storage_isolated``  -- tenant A is denied ``ebs:*`` /
+      snapshot/attach/copy against tenant B's volume.
+
+    Physical isolation (bare-metal) and switch-fabric isolation are out of
+    scope here -- they are covered by SDN04-04/05.
+
+    Config:
+        step_output: The step output to check
+
+    Step output:
+        tenant_a_id: Non-empty identifier for the source tenant
+        tenant_b_id: Non-empty identifier for the target tenant
+        tests: dict with network_isolated, data_isolated,
+               compute_isolated, storage_isolated
+    """
+
+    description: ClassVar[str] = "Check hard tenant isolation across network, data, compute, and storage"
+    markers: ClassVar[list[str]] = ["security", "network", "iam"]
+
+    def run(self) -> None:
+        """Validate the four tenant-isolation sub-claims from step output."""
+        step_output = self.config.get("step_output", {})
+
+        for field in ("tenant_a_id", "tenant_b_id"):
+            value = step_output.get(field)
+            if not isinstance(value, str) or not value.strip():
+                self.set_failed(f"Tenant isolation output missing non-empty '{field}'")
+                return
+
+        required = [
+            "network_isolated",
+            "data_isolated",
+            "compute_isolated",
+            "storage_isolated",
+        ]
+        if not check_required_tests(self, required, "Tenant isolation tests failed"):
+            return
+
+        tenant_a = step_output["tenant_a_id"].strip()
+        tenant_b = step_output["tenant_b_id"].strip()
+        self.set_passed(f"Hard tenant isolation verified ({tenant_a} cannot reach {tenant_b})")
+
+
 class BmcProtocolSecurityCheck(BaseValidation):
     """Validate BMC management protocols enforce CNP10-01 controls.
 

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -97,7 +97,7 @@ class TenantIsolationCheck(BaseValidation):
 
     * ``network_isolated``  -- tenant A's network has no route to tenant B's
       network (no peering, no shared route, SG/NACL deny).
-    * ``data_isolated``     -- tenant A is denied ``kms:Decrypt`` on tenant
+    * ``data_isolated``     -- tenant A is denied ``kms:Encrypt`` on tenant
       B's CMK and ``s3:GetObject`` on tenant B's bucket.
     * ``compute_isolated``  -- tenant A is denied ``ec2:*`` /
       ``ssm:StartSession`` against tenant B's instance.

--- a/isvtest/tests/test_security.py
+++ b/isvtest/tests/test_security.py
@@ -681,3 +681,18 @@ class TestTenantIsolationCheck:
 
         assert result["passed"] is False
         assert "tests" in result["error"].lower()
+
+    def test_skips_when_step_marks_skipped(self) -> None:
+        """TenantIsolationCheck pytest.skips through both run() and execute() when flagged."""
+        step_output = {
+            "success": True,
+            "skipped": True,
+            "skip_reason": "tenant isolation fixture not provisionable (AccessDenied)",
+            "tests": {},
+        }
+
+        with pytest.raises(pytest.skip.Exception, match="tenant isolation fixture not provisionable"):
+            TenantIsolationCheck(config={"step_output": step_output}).run()
+
+        with pytest.raises(pytest.skip.Exception, match="tenant isolation fixture not provisionable"):
+            TenantIsolationCheck(config={"step_output": step_output}).execute()

--- a/isvtest/tests/test_security.py
+++ b/isvtest/tests/test_security.py
@@ -25,6 +25,7 @@ from isvtest.validations.security import (
     MfaEnforcedCheck,
     OidcUserAuthCheck,
     ShortLivedCredentialsCheck,
+    TenantIsolationCheck,
 )
 
 REQUIRED_BMC_PROTOCOL_TESTS = [
@@ -595,3 +596,88 @@ def test_short_lived_credentials_check_skips_when_step_marks_skipped() -> None:
 
     with pytest.raises(pytest.skip.Exception, match="GetSessionToken not available"):
         ShortLivedCredentialsCheck(config={"step_output": step_output}).execute()
+
+
+TENANT_ISOLATION_REQUIRED_TESTS = {
+    "network_isolated": {"passed": True},
+    "data_isolated": {"passed": True},
+    "compute_isolated": {"passed": True},
+    "storage_isolated": {"passed": True},
+}
+
+
+def _tenant_isolation_step_output(**overrides: Any) -> dict[str, Any]:
+    """Return a valid tenant-isolation step output with optional overrides."""
+    output: dict[str, Any] = {
+        "success": True,
+        "platform": "security",
+        "test_name": "tenant_isolation_test",
+        "tenant_a_id": "isv-sec11-test-aaaa1111",
+        "tenant_b_id": "isv-sec11-test-bbbb2222",
+        "tests": deepcopy(TENANT_ISOLATION_REQUIRED_TESTS),
+    }
+    output.update(overrides)
+    return output
+
+
+class TestTenantIsolationCheck:
+    """Tests for SEC11-01 hard tenant-isolation validation."""
+
+    def test_passes_when_all_four_dimensions_isolated(self) -> None:
+        """Pass when all four sub-claims are reported isolated."""
+        result = TenantIsolationCheck(config={"step_output": _tenant_isolation_step_output()}).execute()
+
+        assert result["passed"] is True
+        assert "Hard tenant isolation verified" in result["output"]
+        assert "isv-sec11-test-aaaa1111" in result["output"]
+        assert "isv-sec11-test-bbbb2222" in result["output"]
+
+    def test_fails_when_data_isolation_breached(self) -> None:
+        """Fail with the specific contract key when cross-tenant KMS/S3 access leaks."""
+        tests = deepcopy(TENANT_ISOLATION_REQUIRED_TESTS)
+        tests["data_isolated"] = {"passed": False, "error": "kms:Decrypt unexpectedly allowed across tenants"}
+        result = TenantIsolationCheck(config={"step_output": _tenant_isolation_step_output(tests=tests)}).execute()
+
+        assert result["passed"] is False
+        assert "data_isolated" in result["error"]
+        assert "kms:Decrypt unexpectedly allowed" in result["error"]
+
+    def test_fails_when_compute_isolation_breached(self) -> None:
+        """Fail when tenant A can act on tenant B's compute resources."""
+        tests = deepcopy(TENANT_ISOLATION_REQUIRED_TESTS)
+        tests["compute_isolated"] = {"passed": False, "error": "ec2:DescribeInstances unexpectedly succeeded"}
+        result = TenantIsolationCheck(config={"step_output": _tenant_isolation_step_output(tests=tests)}).execute()
+
+        assert result["passed"] is False
+        assert "compute_isolated" in result["error"]
+
+    def test_fails_when_required_sub_claim_missing(self) -> None:
+        """Fail when one of the four required sub-claims is absent from tests."""
+        tests = {name: result for name, result in TENANT_ISOLATION_REQUIRED_TESTS.items() if name != "storage_isolated"}
+        result = TenantIsolationCheck(config={"step_output": _tenant_isolation_step_output(tests=tests)}).execute()
+
+        assert result["passed"] is False
+        assert "storage_isolated" in result["error"]
+
+    def test_fails_when_tenant_a_id_missing(self) -> None:
+        """Fail when the source tenant identifier is empty -- guards against silent fixture failures."""
+        result = TenantIsolationCheck(config={"step_output": _tenant_isolation_step_output(tenant_a_id="")}).execute()
+
+        assert result["passed"] is False
+        assert "tenant_a_id" in result["error"]
+
+    def test_fails_when_tenant_b_id_missing(self) -> None:
+        """Fail when the target tenant identifier is empty."""
+        result = TenantIsolationCheck(
+            config={"step_output": _tenant_isolation_step_output(tenant_b_id="   ")}
+        ).execute()
+
+        assert result["passed"] is False
+        assert "tenant_b_id" in result["error"]
+
+    def test_fails_when_tests_dict_missing(self) -> None:
+        """Fail when the step output does not include any tests."""
+        result = TenantIsolationCheck(config={"step_output": {"tenant_a_id": "a", "tenant_b_id": "b"}}).execute()
+
+        assert result["passed"] is False
+        assert "tests" in result["error"].lower()


### PR DESCRIPTION
## Summary

Adds `TenantIsolationCheck` to the security suite, verifying hard logical isolation between two tenants across four orthogonal surfaces:

- **network**: tenant A's VPC has no peering, no shared Transit Gateway, and no route to tenant B's CIDR
- **data**: tenant A's IAM principal is denied `kms:Encrypt` on B's CMK and `s3:GetObject` on B's bucket
- **compute**: tenant A is denied `ec2:StopInstances` (DryRun) and `ssm:StartSession` against B's instance
- **storage**: tenant A is denied `ec2:CreateSnapshot` (DryRun) and `ec2:AttachVolume` (DryRun) against B's volume

Physical isolation (bare-metal) and IB switch-fabric isolation are out of scope (covered separately).

## Changes

- `TenantIsolationCheck` validation (mirrors `BmcTenantIsolationCheck`'s JSON-driven shape) plus security-suite wiring.
- AWS reference script provisions two ephemeral tenants in `try` / `finally` (each = VPC + subnet + SG, scoped IAM user, KMS CMK, S3 bucket, t3.micro EC2, EBS volume, prefixed `isv-sec11-test-<uuid>`), runs cross-tenant negative probes from tenant A's STS creds against tenant B's resources, and asserts `AccessDenied` / `UnauthorizedOperation`.
- Setup `AccessDenied` on the orchestrator principal emits a structured skip payload rather than fabricating a pass.
- Cleanup wraps the `InstanceTerminated` waiter to catch `WaiterError` (it treats `pending` as a terminal failure when setup dies mid-launch) so a downstream waiter can't mask the original error. The first error is captured via `classify_aws_error` *before* cleanup runs, and the result dict is always emitted in `finally` so the validation contract holds.
- Security teardown safety-net sweeps leftover SEC11 fixture: IAM users (`isv-sec11-test-` prefix joins `OWNED_USER_PREFIXES`), EC2 instances, EBS volumes, VPCs / subnets / SGs, KMS aliases + their target keys, S3 buckets. All sweeps tag-scoped (`CreatedBy=isvtest`) and routed through `delete_with_retry`. Step timeout bumped 60s → 300s to fit the worst-case waiter.
- `my-isv` security scaffold/demo stub with a cloud-agnostic TODO and `DEMO_MODE` dummy success.
- Logging: when `ISVTEST_INCLUDE_UNRELEASED=1` enumerates each unreleased check by name; otherwise emits a top-level "Release manifest gate active: N validation(s) unreleased" announcement so newly-added validations don't silently no-op.

## Validation

- [x] `pytest isvtest/tests isvctl/tests` — 1196 passed
- [x] `make lint`
- [x] `make demo-test`
- [x] Live `isvctl test run -f providers/aws/config/security.yaml` against an SSO orchestrator profile — `[PASS] All phases completed successfully`, `TenantIsolationCheck: PASSED`, no leaked SEC11 fixture in `us-west-2`.

## Test plan

- [x] Manual AWS smoke on an SSO orchestrator profile, confirming both tenants are provisioned, all four cross-tenant probes return `AccessDenied` / `UnauthorizedOperation`, and the IAM users + inline policies + access keys + KMS aliases + KMS keys + S3 buckets + instances + volumes + VPCs are cleaned up on exit.
- [x] Confirm setup `AccessDenied` on the orchestrator principal yields a structured skip rather than a SEC11-01 failure.
- [x] Confirm a partial-fixture failure surfaces as a real failure (not a fabricated skip).

Closes https://github.com/NVIDIA/ISV-NCP-Validation-Suite/issues/305

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant isolation security validation (SEC11-01) covering network, data, compute, and storage; provider workflows include a tenant-isolation test and CLI script with demo mode.

* **Documentation**
  * Guidance for validating unreleased tests locally via an environment flag.
  * New guidance listing files that must not be edited in feature PRs.

* **Tests**
  * Extensive unit tests for tenant isolation and enhanced security cleanup coverage.

* **Chores**
  * Teardown/cleanup expanded to handle additional security resources and longer timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->