### PR TITLE
chore: colocate bump-version tests with the script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,8 @@ test: ## Run tests for all packages
 			(cd $$pkg && uv run pytest) || exit 1; \
 		fi; \
 	done
+	@echo "Testing scripts..."
+	@uv run pytest scripts/tests || exit 1
 	@echo ""
 	@echo "✅ All tests passed!"
 
@@ -166,6 +168,11 @@ clean: ## Clean build artifacts and test outputs
 		find $$pkg -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true; \
 		find $$pkg -type f -name "*.pyc" -delete 2>/dev/null || true; \
 	done
+	@echo "Cleaning scripts..."
+	@rm -f scripts/.coverage
+	@find scripts -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	@find scripts -type d -name ".pytest_cache" -exec rm -rf {} + 2>/dev/null || true
+	@find scripts -type f -name "*.pyc" -delete 2>/dev/null || true
 	@echo "✅ Clean complete!"
 
 update-spdx-headers: ## Update SPDX headers in all packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,16 @@ override-dependencies = [
     "pyasn1>=0.6.3",
     "requests>=2.32.5",
 ]
+
+[tool.ruff]
+line-length = 120
+target-version = "py312"
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"
+
+[tool.ruff.lint]
+select = ["F", "E", "W", "I", "A", "UP", "RUF"]
+ignore = ["E501"]

--- a/scripts/add_spdx_headers.py
+++ b/scripts/add_spdx_headers.py
@@ -139,9 +139,7 @@ def main() -> int:
     if args.check:
         missing = check_headers(files)
         if missing:
-            print(
-                f"\n{missing} file(s) missing SPDX headers. Run 'make update-spdx-headers' to fix."
-            )
+            print(f"\n{missing} file(s) missing SPDX headers. Run 'make update-spdx-headers' to fix.")
             return 1
         print("\nAll files have SPDX headers.")
         return 0

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -68,15 +68,9 @@ def _load_release_manifest_version(manifest_path: Path) -> str:
     version = data.get("version")
     tests = data.get("tests")
     if not isinstance(version, str) or not version:
-        raise ValueError(
-            "released test manifest requires non-empty string field 'version'"
-        )
-    if not isinstance(tests, list) or not all(
-        isinstance(name, str) and name for name in tests
-    ):
-        raise ValueError(
-            "released test manifest requires 'tests' to be a list of non-empty strings"
-        )
+        raise ValueError("released test manifest requires non-empty string field 'version'")
+    if not isinstance(tests, list) or not all(isinstance(name, str) and name for name in tests):
+        raise ValueError("released test manifest requires 'tests' to be a list of non-empty strings")
 
     return version
 
@@ -177,25 +171,17 @@ def _confirm(base: str, base_source: str, new: str) -> None:
 
     if new_parts > base_parts:
         if new_parts[0] > base_parts[0] + 1:
-            warnings.append(
-                f"skipping major versions ({base_parts[0]} -> {new_parts[0]})"
-            )
+            warnings.append(f"skipping major versions ({base_parts[0]} -> {new_parts[0]})")
         elif new_parts[0] == base_parts[0] and new_parts[1] > base_parts[1] + 1:
-            warnings.append(
-                f"skipping minor versions ({base_parts[1]} -> {new_parts[1]})"
-            )
+            warnings.append(f"skipping minor versions ({base_parts[1]} -> {new_parts[1]})")
         elif new_parts[:2] == base_parts[:2] and new_parts[2] > base_parts[2] + 1:
-            warnings.append(
-                f"skipping patch versions ({base_parts[2]} -> {new_parts[2]})"
-            )
+            warnings.append(f"skipping patch versions ({base_parts[2]} -> {new_parts[2]})")
 
         # Non-zero trailing digits on major/minor bump (e.g. 0.4.2 -> 0.5.2 should be 0.5.0)
         if new_parts[0] != base_parts[0] and (new_parts[1] != 0 or new_parts[2] != 0):
             warnings.append(f"major bump should reset to {new_parts[0]}.0.0")
         elif new_parts[1] != base_parts[1] and new_parts[2] != 0:
-            warnings.append(
-                f"minor bump should reset to {new_parts[0]}.{new_parts[1]}.0"
-            )
+            warnings.append(f"minor bump should reset to {new_parts[0]}.{new_parts[1]}.0")
 
     if new == base:
         print(f"Already at {base}, nothing to do.")
@@ -254,9 +240,7 @@ def refresh_released_tests(new_version: str) -> None:
 def check(expected: str) -> None:
     """Verify all pyproject.toml files already have the expected version."""
     if not SEMVER_RE.match(expected):
-        print(
-            f"error: '{expected}' is not valid semver (expected X.Y.Z)", file=sys.stderr
-        )
+        print(f"error: '{expected}' is not valid semver (expected X.Y.Z)", file=sys.stderr)
         sys.exit(1)
 
     ok = True

--- a/scripts/check_md_links.py
+++ b/scripts/check_md_links.py
@@ -50,10 +50,7 @@ def find_markdown_files(root: Path) -> list[Path]:
         rel = path.relative_to(root)
         if any(part in SKIP_DIRS for part in rel.parts):
             continue
-        if (
-            any(part.startswith(".") for part in rel.parts)
-            and rel.parts[0] != ".github"
-        ):
+        if any(part.startswith(".") for part in rel.parts) and rel.parts[0] != ".github":
             continue
         files.append(path)
     return files
@@ -63,9 +60,7 @@ def check_links(root: Path, md_files: list[Path]) -> list[tuple[Path, int, str]]
     """Return list of (file, line_number, url) for broken relative links."""
     broken: list[tuple[Path, int, str]] = []
     for md in md_files:
-        for lineno, line in enumerate(
-            md.read_text(errors="replace").splitlines(), start=1
-        ):
+        for lineno, line in enumerate(md.read_text(errors="replace").splitlines(), start=1):
             for url in LINK_RE.findall(line):
                 if any(url.startswith(p) for p in SKIP_PREFIXES):
                     continue

--- a/scripts/tests/test_bump_version.py
+++ b/scripts/tests/test_bump_version.py
@@ -23,7 +23,7 @@ import pytest
 
 # Load bump-version.py as a module (filename has a hyphen so normal import won't work)
 _spec = importlib.util.spec_from_file_location(
-    "bump_version", Path(__file__).resolve().parent.parent.parent / "scripts" / "bump-version.py"
+    "bump_version", Path(__file__).resolve().parent.parent / "bump-version.py"
 )
 assert _spec and _spec.loader
 bump_version = importlib.util.module_from_spec(_spec)


### PR DESCRIPTION
## Summary

Moves `test_bump_version.py` from `isvreporter/tests/` to `scripts/tests/`, and wires the new location into `make test` / `make clean`.

## Changes

- Renames `isvreporter/tests/test_bump_version.py` → `scripts/tests/test_bump_version.py` and updates the `spec_from_file_location` path to point at the sibling `scripts/bump-version.py`.
- Extends the root `Makefile`:
  - `test` now runs `uv run pytest scripts/tests` after the per-package loop, so script tests don't silently drop off CI.
  - `clean` sweeps `scripts/.coverage`, `__pycache__`, `.pytest_cache`, and `*.pyc` under `scripts/`.

## Validation

- [x] `make test` — all packages plus `scripts/tests` pass
- [x] `make coverage` - no coverage change - this test was already omitted from test coverage (which covers the `{isvctl,isvtest,isvreporter}/src/` directories)
- [x] `make lint`

## Test plan

- [x] Confirm `make test` discovers and runs `scripts/tests/test_bump_version.py`.
- [x] Confirm `make clean` removes the new `scripts/` artifacts.
- [x] Confirm `make coverage` does not include the `scripts/{tests,}` directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tests now run an additional script-level test suite as part of the main test target.
  * Cleanup extended to remove Python cache and coverage artifacts under script directories.
  * Project lint/format configuration added to standardize style.
  * Minor script and test-path tweaks plus message formatting refinements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->