### PR TITLE
fix: scope K8s node counts for test pools

### DIFF
--- a/isvctl/configs/providers/aws/config/eks.yaml
+++ b/isvctl/configs/providers/aws/config/eks.yaml
@@ -70,10 +70,11 @@ commands:
       # Scale the same pool to a new target count. Re-applies the
       # terraform-node-pool module with a bumped desired_size; create_node_pool.sh
       # is reused because `terraform apply` is idempotent. The emitted
-      # node_pool payload carries the new replica count, which the second
-      # K8sNodePoolCheck invocation in the suite asserts on.
+      # node_pool payload carries the new replica count. This runs in the test
+      # phase so the create check can assert desired_size=1 before the pool is
+      # scaled to 2 and asserted by the update check.
       - name: update_test_node_pool
-        phase: setup
+        phase: test
         command: "../scripts/eks/create_node_pool.sh"
         output_schema: node_pool
         timeout: 900
@@ -105,6 +106,16 @@ commands:
 
 tests:
   description: "AWS EKS GPU cluster validation"
+
+  validations:
+    kubernetes:
+      checks:
+        K8sNodeCountCheck:
+          # Keep the generic node count scoped to the baseline cluster. The
+          # test phase intentionally scales a temporary CPU node pool before
+          # this check runs; K8sNodePoolCheck validates that pool separately.
+          count: "{{ steps.setup.kubernetes.node_count | default(4, true) }}"
+          exclude_label_selector: "{{ steps.update_test_node_pool.label_selector | default('', true) }}"
 
   exclude:
     tests:

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -50,6 +50,43 @@ tests:
     show_skipped_tests: false
 
   validations:
+    # Provider-agnostic node-pool CRUD outcome checks. Keep this category
+    # before the regular Kubernetes checks/workloads: update operations can
+    # run in the test phase, and their K8sNodePoolCheck must wait for node
+    # convergence before the rest of the phase exercises the cluster.
+    #
+    # Each provisioning step (EKS: terraform; CAPI: kubectl apply) emits a
+    # `node_pool` JSON payload that seeds the expected shape below; labels,
+    # taints, and instance types come across as JSON strings so Jinja
+    # string rendering doesn't mangle the structure, and K8sNodePoolCheck
+    # json-parses them. The `step` field binds each check to the phase of
+    # the operation it validates, so create can be asserted before update
+    # scales the same pool. The check is listed twice - once per operation -
+    # so list form is required (dict form would collide on the class name).
+    k8s_node_pools:
+      - K8sNodePoolCheck:
+          # Create: pool reaches desired replica count.
+          step: create_test_node_pool
+          label_selector: "{{ steps.create_test_node_pool.label_selector }}"
+          expected_replicas: "{{ steps.create_test_node_pool.expected_replicas | default(1, true) }}"
+          expected_labels: "{{ steps.create_test_node_pool.expected_labels_json | default('{}', true) }}"
+          expected_taints: "{{ steps.create_test_node_pool.expected_taints_json | default('[]', true) }}"
+          expected_instance_types: "{{ steps.create_test_node_pool.expected_instance_types_json | default('[]', true) }}"
+          node_type: "{{ steps.create_test_node_pool.node_type | default('cpu') }}"
+          wait_timeout: 900
+          poll_interval: 10
+      - K8sNodePoolCheck:
+          # Update (scale): same pool converges to the new count.
+          step: update_test_node_pool
+          label_selector: "{{ steps.update_test_node_pool.label_selector }}"
+          expected_replicas: "{{ steps.update_test_node_pool.expected_replicas | default(2, true) }}"
+          expected_labels: "{{ steps.update_test_node_pool.expected_labels_json | default('{}', true) }}"
+          expected_taints: "{{ steps.update_test_node_pool.expected_taints_json | default('[]', true) }}"
+          expected_instance_types: "{{ steps.update_test_node_pool.expected_instance_types_json | default('[]', true) }}"
+          node_type: "{{ steps.update_test_node_pool.node_type | default('cpu') }}"
+          wait_timeout: 900
+          poll_interval: 10
+
     kubernetes:
       checks:
         K8sNodeCountCheck:
@@ -202,35 +239,6 @@ tests:
           timeout: 1800
           genai_perf_requests: 200
           genai_perf_concurrency: 8
-
-    # Provider-agnostic node-pool CRUD outcome checks. Each
-    # provisioning step (EKS: terraform; CAPI: kubectl apply) emits a
-    # `node_pool` JSON payload that seeds the expected shape below; labels,
-    # taints, and instance types come across as JSON strings so Jinja
-    # string rendering doesn't mangle the structure, and K8sNodePoolCheck
-    # json-parses them. The check is listed twice - once per operation -
-    # so list form is required (dict form would collide on the class name).
-    k8s_node_pools:
-      - K8sNodePoolCheck:
-          # Create: pool reaches desired replica count.
-          label_selector: "{{ steps.create_test_node_pool.label_selector }}"
-          expected_replicas: "{{ steps.create_test_node_pool.expected_replicas | default(1, true) }}"
-          expected_labels: "{{ steps.create_test_node_pool.expected_labels_json | default('{}', true) }}"
-          expected_taints: "{{ steps.create_test_node_pool.expected_taints_json | default('[]', true) }}"
-          expected_instance_types: "{{ steps.create_test_node_pool.expected_instance_types_json | default('[]', true) }}"
-          node_type: "{{ steps.create_test_node_pool.node_type | default('cpu') }}"
-          wait_timeout: 900
-          poll_interval: 10
-      - K8sNodePoolCheck:
-          # Update (scale): same pool converges to the new count.
-          label_selector: "{{ steps.update_test_node_pool.label_selector }}"
-          expected_replicas: "{{ steps.update_test_node_pool.expected_replicas | default(2, true) }}"
-          expected_labels: "{{ steps.update_test_node_pool.expected_labels_json | default('{}', true) }}"
-          expected_taints: "{{ steps.update_test_node_pool.expected_taints_json | default('[]', true) }}"
-          expected_instance_types: "{{ steps.update_test_node_pool.expected_instance_types_json | default('[]', true) }}"
-          node_type: "{{ steps.update_test_node_pool.node_type | default('cpu') }}"
-          wait_timeout: 900
-          poll_interval: 10
 
     k8s_observability:
       checks:

--- a/isvctl/tests/test_merger.py
+++ b/isvctl/tests/test_merger.py
@@ -21,6 +21,8 @@ from isvctl.config.merger import (
     merge_yaml_files,
     parse_set_value,
 )
+from isvctl.config.schema import RunConfig
+from isvctl.orchestrator.context import Context
 
 
 class TestDeepMerge:
@@ -411,6 +413,24 @@ class TestImportEndToEnd:
         validations = result["tests"]["validations"]
         assert "kubernetes" in validations
         assert "k8s_workloads" in validations
+        node_count_check = validations["kubernetes"]["checks"]["K8sNodeCountCheck"]
+        node_count = node_count_check["count"]
+        exclude_selector = node_count_check["exclude_label_selector"]
+        assert "steps.update_test_node_pool.label_selector" in exclude_selector
+        config = RunConfig.model_validate(result)
+        context = Context(config)
+        for step in config.get_steps("kubernetes"):
+            context.set_step_phase(step.name, step.phase or "setup")
+        context.set_requested_phases({"setup", "test", "teardown"})
+        context.set_current_phase("test", config.get_phases("kubernetes"))
+        context.set_step_output("setup", {"kubernetes": {"node_count": 3}})
+        context.set_step_output(
+            "update_test_node_pool",
+            {"label_selector": "eks.amazonaws.com/nodegroup=isv-test-pool"},
+        )
+        assert context.render_string(node_count) == "3"
+        assert context.render_string(exclude_selector) == "eks.amazonaws.com/nodegroup=isv-test-pool"
+        assert context.get_warnings() == []
         assert result["tests"]["platform"] == "kubernetes"
 
     def test_aws_bare_metal_overrides_serial_console_retention_check(self) -> None:

--- a/isvtest/src/isvtest/validations/k8s_nodes.py
+++ b/isvtest/src/isvtest/validations/k8s_nodes.py
@@ -9,6 +9,7 @@
 # its affiliates is strictly prohibited.
 
 import json
+import shlex
 from typing import ClassVar
 
 from isvtest.core.k8s import get_kubectl_base_shell
@@ -16,43 +17,133 @@ from isvtest.core.validation import BaseValidation
 
 
 class K8sNodeCountCheck(BaseValidation):
+    """Verify the cluster has the expected number of nodes.
+
+    Config keys:
+    * ``count`` - exact expected count. Optional when ``min_count`` is set.
+    * ``min_count`` - minimum accepted count. Optional when ``count`` is set.
+    * ``label_selector`` - optional kubectl selector limiting counted nodes.
+    * ``exclude_label_selector`` - optional kubectl selector for nodes to
+      subtract from the count. When ``label_selector`` is also set, only nodes
+      matching both selectors are subtracted.
+    """
+
     description = "Verify the cluster has the expected number of nodes."
     markers: ClassVar[list[str]] = ["kubernetes"]
 
     def run(self) -> None:
         expected_count = self.config.get("count")
-        if expected_count is None:
-            self.log.info("Skipping: expected count not configured")
-            self.set_passed("Skipped: expected count not configured")
+        min_count = self.config.get("min_count")
+        if expected_count is None and min_count is None:
+            self.log.info("Skipping: expected count/min_count not configured")
+            self.set_passed("Skipped: expected count/min_count not configured")
+            return
+        if expected_count is not None and min_count is not None:
+            self.set_failed("Configure only one of 'count' or 'min_count'")
             return
 
-        # Convert to int (Jinja2 templating may produce strings)
+        expected = self._coerce_non_negative_int(expected_count, "count") if expected_count is not None else None
+        minimum = self._coerce_non_negative_int(min_count, "min_count") if min_count is not None else None
+        if self._error:
+            return
+
         try:
-            expected_count = int(expected_count)
-        except (ValueError, TypeError):
-            self.set_failed(f"Invalid expected count: {expected_count}")
+            label_selector = _optional_selector(self.config.get("label_selector"), "label_selector")
+            exclude_selector = _optional_selector(self.config.get("exclude_label_selector"), "exclude_label_selector")
+        except ValueError as exc:
+            self.set_failed(str(exc))
             return
 
-        kubectl_base = get_kubectl_base_shell()
-        cmd = f"{kubectl_base} get nodes --no-headers | wc -l"
+        node_names = self._get_node_names(label_selector)
+        if node_names is None:
+            return
+
+        counted_nodes = set(node_names)
+        if exclude_selector:
+            subtract_selector = _combine_label_selectors(label_selector, exclude_selector)
+            excluded_names = self._get_node_names(subtract_selector)
+            if excluded_names is None:
+                return
+            counted_nodes -= set(excluded_names)
+
+        actual_count = len(counted_nodes)
+        scope = _scope_description(label_selector, exclude_selector)
+
+        if expected is not None:
+            if actual_count != expected:
+                self.set_failed(f"Node count mismatch{scope}: expected {expected}, found {actual_count}")
+                return
+            self.set_passed(f"Node count matched{scope}: {actual_count}")
+            return
+
+        if minimum is not None and actual_count < minimum:
+            self.set_failed(f"Node count below minimum{scope}: expected at least {minimum}, found {actual_count}")
+            return
+        self.set_passed(f"Node count matched{scope}: {actual_count} >= {minimum}")
+
+    def _coerce_non_negative_int(self, value: object, field: str) -> int:
+        """Coerce config values from YAML/Jinja strings to a non-negative integer."""
+        if isinstance(value, bool):
+            self.set_failed(f"Invalid {field}: {value!r}")
+            return 0
+        try:
+            parsed = int(value)
+        except (ValueError, TypeError):
+            self.set_failed(f"Invalid {field}: {value}")
+            return 0
+        if parsed < 0:
+            self.set_failed(f"Invalid {field}: {parsed} (must be >= 0)")
+            return 0
+        return parsed
+
+    def _get_node_names(self, label_selector: str | None) -> list[str] | None:
+        """Return node names matching ``label_selector`` or set failure."""
+        selector_args = f" -l {shlex.quote(label_selector)}" if label_selector else ""
+        cmd = f"{get_kubectl_base_shell()} get nodes{selector_args} -o name"
 
         result = self.run_command(cmd)
-
         if result.exit_code != 0:
             self.set_failed(f"Failed to get node count: {result.stderr}")
-            return
+            return None
 
-        try:
-            actual_count = int(result.stdout.strip())
-        except ValueError:
-            self.set_failed(f"Invalid node count output: {result.stdout}")
-            return
+        return _parse_kubectl_name_output(result.stdout)
 
-        if actual_count != expected_count:
-            self.set_failed(f"Node count mismatch: expected {expected_count}, found {actual_count}")
-            return
 
-        self.set_passed(f"Node count matched: {actual_count}")
+def _optional_selector(value: object, field: str) -> str | None:
+    """Return a stripped label selector or ``None`` for unset/blank values."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"Invalid {field}: expected string, got {type(value).__name__}")
+    stripped = value.strip()
+    return stripped or None
+
+
+def _combine_label_selectors(*selectors: str | None) -> str | None:
+    """Combine label selectors with Kubernetes AND semantics."""
+    parts = [selector.strip().strip(",") for selector in selectors if selector and selector.strip().strip(",")]
+    return ",".join(parts) if parts else None
+
+
+def _parse_kubectl_name_output(stdout: str) -> list[str]:
+    """Parse ``kubectl get nodes -o name`` output into bare node names."""
+    names: list[str] = []
+    for line in stdout.splitlines():
+        item = line.strip()
+        if not item:
+            continue
+        names.append(item.split("/", 1)[1] if "/" in item else item)
+    return names
+
+
+def _scope_description(label_selector: str | None, exclude_selector: str | None) -> str:
+    """Format selector scope for pass/fail messages."""
+    parts: list[str] = []
+    if label_selector:
+        parts.append(f"selector={label_selector!r}")
+    if exclude_selector:
+        parts.append(f"excluding={exclude_selector!r}")
+    return f" ({', '.join(parts)})" if parts else ""
 
 
 class K8sNodeReadyCheck(BaseValidation):

--- a/isvtest/tests/test_k8s_nodes.py
+++ b/isvtest/tests/test_k8s_nodes.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Unit tests for ``isvtest.validations.k8s_nodes``."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from isvtest.core.runners import CommandResult, Runner
+from isvtest.validations.k8s_nodes import (
+    K8sNodeCountCheck,
+    _combine_label_selectors,
+    _parse_kubectl_name_output,
+)
+
+
+def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    """Return a successful ``CommandResult`` with the given stdout/stderr."""
+    return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _fail(stderr: str = "boom") -> CommandResult:
+    """Return a failing ``CommandResult``."""
+    return CommandResult(exit_code=1, stdout="", stderr=stderr, duration=0.0)
+
+
+class StubRunner(Runner):
+    """Runner that returns preloaded command results and records commands."""
+
+    def __init__(self, responses: list[CommandResult]) -> None:
+        self.responses = list(responses)
+        self.commands: list[str | list[str]] = []
+
+    def run(self, cmd: str | list[str], timeout: int = 60) -> CommandResult:
+        self.commands.append(cmd)
+        return self.responses.pop(0)
+
+
+def _run_check(config: dict[str, object], responses: list[CommandResult]) -> tuple[dict[str, object], StubRunner]:
+    runner = StubRunner(responses)
+    check = K8sNodeCountCheck(runner=runner, config=config)
+    with patch("isvtest.validations.k8s_nodes.get_kubectl_base_shell", return_value="kubectl"):
+        result = check.execute()
+    return result, runner
+
+
+def test_parse_kubectl_name_output_strips_kind_prefix() -> None:
+    """Verify _parse_kubectl_name_output strips the 'kind/' prefix from names."""
+    assert _parse_kubectl_name_output("node/base-1\nnode/base-2\n\n") == ["base-1", "base-2"]
+
+
+def test_combine_label_selectors_uses_and_semantics() -> None:
+    """Verify label selectors are combined with Kubernetes AND semantics."""
+    assert _combine_label_selectors("role=gpu", "pool=test") == "role=gpu,pool=test"
+
+
+def test_node_count_exact_count_passes() -> None:
+    """Verify an exact node count match passes."""
+    result, runner = _run_check({"count": 2}, [_ok("node/base-1\nnode/base-2\n")])
+
+    assert result["passed"] is True
+    assert result["output"] == "Node count matched: 2"
+    assert runner.commands == ["kubectl get nodes -o name"]
+
+
+def test_node_count_with_label_selector_counts_scoped_nodes() -> None:
+    """Verify node counting honors the configured label selector."""
+    result, runner = _run_check(
+        {"count": 1, "label_selector": "nvidia.com/gpu.present=true"},
+        [_ok("node/gpu-1\n")],
+    )
+
+    assert result["passed"] is True
+    assert runner.commands == ["kubectl get nodes -l nvidia.com/gpu.present=true -o name"]
+
+
+def test_node_count_excludes_matching_nodes() -> None:
+    """Verify node counting excludes nodes that match the exclusion selector."""
+    result, runner = _run_check(
+        {"count": 2, "exclude_label_selector": "isv.ncp.validation/workload=data-ingest"},
+        [
+            _ok("node/base-1\nnode/base-2\nnode/test-1\nnode/test-2\n"),
+            _ok("node/test-1\nnode/test-2\n"),
+        ],
+    )
+
+    assert result["passed"] is True
+    assert result["output"] == "Node count matched (excluding='isv.ncp.validation/workload=data-ingest'): 2"
+    assert runner.commands == [
+        "kubectl get nodes -o name",
+        "kubectl get nodes -l isv.ncp.validation/workload=data-ingest -o name",
+    ]
+
+
+def test_exclusion_is_intersected_with_label_selector() -> None:
+    """Verify exclusion selectors are scoped by the primary label selector."""
+    result, runner = _run_check(
+        {
+            "count": 1,
+            "label_selector": "node-role.kubernetes.io/worker=true",
+            "exclude_label_selector": "pool=test",
+        },
+        [
+            _ok("node/worker-1\nnode/test-1\n"),
+            _ok("node/test-1\n"),
+        ],
+    )
+
+    assert result["passed"] is True
+    assert runner.commands == [
+        "kubectl get nodes -l node-role.kubernetes.io/worker=true -o name",
+        "kubectl get nodes -l node-role.kubernetes.io/worker=true,pool=test -o name",
+    ]
+
+
+def test_node_count_min_count_passes_when_actual_is_higher() -> None:
+    """Verify min_count passes when the actual node count is higher."""
+    result, _runner = _run_check({"min_count": 2}, [_ok("node/base-1\nnode/base-2\nnode/extra\n")])
+
+    assert result["passed"] is True
+    assert result["output"] == "Node count matched: 3 >= 2"
+
+
+def test_node_count_mismatch_fails() -> None:
+    """Verify mismatched exact node counts fail with a clear error."""
+    result, _runner = _run_check({"count": 3}, [_ok("node/base-1\nnode/base-2\n")])
+
+    assert result["passed"] is False
+    assert result["error"] == "Node count mismatch: expected 3, found 2"
+
+
+def test_node_count_fails_when_kubectl_fails() -> None:
+    """Verify kubectl failures are reported as node count failures."""
+    result, _runner = _run_check({"count": 1}, [_fail("cluster unavailable")])
+
+    assert result["passed"] is False
+    assert result["error"] == "Failed to get node count: cluster unavailable"
+
+
+def test_node_count_rejects_count_and_min_count_together() -> None:
+    """Verify count and min_count cannot be configured together."""
+    result, _runner = _run_check({"count": 1, "min_count": 1}, [])
+
+    assert result["passed"] is False
+    assert result["error"] == "Configure only one of 'count' or 'min_count'"

--- a/isvtest/tests/test_main.py
+++ b/isvtest/tests/test_main.py
@@ -175,6 +175,73 @@ class TestTransformValidationsForPytest:
         # for this phase, it keeps the bare class name.
         assert keys == ["InstanceStateCheck"]
 
+    def test_list_entries_infer_distinct_phases_from_steps(self) -> None:
+        """Repeated checks can validate separate lifecycle operations."""
+        step_outputs = {
+            "create_test_node_pool": {"expected_replicas": 1},
+            "update_test_node_pool": {"expected_replicas": 2},
+        }
+        step_phases = {
+            "create_test_node_pool": "setup",
+            "update_test_node_pool": "test",
+        }
+        validations: dict[str, Any] = {
+            "k8s_node_pools": [
+                {
+                    "K8sNodePoolCheck": {
+                        "step": "create_test_node_pool",
+                        "expected_replicas": 1,
+                    }
+                },
+                {
+                    "K8sNodePoolCheck": {
+                        "step": "update_test_node_pool",
+                        "expected_replicas": 2,
+                    }
+                },
+            ],
+        }
+
+        setup_result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "setup")
+        test_result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
+
+        setup_params = setup_result[0]["K8sNodePoolCheck"]
+        test_params = test_result[0]["K8sNodePoolCheck"]
+        assert setup_params["expected_replicas"] == 1
+        assert setup_params["step_output"] == step_outputs["create_test_node_pool"]
+        assert test_params["expected_replicas"] == 2
+        assert test_params["step_output"] == step_outputs["update_test_node_pool"]
+
+    def test_step_scoped_checks_preserve_order_before_default_test_checks(self) -> None:
+        """A phase-scoped convergence check can gate later default test checks."""
+        step_outputs = {
+            "update_test_node_pool": {"expected_replicas": 2},
+        }
+        step_phases = {
+            "update_test_node_pool": "test",
+        }
+        validations: dict[str, Any] = {
+            "k8s_node_pools": [
+                {
+                    "K8sNodePoolCheck": {
+                        "step": "update_test_node_pool",
+                        "expected_replicas": 2,
+                    }
+                }
+            ],
+            "k8s_workloads": {
+                "checks": {
+                    "K8sGpuStressWorkload": {
+                        "timeout": 300,
+                    }
+                }
+            },
+        }
+
+        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
+
+        assert self._keys(result) == ["K8sNodePoolCheck", "K8sGpuStressWorkload"]
+
     def test_empty_validations(self) -> None:
         """Empty input returns empty list."""
         assert _transform_validations_for_pytest({}, {}, {}, "test") == []


### PR DESCRIPTION
## Summary

Keeps the provider-agnostic node-pool CRUD checks ordered around the lifecycle boundary so setup validates the create state before the EKS test pool is scaled in the test phase. Also scopes the generic K8s node count check away from the temporary test pool.

## Changes

- Adds explicit `step` bindings to the two `K8sNodePoolCheck` entries and keeps them before the regular Kubernetes checks so phase-scoped convergence gates later checks.
- Moves `update_test_node_pool` to the AWS EKS `test` phase and excludes its selector from the baseline `K8sNodeCountCheck`.
- Extends `K8sNodeCountCheck` with `min_count`, label selector, and exclusion selector support.
- Adds coverage for phase inference, node-count selector behavior, and AWS config merge rendering.

## Validation

- [x] `uv run pytest isvtest/tests/test_main.py isvtest/tests/test_k8s_nodes.py isvctl/tests/test_merger.py` - 69 passed
- [x] Live `isvctl test run` against an EKS cluster

## Test plan

- [x] Confirm create/update node-pool checks infer separate phases from their bound steps.
- [x] Confirm the update pool check runs before default test-phase checks.
- [x] Confirm the generic node count check can exclude temporary test-pool nodes.
- [x] Confirm `isvctl/configs/providers/aws/config/eks.yaml` works against a live EKS cluster.

Generated with [Codex](https://openai.com/codex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node-pool scaling now runs after baseline checks; provider-agnostic node-pool convergence checks are explicitly bound to provisioning phases.
  * Node-count checks accept exact or minimum counts, support templated expected counts, can exclude nodes by label selectors, and count nodes by parsing names (not line counts).

* **Tests**
  * Added unit and integration tests covering node-count parsing, selector combination/exclusion, min-count behavior, phase-scoped validation emission, and related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->