### PR TITLE
feat: add catalog list command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,18 @@ Config (YAML) → Script (any language) → JSON output → Validations (asserti
    `"{{region}}"`. The orchestrator warns when a template references a missing step or
    field (catches `ChainableUndefined` silent fallbacks).
 
+### JSON contract discipline
+
+- Test stdout JSON is the provider-neutral contract between scripts and
+  validations. Use ISV-agnostic names and avoid AWS-specific resource concepts
+  unless a validation or later step consumes them.
+- Keep output minimal: `success`, `platform`, `test_name`, and
+  `tests.<check>.passed/message/probes` are usually enough. Omit IDs, regions,
+  endpoint inventories, and other fields that do not affect behavior.
+- Failure/skip diagnostics are allowed, but keep them concise and generic:
+  top-level `error`/`error_type`, `tests.<check>.error`, `skip_reason`, or
+  `cleanup_errors`. Avoid raw provider responses and resource dumps.
+
 ### Lifecycle invariants (non-obvious)
 
 - Phases run in order: `setup → test → teardown`.

--- a/isvctl/src/isvctl/cli/catalog.py
+++ b/isvctl/src/isvctl/cli/catalog.py
@@ -19,6 +19,9 @@ from typing import Annotated
 
 import typer
 from isvtest.catalog import build_catalog, get_catalog_version
+from isvtest.release_manifest import load_released_tests
+from rich.console import Console
+from rich.table import Table
 
 from isvctl.cli import setup_logging
 from isvctl.cli.common import get_output_dir
@@ -30,6 +33,65 @@ app = typer.Typer(
     help="Manage the test catalog for coverage tracking",
     no_args_is_help=True,
 )
+
+console = Console()
+
+
+@app.command("list")
+def list_cmd(
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit the catalog as JSON instead of a table"),
+    ] = False,
+    unreleased: Annotated[
+        bool,
+        typer.Option("--unreleased", help="Show only tests not present in the release manifest"),
+    ] = False,
+) -> None:
+    """List the tests that would be uploaded by `isvctl catalog push`.
+
+    Released tests only by default. Set ``ISVTEST_INCLUDE_UNRELEASED=1`` to
+    include unreleased validations (matches the gate used at run time and by
+    `catalog push`), or use ``--unreleased`` to list only unreleased tests.
+
+    Examples:
+        isvctl catalog list
+        isvctl catalog list --json
+        isvctl catalog list --unreleased
+        ISVTEST_INCLUDE_UNRELEASED=1 isvctl catalog list
+    """
+    if unreleased:
+        released_tests = load_released_tests()
+        catalog_entries = [entry for entry in build_catalog(released_only=False) if entry["name"] not in released_tests]
+    else:
+        catalog_entries = build_catalog()
+    catalog_version = get_catalog_version()
+
+    if json_output:
+        typer.echo(json.dumps({"isvTestVersion": catalog_version, "entries": catalog_entries}, indent=2))
+        return
+
+    table = Table(
+        title=f"Test Catalog ({len(catalog_entries)} tests, version {catalog_version})",
+        title_justify="left",
+        show_header=True,
+        header_style="bold",
+        padding=(0, 1),
+    )
+    table.add_column("Test", style="green", no_wrap=True)
+    table.add_column("Platforms", style="cyan")
+    table.add_column("Markers", style="dim")
+    table.add_column("Description")
+
+    for entry in sorted(catalog_entries, key=lambda e: e["name"]):
+        table.add_row(
+            entry["name"],
+            ", ".join(entry.get("platforms") or []) or "-",
+            ", ".join(entry.get("markers") or []) or "-",
+            entry.get("description") or "-",
+        )
+
+    console.print(table)
 
 
 @app.command("push")

--- a/isvctl/tests/test_catalog_cli.py
+++ b/isvctl/tests/test_catalog_cli.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Unit tests for the catalog CLI subcommand."""
+
+import json
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from isvctl.cli.catalog import app
+
+runner = CliRunner()
+
+_FAKE_ENTRIES = [
+    {
+        "name": "AlphaCheck",
+        "description": "Alpha description",
+        "markers": ["kubernetes"],
+        "module": "isvtest.validations.alpha",
+        "platforms": ["KUBERNETES"],
+    },
+    {
+        "name": "BetaCheck",
+        "description": "",
+        "markers": [],
+        "module": "isvtest.validations.beta",
+        "platforms": [],
+    },
+]
+
+
+def test_catalog_help() -> None:
+    """Top-level catalog help mentions the new list command."""
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "list" in result.output
+
+
+def test_catalog_list_table() -> None:
+    """`catalog list` renders a table containing the discovered tests."""
+    with (
+        patch("isvctl.cli.catalog.build_catalog", return_value=_FAKE_ENTRIES),
+        patch("isvctl.cli.catalog.get_catalog_version", return_value="1.2.3"),
+    ):
+        result = runner.invoke(app, ["list"])
+
+    assert result.exit_code == 0, result.output
+    assert "AlphaCheck" in result.output
+    assert "BetaCheck" in result.output
+    assert "1.2.3" in result.output
+
+
+def test_catalog_list_json() -> None:
+    """`catalog list --json` emits parseable JSON matching the saved artifact shape."""
+    with (
+        patch("isvctl.cli.catalog.build_catalog", return_value=_FAKE_ENTRIES),
+        patch("isvctl.cli.catalog.get_catalog_version", return_value="1.2.3"),
+    ):
+        result = runner.invoke(app, ["list", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["isvTestVersion"] == "1.2.3"
+    assert payload["entries"] == _FAKE_ENTRIES
+
+
+def test_catalog_list_unreleased_json() -> None:
+    """`catalog list --unreleased` emits only entries missing from the release manifest."""
+    with (
+        patch("isvctl.cli.catalog.build_catalog", return_value=_FAKE_ENTRIES) as build_catalog,
+        patch("isvctl.cli.catalog.load_released_tests", return_value={"AlphaCheck"}),
+        patch("isvctl.cli.catalog.get_catalog_version", return_value="1.2.3"),
+    ):
+        result = runner.invoke(app, ["list", "--unreleased", "--json"])
+
+    assert result.exit_code == 0, result.output
+    build_catalog.assert_called_once_with(released_only=False)
+    payload = json.loads(result.output)
+    assert payload["entries"] == [_FAKE_ENTRIES[1]]


### PR DESCRIPTION
## Summary
- Add `isvctl catalog list` with table and JSON output for inspecting catalog entries locally.
- Add `--unreleased` filtering to show catalog entries not present in the release manifest.
- Document provider-neutral, minimal JSON output guidance for future validation scripts.

## Test plan
- [x] `uv run pytest isvctl/tests/test_catalog_cli.py`
- [x] Pre-commit hooks passed during commits


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `isvctl catalog list` command to display catalog entries as a formatted table or JSON output using `--json` flag.
  * Added `--unreleased` option to filter and display only unreleased catalog entries.

* **Documentation**
  * Added JSON contract discipline guidelines for step script output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->