### PR TITLE
chore: show useful stderr for failed steps

### DIFF
--- a/isvctl/src/isvctl/orchestrator/step_executor.py
+++ b/isvctl/src/isvctl/orchestrator/step_executor.py
@@ -55,12 +55,14 @@ from typing import Any
 from isvctl.config.output_schemas import get_schema_for_step, validate_output
 from isvctl.config.schema import StepConfig
 from isvctl.orchestrator.context import Context, _create_jinja_env
-from isvctl.redaction import mask_sensitive_args
+from isvctl.redaction import mask_sensitive_args, redact_text
 
 logger = logging.getLogger(__name__)
 
 
 _STEP_PATH_RE = re.compile(r"steps\.([\w.]+)")
+_STDERR_EXCERPT_HEAD_LINES = 20
+_STDERR_EXCERPT_TAIL_LINES = 80
 
 
 class MissingStepRefError(Exception):
@@ -79,6 +81,35 @@ class MissingStepRefError(Exception):
         super().__init__(
             f"template arg {arg!r} references undefined step output 'steps.{path}' with no `| default(...)` fallback"
         )
+
+
+def _format_stderr_excerpt(
+    stderr: str,
+    *,
+    head_lines: int = _STDERR_EXCERPT_HEAD_LINES,
+    tail_lines: int = _STDERR_EXCERPT_TAIL_LINES,
+) -> str:
+    """Return a redacted, line-based stderr excerpt for CLI error summaries."""
+    redacted = redact_text(stderr.strip())
+    if not redacted:
+        return ""
+
+    lines = redacted.splitlines()
+    max_lines = head_lines + tail_lines
+    if len(lines) <= max_lines:
+        return redacted
+
+    head = lines[:head_lines]
+    tail = lines[-tail_lines:] if tail_lines else []
+    omitted = len(lines) - len(head) - len(tail)
+    marker = f"... stderr truncated; omitted {omitted} lines (showing first {len(head)} and last {len(tail)}) ..."
+    return "\n".join(head + [marker] + tail)
+
+
+def _write_full_stderr(step_name: str, stderr: str) -> None:
+    """Write full redacted stderr for a failed step when verbose logging is enabled."""
+    redacted = redact_text(stderr.rstrip())
+    sys.stderr.write(f"\n--- stderr from step '{step_name}' ---\n{redacted}\n--- end stderr ---\n")
 
 
 def _find_missing_step_path(arg: str, steps_data: dict[str, Any]) -> str | None:
@@ -452,7 +483,9 @@ class StepExecutor:
                 else:
                     step_result.error = f"Command exited with code {result.returncode}"
                     if result.stderr:
-                        step_result.error += f": {result.stderr.strip()[:200]}"
+                        step_result.error += f": {_format_stderr_excerpt(result.stderr)}"
+                if result.stderr and logger.isEnabledFor(logging.DEBUG):
+                    _write_full_stderr(step.name, result.stderr)
                 return step_result
 
             # Validate against explicit or auto-detected schema

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -21,6 +21,7 @@ from isvctl.orchestrator.step_executor import (
     MissingStepRefError,
     StepExecutor,
     _find_missing_step_path,
+    _format_stderr_excerpt,
 )
 
 
@@ -479,6 +480,69 @@ class TestStepExecutorBestEffort:
 
         executed = [s.name for s in results.steps]
         assert executed == ["fail_step", "ok_step"]
+
+
+_NOISY_FAILING_SCRIPT = """#!/bin/sh
+i=0
+while [ "$i" -le 104 ]; do
+  echo "stderr line $i" >&2
+  i=$((i + 1))
+done
+echo "AWS_SECRET_ACCESS_KEY=super-secret" >&2
+exit 7
+"""
+
+
+class TestStderrExcerpt:
+    """Tests for failed-step stderr excerpts."""
+
+    def test_short_excerpt_preserves_lines_and_redacts_secrets(self) -> None:
+        """Short stderr is preserved while sensitive key/value pairs are masked."""
+        excerpt = _format_stderr_excerpt(
+            "first line\nAWS_SECRET_ACCESS_KEY=super-secret\nlast line\n",
+            head_lines=2,
+            tail_lines=2,
+        )
+
+        assert "first line" in excerpt
+        assert "last line" in excerpt
+        assert "AWS_SECRET_ACCESS_KEY=***" in excerpt
+        assert "super-secret" not in excerpt
+
+    def test_long_excerpt_keeps_head_and_tail_lines(self) -> None:
+        """Long stderr keeps early context and trailing root-cause lines."""
+        stderr = "\n".join(f"stderr line {i}" for i in range(10))
+
+        excerpt = _format_stderr_excerpt(stderr, head_lines=2, tail_lines=3)
+
+        assert "stderr line 0" in excerpt
+        assert "stderr line 1" in excerpt
+        assert "stderr line 2" not in excerpt
+        assert "stderr line 6" not in excerpt
+        assert "stderr line 7" in excerpt
+        assert "stderr line 9" in excerpt
+        assert "omitted 5 lines" in excerpt
+
+    def test_failed_step_error_uses_redacted_head_tail_stderr(self, tmp_path: Path) -> None:
+        """Failed command summaries use the redacted line-based stderr excerpt."""
+        script_path = tmp_path / "noisy_fail.sh"
+        script_path.write_text(_NOISY_FAILING_SCRIPT)
+        script_path.chmod(0o755)
+
+        executor = StepExecutor()
+        context = Context(RunConfig())
+        steps = [StepConfig(name="fail_step", command=str(script_path), phase="setup")]
+
+        results = executor.execute_steps(steps, context)
+
+        error = results.steps[0].error or ""
+        assert "Command exited with code 7" in error
+        assert "stderr line 0" in error
+        assert "stderr line 20" not in error
+        assert "stderr line 104" in error
+        assert "AWS_SECRET_ACCESS_KEY=***" in error
+        assert "super-secret" not in error
+        assert "stderr truncated" in error
 
 
 class TestMissingStepRefDetection:


### PR DESCRIPTION
## Summary

Surface a redacted, head/tail stderr excerpt when a step exits non-zero so users can diagnose failures from the CLI summary instead of having to re-run with debug logging. The previous summary truncated stderr to the first 200 characters, which often clipped before the root-cause line.

## Changes

- Adds `_format_stderr_excerpt` in `isvctl/src/isvctl/orchestrator/step_executor.py` that strips, redacts, and keeps the first 20 / last 80 lines of stderr, with a marker noting how many lines were omitted.
- Replaces the 200-char truncation in the failed-command summary with the new excerpt.
- Adds `_write_full_stderr` to dump the full redacted stderr to `sys.stderr` when debug logging is enabled, so verbose runs still get everything.
- Adds focused tests in `isvctl/tests/test_orchestrator_loop.py` covering short-input redaction, long-input head/tail behaviour, and an end-to-end failed step that exercises both excerpt formatting and secret redaction.

## Validation

- [x] `make test`
- [x] `make lint`

## Test plan

- [x] Confirm a failed step's CLI error now includes the redacted head/tail excerpt instead of a 200-char prefix.
- [x] Confirm secrets in stderr (e.g. `AWS_SECRET_ACCESS_KEY=...`) are masked in both the summary and the debug-log dump.
- [x] Confirm short stderr is preserved verbatim and only long stderr is truncated with the omitted-lines marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for failed steps by including redacted, truncated stderr excerpts that preserve head/tail context and show omitted-line notices while hiding sensitive data.
  * Enhanced debug/verbose logging to record the full redacted stderr when troubleshooting.

* **Tests**
  * Added tests covering stderr excerpting, truncation behavior, and redaction in various short/long and failing-step scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->