### PR TITLE
fix: restrict EKS API endpoint allowlist

### DIFF
--- a/isvctl/configs/providers/aws/config/eks.yaml
+++ b/isvctl/configs/providers/aws/config/eks.yaml
@@ -47,8 +47,6 @@ commands:
           TF_VAR_region: "us-west-2"
           TF_VAR_gpu_node_instance_types: '["g5.2xlarge"]'
           TF_VAR_gpu_node_desired_size: "1"
-          # Override with your IP for security
-          TF_VAR_cluster_endpoint_public_access_cidrs: '["0.0.0.0/0"]'
 
       # Test the Terraform node-pool create path. Runs after the
       # cluster is up; reads cluster state via terraform_remote_state in the

--- a/isvctl/configs/providers/aws/scripts/eks/docs/aws-eks.md
+++ b/isvctl/configs/providers/aws/scripts/eks/docs/aws-eks.md
@@ -26,6 +26,9 @@ terraform --version
 # kubectl (or set KUBECTL env var to use an alternative CLI, e.g., "oc")
 kubectl version --client
 
+# curl (used to auto-detect your public IP for the EKS API allowlist)
+curl --version
+
 # Helm (v3)
 helm version
 
@@ -131,6 +134,11 @@ TF_VAR_gpu_node_desired_size=2 \
   uv run isvctl test run -f isvctl/configs/providers/aws/config/eks.yaml --phase setup
 ```
 
+By default, setup auto-detects the caller's public IPv4 address and passes
+`TF_VAR_cluster_endpoint_public_access_cidrs='["<detected-ip>/32"]'` to Terraform.
+Set `TF_VAR_cluster_endpoint_public_access_cidrs` yourself when running from a
+known VPN, proxy, or CI egress range.
+
 Or create a custom config file:
 
 ```yaml
@@ -164,7 +172,7 @@ uv run isvctl test run -f isvctl/configs/providers/aws/config/eks.yaml -f my-aws
 | `TF_VAR_gpu_node_desired_size` | 1 | Number of GPU nodes |
 | `TF_VAR_system_node_instance_types` | ["m5.large"] | System node instance types |
 | `TF_VAR_system_node_desired_size` | 2 | Number of system nodes |
-| `TF_VAR_cluster_endpoint_public_access_cidrs` | ["203.0.113.0/24"] | **Required**: Your IP allowlist for EKS API |
+| `TF_VAR_cluster_endpoint_public_access_cidrs` | Auto-detected caller IPv4 `/32` | EKS API allowlist; override for VPN/proxy/CI egress ranges |
 | `TF_VAR_enable_efs` | true | Enable EFS for NIM cache |
 
 #### Supported GPU Instance Types
@@ -347,13 +355,17 @@ echo "=== VALIDATION COMPLETE ==="
 If you can't connect to the cluster:
 
 ```bash
-# Check your IP is in the allowlist
-curl ifconfig.me
+# Check the public IP your shell is using
+curl https://checkip.amazonaws.com
 
 # Update allowlist
 TF_VAR_cluster_endpoint_public_access_cidrs='["YOUR.IP/32"]' \
   terraform apply
 ```
+
+Clusters created with older versions of this config may still have
+`0.0.0.0/0` in the EKS API allowlist. Re-apply Terraform with a restricted
+CIDR, or run the EKS teardown phase and create the cluster again.
 
 ### Test Failures
 

--- a/isvctl/configs/providers/aws/scripts/eks/setup.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/setup.sh
@@ -19,15 +19,80 @@
 #   - AWS CLI configured with appropriate credentials
 #   - kubectl
 #   - jq
+#   - curl (unless TF_VAR_cluster_endpoint_public_access_cidrs is set)
 #
 # Environment Variables:
 #   - TF_VAR_*: Terraform variables (e.g., TF_VAR_region, TF_VAR_gpu_node_instance_types)
+#   - TF_VAR_cluster_endpoint_public_access_cidrs: Optional EKS API allowlist.
+#     Defaults to the caller's auto-detected public IPv4 /32.
 #   - TF_AUTO_APPROVE: Set to "true" to skip Terraform approval prompt (default: false)
 #   - SKIP_PREFLIGHT: Set to "true" to skip infrastructure validation (default: false)
 #
 # Output: JSON inventory conforming to isvctl schema
 
 set -eo pipefail
+
+is_ipv4_address() {
+    local ip="$1"
+    local IFS=.
+    local -a octets
+
+    [[ "$ip" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]] || return 1
+    read -r -a octets <<< "$ip"
+    [ "${#octets[@]}" -eq 4 ] || return 1
+
+    for octet in "${octets[@]}"; do
+        if ((10#$octet > 255)); then
+            return 1
+        fi
+    done
+
+    return 0
+}
+
+detect_public_ipv4() {
+    local url
+    local ip
+
+    for url in \
+        "https://checkip.amazonaws.com" \
+        "https://api.ipify.org" \
+        "https://ifconfig.me/ip"; do
+        ip="$(curl -fsS --max-time 5 "$url" 2>/dev/null | tr -d '[:space:]' || true)"
+        if is_ipv4_address "$ip"; then
+            echo "$ip"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+configure_eks_endpoint_allowlist() {
+    if [ -n "${TF_VAR_cluster_endpoint_public_access_cidrs:-}" ]; then
+        echo "Configured EKS API allowlist for Terraform: ${TF_VAR_cluster_endpoint_public_access_cidrs}" >&2
+        return
+    fi
+
+    if ! command -v curl &> /dev/null; then
+        echo "Error: curl not found - required to auto-detect the EKS API allowlist." >&2
+        echo "Set TF_VAR_cluster_endpoint_public_access_cidrs='[\"YOUR.IP.ADDRESS/32\"]' to bypass detection." >&2
+        exit 1
+    fi
+
+    echo "Detecting caller public IPv4 for EKS API allowlist..." >&2
+
+    local public_ip
+    public_ip="$(detect_public_ipv4 || true)"
+    if [ -z "$public_ip" ]; then
+        echo "Error: Could not auto-detect caller public IPv4 for the EKS API allowlist." >&2
+        echo "Set TF_VAR_cluster_endpoint_public_access_cidrs='[\"YOUR.IP.ADDRESS/32\"]' and retry." >&2
+        exit 1
+    fi
+
+    export TF_VAR_cluster_endpoint_public_access_cidrs="[\"${public_ip}/32\"]"
+    echo "Configured EKS API allowlist for Terraform: ${TF_VAR_cluster_endpoint_public_access_cidrs}" >&2
+}
 
 # Get script directory for relative paths
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -68,6 +133,8 @@ if ! aws sts get-caller-identity &> /dev/null 2>&1; then
     echo "Error: AWS credentials not configured" >&2
     exit 1
 fi
+
+configure_eks_endpoint_allowlist
 
 # -----------------------------------------------------------------------------
 # Terraform Provisioning
@@ -163,6 +230,10 @@ aws eks update-kubeconfig --name "$EKS_CLUSTER_NAME" --region "$AWS_REGION" >&2
 
 if ! kubectl cluster-info &> /dev/null 2>&1; then
     echo "Error: Cannot connect to EKS cluster" >&2
+    echo "Hint: re-running setup against a pre-existing cluster does not push the configured" >&2
+    echo "      EKS API allowlist (TF_VAR_cluster_endpoint_public_access_cidrs). If you are" >&2
+    echo "      running from a different IP than the original apply, run 'terraform apply' in" >&2
+    echo "      $TERRAFORM_DIR or run the teardown phase and re-create the cluster." >&2
     exit 1
 fi
 

--- a/isvctl/tests/test_merger.py
+++ b/isvctl/tests/test_merger.py
@@ -433,6 +433,15 @@ class TestImportEndToEnd:
         assert context.get_warnings() == []
         assert result["tests"]["platform"] == "kubernetes"
 
+    def test_aws_eks_does_not_hardcode_world_open_endpoint_allowlist(self) -> None:
+        """EKS setup must not create clusters that make the security suite fail."""
+        result = merge_yaml_files([self.CONFIGS_DIR / "providers" / "aws" / "config" / "eks.yaml"])
+        setup_step = next(step for step in result["commands"]["kubernetes"]["steps"] if step["name"] == "setup")
+        setup_env = setup_step.get("env", {})
+
+        assert "TF_VAR_cluster_endpoint_public_access_cidrs" not in setup_env
+        assert "0.0.0.0/0" not in str(setup_step)
+
     def test_aws_bare_metal_overrides_serial_console_retention_check(self) -> None:
         """AWS BM must not inherit the retention check until archive evidence exists."""
         result = merge_yaml_files([self.CONFIGS_DIR / "providers" / "aws" / "config" / "bare_metal.yaml"])


### PR DESCRIPTION
## Summary

Stops the AWS EKS reference config from hard-coding `0.0.0.0/0` for the EKS public API endpoint allowlist, which created clusters that immediately failed the security suite. Setup now auto-detects the caller's public IPv4 `/32` and lets operators override for VPN, proxy, or CI egress ranges.

## Changes

- Removes the hard-coded `TF_VAR_cluster_endpoint_public_access_cidrs='["0.0.0.0/0"]'` env override from `isvctl/configs/providers/aws/config/eks.yaml`.
- Adds a `configure_eks_endpoint_allowlist` shell helper to `aws/scripts/eks/setup.sh` that auto-detects the caller's public IPv4 (via `checkip.amazonaws.com`, `api.ipify.org`, `ifconfig.me/ip`), validates the response, and exports `TF_VAR_cluster_endpoint_public_access_cidrs='["<ip>/32"]'` when the variable is unset. Surfaces a clear error and bypass instructions if `curl` is missing or all detection endpoints fail.
- Adds a `kubectl cluster-info` failure hint pointing operators at re-applying Terraform when running from a different IP than the original apply, since setup does not re-push the allowlist against a pre-existing cluster.
- Updates `aws-eks.md` to document the auto-detection behaviour, the new `curl` prerequisite, and a note for clusters created with older versions of this config that may still have `0.0.0.0/0` in the allowlist.
- Adds a merger test asserting the EKS suite does not ship a hard-coded world-open allowlist.

## Validation

- [x] `make test`
- [x] `make format`
- [x] Live `isvctl test run -f isvctl/configs/providers/aws/config/eks.yaml --phase setup` against an AWS account, confirming Terraform receives the auto-detected `/32` and the cluster comes up reachable.

## Test plan

- [x] Live setup with `TF_VAR_cluster_endpoint_public_access_cidrs` unset — confirm the script logs the detected IP and Terraform applies with that `/32`.
- [x] Live setup with `TF_VAR_cluster_endpoint_public_access_cidrs` pre-set — confirm the script honours the override and skips detection.
- [x] Setup on a host without `curl` and no override — confirm the script exits with the bypass instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic detection of public IP address for EKS API endpoint access configuration.

* **Documentation**
  * Enhanced AWS EKS setup guide with IP auto-detection behavior explanation and troubleshooting steps.
  * Improved error messaging for cluster connectivity issues.

* **Bug Fixes**
  * Removed hardcoded world-open endpoint allowlist configuration.

* **Tests**
  * Added validation to prevent world-open endpoint allowlist in future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->