### PR TITLE
test: use tmp_path fixture for script-writing tests

### DIFF
--- a/isvctl/tests/test_orchestrator.py
+++ b/isvctl/tests/test_orchestrator.py
@@ -11,7 +11,6 @@
 """Tests for orchestration components."""
 
 import logging
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -19,6 +18,13 @@ import pytest
 from isvctl.config.schema import CommandConfig, CommandOutput, RunConfig
 from isvctl.orchestrator.commands import CommandExecutor
 from isvctl.orchestrator.context import Context
+
+
+def _write_script(tmp_path: Path, name: str, content: str) -> str:
+    path = tmp_path / name
+    path.write_text(content)
+    path.chmod(0o755)
+    return str(path)
 
 
 class TestCommandExecutor:
@@ -66,33 +72,26 @@ class TestCommandExecutor:
         assert result.success
         assert "nodes=8" in result.stdout
 
-    def test_validate_json_output(self) -> None:
+    def test_validate_json_output(self, tmp_path: Path) -> None:
         """Test JSON output validation."""
         executor = CommandExecutor()
-
-        # Create a script that outputs valid JSON
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
-            f.write(
-                """#!/bin/bash
+        script_path = _write_script(
+            tmp_path,
+            "valid_json.sh",
+            """#!/bin/bash
 cat << 'EOF'
 {"platform": "kubernetes", "cluster_name": "test-123", "kubernetes": {"node_count": 4}}
 EOF
-"""
-            )
-            script_path = f.name
+""",
+        )
 
-        try:
-            Path(script_path).chmod(0o755)
+        config = CommandConfig(command=script_path)
+        result = executor.execute(config, validate_output=True)
 
-            config = CommandConfig(command=script_path)
-            result = executor.execute(config, validate_output=True)
-
-            assert result.success
-            assert result.output is not None
-            assert result.output.platform == "kubernetes"
-            assert result.output.cluster_name == "test-123"
-        finally:
-            Path(script_path).unlink(missing_ok=True)
+        assert result.success
+        assert result.output is not None
+        assert result.output.platform == "kubernetes"
+        assert result.output.cluster_name == "test-123"
 
     def test_validate_invalid_json(self) -> None:
         """Test handling of invalid JSON output."""
@@ -166,31 +165,24 @@ EOF
         assert not result.success
         assert "no output" in result.error
 
-    def test_validate_output_validation_error(self) -> None:
+    def test_validate_output_validation_error(self, tmp_path: Path) -> None:
         """Test handling of pydantic validation errors."""
         executor = CommandExecutor()
-
-        # Create a script that outputs JSON but doesn't match schema
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
-            f.write(
-                """#!/bin/bash
+        script_path = _write_script(
+            tmp_path,
+            "wrong_schema.sh",
+            """#!/bin/bash
 cat << 'EOF'
 {"invalid": "schema"}
 EOF
-"""
-            )
-            script_path = f.name
+""",
+        )
 
-        try:
-            Path(script_path).chmod(0o755)
+        config = CommandConfig(command=script_path)
+        result = executor.execute(config, validate_output=True)
 
-            config = CommandConfig(command=script_path)
-            result = executor.execute(config, validate_output=True)
-
-            assert not result.success
-            assert "validation failed" in result.error
-        finally:
-            Path(script_path).unlink(missing_ok=True)
+        assert not result.success
+        assert "validation failed" in result.error
 
 
 class TestContext:

--- a/isvctl/tests/test_orchestrator.py
+++ b/isvctl/tests/test_orchestrator.py
@@ -21,6 +21,19 @@ from isvctl.orchestrator.context import Context
 
 
 def _write_script(tmp_path: Path, name: str, content: str) -> str:
+    """Create an executable script file under tmp_path and return its path.
+
+    Args:
+        tmp_path: Temporary directory where the script is written.
+        name: Script filename to create.
+        content: Script contents to write.
+
+    Returns:
+        String path to the created script.
+
+    Side effects:
+        Writes the file and sets executable mode 0o755.
+    """
     path = tmp_path / name
     path.write_text(content)
     path.chmod(0o755)

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -10,7 +10,6 @@
 
 """Tests for orchestrator loop."""
 
-import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
@@ -23,6 +22,30 @@ from isvctl.orchestrator.step_executor import (
     _find_missing_step_path,
     _format_stderr_excerpt,
 )
+
+_INVENTORY_SCRIPT = (
+    '#!/bin/bash\necho \'{"success": true, "platform": "kubernetes", '
+    '"cluster_name": "test", "node_count": 1, "kubernetes": {"node_count": 1}}\'\n'
+)
+
+_OK_SCRIPT = "#!/bin/bash\necho '{\"success\": true}'\n"
+
+_NOISY_FAILING_SCRIPT = """#!/bin/sh
+i=0
+while [ "$i" -le 104 ]; do
+  echo "stderr line $i" >&2
+  i=$((i + 1))
+done
+echo "AWS_SECRET_ACCESS_KEY=super-secret" >&2
+exit 7
+"""
+
+
+def _write_script(tmp_path: Path, name: str, content: str) -> str:
+    path = tmp_path / name
+    path.write_text(content)
+    path.chmod(0o755)
+    return str(path)
 
 
 class TestOrchestrator:
@@ -43,45 +66,39 @@ class TestOrchestrator:
         platform = orchestrator._detect_platform()
         assert platform == "kubernetes"
 
-    def test_run_setup_phase_success(self) -> None:
+    def test_run_setup_phase_success(self, tmp_path: Path) -> None:
         """Test successful setup phase execution."""
-        # Create a script that outputs valid JSON inventory
         # Must match the "cluster" schema: success, platform, cluster_name, node_count (at root)
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
-            f.write(
-                """#!/bin/bash
+        script_path = _write_script(
+            tmp_path,
+            "setup_cluster.sh",
+            """#!/bin/bash
 cat << 'EOF'
 {"success": true, "platform": "kubernetes", "cluster_name": "test-cluster", "node_count": 4, "kubernetes": {"node_count": 4}}
 EOF
-"""
-            )
-            script_path = f.name
+""",
+        )
 
-        try:
-            Path(script_path).chmod(0o755)
+        config = RunConfig(
+            commands={
+                "kubernetes": PlatformCommands(
+                    steps=[
+                        StepConfig(name="setup_cluster", command=script_path, phase="setup"),
+                    ]
+                )
+            },
+            tests=ValidationConfig(platform="kubernetes"),
+        )
+        orchestrator = Orchestrator(config)
 
-            config = RunConfig(
-                commands={
-                    "kubernetes": PlatformCommands(
-                        steps=[
-                            StepConfig(name="setup_cluster", command=script_path, phase="setup"),
-                        ]
-                    )
-                },
-                tests=ValidationConfig(platform="kubernetes"),
-            )
-            orchestrator = Orchestrator(config)
+        result = orchestrator.run(phases=[Phase.SETUP])
 
-            result = orchestrator.run(phases=[Phase.SETUP])
-
-            assert result.success
-            assert len(result.phases) == 1
-            assert result.phases[0].phase == Phase.SETUP
-            assert result.phases[0].success
-            assert result.inventory is not None
-            assert "setup_cluster" in result.inventory
-        finally:
-            Path(script_path).unlink(missing_ok=True)
+        assert result.success
+        assert len(result.phases) == 1
+        assert result.phases[0].phase == Phase.SETUP
+        assert result.phases[0].success
+        assert result.inventory is not None
+        assert "setup_cluster" in result.inventory
 
     def test_run_setup_phase_command_failure(self) -> None:
         """Test setup phase with command failure."""
@@ -205,50 +222,40 @@ EOF
         assert not result.success
         assert "Cannot determine platform" in result.phases[0].message
 
-    def test_teardown_runs_when_setup_validation_fails(self) -> None:
+    def test_teardown_runs_when_setup_validation_fails(self, tmp_path: Path) -> None:
         """Teardown must run when setup steps succeed but setup validations fail.
 
         Regression test for issue where validation failures in setup caused
         teardown to be skipped, leaking cloud resources.
         """
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
-            f.write(
-                '#!/bin/bash\necho \'{"success": true, "platform": "kubernetes", '
-                '"cluster_name": "test", "node_count": 1, "kubernetes": {"node_count": 1}}\'\n'
-            )
-            setup_script = f.name
+        setup_script = _write_script(tmp_path, "setup.sh", _INVENTORY_SCRIPT)
 
-        try:
-            Path(setup_script).chmod(0o755)
+        config = RunConfig(
+            commands={
+                "kubernetes": PlatformCommands(
+                    steps=[
+                        StepConfig(name="setup_cluster", command=setup_script, phase="setup"),
+                        StepConfig(name="cleanup", command="echo", args=["done"], phase="teardown"),
+                    ]
+                )
+            },
+            tests=ValidationConfig(platform="kubernetes"),
+        )
+        orchestrator = Orchestrator(config)
 
-            config = RunConfig(
-                commands={
-                    "kubernetes": PlatformCommands(
-                        steps=[
-                            StepConfig(name="setup_cluster", command=setup_script, phase="setup"),
-                            StepConfig(name="cleanup", command="echo", args=["done"], phase="teardown"),
-                        ]
-                    )
-                },
-                tests=ValidationConfig(platform="kubernetes"),
-            )
-            orchestrator = Orchestrator(config)
+        failing_validations = [{"name": "FakeCheck", "passed": False, "error": "simulated"}]
+        with patch.object(
+            orchestrator.step_executor,
+            "run_validations_for_phase",
+            side_effect=lambda phase, *a, **kw: failing_validations if phase == "setup" else [],
+        ):
+            result = orchestrator.run(teardown_on_failure=True)
 
-            failing_validations = [{"name": "FakeCheck", "passed": False, "error": "simulated"}]
-            with patch.object(
-                orchestrator.step_executor,
-                "run_validations_for_phase",
-                side_effect=lambda phase, *a, **kw: failing_validations if phase == "setup" else [],
-            ):
-                result = orchestrator.run(teardown_on_failure=True)
-
-            assert not result.success
-            teardown_phases = [p for p in result.phases if p.phase == Phase.TEARDOWN]
-            assert len(teardown_phases) == 1, "teardown phase must run even when setup validations fail"
-            teardown_step_names = [s["name"] for s in teardown_phases[0].details["steps"]]
-            assert "cleanup" in teardown_step_names, "teardown step must have executed"
-        finally:
-            Path(setup_script).unlink(missing_ok=True)
+        assert not result.success
+        teardown_phases = [p for p in result.phases if p.phase == Phase.TEARDOWN]
+        assert len(teardown_phases) == 1, "teardown phase must run even when setup validations fail"
+        teardown_step_names = [s["name"] for s in teardown_phases[0].details["steps"]]
+        assert "cleanup" in teardown_step_names, "teardown step must have executed"
 
     def test_teardown_skipped_when_setup_steps_did_not_run(self) -> None:
         """Teardown must be skipped when no setup steps executed."""
@@ -272,52 +279,37 @@ EOF
         assert "SKIPPED" in teardown_phases[0].message
         assert "setup steps did not run" in teardown_phases[0].message
 
-    def test_teardown_continues_after_step_failure(self) -> None:
+    def test_teardown_continues_after_step_failure(self, tmp_path: Path) -> None:
         """All teardown steps must run even if an earlier teardown step fails.
 
         Regression test for issue where the first failing teardown step caused
         remaining teardown steps to be skipped (e.g., VM not deleted after
         NIM teardown failed).
         """
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
-            f.write(
-                '#!/bin/bash\necho \'{"success": true, "platform": "kubernetes", '
-                '"cluster_name": "test", "node_count": 1, "kubernetes": {"node_count": 1}}\'\n'
-            )
-            setup_script = f.name
+        setup_script = _write_script(tmp_path, "setup.sh", _INVENTORY_SCRIPT)
+        teardown_ok_script = _write_script(tmp_path, "teardown_ok.sh", _OK_SCRIPT)
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
-            f.write("#!/bin/bash\necho '{\"success\": true}'\n")
-            teardown_ok_script = f.name
+        config = RunConfig(
+            commands={
+                "kubernetes": PlatformCommands(
+                    steps=[
+                        StepConfig(name="setup_cluster", command=setup_script, phase="setup"),
+                        StepConfig(name="teardown_nim", command="false", phase="teardown"),
+                        StepConfig(name="teardown_vm", command=teardown_ok_script, phase="teardown"),
+                    ]
+                )
+            },
+            tests=ValidationConfig(platform="kubernetes"),
+        )
+        orchestrator = Orchestrator(config)
+        result = orchestrator.run(teardown_on_failure=True)
 
-        try:
-            Path(setup_script).chmod(0o755)
-            Path(teardown_ok_script).chmod(0o755)
+        teardown_phases = [p for p in result.phases if p.phase == Phase.TEARDOWN]
+        assert len(teardown_phases) == 1
 
-            config = RunConfig(
-                commands={
-                    "kubernetes": PlatformCommands(
-                        steps=[
-                            StepConfig(name="setup_cluster", command=setup_script, phase="setup"),
-                            StepConfig(name="teardown_nim", command="false", phase="teardown"),
-                            StepConfig(name="teardown_vm", command=teardown_ok_script, phase="teardown"),
-                        ]
-                    )
-                },
-                tests=ValidationConfig(platform="kubernetes"),
-            )
-            orchestrator = Orchestrator(config)
-            result = orchestrator.run(teardown_on_failure=True)
-
-            teardown_phases = [p for p in result.phases if p.phase == Phase.TEARDOWN]
-            assert len(teardown_phases) == 1
-
-            step_names = [s["name"] for s in teardown_phases[0].details["steps"]]
-            assert "teardown_nim" in step_names, "first teardown step must be recorded"
-            assert "teardown_vm" in step_names, "second teardown step must run despite first failure"
-        finally:
-            Path(setup_script).unlink(missing_ok=True)
-            Path(teardown_ok_script).unlink(missing_ok=True)
+        step_names = [s["name"] for s in teardown_phases[0].details["steps"]]
+        assert "teardown_nim" in step_names, "first teardown step must be recorded"
+        assert "teardown_vm" in step_names, "second teardown step must run despite first failure"
 
 
 class TestTeardownOnlyPhase:
@@ -375,36 +367,29 @@ class TestTeardownOnlyPhase:
         setup_phases = [p for p in result.phases if p.phase == Phase.SETUP]
         assert len(setup_phases) == 0, "setup phase must not appear when only teardown is requested"
 
-    def test_teardown_only_best_effort_continues_past_failures(self) -> None:
+    def test_teardown_only_best_effort_continues_past_failures(self, tmp_path: Path) -> None:
         """Teardown-only run must use best-effort so all cleanup steps execute."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
-            f.write("#!/bin/bash\necho '{\"success\": true}'\n")
-            ok_script = f.name
+        ok_script = _write_script(tmp_path, "teardown_ok.sh", _OK_SCRIPT)
 
-        try:
-            Path(ok_script).chmod(0o755)
+        config = RunConfig(
+            commands={
+                "kubernetes": PlatformCommands(
+                    steps=[
+                        StepConfig(name="teardown_nim", command="false", phase="teardown"),
+                        StepConfig(name="teardown_vm", command=ok_script, phase="teardown"),
+                    ]
+                )
+            },
+            tests=ValidationConfig(platform="kubernetes"),
+        )
+        orchestrator = Orchestrator(config)
+        result = orchestrator.run(phases=[Phase.TEARDOWN])
 
-            config = RunConfig(
-                commands={
-                    "kubernetes": PlatformCommands(
-                        steps=[
-                            StepConfig(name="teardown_nim", command="false", phase="teardown"),
-                            StepConfig(name="teardown_vm", command=ok_script, phase="teardown"),
-                        ]
-                    )
-                },
-                tests=ValidationConfig(platform="kubernetes"),
-            )
-            orchestrator = Orchestrator(config)
-            result = orchestrator.run(phases=[Phase.TEARDOWN])
-
-            teardown_phases = [p for p in result.phases if p.phase == Phase.TEARDOWN]
-            assert len(teardown_phases) == 1
-            step_names = [s["name"] for s in teardown_phases[0].details["steps"]]
-            assert "teardown_nim" in step_names, "failing teardown step must be recorded"
-            assert "teardown_vm" in step_names, "second teardown step must run despite first failure"
-        finally:
-            Path(ok_script).unlink(missing_ok=True)
+        teardown_phases = [p for p in result.phases if p.phase == Phase.TEARDOWN]
+        assert len(teardown_phases) == 1
+        step_names = [s["name"] for s in teardown_phases[0].details["steps"]]
+        assert "teardown_nim" in step_names, "failing teardown step must be recorded"
+        assert "teardown_vm" in step_names, "second teardown step must run despite first failure"
 
     def test_teardown_still_skipped_when_setup_requested_but_did_not_run(self) -> None:
         """When both setup and teardown are requested, teardown is still gated on setup execution.

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -42,6 +42,19 @@ exit 7
 
 
 def _write_script(tmp_path: Path, name: str, content: str) -> str:
+    """Create an executable script file under tmp_path and return its path.
+
+    Args:
+        tmp_path: Temporary directory where the script is written.
+        name: Script filename to create.
+        content: Script contents to write.
+
+    Returns:
+        String path to the created script.
+
+    Side effects:
+        Writes the file and sets executable mode 0o755.
+    """
     path = tmp_path / name
     path.write_text(content)
     path.chmod(0o755)

--- a/isvctl/tests/test_yaml2json.py
+++ b/isvctl/tests/test_yaml2json.py
@@ -32,6 +32,16 @@ def run_yaml2json(yaml_file: str) -> tuple[int, str, str]:
 
 
 def _write_yaml(tmp_path: Path, content: str, name: str = "input.yaml") -> str:
+    """Write YAML content to a temporary file and return its path.
+
+    Args:
+        tmp_path: Temporary directory where the YAML file is written.
+        content: YAML content to write.
+        name: YAML filename to create.
+
+    Returns:
+        String path to the written YAML file.
+    """
     path = tmp_path / name
     path.write_text(content)
     return str(path)

--- a/isvctl/tests/test_yaml2json.py
+++ b/isvctl/tests/test_yaml2json.py
@@ -12,10 +12,8 @@
 
 import json
 import os
-import stat
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -33,57 +31,48 @@ def run_yaml2json(yaml_file: str) -> tuple[int, str, str]:
     return result.returncode, result.stdout, result.stderr
 
 
+def _write_yaml(tmp_path: Path, content: str, name: str = "input.yaml") -> str:
+    path = tmp_path / name
+    path.write_text(content)
+    return str(path)
+
+
 class TestYaml2Json:
     """Tests for yaml2json script."""
 
-    def test_valid_yaml(self) -> None:
+    def test_valid_yaml(self, tmp_path: Path) -> None:
         """Test converting valid YAML to JSON."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            f.write("key: value\nnumber: 42\n")
-            yaml_file = f.name
+        yaml_file = _write_yaml(tmp_path, "key: value\nnumber: 42\n")
 
-        try:
-            exit_code, stdout, stderr = run_yaml2json(yaml_file)
-            assert exit_code == 0
-            assert stderr == ""
-            data = json.loads(stdout)
-            assert data == {"key": "value", "number": 42}
-        finally:
-            Path(yaml_file).unlink(missing_ok=True)
+        exit_code, stdout, stderr = run_yaml2json(yaml_file)
+        assert exit_code == 0
+        assert stderr == ""
+        data = json.loads(stdout)
+        assert data == {"key": "value", "number": 42}
 
-    def test_empty_yaml(self) -> None:
+    def test_empty_yaml(self, tmp_path: Path) -> None:
         """Test handling empty YAML file."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            f.write("")
-            yaml_file = f.name
+        yaml_file = _write_yaml(tmp_path, "")
 
-        try:
-            exit_code, stdout, stderr = run_yaml2json(yaml_file)
-            assert exit_code == 0
-            assert stderr == ""
-            data = json.loads(stdout)
-            assert data == {}
-        finally:
-            Path(yaml_file).unlink(missing_ok=True)
+        exit_code, stdout, stderr = run_yaml2json(yaml_file)
+        assert exit_code == 0
+        assert stderr == ""
+        data = json.loads(stdout)
+        assert data == {}
 
-    def test_yaml_with_datetime(self) -> None:
+    def test_yaml_with_datetime(self, tmp_path: Path) -> None:
         """Test handling unquoted YAML timestamp (datetime type)."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            # Unquoted dates in YAML are parsed as datetime objects
-            f.write("created: 2025-01-14\nupdated: 2025-01-14T10:30:00\n")
-            yaml_file = f.name
+        # Unquoted dates in YAML are parsed as datetime objects
+        yaml_file = _write_yaml(tmp_path, "created: 2025-01-14\nupdated: 2025-01-14T10:30:00\n")
 
-        try:
-            exit_code, stdout, stderr = run_yaml2json(yaml_file)
-            assert exit_code == 0
-            assert stderr == ""
-            data = json.loads(stdout)
-            # datetime objects should be serialized as strings
-            assert "created" in data
-            assert "updated" in data
-            assert "2025-01-14" in data["created"]
-        finally:
-            Path(yaml_file).unlink(missing_ok=True)
+        exit_code, stdout, stderr = run_yaml2json(yaml_file)
+        assert exit_code == 0
+        assert stderr == ""
+        data = json.loads(stdout)
+        # datetime objects should be serialized as strings
+        assert "created" in data
+        assert "updated" in data
+        assert "2025-01-14" in data["created"]
 
     def test_file_not_found(self) -> None:
         """Test handling non-existent file."""
@@ -92,43 +81,28 @@ class TestYaml2Json:
         assert "File not found" in stderr
 
     @pytest.mark.skipif(os.geteuid() == 0, reason="Root can read any file regardless of permissions")
-    def test_permission_error(self) -> None:
+    def test_permission_error(self, tmp_path: Path) -> None:
         """Test handling file permission errors."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            f.write("key: value\n")
-            yaml_file = f.name
+        yaml_file = _write_yaml(tmp_path, "key: value\n")
+        os.chmod(yaml_file, 0)
 
-        try:
-            # Remove read permissions
-            os.chmod(yaml_file, 0)
+        exit_code, _stdout, stderr = run_yaml2json(yaml_file)
+        assert exit_code == 1
+        assert "Cannot read file" in stderr or "Permission denied" in stderr
 
-            exit_code, _stdout, stderr = run_yaml2json(yaml_file)
-            assert exit_code == 1
-            assert "Cannot read file" in stderr or "Permission denied" in stderr
-        finally:
-            # Restore permissions for cleanup
-            os.chmod(yaml_file, stat.S_IRUSR | stat.S_IWUSR)
-            Path(yaml_file).unlink(missing_ok=True)
-
-    def test_invalid_yaml(self) -> None:
+    def test_invalid_yaml(self, tmp_path: Path) -> None:
         """Test handling invalid YAML syntax."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            f.write("key: [unclosed bracket\n")
-            yaml_file = f.name
+        yaml_file = _write_yaml(tmp_path, "key: [unclosed bracket\n")
 
-        try:
-            exit_code, _stdout, stderr = run_yaml2json(yaml_file)
-            assert exit_code == 1
-            assert "Invalid YAML" in stderr
-        finally:
-            Path(yaml_file).unlink(missing_ok=True)
+        exit_code, _stdout, stderr = run_yaml2json(yaml_file)
+        assert exit_code == 1
+        assert "Invalid YAML" in stderr
 
-    def test_is_a_directory(self) -> None:
+    def test_is_a_directory(self, tmp_path: Path) -> None:
         """Test handling when path is a directory."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            exit_code, _stdout, stderr = run_yaml2json(tmpdir)
-            assert exit_code == 1
-            assert "Cannot read file" in stderr or "Is a directory" in stderr
+        exit_code, _stdout, stderr = run_yaml2json(str(tmp_path))
+        assert exit_code == 1
+        assert "Cannot read file" in stderr or "Is a directory" in stderr
 
     def test_no_arguments(self) -> None:
         """Test handling missing arguments."""

--- a/isvreporter/tests/test_junit_parser.py
+++ b/isvreporter/tests/test_junit_parser.py
@@ -10,7 +10,6 @@
 
 """Tests for JUnit XML parser."""
 
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -58,11 +57,11 @@ Test is not ready yet
 
 
 @pytest.fixture
-def junit_xml_file(sample_junit_xml: str) -> Path:
+def junit_xml_file(sample_junit_xml: str, tmp_path: Path) -> Path:
     """Create a temporary JUnit XML file."""
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
-        f.write(sample_junit_xml)
-        return Path(f.name)
+    path = tmp_path / "report.xml"
+    path.write_text(sample_junit_xml)
+    return path
 
 
 def test_parse_junit_xml_basic(junit_xml_file: Path) -> None:
@@ -210,7 +209,7 @@ def test_junit_report_to_dict(junit_xml_file: Path) -> None:
     assert len(report_dict["testResults"]) == 5
 
 
-def test_parse_single_testsuite() -> None:
+def test_parse_single_testsuite(tmp_path: Path) -> None:
     """Test parsing XML with single testsuite (no testsuites wrapper)."""
     xml_content = """<?xml version="1.0" encoding="utf-8"?>
 <testsuite name="single-suite" errors="0" failures="1" skipped="0" tests="2" time="0.5">
@@ -220,9 +219,8 @@ def test_parse_single_testsuite() -> None:
   </testcase>
 </testsuite>"""
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
-        f.write(xml_content)
-        xml_file = Path(f.name)
+    xml_file = tmp_path / "single.xml"
+    xml_file.write_text(xml_content)
 
     report = parse_junit_xml(xml_file)
 
@@ -232,16 +230,15 @@ def test_parse_single_testsuite() -> None:
     assert len(report.suites) == 1
 
 
-def test_empty_junit_xml() -> None:
+def test_empty_junit_xml(tmp_path: Path) -> None:
     """Test parsing empty test suite."""
     xml_content = """<?xml version="1.0" encoding="utf-8"?>
 <testsuites>
   <testsuite name="empty" errors="0" failures="0" skipped="0" tests="0" time="0"></testsuite>
 </testsuites>"""
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
-        f.write(xml_content)
-        xml_file = Path(f.name)
+    xml_file = tmp_path / "empty.xml"
+    xml_file.write_text(xml_content)
 
     report = parse_junit_xml(xml_file)
 

--- a/isvreporter/tests/test_platform.py
+++ b/isvreporter/tests/test_platform.py
@@ -24,6 +24,15 @@ from isvreporter.platform import (
 
 
 def _write_config(tmp_path: Path, content: str) -> Path:
+    """Write content to config.yaml under tmp_path and return the file path.
+
+    Args:
+        tmp_path: Temporary directory where config.yaml is written.
+        content: Config content to write.
+
+    Returns:
+        Path to the written config.yaml file.
+    """
     path = tmp_path / "config.yaml"
     path.write_text(content)
     return path

--- a/isvreporter/tests/test_platform.py
+++ b/isvreporter/tests/test_platform.py
@@ -10,7 +10,6 @@
 
 """Tests for platform module."""
 
-import tempfile
 from pathlib import Path
 
 from isvreporter.platform import (
@@ -22,6 +21,12 @@ from isvreporter.platform import (
     is_valid_platform,
     normalize_platform,
 )
+
+
+def _write_config(tmp_path: Path, content: str) -> Path:
+    path = tmp_path / "config.yaml"
+    path.write_text(content)
+    return path
 
 
 class TestNormalizePlatform:
@@ -98,55 +103,37 @@ class TestIsValidPlatform:
 class TestGetPlatformFromConfig:
     """Tests for get_platform_from_config function."""
 
-    def test_valid_config_with_platform(self) -> None:
+    def test_valid_config_with_platform(self, tmp_path: Path) -> None:
         """Test reading platform from valid config."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            f.write("tests:\n  platform: slurm\n")
-            f.flush()
-            result = get_platform_from_config(f.name)
-            assert result == SLURM
+        config = _write_config(tmp_path, "tests:\n  platform: slurm\n")
+        assert get_platform_from_config(str(config)) == SLURM
 
-    def test_config_with_k8s_alias(self) -> None:
+    def test_config_with_k8s_alias(self, tmp_path: Path) -> None:
         """Test reading k8s alias from config."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            f.write("tests:\n  platform: k8s\n")
-            f.flush()
-            result = get_platform_from_config(f.name)
-            assert result == KUBERNETES
+        config = _write_config(tmp_path, "tests:\n  platform: k8s\n")
+        assert get_platform_from_config(str(config)) == KUBERNETES
 
-    def test_config_without_tests_section(self) -> None:
+    def test_config_without_tests_section(self, tmp_path: Path) -> None:
         """Test that missing tests section returns default."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            f.write("commands:\n  setup: echo hello\n")
-            f.flush()
-            result = get_platform_from_config(f.name)
-            assert result == DEFAULT_PLATFORM
+        config = _write_config(tmp_path, "commands:\n  setup: echo hello\n")
+        assert get_platform_from_config(str(config)) == DEFAULT_PLATFORM
 
-    def test_config_without_platform(self) -> None:
+    def test_config_without_platform(self, tmp_path: Path) -> None:
         """Test that missing platform field returns default."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            f.write("tests:\n  markers: [unit]\n")
-            f.flush()
-            result = get_platform_from_config(f.name)
-            assert result == DEFAULT_PLATFORM
+        config = _write_config(tmp_path, "tests:\n  markers: [unit]\n")
+        assert get_platform_from_config(str(config)) == DEFAULT_PLATFORM
 
     def test_nonexistent_file_returns_default(self) -> None:
         """Test that nonexistent file returns default."""
         result = get_platform_from_config("/nonexistent/path/config.yaml")
         assert result == DEFAULT_PLATFORM
 
-    def test_invalid_yaml_returns_default(self) -> None:
+    def test_invalid_yaml_returns_default(self, tmp_path: Path) -> None:
         """Test that invalid YAML returns default."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            f.write("this is not: valid: yaml: content:\n  - bad")
-            f.flush()
-            result = get_platform_from_config(f.name)
-            assert result == DEFAULT_PLATFORM
+        config = _write_config(tmp_path, "this is not: valid: yaml: content:\n  - bad")
+        assert get_platform_from_config(str(config)) == DEFAULT_PLATFORM
 
-    def test_accepts_path_object(self) -> None:
+    def test_accepts_path_object(self, tmp_path: Path) -> None:
         """Test that Path objects are accepted."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            f.write("tests:\n  platform: kubernetes\n")
-            f.flush()
-            result = get_platform_from_config(Path(f.name))
-            assert result == KUBERNETES
+        config = _write_config(tmp_path, "tests:\n  platform: kubernetes\n")
+        assert get_platform_from_config(config) == KUBERNETES


### PR DESCRIPTION
## Summary

Replace the `NamedTemporaryFile(delete=False)` + `try/finally + unlink` ritual across the test suite with pytest's `tmp_path` fixture. Same coverage, fewer lines, no manual cleanup, no `chmod`-restore dance for the perm-error test.

## Changes

- `isvctl/tests/test_orchestrator.py`, `isvctl/tests/test_orchestrator_loop.py` — convert script-writing tests to `tmp_path`; add a small `_write_script(tmp_path, name, content)` helper; hoist the shared inventory/ok bash scripts to module-level constants so duplicate heredocs don't drift apart.
- `isvctl/tests/test_yaml2json.py` — convert 6 tests; add `_write_yaml(tmp_path, content)` helper; drop the now-unused `stat` and `tempfile` imports and the perm-restore step (POSIX `shutil.rmtree` cleans mode-0 files via the parent dir's perms).
- `isvreporter/tests/test_junit_parser.py` — `junit_xml_file` fixture now takes `tmp_path`; the two inline tests use `tmp_path / "*.xml"` directly.
- `isvreporter/tests/test_platform.py` — convert 6 tests via a `_write_config(tmp_path, content)` helper.

## Validation

- [x] `make test`
- [x] `make lint`
- [x] `make format`

## Test plan

- [x] All converted tests pass under `make test` (683 + 40).
- [x] `test_permission_error` still exercises the unreadable-file path on POSIX (gated on `os.geteuid() == 0`).
- [x] No remaining `tempfile` / `NamedTemporaryFile` usage under `isvctl/tests/`, `isvreporter/tests/`, `isvtest/tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored test infrastructure to use pytest tmp_path for temporary file handling.
  * Added utilities to centralize reusable test assets and simplify script/file creation.
  * Expanded coverage with new scenarios for permission errors, invalid inputs, directory handling, and teardown resilience (ensuring teardown steps run/continue despite failures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->