### PR TITLE
fix: surface SSH diagnostics during verbose deploy

### DIFF
--- a/isvctl/src/isvctl/cli/deploy.py
+++ b/isvctl/src/isvctl/cli/deploy.py
@@ -317,7 +317,7 @@ def run(
     )
 
     # Create SSH and SCP clients
-    ssh = SSHClient(host=remote_ip, user=user, port=port, jumphost=jumphost)
+    ssh = SSHClient(host=remote_ip, user=user, port=port, jumphost=jumphost, quiet=not verbose)
     scp = SCPTransfer(host=remote_ip, user=user, port=port, jumphost=jumphost)
 
     # Create temporary archive

--- a/isvctl/src/isvctl/remote/ssh.py
+++ b/isvctl/src/isvctl/remote/ssh.py
@@ -60,6 +60,7 @@ class SSHClient:
         port: int = 22,
         jumphost: str | None = None,
         timeout: int = 30,
+        quiet: bool = True,
     ) -> None:
         """Initialize SSH client.
 
@@ -69,21 +70,23 @@ class SSHClient:
             port: SSH port (default: 22)
             jumphost: Optional jump host in format "host" or "host:port"
             timeout: Connection timeout in seconds
+            quiet: Suppress non-fatal SSH diagnostics for routine commands
         """
         self.host = host
         self.user = user
         self.port = port
         self.jumphost = jumphost
         self.timeout = timeout
+        self.quiet = quiet
 
-    def _build_ssh_options(self) -> list[str]:
+    def _build_ssh_options(self, *, quiet: bool | None = None) -> list[str]:
         """Build common SSH options.
 
         Returns:
             List of SSH command-line options
         """
+        effective_quiet = self.quiet if quiet is None else quiet
         opts = [
-            "-q",  # Quiet mode
             "-o",
             "StrictHostKeyChecking=accept-new",
             "-o",
@@ -91,6 +94,9 @@ class SSHClient:
             "-o",
             "BatchMode=yes",  # Disable password prompts
         ]
+
+        if effective_quiet:
+            opts.insert(0, "-q")
 
         if self.port != 22:
             opts.extend(["-p", str(self.port)])
@@ -113,6 +119,7 @@ class SSHClient:
         command: str,
         stream: bool = False,
         env: dict[str, str] | None = None,
+        quiet: bool | None = None,
     ) -> SSHResult:
         """Execute a command on the remote host.
 
@@ -120,11 +127,12 @@ class SSHClient:
             command: Shell command to execute (can be a multi-line script)
             stream: If True, stream output to stdout/stderr in real-time
             env: Optional environment variables to pass to the remote command
+            quiet: Override whether SSH suppresses non-fatal diagnostics
 
         Returns:
             SSHResult with execution details
         """
-        cmd = ["ssh", "-T"] + self._build_ssh_options() + [self._build_target()]
+        cmd = ["ssh", "-T"] + self._build_ssh_options(quiet=quiet) + [self._build_target()]
 
         # Build the remote command with optional env vars
         remote_cmd = command
@@ -304,7 +312,7 @@ class SSHClient:
         Returns:
             SSHResult with connection test details
         """
-        return self.execute("echo ok")
+        return self.execute("echo ok", quiet=False)
 
     def is_connection_error(self, result: SSHResult) -> bool:
         """Check if an SSHResult indicates a connection failure.

--- a/isvctl/tests/test_remote_ssh.py
+++ b/isvctl/tests/test_remote_ssh.py
@@ -26,6 +26,7 @@ class TestSSHClient:
         assert ssh.port == 22
         assert ssh.jumphost is None
         assert ssh.timeout == 30
+        assert ssh.quiet is True
 
     def test_init_with_all_options(self) -> None:
         """Test initialization with all options."""
@@ -35,12 +36,14 @@ class TestSSHClient:
             port=2222,
             jumphost="bastion:2260",
             timeout=60,
+            quiet=False,
         )
         assert ssh.host == "192.168.1.100"
         assert ssh.user == "ubuntu"
         assert ssh.port == 2222
         assert ssh.jumphost == "bastion:2260"
         assert ssh.timeout == 60
+        assert ssh.quiet is False
 
     def test_build_ssh_options_basic(self) -> None:
         """Test SSH options for basic connection."""
@@ -51,6 +54,22 @@ class TestSSHClient:
         assert "StrictHostKeyChecking=accept-new" in " ".join(opts)
         assert "BatchMode=yes" in " ".join(opts)
         assert "-p" not in opts  # Default port, no -p flag
+
+    def test_build_ssh_options_not_quiet(self) -> None:
+        """Test SSH options can leave diagnostics enabled."""
+        ssh = SSHClient(host="192.168.1.100", user="nvidia", quiet=False)
+        opts = ssh._build_ssh_options()
+
+        assert "-q" not in opts
+        assert "StrictHostKeyChecking=accept-new" in " ".join(opts)
+        assert "BatchMode=yes" in " ".join(opts)
+
+    def test_build_ssh_options_quiet_override(self) -> None:
+        """Test per-command quiet override."""
+        ssh = SSHClient(host="192.168.1.100", user="nvidia")
+        opts = ssh._build_ssh_options(quiet=False)
+
+        assert "-q" not in opts
 
     def test_build_ssh_options_custom_port(self) -> None:
         """Test SSH options with custom port."""
@@ -160,6 +179,8 @@ class TestSSHClient:
         ssh = SSHClient(host="192.168.1.100", user="nvidia")
         result = ssh.test_connection()
         assert result.success is True
+        cmd = mock_run.call_args[0][0]
+        assert "-q" not in cmd
 
     @patch("subprocess.run")
     def test_is_connection_error(self, mock_run: MagicMock) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSH operations now support configurable quiet mode, reducing diagnostic output by default.
  * Quiet mode can be overridden on a per-operation basis for detailed diagnostics when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->