### PR TITLE
fix: drop step-gated validations whose step isn't configured

### DIFF
--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -27,7 +27,7 @@ from typing import Any
 from isvctl.config.schema import RunConfig
 from isvctl.orchestrator.commands import CommandExecutor
 from isvctl.orchestrator.context import Context
-from isvctl.orchestrator.step_executor import StepExecutor, StepResults
+from isvctl.orchestrator.step_executor import StepExecutor, StepResults, filter_unconfigured_step_entries
 from isvctl.redaction import redact_dict, redact_junit_xml_tree
 
 logger = logging.getLogger(__name__)
@@ -263,9 +263,14 @@ class Orchestrator:
             self.context.set_step_phase(step.name, step_phase)
 
         # Get all validations from config
-        all_validations = {}
+        all_validations: dict[str, Any] = {}
         if self.config.tests and self.config.tests.validations:
             all_validations = self.config.tests.validations
+
+        # Drop entries whose step: is not in the run's configured steps, so
+        # their dead Jinja templates never render. See filter_unconfigured_step_entries.
+        configured_steps = set(self.context.get_all_step_phases().keys())
+        all_validations = filter_unconfigured_step_entries(all_validations, configured_steps)
 
         # Get exclude config for filtering validations
         exclude_markers: list[str] = []

--- a/isvctl/src/isvctl/orchestrator/step_executor.py
+++ b/isvctl/src/isvctl/orchestrator/step_executor.py
@@ -161,6 +161,76 @@ def _deselected_validation_class_names(
     return excluded
 
 
+def filter_unconfigured_step_entries(
+    all_validations: dict[str, Any],
+    configured_steps: set[str],
+) -> dict[str, Any]:
+    """Drop validation entries whose ``step:`` references a step not in ``configured_steps``.
+
+    Without this, dead entries reach Jinja rendering and emit "step has no
+    output" warnings before isvtest re-skips them. Mirrors the two formats
+    accepted by ``isvtest._normalize_validation_configs`` (list-form and
+    group-defaults dict-form). Per-check ``step`` overrides the group default;
+    a missing group ``step`` drops the whole category. Returns a new dict;
+    input is not mutated.
+    """
+
+    def _drop(name: str, params: Any, category: str, group_step: str | None) -> bool:
+        if not isinstance(params, dict):
+            return False
+        step_name = params.get("step", group_step)
+        if step_name and step_name not in configured_steps:
+            logger.info(f"Dropping validation '{name}' in [{category}]: step '{step_name}' is not configured")
+            return True
+        return False
+
+    filtered: dict[str, Any] = {}
+    for category, category_config in all_validations.items():
+        if isinstance(category_config, list):
+            kept_list: list[Any] = []
+            for item in category_config:
+                if isinstance(item, dict) and len(item) == 1:
+                    name, params = next(iter(item.items()))
+                    if _drop(name, params, category, group_step=None):
+                        continue
+                kept_list.append(item)
+            if kept_list:
+                filtered[category] = kept_list
+            continue
+
+        if isinstance(category_config, dict) and "checks" in category_config:
+            group_step = category_config.get("step")
+            if group_step and group_step not in configured_steps:
+                logger.info(f"Dropping all validations in [{category}]: group step '{group_step}' is not configured")
+                continue
+            checks = category_config["checks"]
+            if isinstance(checks, list):
+                kept_checks_list: list[Any] = []
+                for item in checks:
+                    if isinstance(item, dict) and len(item) == 1:
+                        name, params = next(iter(item.items()))
+                        if _drop(name, params, category, group_step):
+                            continue
+                    kept_checks_list.append(item)
+                if kept_checks_list:
+                    filtered[category] = {**category_config, "checks": kept_checks_list}
+            elif isinstance(checks, dict):
+                kept_checks_dict: dict[str, Any] = {}
+                for name, params in checks.items():
+                    if _drop(name, params, category, group_step):
+                        continue
+                    kept_checks_dict[name] = params
+                if kept_checks_dict:
+                    filtered[category] = {**category_config, "checks": kept_checks_dict}
+            else:
+                filtered[category] = category_config
+            continue
+
+        filtered[category] = category_config
+
+    return filtered
+
+
 @dataclass
 class StepResult:
     """Result of executing a single step.

--- a/isvctl/tests/test_orchestrator.py
+++ b/isvctl/tests/test_orchestrator.py
@@ -18,6 +18,7 @@ import pytest
 from isvctl.config.schema import CommandConfig, CommandOutput, RunConfig
 from isvctl.orchestrator.commands import CommandExecutor
 from isvctl.orchestrator.context import Context
+from isvctl.orchestrator.step_executor import filter_unconfigured_step_entries
 
 
 def _write_script(tmp_path: Path, name: str, content: str) -> str:
@@ -518,3 +519,148 @@ class TestContext:
         assert len(messages) == 1
         assert "step 'setup' has no output" in messages[0]
         assert not any("create_test_node_pool" in m for m in messages)
+
+
+class TestFilterUnconfiguredStepEntries:
+    """Tests for filter_unconfigured_step_entries.
+
+    Covers the two formats accepted by isvtest._normalize_validation_configs
+    (list-form and group-defaults dict-form) plus the no-step-ref pass-through
+    case. The k8s suite uses list-form for k8s_node_pools, so that case is
+    the actual production driver - the others are guards against shape drift.
+    """
+
+    def test_drops_listform_entry_with_unconfigured_step(self, caplog: pytest.LogCaptureFixture) -> None:
+        """List-form entry with step:<missing> is dropped and logged once."""
+        validations = {
+            "k8s_node_pools": [
+                {"K8sNodePoolCheck": {"step": "create_test_node_pool", "expected_replicas": 1}},
+                {"K8sNodePoolCheck": {"step": "update_test_node_pool", "expected_replicas": 2}},
+            ],
+        }
+
+        with caplog.at_level(logging.INFO, logger="isvctl.orchestrator.step_executor"):
+            result = filter_unconfigured_step_entries(validations, configured_steps={"setup", "teardown"})
+
+        assert result == {}
+        messages = [r.message for r in caplog.records]
+        assert len(messages) == 2
+        assert all("K8sNodePoolCheck" in m for m in messages)
+        assert any("create_test_node_pool" in m for m in messages)
+        assert any("update_test_node_pool" in m for m in messages)
+
+    def test_keeps_listform_entry_with_configured_step(self) -> None:
+        """List-form entry whose step is configured is left intact."""
+        validations = {
+            "k8s_node_pools": [
+                {"K8sNodePoolCheck": {"step": "create_test_node_pool", "expected_replicas": 1}},
+            ],
+        }
+
+        result = filter_unconfigured_step_entries(validations, configured_steps={"create_test_node_pool"})
+
+        assert result == validations
+
+    def test_keeps_listform_entry_without_step_ref(self) -> None:
+        """List-form entry with no ``step:`` field is never dropped."""
+        validations = {
+            "kubernetes": [
+                {"K8sNodeCountCheck": {"count": 4}},
+            ],
+        }
+
+        result = filter_unconfigured_step_entries(validations, configured_steps=set())
+
+        assert result == validations
+
+    def test_drops_dict_of_checks_entry_with_unconfigured_step(self) -> None:
+        """Group-defaults dict-of-checks: per-check step gating drops only that check."""
+        validations = {
+            "kubernetes": {
+                "checks": {
+                    "K8sNodeCountCheck": {"count": 4},
+                    "K8sNodePoolCheck": {"step": "create_test_node_pool"},
+                },
+            },
+        }
+
+        result = filter_unconfigured_step_entries(validations, configured_steps={"setup"})
+
+        assert result == {"kubernetes": {"checks": {"K8sNodeCountCheck": {"count": 4}}}}
+
+    def test_drops_whole_category_when_group_step_unconfigured(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Group-level ``step:`` referencing a missing step drops the entire category."""
+        validations = {
+            "setup_state": {
+                "step": "launch_instance",
+                "checks": {
+                    "InstanceStateCheck": {},
+                    "InstanceCreatedCheck": {},
+                },
+            },
+        }
+
+        with caplog.at_level(logging.INFO, logger="isvctl.orchestrator.step_executor"):
+            result = filter_unconfigured_step_entries(validations, configured_steps={"setup"})
+
+        assert result == {}
+        messages = [r.message for r in caplog.records]
+        assert len(messages) == 1
+        assert "launch_instance" in messages[0]
+        assert "[setup_state]" in messages[0]
+
+    def test_per_check_step_overrides_group_step(self) -> None:
+        """A per-check ``step:`` overrides the group default for filtering decisions."""
+        validations = {
+            "setup_state": {
+                "step": "launch_instance",
+                "checks": {
+                    "InstanceStateCheck": {"step": "describe_instance"},  # overridden
+                    "InstanceCreatedCheck": {},  # inherits group step
+                },
+            },
+        }
+
+        result = filter_unconfigured_step_entries(
+            validations,
+            configured_steps={"launch_instance"},  # describe_instance is missing
+        )
+
+        assert result == {
+            "setup_state": {
+                "step": "launch_instance",
+                "checks": {"InstanceCreatedCheck": {}},
+            },
+        }
+
+    def test_groupdefaults_listform_checks(self) -> None:
+        """Group-defaults with list-of-checks (instead of dict-of-checks) also filters per check."""
+        validations = {
+            "k8s_node_pools": {
+                "step": "create_test_node_pool",
+                "checks": [
+                    {"K8sNodePoolCheck": {"expected_replicas": 1}},
+                ],
+            },
+        }
+
+        result = filter_unconfigured_step_entries(validations, configured_steps={"setup"})
+
+        assert result == {}
+
+    def test_does_not_mutate_input(self) -> None:
+        """Filtering must not mutate the caller's validations dict."""
+        validations = {
+            "k8s_node_pools": [
+                {"K8sNodePoolCheck": {"step": "create_test_node_pool"}},
+            ],
+        }
+        snapshot = {
+            "k8s_node_pools": [
+                {"K8sNodePoolCheck": {"step": "create_test_node_pool"}},
+            ],
+        }
+
+        filter_unconfigured_step_entries(validations, configured_steps=set())
+
+        assert validations == snapshot


### PR DESCRIPTION
The orchestrator rendered Jinja templates for every validation entry, even when the entry's `step:` referenced a step the active run never configured (e.g. k8s suite's K8sNodePoolCheck gates on `create_test_node_pool`, which only the EKS provider overlay defines). That produced "step has no output" warnings per templated field, plus a redundant "Skipping validation" log from isvtest's normalization layer.

Filter those entries upfront in the orchestrator, before render_dict, so dead templates never render and isvtest never sees them. One INFO line per dropped entry replaces the warning + skip noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validations for unconfigured steps are now properly filtered out, preventing irrelevant validation templates from being rendered or executed during runs.

* **Tests**
  * Added comprehensive test coverage for validation filtering functionality, including edge cases with list and dict-form configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->