### PR TITLE
refactor: unified validation resolution pipeline

### DIFF
--- a/isvctl/src/isvctl/cli/test.py
+++ b/isvctl/src/isvctl/cli/test.py
@@ -415,18 +415,20 @@ def run(
                     vr_message = vr.get("message", "")
                     vr_category = vr.get("category", "")
                     category_prefix = f"[{vr_category}] " if vr_category else ""
-                    if vr.get("skipped"):
+                    if vr.get("state") == "error":
+                        vr_status = typer.style("ERROR", fg=typer.colors.RED)
+                        reason = vr.get("error_reason")
+                    elif vr.get("skipped"):
                         vr_status = typer.style("SKIPPED", fg=typer.colors.YELLOW)
+                        reason = vr.get("skip_reason")
                     elif vr.get("passed", False):
                         vr_status = typer.style("PASSED", fg=typer.colors.GREEN)
+                        reason = None
                     else:
                         vr_status = typer.style("FAILED", fg=typer.colors.RED)
-                    typer.echo(f"  {category_prefix}{vr_name}: {vr_status} - {vr_message}")
-
-    if result.context_warnings:
-        typer.echo(typer.style("WARNINGS", fg=typer.colors.YELLOW))
-        for w in result.context_warnings:
-            typer.echo(typer.style(f"  - {w}", fg=typer.colors.YELLOW))
+                        reason = None
+                    detail = f"{reason}: {vr_message}" if reason and vr_message else (reason or vr_message)
+                    typer.echo(f"  {category_prefix}{vr_name}: {vr_status} - {detail}")
 
     typer.echo("-" * 60)
     if result.success:

--- a/isvctl/src/isvctl/orchestrator/context.py
+++ b/isvctl/src/isvctl/orchestrator/context.py
@@ -17,9 +17,7 @@ enriched with inventory data from command outputs.
 
 import copy
 import json
-import logging
 import os
-import re
 from datetime import UTC, datetime
 from typing import Any
 
@@ -28,8 +26,6 @@ from jinja2 import ChainableUndefined, Environment
 
 from isvctl.config.schema import CommandOutput, RunConfig
 from isvctl.redaction import filter_env
-
-logger = logging.getLogger(__name__)
 
 
 def _create_jinja_env() -> Environment:
@@ -99,27 +95,6 @@ class Context:
         # Step phases (for inferring validation phase from step)
         self._step_phases: dict[str, str] = {}
 
-        # Track which missing steps have already been warned about
-        self._warned_missing_steps: set[str] = set()
-        self._context_warnings: list[str] = []
-
-        # Phases that were actually requested (set by orchestrator)
-        self._requested_phases: set[str] | None = None
-
-        # Phase currently being rendered (set before each per-phase render).
-        # Used to suppress warnings for steps whose phase hasn't had a chance
-        # to run yet (i.e., their phase comes after the current phase).
-        self._current_phase: str | None = None
-        self._phase_order: list[str] = []
-
-        # Validation class names whose templates should not emit "missing step"
-        # warnings. Populated with classes that pytest will deselect anyway
-        # (e.g. because their marker is in exclude.markers). render_dict enters
-        # a suppression zone when it recurses into a key matching one of these
-        # (exact or variant form "ClassName-*"). See set_silenced_validation_names.
-        self._silenced_validation_names: set[str] = set()
-        self._warning_suppression_depth: int = 0
-
         # Layer 6: Environment variables (for {{env.VAR}} access)
         # Must be loaded before settings so settings can reference env vars.
         # Sensitive variables (API keys, secrets) are excluded to prevent
@@ -170,62 +145,7 @@ class Context:
             Subsequent step can reference:
             >>> args: ["--cluster", "{{ steps.setup.cluster_name }}"]
         """
-        self.data.setdefault("steps", {})[step_name] = output
-
-    def set_requested_phases(self, phases: set[str]) -> None:
-        """Record which phases were requested for this run.
-
-        Used to suppress warnings for steps in phases that were
-        intentionally skipped (e.g., ``--phase teardown``).
-
-        Args:
-            phases: Set of phase names that were requested
-        """
-        self._requested_phases = phases
-
-    def set_silenced_validation_names(self, names: set[str]) -> None:
-        """Declare validation classes whose template refs must not warn.
-
-        Used by the orchestrator to point Context at classes that pytest
-        will deselect (marker or test-name exclusion). When ``render_dict``
-        recurses into a dict key that matches one of these names exactly
-        or as a variant prefix (``"ClassName-..."``), warnings about missing
-        step data are suppressed inside that subtree.
-
-        Args:
-            names: Class names to silence (e.g. ``{"K8sNodePoolCheck"}``).
-        """
-        self._silenced_validation_names = set(names or ())
-
-    def _is_silenced_validation_name(self, name: str) -> bool:
-        """Return True if ``name`` matches a silenced class exactly or as a variant."""
-        if not isinstance(name, str) or not self._silenced_validation_names:
-            return False
-        if name in self._silenced_validation_names:
-            return True
-        for base in self._silenced_validation_names:
-            if name.startswith(f"{base}-"):
-                return True
-        return False
-
-    def set_current_phase(self, phase: str, phase_order: list[str] | None = None) -> None:
-        """Record the phase currently being rendered.
-
-        Used by ``_warn_missing_step_defaults`` to suppress warnings for
-        steps whose phase hasn't had a chance to run yet (i.e., the step's
-        phase comes after ``phase`` in ``phase_order``). Without this, a
-        template in a later-phase validation (e.g. a ``test``-phase check
-        referencing ``steps.describe_instance``) would falsely warn while
-        validations are being rendered for an earlier phase.
-
-        Args:
-            phase: Current phase being rendered (e.g., ``'setup'``, ``'test'``).
-            phase_order: Ordered list of all configured phases. If provided,
-                replaces the known phase order used for ordering comparisons.
-        """
-        self._current_phase = phase
-        if phase_order is not None:
-            self._phase_order = list(phase_order)
+        self.data["steps"][step_name] = output
 
     def set_step_phase(self, step_name: str, phase: str) -> None:
         """Record the phase a step belongs to.
@@ -268,25 +188,6 @@ class Context:
         """
         return self.data.get("steps", {}).get(step_name, {})
 
-    def get_command_context(self) -> dict[str, Any]:
-        """Get context for command argument templating.
-
-        Returns the full layered context (context, lab, builtin, inventory)
-        for use in Jinja2 template rendering.
-
-        Returns:
-            Context dictionary for Jinja2 rendering
-        """
-        return self.data
-
-    def get_test_context(self) -> dict[str, Any]:
-        """Get context for test configuration templating.
-
-        Returns:
-            Context dictionary for Jinja2 rendering
-        """
-        return self.data
-
     def get_accumulated_context(self) -> dict[str, Any]:
         """Get all context including step outputs for Jinja2 templating.
 
@@ -302,10 +203,6 @@ class Context:
         """
         return self.data
 
-    def get_warnings(self) -> list[str]:
-        """Return any warnings about missing step data or fields."""
-        return list(self._context_warnings)
-
     def render_string(self, template_str: str) -> str:
         """Render a Jinja2 template string with context.
 
@@ -318,101 +215,12 @@ class Context:
         if "{{" not in template_str or "}}" not in template_str:
             return template_str
 
-        self._warn_missing_step_defaults(template_str)
-
         env = _create_jinja_env()
         template = env.from_string(template_str)
         return template.render(**self.data)
 
-    _STEP_PATH_RE = re.compile(r"steps\.([\w.]+)")
-
-    def _warn_missing_step_defaults(self, template_str: str) -> None:
-        """Warn when a template references missing step data.
-
-        Detects two cases that ``ChainableUndefined`` would silently absorb:
-
-        1. **Step not run** - ``steps.setup`` is empty because ``--phase test``
-           skipped setup.
-        2. **Field not found** - ``steps.setup`` has output but the referenced
-           field doesn't exist (typo, rename, wrong variable).
-
-        Emits a one-time warning per unique path so operators know defaults
-        are in effect and can verify they're correct.
-
-        Args:
-            template_str: Jinja2 template string to scan for step references
-        """
-        # Suppress everything while rendering a subtree that belongs to a
-        # validation class pytest will deselect anyway (see
-        # set_silenced_validation_names). Dead templates inside a never-running
-        # check should not warn.
-        if self._warning_suppression_depth > 0:
-            return
-        steps_data = self.data.get("steps", {})
-        for match in self._STEP_PATH_RE.finditer(template_str):
-            full_path = match.group(1)
-            parts = full_path.split(".")
-            step_name = parts[0]
-            warn_key = f"steps.{full_path}"
-
-            if warn_key in self._warned_missing_steps:
-                continue
-
-            if step_name not in steps_data or not steps_data[step_name]:
-                # Suppress warning if the step's phase wasn't requested
-                step_phase = self._step_phases.get(step_name)
-                if self._requested_phases and step_phase and step_phase not in self._requested_phases:
-                    continue
-                # Suppress warning if the step's phase hasn't had a chance to
-                # run yet (i.e., it comes after the phase currently being
-                # rendered). Without this, rendering validations for an early
-                # phase falsely warns about every step referenced by later
-                # phases' validations.
-                if step_phase and self._current_phase and self._phase_order:
-                    try:
-                        step_idx = self._phase_order.index(step_phase)
-                        curr_idx = self._phase_order.index(self._current_phase)
-                    except ValueError:
-                        step_idx = curr_idx = -1
-                    if step_idx > curr_idx >= 0:
-                        continue
-                self._warned_missing_steps.add(warn_key)
-                msg = f"step '{step_name}' has no output (not run?), using defaults for: steps.{full_path}"
-                logger.warning(msg)
-                self._context_warnings.append(msg)
-                continue
-
-            # Step has output - walk the path to check for missing fields
-            node = steps_data
-            for i, part in enumerate(parts):
-                if isinstance(node, dict) and part in node:
-                    node = node[part]
-                elif isinstance(node, dict):
-                    missing = parts[i]
-                    available = ", ".join(sorted(node.keys())) if node else "(empty)"
-                    self._warned_missing_steps.add(warn_key)
-                    msg = f"'{missing}' not found in steps.{'.'.join(parts[:i])} (available: {available})"
-                    logger.warning(msg)
-                    self._context_warnings.append(msg)
-                    break
-                else:
-                    self._warned_missing_steps.add(warn_key)
-                    msg = (
-                        f"cannot descend into steps.{'.'.join(parts[:i])} "
-                        f"(found {type(node).__name__}), using defaults for: steps.{full_path}"
-                    )
-                    logger.warning(msg)
-                    self._context_warnings.append(msg)
-                    break
-
     def render_dict(self, data: dict[str, Any]) -> dict[str, Any]:
         """Recursively render all string values in a dictionary.
-
-        When a key matches a silenced validation name (see
-        ``set_silenced_validation_names``), the entire subtree under that key
-        is rendered with missing-step warnings suppressed. That subtree's
-        templates point at a check pytest will deselect, so the refs are
-        effectively dead code and warnings would be noise.
 
         Args:
             data: Dictionary with potential template strings
@@ -422,21 +230,14 @@ class Context:
         """
         result = {}
         for key, value in data.items():
-            silence = self._is_silenced_validation_name(key)
-            if silence:
-                self._warning_suppression_depth += 1
-            try:
-                if isinstance(value, str):
-                    result[key] = self.render_string(value)
-                elif isinstance(value, dict):
-                    result[key] = self.render_dict(value)
-                elif isinstance(value, list):
-                    result[key] = self._render_list(value)
-                else:
-                    result[key] = value
-            finally:
-                if silence:
-                    self._warning_suppression_depth -= 1
+            if isinstance(value, str):
+                result[key] = self.render_string(value)
+            elif isinstance(value, dict):
+                result[key] = self.render_dict(value)
+            elif isinstance(value, list):
+                result[key] = self._render_list(value)
+            else:
+                result[key] = value
         return result
 
     def _render_list(self, items: list[Any]) -> list[Any]:
@@ -459,11 +260,3 @@ class Context:
             else:
                 result.append(item)
         return result
-
-    def to_inventory_dict(self) -> dict[str, Any]:
-        """Convert inventory to format expected by isvtest.
-
-        Returns:
-            Dictionary matching isvtest inventory schema
-        """
-        return self.data.get("inventory", {})

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -24,6 +24,19 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
+from isvtest.core.resolution import (
+    ErrorReason,
+    ResolvedEntry,
+    SkipReason,
+    State,
+    ValidationEntry,
+    get_entry_phase,
+    parse_validations,
+    resolve_entries,
+)
+from isvtest.main import run_validations_via_pytest
+from isvtest.release_manifest import INCLUDE_UNRELEASED_ENV, load_released_test_filter
+
 from isvctl.config.schema import RunConfig
 from isvctl.orchestrator.commands import CommandExecutor
 from isvctl.orchestrator.context import Context
@@ -67,44 +80,110 @@ class OrchestratorResult:
         success: Whether all phases succeeded
         phases: Results for each phase that was executed
         inventory: Final inventory data (step outputs)
-        context_warnings: Template/context warnings collected during orchestration
     """
 
     success: bool
     phases: list[PhaseResult]
     inventory: dict[str, Any] | None = None
-    context_warnings: list[str] = field(default_factory=list)
+    validations: list[ResolvedEntry] = field(default_factory=list)
 
 
-def _merge_junit_xmls(phase_files: list[Path], output_path: Path) -> None:
+def _fold_suite(target: ET.Element, source: ET.Element) -> None:
+    """Append source's testcases into target and add their counter contributions.
+
+    Used when multiple per-phase XML files contribute to the same logical
+    testsuite (pytest's run + the orchestrator's pre-resolved / deselected
+    stubs for the same phase). Both producers always emit the counter and
+    time attributes, so we parse them strictly: a missing/malformed value
+    indicates a bug we want to surface, not paper over.
+    """
+    for case in source.findall("testcase"):
+        target.append(case)
+    for attr in ("tests", "failures", "errors", "skipped"):
+        target.set(attr, str(int(target.get(attr, "0")) + int(source.get(attr, "0"))))
+    target.set("time", f"{float(target.get('time', '0')) + float(source.get('time', '0')):.3f}")
+
+
+def _sort_suite_testcases(suite: ET.Element, name_order: list[str]) -> None:
+    """Reorder a suite's <testcase> children to match a canonical name order.
+
+    Pre-resolved stub testcases get appended before pytest's ones during
+    merge, which makes the dashboard show every skipped check at the top of
+    the suite. Sorting here puts each testcase back where its name appears
+    in the YAML config, interleaving skips with the rest.
+
+    Subtests carry the parent name before ``::``; they sort with their
+    parent and keep their relative order via Python's stable sort.
+    """
+    order_index: dict[str, int] = {}
+    for i, name in enumerate(name_order):
+        order_index.setdefault(name, i)
+    fallback = len(name_order)
+
+    def key(case: ET.Element) -> int:
+        case_name = case.get("name") or ""
+        return order_index.get(case_name.split("::", 1)[0], fallback)
+
+    # ElementTree has no in-place sort; remove + re-append in sorted order
+    # leaves each case at the end of the suite in turn, so after we touch all
+    # of them they're laid out in sorted order. Stable sort keeps subtests in
+    # pytest's emitted order beside their parent.
+    for case in sorted(suite.findall("testcase"), key=key):
+        suite.remove(case)
+        suite.append(case)
+
+
+def _merge_junit_xmls(
+    phase_files: list[Path],
+    output_path: Path,
+    name_order: list[str] | None = None,
+) -> None:
     """Merge multiple per-phase JUnit XML files into a single file.
 
     Combines all <testsuite> elements from each phase file into a single
-    <testsuites> root element. This allows multi-phase orchestration runs
-    to produce a single comprehensive JUnit XML report.
+    <testsuites> root element. Suites with the same ``name`` are folded into
+    a single testsuite (testcases concatenated, counters summed) so a phase's
+    pytest output and its pre-resolved/deselected stubs render as one suite
+    on dashboards instead of separate cards.
 
     Args:
         phase_files: List of per-phase JUnit XML file paths
         output_path: Final output path for the merged XML
+        name_order: Optional list of validation names defining the canonical
+            order. When provided, each merged suite's testcases are sorted to
+            match it (typically YAML config order from ``parse_validations``).
     """
     root = ET.Element("testsuites")
     root.set("name", "isvctl validation tests")
+    suites_by_name: dict[str, ET.Element] = {}
 
     for phase_file in phase_files:
         if not phase_file.exists():
             continue
         try:
             tree = ET.parse(phase_file)
-            phase_root = tree.getroot()
-            # Handle both <testsuites><testsuite>... and direct <testsuite>
-            if phase_root.tag == "testsuites":
-                for suite in phase_root:
-                    root.append(suite)
-            elif phase_root.tag == "testsuite":
-                root.append(phase_root)
         except ET.ParseError:
             logger.warning(f"Failed to parse JUnit XML: {phase_file}")
             continue
+        phase_root = tree.getroot()
+        if phase_root.tag == "testsuites":
+            suites = [s for s in phase_root if s.tag == "testsuite"]
+        elif phase_root.tag == "testsuite":
+            suites = [phase_root]
+        else:
+            continue
+        for suite in suites:
+            name = suite.get("name") or ""
+            existing = suites_by_name.get(name)
+            if existing is None:
+                suites_by_name[name] = suite
+                root.append(suite)
+            else:
+                _fold_suite(existing, suite)
+
+    if name_order:
+        for suite in suites_by_name.values():
+            _sort_suite_testcases(suite, name_order)
 
     redact_junit_xml_tree(root)
 
@@ -112,6 +191,107 @@ def _merge_junit_xmls(phase_files: list[Path], output_path: Path) -> None:
     ET.indent(tree, space="    ")
     tree.write(str(output_path), encoding="utf-8", xml_declaration=True)
     logger.info(f"JUnit XML report written to: {output_path}")
+
+
+def _entries_missing_from_junit(entries: list[ResolvedEntry], junit_path: Path | None) -> list[ResolvedEntry]:
+    """Return executed entries whose names aren't present in a pytest JUnit XML.
+
+    Entries deselected by ``-k``/``-m`` are returned by pytest with a terminal
+    state but never appear in pytest's XML. This helper finds them so the
+    orchestrator can emit a stub testcase for each, preserving the "every
+    config-declared validation reaches the report" invariant.
+
+    A non-existent file is the normal path for phases that ran no pytest
+    validations (e.g., setup/teardown); silently return the entries as-is.
+    A file that exists but fails to parse is a real problem worth logging.
+    """
+    if junit_path is None or not junit_path.exists():
+        return list(entries)
+    try:
+        tree = ET.parse(junit_path)
+    except ET.ParseError:
+        logger.warning(f"Failed to parse JUnit XML: {junit_path}; treating all executed entries as missing")
+        return list(entries)
+    captured = {case.get("name") for case in tree.iter("testcase") if case.get("name")}
+    return [entry for entry in entries if entry.entry.name not in captured]
+
+
+def _write_terminal_junit_xml(entries: list[ResolvedEntry], output_path: Path, suite_name: str) -> None:
+    """Write JUnit XML for terminal entries that did not run through pytest.
+
+    Attribute layout mirrors pytest's: ``type`` carries the typed reason (enum
+    value), ``message`` carries the human-readable text. The element body is
+    left empty for skipped entries (no stack trace exists) so dashboards do
+    not render a misleading "Stack Trace: <same as message>" panel; error
+    entries keep the body so any captured diagnostic survives.
+    """
+    suite = ET.Element("testsuite")
+    suite.set("name", suite_name)
+    suite.set("tests", str(len(entries)))
+    suite.set("failures", "0")
+    suite.set("errors", str(sum(1 for entry in entries if entry.state == State.ERROR)))
+    suite.set("skipped", str(sum(1 for entry in entries if entry.state == State.SKIPPED)))
+    suite.set("time", f"{sum(entry.duration_seconds for entry in entries):.3f}")
+
+    for entry in entries:
+        case = ET.SubElement(suite, "testcase")
+        case.set("name", entry.entry.name)
+        case.set("time", f"{entry.duration_seconds:.3f}")
+        if entry.state == State.SKIPPED:
+            reason = entry.skip_reason or SkipReason.OPERATOR
+            skipped = ET.SubElement(case, "skipped")
+            skipped.set("type", reason.value)
+            skipped.set("message", entry.message or reason.value)
+        elif entry.state == State.ERROR:
+            reason = entry.error_reason or ErrorReason.RUNTIME_EXCEPTION
+            error = ET.SubElement(case, "error")
+            error.set("type", reason.value)
+            error.set("message", entry.message or reason.value)
+            if entry.message:
+                error.text = entry.message
+
+    tree = ET.ElementTree(suite)
+    ET.indent(tree, space="    ")
+    tree.write(str(output_path), encoding="utf-8", xml_declaration=True)
+
+
+def _resolved_entry_to_result_dict(entry: ResolvedEntry) -> dict[str, Any]:
+    """Convert a resolved entry to the CLI/result detail dictionary."""
+    skipped = entry.state == State.SKIPPED
+    passed = entry.state in {State.PASSED, State.SKIPPED}
+    return {
+        "name": entry.entry.name,
+        "passed": passed,
+        "skipped": skipped,
+        "message": entry.message,
+        "category": entry.entry.category,
+        "state": entry.state.value if entry.state else None,
+        "skip_reason": entry.skip_reason.value if entry.skip_reason else None,
+        "error_reason": entry.error_reason.value if entry.error_reason else None,
+    }
+
+
+def _resolved_entry_success(entry: ResolvedEntry) -> bool:
+    """Return whether a resolved validation outcome should keep the phase successful."""
+    return entry.state in {State.PASSED, State.SKIPPED}
+
+
+def _phase_enum_for_name(phase_name: str) -> Phase:
+    """Map a configured phase name to the display enum."""
+    if phase_name == "setup":
+        return Phase.SETUP
+    if phase_name == "teardown":
+        return Phase.TEARDOWN
+    return Phase.TEST
+
+
+def _has_explicit_pytest_selection(extra_pytest_args: list[str] | None) -> bool:
+    """Return whether pytest args explicitly select tests or markers."""
+    if not extra_pytest_args:
+        return False
+    return any(
+        arg == "-k" or arg.startswith("-k=") or arg == "-m" or arg.startswith("-m=") for arg in extra_pytest_args
+    )
 
 
 class Orchestrator:
@@ -139,7 +319,6 @@ class Orchestrator:
         self.executor = CommandExecutor(working_dir=working_dir)
         self.step_executor = StepExecutor(working_dir=working_dir)
         self._results: list[PhaseResult] = []
-        # Validation options (set in run())
         self._extra_pytest_args: list[str] | None = None
         self._verbose: bool = False
         self._junitxml: str | None = None
@@ -174,7 +353,6 @@ class Orchestrator:
         self._verbose = verbose
         self._junitxml = junitxml
 
-        # Determine platform from test config
         platform = self._detect_platform()
         if not platform:
             return OrchestratorResult(
@@ -228,11 +406,9 @@ class Orchestrator:
                 ],
             )
 
-        # Get phases from config (defines execution order)
         config_phases = self.config.get_phases(platform)
         logger.info(f"Configured phases: {config_phases}")
 
-        # Validate all steps have a phase in the config phases list
         for step in steps:
             step_phase = (step.phase or "setup").lower()
             if step_phase not in config_phases:
@@ -247,7 +423,6 @@ class Orchestrator:
                     ],
                 )
 
-        # Group steps by phase
         steps_by_phase: dict[str, list] = {phase: [] for phase in config_phases}
         for step in steps:
             step_phase = (step.phase or "setup").lower()
@@ -262,34 +437,30 @@ class Orchestrator:
             step_phase = (step.phase or "setup").lower()
             self.context.set_step_phase(step.name, step_phase)
 
-        # Get all validations from config
         all_validations = {}
         if self.config.tests and self.config.tests.validations:
             all_validations = self.config.tests.validations
+        validation_entries = parse_validations(all_validations)
+        resolved_validations_by_index: dict[int, ResolvedEntry] = {}
+        released_tests = load_released_test_filter()
+        if released_tests is None:
+            logger.info(f"Including unreleased validations because {INCLUDE_UNRELEASED_ENV} is enabled")
 
-        # Get exclude config for filtering validations
         exclude_markers: list[str] = []
         exclude_tests: list[str] = []
         if self.config.tests and self.config.tests.exclude:
             exclude_markers = self.config.tests.exclude.get("markers", [])
             exclude_tests = self.config.tests.exclude.get("tests", [])
+        resolution_exclude_markers = [] if _has_explicit_pytest_selection(self._extra_pytest_args) else exclude_markers
 
         phase_results: list[PhaseResult] = []
         overall_success = True
-        setup_steps_ran = False  # Track whether setup steps executed (for teardown gating)
+        setup_steps_ran = False
 
-        # Build set of requested phase names for filtering
         requested_phase_names = {p.value for p in requested_phases}
 
-        # Tell context which phases were requested so it can suppress
-        # warnings for steps in intentionally skipped phases
-        if Phase.ALL in requested_phases:
-            self.context.set_requested_phases(set(config_phases))
-        else:
-            self.context.set_requested_phases(requested_phase_names)
-
-        # Per-phase JUnit XML: use temp files per phase, merge at the end
-        # This prevents later phases from overwriting earlier phases' results
+        # Per-phase JUnit XML files merge at the end so later phases don't
+        # overwrite earlier ones.
         junit_tmpdir: str | None = None
         phase_junit_files: list[Path] = []
 
@@ -297,26 +468,15 @@ class Orchestrator:
             if self._junitxml:
                 junit_tmpdir = tempfile.mkdtemp(prefix="junit-phases-")
 
-            # Execute phases in configured order
             for phase_name in config_phases:
-                # Skip phases not in requested_phases (don't add to results at all)
                 if phase_name not in requested_phase_names and Phase.ALL not in requested_phases:
                     continue
                 phase_steps = steps_by_phase.get(phase_name, [])
+                phase_enum = _phase_enum_for_name(phase_name)
 
-                # Map phase name to Phase enum for display (setup/teardown are special)
-                if phase_name == "setup":
-                    phase_enum = Phase.SETUP
-                elif phase_name == "teardown":
-                    phase_enum = Phase.TEARDOWN
-                else:
-                    phase_enum = Phase.TEST  # Use TEST for display of custom phases
-
-                # Check if this phase should run
                 is_teardown = phase_name == "teardown"
                 skip_reason: str | None = None
 
-                # Skip non-teardown phases if previous phase failed
                 if not overall_success and not is_teardown:
                     skip_reason = "previous phase failed"
 
@@ -335,17 +495,15 @@ class Orchestrator:
 
                 if skip_reason:
                     logger.info(f"Skipping {phase_name}: {skip_reason}")
-                    # Add a skipped phase result for visibility
                     phase_results.append(
                         PhaseResult(
                             phase=phase_enum,
-                            success=True,  # Skipped is not a failure
+                            success=True,
                             message=f"SKIPPED: {skip_reason}",
                         )
                     )
                     continue
 
-                # Execute steps for this phase
                 if phase_steps:
                     step_results = self.step_executor.execute_steps(phase_steps, self.context, best_effort=is_teardown)
                 else:
@@ -354,53 +512,118 @@ class Orchestrator:
                 if phase_name == "setup" and step_results.steps:
                     setup_steps_ran = True
 
-                # Use a per-phase temp file for JUnit XML to avoid overwriting
                 phase_junitxml: str | None = None
                 if junit_tmpdir:
                     phase_junitxml = str(Path(junit_tmpdir) / f"junit-{phase_name}.xml")
 
-                # Tell the context which phase is being rendered so it can
-                # suppress "step has no output (not run?)" warnings for steps
-                # whose phase comes after the current one (they simply
-                # haven't had a chance to run yet).
-                self.context.set_current_phase(phase_name, config_phases)
-
-                # Run validations for this phase (excluding categories that match exclude markers)
-                test_settings = self.config.tests.settings if self.config.tests else {}
-                phase_validations = self.step_executor.run_validations_for_phase(
-                    phase_name,
-                    all_validations,
-                    self.context,
-                    exclude_markers=exclude_markers,
-                    exclude_tests=exclude_tests,
-                    settings=test_settings,
-                    extra_pytest_args=self._extra_pytest_args,
-                    verbose=self._verbose,
-                    junitxml=phase_junitxml,
-                    suite_name=f"{platform}/{phase_name}",
+                step_phases_snapshot = self.context.get_all_step_phases()
+                phase_entry_indexes = [
+                    index
+                    for index, entry in enumerate(validation_entries)
+                    if index not in resolved_validations_by_index
+                    and get_entry_phase(entry, step_phases_snapshot) == phase_name
+                ]
+                phase_entries = [validation_entries[index] for index in phase_entry_indexes]
+                resolved_phase_entries = self._resolve_validation_entries(
+                    phase_entries,
+                    requested_phase_names if Phase.ALL not in requested_phases else set(config_phases),
+                    set(resolution_exclude_markers),
+                    set(exclude_tests),
+                    released_tests,
                 )
+                ready_entries = [entry for entry in resolved_phase_entries if entry.is_ready]
+                terminal_before_pytest = [entry for entry in resolved_phase_entries if not entry.is_ready]
 
-                # Collect per-phase JUnit XML if it was generated
-                if phase_junitxml and Path(phase_junitxml).exists():
-                    phase_junit_files.append(Path(phase_junitxml))
+                # Write a per-phase stub for entries pre-resolved to SKIPPED/ERROR.
+                # Suite name matches pytest's so the merger collapses them into one suite.
+                if terminal_before_pytest and junit_tmpdir:
+                    terminal_junit = Path(junit_tmpdir) / f"junit-{phase_name}-resolved.xml"
+                    _write_terminal_junit_xml(terminal_before_pytest, terminal_junit, f"{platform}/{phase_name}")
+                    phase_junit_files.append(terminal_junit)
 
-                # Only add phase result if there were steps or validations
+                test_settings = self.config.tests.settings if self.config.tests else {}
+                if ready_entries:
+                    _exit_code, executed_entries = run_validations_via_pytest(
+                        entries=ready_entries,
+                        settings=test_settings,
+                        inventory=self.context.get_accumulated_context(),
+                        extra_pytest_args=self._extra_pytest_args,
+                        verbose=self._verbose,
+                        junitxml=phase_junitxml,
+                        suite_name=f"{platform}/{phase_name}",
+                    )
+                else:
+                    executed_entries = []
+
+                phase_junit_path = Path(phase_junitxml) if phase_junitxml else None
+                if phase_junit_path and phase_junit_path.exists():
+                    phase_junit_files.append(phase_junit_path)
+
+                # Entries deselected by pytest -k / -m are terminalized in memory but
+                # not written to pytest's XML. Stub them so they reach the merged report.
+                missing_executed = _entries_missing_from_junit(executed_entries, phase_junit_path)
+                if missing_executed and junit_tmpdir:
+                    deselected_junit = Path(junit_tmpdir) / f"junit-{phase_name}-deselected.xml"
+                    _write_terminal_junit_xml(missing_executed, deselected_junit, f"{platform}/{phase_name}")
+                    phase_junit_files.append(deselected_junit)
+
+                executed_iter = iter(executed_entries)
+                terminal_phase_entries = [
+                    next(executed_iter) if resolved_entry.is_ready else resolved_entry
+                    for resolved_entry in resolved_phase_entries
+                ]
+                for index, resolved_entry in zip(phase_entry_indexes, terminal_phase_entries, strict=True):
+                    resolved_validations_by_index[index] = resolved_entry
+
+                phase_validations = [_resolved_entry_to_result_dict(entry) for entry in terminal_phase_entries]
+
                 if phase_steps or phase_validations:
                     phase_results.append(
                         self._create_phase_result(phase_enum, step_results, phase_validations, phase_name)
                     )
 
-                # Update success status
                 phase_success = step_results.success and all(v.get("passed", False) for v in phase_validations)
                 if not phase_success:
                     overall_success = False
 
-            # Merge per-phase JUnit XMLs into the final output file
+            remaining_entries = [
+                (index, entry)
+                for index, entry in enumerate(validation_entries)
+                if index not in resolved_validations_by_index
+            ]
+            if remaining_entries:
+                terminal_remaining = self._resolve_remaining_validation_entries(
+                    remaining_entries,
+                    requested_phase_names if Phase.ALL not in requested_phases else set(config_phases),
+                    set(resolution_exclude_markers),
+                    set(exclude_tests),
+                    released_tests,
+                    config_phases,
+                )
+                for index, resolved_entry in terminal_remaining:
+                    resolved_validations_by_index[index] = resolved_entry
+                if junit_tmpdir:
+                    step_phases_for_unexecuted = self.context.get_all_step_phases()
+                    unexecuted_by_phase: dict[str, list[ResolvedEntry]] = {}
+                    for _, resolved_entry in terminal_remaining:
+                        entry_phase = get_entry_phase(resolved_entry.entry, step_phases_for_unexecuted)
+                        unexecuted_by_phase.setdefault(entry_phase, []).append(resolved_entry)
+                    for entry_phase, entries_for_phase in unexecuted_by_phase.items():
+                        terminal_junit = Path(junit_tmpdir) / f"junit-{entry_phase}-unexecuted.xml"
+                        _write_terminal_junit_xml(entries_for_phase, terminal_junit, f"{platform}/{entry_phase}")
+                        phase_junit_files.append(terminal_junit)
+                self._append_resolution_only_phase_results(phase_results, terminal_remaining)
+                if not all(_resolved_entry_success(resolved_entry) for _, resolved_entry in terminal_remaining):
+                    overall_success = False
+
             if self._junitxml and phase_junit_files:
-                _merge_junit_xmls(phase_junit_files, Path(self._junitxml))
+                _merge_junit_xmls(
+                    phase_junit_files,
+                    Path(self._junitxml),
+                    name_order=[entry.name for entry in validation_entries],
+                )
 
         finally:
-            # Clean up temp directory
             if junit_tmpdir:
                 shutil.rmtree(junit_tmpdir, ignore_errors=True)
 
@@ -408,7 +631,7 @@ class Orchestrator:
             success=overall_success,
             phases=phase_results,
             inventory=self.context.get_accumulated_context().get("steps", {}),
-            context_warnings=self.context.get_warnings(),
+            validations=[resolved_validations_by_index[index] for index in sorted(resolved_validations_by_index)],
         )
 
     def _create_phase_result(
@@ -467,6 +690,88 @@ class Orchestrator:
                 "validations": validation_results,
             },
         )
+
+    def _resolve_validation_entries(
+        self,
+        entries: list[ValidationEntry],
+        requested_phase_names: set[str],
+        exclude_markers: set[str],
+        exclude_tests: set[str],
+        released_tests: set[str] | None,
+    ) -> list[ResolvedEntry]:
+        """Resolve validation entries against the current orchestration context."""
+        step_outputs = self.context.get_accumulated_context().get("steps", {})
+        return resolve_entries(
+            entries,
+            step_outputs=step_outputs,
+            step_phases=self.context.get_all_step_phases(),
+            requested_phases=requested_phase_names,
+            exclude_markers=exclude_markers,
+            exclude_tests=exclude_tests,
+            released_tests=released_tests,
+            render_context=self.context.get_accumulated_context(),
+        )
+
+    def _resolve_remaining_validation_entries(
+        self,
+        entries: list[tuple[int, ValidationEntry]],
+        requested_phase_names: set[str],
+        exclude_markers: set[str],
+        exclude_tests: set[str],
+        released_tests: set[str] | None,
+        config_phases: list[str],
+    ) -> list[tuple[int, ResolvedEntry]]:
+        """Resolve entries left after the phase loop and terminalize ready entries."""
+        resolved_entries = self._resolve_validation_entries(
+            [entry for _, entry in entries],
+            requested_phase_names,
+            exclude_markers,
+            exclude_tests,
+            released_tests,
+        )
+        step_phases = self.context.get_all_step_phases()
+        terminal_entries: list[tuple[int, ResolvedEntry]] = []
+        for (index, entry), resolved in zip(entries, resolved_entries, strict=True):
+            if resolved.is_ready:
+                phase_name = get_entry_phase(entry, step_phases)
+                if phase_name in config_phases:
+                    message = f"phase '{phase_name}' did not run"
+                else:
+                    message = f"phase '{phase_name}' is not configured for this run"
+                resolved = ResolvedEntry(
+                    entry=entry,
+                    rendered_params=resolved.rendered_params,
+                    state=State.SKIPPED,
+                    skip_reason=SkipReason.PHASE_NOT_REQUESTED,
+                    message=message,
+                )
+            terminal_entries.append((index, resolved))
+        return terminal_entries
+
+    def _append_resolution_only_phase_results(
+        self,
+        phase_results: list[PhaseResult],
+        entries: list[tuple[int, ResolvedEntry]],
+    ) -> None:
+        """Append phase results that only contain unexecuted validation outcomes."""
+        step_phases = self.context.get_all_step_phases()
+        by_phase: dict[str, list[ResolvedEntry]] = {}
+        for _, entry in entries:
+            phase_name = get_entry_phase(entry.entry, step_phases)
+            by_phase.setdefault(phase_name, []).append(entry)
+
+        for phase_name, resolved_entries in by_phase.items():
+            phase_results.append(
+                PhaseResult(
+                    phase=_phase_enum_for_name(phase_name),
+                    success=all(_resolved_entry_success(entry) for entry in resolved_entries),
+                    message=f"{phase_name} phase validations resolved without execution",
+                    details={
+                        "steps": [],
+                        "validations": [_resolved_entry_to_result_dict(entry) for entry in resolved_entries],
+                    },
+                )
+            )
 
     def _detect_platform(self) -> str | None:
         """Detect platform from configuration.

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -238,7 +238,7 @@ def _write_terminal_junit_xml(entries: list[ResolvedEntry], output_path: Path, s
         case.set("name", entry.entry.name)
         case.set("time", f"{entry.duration_seconds:.3f}")
         if entry.state == State.SKIPPED:
-            reason = entry.skip_reason or SkipReason.OPERATOR
+            reason = entry.skip_reason or SkipReason.EXCLUDED
             skipped = ET.SubElement(case, "skipped")
             skipped.set("type", reason.value)
             skipped.set("message", entry.message or reason.value)

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -509,7 +509,11 @@ class Orchestrator:
                 else:
                     step_results = StepResults()
 
-                if phase_name == "setup" and step_results.steps:
+                # ``step_results.steps`` includes placeholder records for skip:true
+                # steps; require at least one step that wasn't skipped before letting
+                # teardown run (otherwise a fully-skipped setup would falsely "satisfy"
+                # the teardown gate even though no resources were created).
+                if phase_name == "setup" and any(not step.skip for step in phase_steps):
                     setup_steps_ran = True
 
                 phase_junitxml: str | None = None

--- a/isvctl/src/isvctl/orchestrator/step_executor.py
+++ b/isvctl/src/isvctl/orchestrator/step_executor.py
@@ -132,35 +132,6 @@ def _find_missing_step_path(arg: str, steps_data: dict[str, Any]) -> str | None:
     return None
 
 
-def _deselected_validation_class_names(
-    exclude_markers: list[str] | None,
-    exclude_tests: list[str] | None,
-) -> set[str]:
-    """Return validation class names pytest would deselect for the given exclusions.
-
-    A class is deselected when its name is in ``exclude_tests`` or any of its
-    ``markers`` is in ``exclude_markers``. This mirrors conftest.py's
-    collection-time filtering so we can silence template-warning emission for
-    templates inside checks that will never run.
-
-    Returns an empty set if isvtest isn't importable (falls back to current
-    noisy behavior rather than crashing the orchestrator).
-    """
-    excluded: set[str] = set(exclude_tests or ())
-    if not exclude_markers:
-        return excluded
-    try:
-        from isvtest.core.discovery import discover_all_tests
-    except ImportError:
-        return excluded
-    ex_markers = set(exclude_markers)
-    for cls in discover_all_tests():
-        cls_markers = getattr(cls, "markers", None) or []
-        if any(m in ex_markers for m in cls_markers):
-            excluded.add(cls.__name__)
-    return excluded
-
-
 @dataclass
 class StepResult:
     """Result of executing a single step.
@@ -224,7 +195,7 @@ class StepExecutor:
     3. Stores output in context for subsequent steps
     4. Continues or stops based on step configuration
 
-    Validations are run separately after phases complete via run_validations_for_phase().
+    Validations are resolved and run by the orchestrator after phase steps complete.
     """
 
     def __init__(self, working_dir: str | Path | None = None) -> None:
@@ -288,102 +259,6 @@ class StepExecutor:
                     break
 
         return results
-
-    def run_validations_for_phase(
-        self,
-        phase: str,
-        all_validations: dict[str, list[dict[str, Any]] | dict[str, Any]],
-        context: Context,
-        exclude_markers: list[str] | None = None,
-        exclude_tests: list[str] | None = None,
-        settings: dict[str, Any] | None = None,
-        extra_pytest_args: list[str] | None = None,
-        verbose: bool = False,
-        junitxml: str | None = None,
-        suite_name: str | None = None,
-    ) -> list[dict[str, Any]]:
-        """Run validations via pytest for a given phase.
-
-        Uses native pytest for full pytest features (markers, filtering, fixtures)
-        while capturing detailed results in-memory for rich output display.
-
-        Determines when validations run based on (in priority order):
-        1. Explicit `phase` field on the validation
-        2. Inferred from `step` - uses the step's phase
-        3. Default: 'test' phase
-
-        Supports two config formats:
-        1. List format (original):
-           validations:
-             category:
-               - CheckName:
-                   step: step_name
-                   phase: setup
-
-        2. Group defaults format (new):
-           validations:
-             category:
-               step: step_name
-               checks:
-                 - CheckName:
-                     other_param: value
-
-        Args:
-            phase: Current phase ('setup', 'test', 'teardown')
-            all_validations: All validations from tests.validations (grouped by category)
-            context: Context with accumulated step outputs and step phases
-            exclude_markers: List of markers to exclude (e.g., ['workload', 'l2'])
-            settings: Test settings dict (e.g., show_skipped_tests)
-            extra_pytest_args: Pytest arguments (-k, -m, -v, etc.)
-            verbose: Enable verbose output
-            junitxml: Path to write JUnit XML report
-            suite_name: Name for the JUnit XML test suite (e.g., phase name)
-
-        Returns:
-            List of validation results with name, passed, message, category
-        """
-        if not all_validations:
-            return []
-
-        try:
-            from isvtest.main import run_validations_via_pytest
-
-            step_outputs = context.get_accumulated_context().get("steps", {})
-            step_phases = context.get_all_step_phases()
-
-            # Tell the context which validation classes pytest will deselect
-            # (marker or test-name exclusion) so render_dict can suppress
-            # "missing step" warnings for templates inside those checks.
-            # Without this, a check like K8sNodePoolCheck (markers=["slow"])
-            # spams warnings about its create_test_node_pool / update_test_node_pool
-            # template refs on providers that don't run node-pool CRUD at all.
-            silenced = _deselected_validation_class_names(exclude_markers, exclude_tests)
-            context.set_silenced_validation_names(silenced)
-
-            # Render Jinja2 templates in validation parameters using context
-            # This handles templates like {{ steps.setup.slurm.partitions.cpu.nodes | length }}
-            rendered_validations = context.render_dict(all_validations)
-
-            _exit_code, results = run_validations_via_pytest(
-                validations=rendered_validations,
-                step_outputs=step_outputs,
-                step_phases=step_phases,
-                phase=phase,
-                extra_pytest_args=extra_pytest_args,
-                exclude_markers=exclude_markers,
-                exclude_tests=exclude_tests,
-                settings=settings,
-                verbose=verbose,
-                junitxml=junitxml,
-                suite_name=suite_name,
-            )
-
-            return results
-
-        except ImportError as e:
-            logger.error(f"Failed to import isvtest: {e}")
-            logger.error("Cannot run validations without isvtest package")
-            return []
 
     def _execute_step(self, step: StepConfig, context: Context) -> StepResult:
         """Execute a single step.

--- a/isvctl/tests/test_merger.py
+++ b/isvctl/tests/test_merger.py
@@ -421,8 +421,6 @@ class TestImportEndToEnd:
         context = Context(config)
         for step in config.get_steps("kubernetes"):
             context.set_step_phase(step.name, step.phase or "setup")
-        context.set_requested_phases({"setup", "test", "teardown"})
-        context.set_current_phase("test", config.get_phases("kubernetes"))
         context.set_step_output("setup", {"kubernetes": {"node_count": 3}})
         context.set_step_output(
             "update_test_node_pool",
@@ -430,7 +428,6 @@ class TestImportEndToEnd:
         )
         assert context.render_string(node_count) == "3"
         assert context.render_string(exclude_selector) == "eks.amazonaws.com/nodegroup=isv-test-pool"
-        assert context.get_warnings() == []
         assert result["tests"]["platform"] == "kubernetes"
 
     def test_aws_eks_does_not_hardcode_world_open_endpoint_allowlist(self) -> None:

--- a/isvctl/tests/test_orchestrator.py
+++ b/isvctl/tests/test_orchestrator.py
@@ -10,10 +10,7 @@
 
 """Tests for orchestration components."""
 
-import logging
 from pathlib import Path
-
-import pytest
 
 from isvctl.config.schema import CommandConfig, CommandOutput, RunConfig
 from isvctl.orchestrator.commands import CommandExecutor
@@ -253,42 +250,6 @@ class TestContext:
         assert result["nested"]["value"] == "prefix-test"
         assert result["list"] == ["test", "static"]
 
-    def test_to_inventory_dict(self) -> None:
-        """Test conversion to isvtest inventory format."""
-        config = RunConfig()
-        context = Context(config)
-
-        output = CommandOutput(
-            platform="kubernetes",
-            cluster_name="my-cluster",
-            kubernetes={
-                "node_count": 4,
-                "driver_version": "580.95.05",
-            },
-        )
-        context.set_inventory(output)
-
-        inventory = context.to_inventory_dict()
-        assert inventory["platform"] == "kubernetes"
-        assert inventory["cluster_name"] == "my-cluster"
-
-    def test_get_command_context(self) -> None:
-        """Test getting context for command templating."""
-        config = RunConfig(context={"node_count": 8}, lab={"id": "lab-001"})
-        context = Context(config)
-
-        cmd_context = context.get_command_context()
-        assert cmd_context["context"]["node_count"] == 8
-        assert cmd_context["lab"]["id"] == "lab-001"
-
-    def test_get_test_context(self) -> None:
-        """Test getting context for test configuration."""
-        config = RunConfig(context={"gpu_count": 4})
-        context = Context(config)
-
-        test_context = context.get_test_context()
-        assert test_context["context"]["gpu_count"] == 4
-
     def test_render_string_without_templates(self) -> None:
         """Test that strings without templates pass through unchanged."""
         config = RunConfig()
@@ -342,179 +303,21 @@ class TestContext:
         assert result["items"][4] is True
         assert result["items"][5] is None
 
-    def test_warns_when_step_output_missing(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Template referencing a step that hasn't run should warn."""
+    def test_missing_step_default_renders(self) -> None:
+        """Templates with `default` filters render even when the step is missing."""
         config = RunConfig()
         context = Context(config)
 
-        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
-            result = context.render_string("{{ steps.setup.kubernetes.total_gpus | default(4, true) }}")
+        result = context.render_string("{{ steps.setup.kubernetes.total_gpus | default(4, true) }}")
 
         assert result == "4"
-        assert len(caplog.records) == 1
-        assert "step 'setup' has no output" in caplog.records[0].message
-        assert len(context.get_warnings()) == 1
 
-    def test_no_warning_when_step_output_present(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Template referencing a step with output should not warn."""
+    def test_step_output_renders_when_present(self) -> None:
+        """Template referencing a step with output renders normally."""
         config = RunConfig()
         context = Context(config)
         context.set_step_output("setup", {"kubernetes": {"total_gpus": 16}})
 
-        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
-            result = context.render_string("{{ steps.setup.kubernetes.total_gpus | default(4, true) }}")
+        result = context.render_string("{{ steps.setup.kubernetes.total_gpus | default(4, true) }}")
 
         assert result == "16"
-        assert len(caplog.records) == 0
-
-    def test_missing_step_warning_deduplicates(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Same path referenced twice should warn only once."""
-        config = RunConfig()
-        context = Context(config)
-
-        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
-            context.render_string("{{ steps.setup.kubernetes.total_gpus | default(16, true) }}")
-            context.render_string("{{ steps.setup.kubernetes.total_gpus | default(4, true) }}")
-
-        assert len(caplog.records) == 1
-
-    def test_warns_when_field_missing_in_step_output(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Typo or wrong field name in a populated step should warn."""
-        config = RunConfig()
-        context = Context(config)
-        context.set_step_output("setup", {"kubernetes": {"total_gpus": 1, "gpu_per_node": 1}})
-
-        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
-            result = context.render_string("{{ steps.setup.kubernetes._total_gpus | default(1, true) }}")
-
-        assert result == "1"
-        assert len(caplog.records) == 1
-        assert "'_total_gpus' not found" in caplog.records[0].message
-        assert "total_gpus" in caplog.records[0].message  # listed in available keys
-        assert len(context.get_warnings()) == 1
-
-    def test_warns_with_available_keys(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Warning for missing field should list available keys at that level."""
-        config = RunConfig()
-        context = Context(config)
-        context.set_step_output("setup", {"kubernetes": {"gpu_per_node": 4, "total_gpus": 16}})
-
-        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
-            context.render_string("{{ steps.setup.kubernetes.typo_field | default(1, true) }}")
-
-        assert len(caplog.records) == 1
-        assert "'typo_field' not found" in caplog.records[0].message
-        assert "gpu_per_node" in caplog.records[0].message
-
-    def test_no_warning_when_step_phase_is_after_current_phase(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Rendering during an earlier phase must not warn about pending later-phase steps.
-
-        Validations are rendered once per phase against the full config, so a
-        ``test``-phase template like ``{{ steps.describe_instance.public_ip }}``
-        is evaluated while ``setup`` is still running. The step exists and will
-        run later; warning here is pure noise.
-        """
-        config = RunConfig()
-        context = Context(config)
-        context.set_requested_phases({"setup", "test", "teardown"})
-        context.set_step_phase("describe_instance", "test")
-        context.set_current_phase("setup", ["setup", "test", "teardown"])
-
-        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
-            result = context.render_string("{{ steps.describe_instance.public_ip | default('1.2.3.4', true) }}")
-
-        assert result == "1.2.3.4"
-        assert caplog.records == []
-        assert context.get_warnings() == []
-
-    def test_warns_when_step_phase_is_current_phase_with_no_output(self, caplog: pytest.LogCaptureFixture) -> None:
-        """A step in the phase currently being rendered that produced no output should warn."""
-        config = RunConfig()
-        context = Context(config)
-        context.set_requested_phases({"setup", "test", "teardown"})
-        context.set_step_phase("launch_instance", "setup")
-        context.set_current_phase("setup", ["setup", "test", "teardown"])
-
-        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
-            context.render_string("{{ steps.launch_instance.instance_id | default('i-0', true) }}")
-
-        assert len(caplog.records) == 1
-        assert "step 'launch_instance' has no output" in caplog.records[0].message
-
-    def test_warns_when_step_phase_is_before_current_phase_with_no_output(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """A step whose phase already completed but produced no output should still warn."""
-        config = RunConfig()
-        context = Context(config)
-        context.set_requested_phases({"setup", "test", "teardown"})
-        context.set_step_phase("launch_instance", "setup")
-        context.set_current_phase("test", ["setup", "test", "teardown"])
-
-        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
-            context.render_string("{{ steps.launch_instance.instance_id | default('i-0', true) }}")
-
-        assert len(caplog.records) == 1
-        assert "step 'launch_instance' has no output" in caplog.records[0].message
-
-    def test_no_warning_inside_silenced_validation_subtree(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Templates inside a validation pytest will deselect must not warn.
-
-        Mirrors the microk8s case: K8sNodePoolCheck is marker-excluded (slow)
-        and references steps that don't exist on the provider. Since the check
-        never runs, its dead template refs should be silent.
-        """
-        config = RunConfig()
-        context = Context(config)
-        context.set_silenced_validation_names({"K8sNodePoolCheck"})
-
-        data = {
-            "k8s_node_pools": {
-                "checks": {
-                    "K8sNodePoolCheck-Create": {
-                        "label_selector": "{{ steps.create_test_node_pool.label_selector }}",
-                        "expected_replicas": "{{ steps.create_test_node_pool.expected_replicas | default(1, true) }}",
-                    },
-                    "K8sNodePoolCheck-Update": {
-                        "label_selector": "{{ steps.update_test_node_pool.label_selector }}",
-                    },
-                },
-            },
-        }
-
-        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
-            context.render_dict(data)
-
-        assert caplog.records == []
-        assert context.get_warnings() == []
-
-    def test_warnings_still_emitted_outside_silenced_subtrees(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Silencing must not leak past the silenced subtree."""
-        config = RunConfig()
-        context = Context(config)
-        context.set_silenced_validation_names({"K8sNodePoolCheck"})
-
-        data = {
-            "k8s_node_pools": {
-                "checks": {
-                    "K8sNodePoolCheck-Create": {
-                        "label_selector": "{{ steps.create_test_node_pool.label_selector }}",
-                    },
-                },
-            },
-            "kubernetes": {
-                "checks": {
-                    "K8sNodeCountCheck": {
-                        "count": "{{ steps.setup.kubernetes.node_count | default(1, true) }}",
-                    },
-                },
-            },
-        }
-
-        with caplog.at_level(logging.WARNING, logger="isvctl.orchestrator.context"):
-            context.render_dict(data)
-
-        messages = [r.message for r in caplog.records]
-        assert len(messages) == 1
-        assert "step 'setup' has no output" in messages[0]
-        assert not any("create_test_node_pool" in m for m in messages)

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -503,6 +503,33 @@ class TestTeardownOnlyPhase:
         step_names = [s["name"] for s in teardown_phases[0].details["steps"]]
         assert "cleanup" in step_names
 
+    def test_full_lifecycle_skips_teardown_when_setup_is_all_skip_placeholders(self) -> None:
+        """skip:true setup placeholders must not falsely satisfy the teardown gate.
+
+        ``execute_steps`` records placeholder StepResults for ``skip: true`` steps,
+        so a naive ``step_results.steps`` truthy-check would let teardown run even
+        though no setup command actually executed. The gate must look at the
+        configured steps' skip flags, not just the result list.
+        """
+        config = RunConfig(
+            commands={
+                "kubernetes": PlatformCommands(
+                    steps=[
+                        StepConfig(name="setup_cluster", command="echo", args=["hi"], phase="setup", skip=True),
+                        StepConfig(name="cleanup", command="echo", args=["bye"], phase="teardown"),
+                    ]
+                )
+            },
+            tests=ValidationConfig(platform="kubernetes"),
+        )
+        orchestrator = Orchestrator(config)
+        result = orchestrator.run(phases=[Phase.SETUP, Phase.TEARDOWN])
+
+        teardown_phases = [p for p in result.phases if p.phase == Phase.TEARDOWN]
+        assert len(teardown_phases) == 1
+        assert "SKIPPED" in teardown_phases[0].message
+        assert "setup steps did not run" in teardown_phases[0].message
+
     def test_teardown_only_does_not_run_setup_steps(self) -> None:
         """When only teardown is requested, setup steps must not execute."""
         config = RunConfig(

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -10,12 +10,26 @@
 
 """Tests for orchestrator loop."""
 
+import xml.etree.ElementTree as ET
 from pathlib import Path
-from unittest.mock import patch
+
+from isvtest.core.resolution import (
+    ErrorReason,
+    ResolvedEntry,
+    SkipReason,
+    State,
+    ValidationEntry,
+)
 
 from isvctl.config.schema import PlatformCommands, RunConfig, StepConfig, ValidationConfig
 from isvctl.orchestrator.context import Context
-from isvctl.orchestrator.loop import Orchestrator, Phase
+from isvctl.orchestrator.loop import (
+    Orchestrator,
+    Phase,
+    _entries_missing_from_junit,
+    _merge_junit_xmls,
+    _write_terminal_junit_xml,
+)
 from isvctl.orchestrator.step_executor import (
     MissingStepRefError,
     StepExecutor,
@@ -252,17 +266,23 @@ EOF
                     ]
                 )
             },
-            tests=ValidationConfig(platform="kubernetes"),
+            tests=ValidationConfig(
+                platform="kubernetes",
+                validations={
+                    "setup_checks": {
+                        "step": "setup_cluster",
+                        "checks": {
+                            "FieldExistsCheck": {
+                                "field": "missing_field",
+                            }
+                        },
+                    }
+                },
+            ),
         )
         orchestrator = Orchestrator(config)
 
-        failing_validations = [{"name": "FakeCheck", "passed": False, "error": "simulated"}]
-        with patch.object(
-            orchestrator.step_executor,
-            "run_validations_for_phase",
-            side_effect=lambda phase, *a, **kw: failing_validations if phase == "setup" else [],
-        ):
-            result = orchestrator.run(teardown_on_failure=True)
+        result = orchestrator.run(teardown_on_failure=True)
 
         assert not result.success
         teardown_phases = [p for p in result.phases if p.phase == Phase.TEARDOWN]
@@ -323,6 +343,128 @@ EOF
         step_names = [s["name"] for s in teardown_phases[0].details["steps"]]
         assert "teardown_nim" in step_names, "first teardown step must be recorded"
         assert "teardown_vm" in step_names, "second teardown step must run despite first failure"
+
+    def test_validation_without_step_output_is_reported_as_skipped(self) -> None:
+        """A configured validation whose step produced no JSON is skipped visibly."""
+        config = RunConfig(
+            commands={
+                "kubernetes": PlatformCommands(
+                    phases=["test"],
+                    steps=[
+                        StepConfig(name="probe", command="true", phase="test"),
+                    ],
+                )
+            },
+            tests=ValidationConfig(
+                platform="kubernetes",
+                validations={
+                    "probe_checks": {
+                        "step": "probe",
+                        "checks": {"StepSuccessCheck": {}},
+                    },
+                },
+            ),
+        )
+        orchestrator = Orchestrator(config)
+
+        result = orchestrator.run(phases=[Phase.TEST])
+
+        assert result.success
+        validations = result.phases[0].details["validations"]
+        assert validations == [
+            {
+                "name": "StepSuccessCheck",
+                "passed": True,
+                "skipped": True,
+                "message": "step 'probe' did not produce output",
+                "category": "probe_checks",
+                "state": "skipped",
+                "skip_reason": "step_no_output",
+                "error_reason": None,
+            }
+        ]
+
+    def test_validation_template_error_is_reported_as_error(self, tmp_path: Path) -> None:
+        """Validation parameter render failures are terminal validation errors."""
+        ok_script = _write_script(tmp_path, "ok.sh", _OK_SCRIPT)
+        config = RunConfig(
+            commands={
+                "kubernetes": PlatformCommands(
+                    phases=["test"],
+                    steps=[
+                        StepConfig(name="probe", command=ok_script, phase="test"),
+                    ],
+                )
+            },
+            tests=ValidationConfig(
+                platform="kubernetes",
+                validations={
+                    "probe_checks": {
+                        "checks": {
+                            "FieldExistsCheck": {
+                                "field": "{{ missing.value }}",
+                            }
+                        },
+                    },
+                },
+            ),
+        )
+        orchestrator = Orchestrator(config)
+
+        result = orchestrator.run(phases=[Phase.TEST])
+
+        assert not result.success
+        validation = result.phases[0].details["validations"][0]
+        assert validation["name"] == "FieldExistsCheck"
+        assert validation["passed"] is False
+        assert validation["skipped"] is False
+        assert validation["state"] == "error"
+        assert validation["error_reason"] == "template_render_failed"
+        assert "failed to render validation parameters" in validation["message"]
+
+    def test_preresolved_skip_and_error_are_written_to_junit(self, tmp_path: Path) -> None:
+        """Merged JUnit includes terminal entries that never went through pytest."""
+        ok_script = _write_script(tmp_path, "ok.sh", _OK_SCRIPT)
+        junit_path = tmp_path / "junit.xml"
+        config = RunConfig(
+            commands={
+                "kubernetes": PlatformCommands(
+                    phases=["test"],
+                    steps=[
+                        StepConfig(name="no_json", command="true", phase="test"),
+                        StepConfig(name="probe", command=ok_script, phase="test"),
+                    ],
+                )
+            },
+            tests=ValidationConfig(
+                platform="kubernetes",
+                validations={
+                    "skip_checks": {
+                        "step": "no_json",
+                        "checks": {"StepSuccessCheck": {}},
+                    },
+                    "error_checks": {
+                        "checks": {
+                            "FieldExistsCheck": {
+                                "field": "{{ missing.value }}",
+                            }
+                        },
+                    },
+                },
+            ),
+        )
+        orchestrator = Orchestrator(config)
+
+        orchestrator.run(phases=[Phase.TEST], junitxml=str(junit_path))
+
+        root = ET.parse(junit_path).getroot()
+        cases = {case.attrib["name"]: case for case in root.iter("testcase")}
+        assert "StepSuccessCheck" in cases
+        assert cases["StepSuccessCheck"].find("skipped") is not None
+        assert cases["StepSuccessCheck"].find("skipped").attrib["type"] == "step_no_output"
+        assert "FieldExistsCheck" in cases
+        assert cases["FieldExistsCheck"].find("error") is not None
+        assert cases["FieldExistsCheck"].find("error").attrib["type"] == "template_render_failed"
 
 
 class TestTeardownOnlyPhase:
@@ -655,3 +797,271 @@ class TestMissingStepRefDetection:
             executor._render_args(args, context)
 
         assert exc_info.value.missing_path == "create_network.network_id"
+
+
+class TestWriteTerminalJunitXml:
+    """JUnit stub generation for entries pre-resolved before pytest."""
+
+    @staticmethod
+    def _entry(
+        name: str,
+        category: str,
+        *,
+        state: State,
+        skip_reason: SkipReason | None = None,
+        error_reason: ErrorReason | None = None,
+        message: str = "",
+    ) -> ResolvedEntry:
+        return ResolvedEntry(
+            entry=ValidationEntry(name=name, category=category, params_template={}),
+            state=state,
+            skip_reason=skip_reason,
+            error_reason=error_reason,
+            message=message,
+        )
+
+    def test_emits_skipped_and_error_testcases(self, tmp_path: Path) -> None:
+        """Each pre-resolved entry produces one testcase with the right child element."""
+        entries = [
+            self._entry(
+                "K8sNodePoolCheck",
+                "cluster",
+                state=State.SKIPPED,
+                skip_reason=SkipReason.STEP_NOT_CONFIGURED,
+                message="step 'create_test_node_pool' is not configured for this run",
+            ),
+            self._entry(
+                "BrokenCheck",
+                "network",
+                state=State.ERROR,
+                error_reason=ErrorReason.TEMPLATE_RENDER_FAILED,
+                message="missing.value is undefined",
+            ),
+        ]
+        output_path = tmp_path / "terminal.xml"
+
+        _write_terminal_junit_xml(entries, output_path, "kubernetes/setup/resolved")
+
+        tree = ET.parse(output_path)
+        suite = tree.getroot()
+        assert suite.tag == "testsuite"
+        assert suite.get("name") == "kubernetes/setup/resolved"
+        assert suite.get("tests") == "2"
+        assert suite.get("errors") == "1"
+        assert suite.get("skipped") == "1"
+
+        cases = suite.findall("testcase")
+        assert [c.get("name") for c in cases] == ["K8sNodePoolCheck", "BrokenCheck"]
+        # classname intentionally not set: dashboards that prefix the testcase
+        # name with classname (e.g., "category.TestName") would otherwise turn
+        # the YAML grouping concept into user-facing noise.
+        assert [c.get("classname") for c in cases] == [None, None]
+
+        skipped = cases[0].find("skipped")
+        assert skipped is not None
+        assert skipped.get("type") == SkipReason.STEP_NOT_CONFIGURED.value
+        assert skipped.get("message") == "step 'create_test_node_pool' is not configured for this run"
+        # Body intentionally empty for skipped: avoids a misleading "Stack Trace"
+        # panel on dashboards that render <skipped>'s body content as a trace.
+        assert not skipped.text
+
+        error = cases[1].find("error")
+        assert error is not None
+        assert error.get("type") == ErrorReason.TEMPLATE_RENDER_FAILED.value
+        assert error.get("message") == "missing.value is undefined"
+        assert error.text == "missing.value is undefined"
+
+    def test_empty_entry_list_produces_zero_count_suite(self, tmp_path: Path) -> None:
+        """An empty entry list still writes a valid empty testsuite."""
+        output_path = tmp_path / "empty.xml"
+
+        _write_terminal_junit_xml([], output_path, "kubernetes/teardown/resolved")
+
+        suite = ET.parse(output_path).getroot()
+        assert suite.get("tests") == "0"
+        assert suite.findall("testcase") == []
+
+
+class TestMergeJunitXmls:
+    """Per-phase XMLs are concatenated; same-named suites fold into one."""
+
+    @staticmethod
+    def _write_suite(
+        path: Path,
+        name: str,
+        cases: list[tuple[str, str | None]],
+        *,
+        time: str = "0.000",
+        skipped: int = 0,
+        errors: int = 0,
+        failures: int = 0,
+    ) -> None:
+        """Write a minimal <testsuite> XML; ``cases`` is ``[(name, child_tag_or_None), ...]``."""
+        suite = ET.Element(
+            "testsuite",
+            attrib={
+                "name": name,
+                "tests": str(len(cases)),
+                "failures": str(failures),
+                "errors": str(errors),
+                "skipped": str(skipped),
+                "time": time,
+            },
+        )
+        for case_name, child_tag in cases:
+            case = ET.SubElement(suite, "testcase", attrib={"name": case_name, "classname": "cluster"})
+            if child_tag:
+                ET.SubElement(case, child_tag, attrib={"message": "x"})
+        ET.ElementTree(suite).write(path, encoding="utf-8", xml_declaration=True)
+
+    def test_distinct_suite_names_are_kept_separate(self, tmp_path: Path) -> None:
+        """Suites with different names produce separate <testsuite> children."""
+        a = tmp_path / "a.xml"
+        b = tmp_path / "b.xml"
+        self._write_suite(a, "kubernetes/setup", [("A", None)])
+        self._write_suite(b, "kubernetes/teardown", [("B", None)])
+        out = tmp_path / "merged.xml"
+
+        _merge_junit_xmls([a, b], out)
+
+        root = ET.parse(out).getroot()
+        suites = root.findall("testsuite")
+        assert [s.get("name") for s in suites] == ["kubernetes/setup", "kubernetes/teardown"]
+
+    def test_same_named_suites_are_folded(self, tmp_path: Path) -> None:
+        """Stub + pytest output for the same phase merge into a single suite."""
+        pytest_xml = tmp_path / "pytest.xml"
+        stub_xml = tmp_path / "stub.xml"
+        self._write_suite(pytest_xml, "kubernetes/test", [("Ran", None)], time="1.500")
+        self._write_suite(
+            stub_xml,
+            "kubernetes/test",
+            [("PreSkipped", "skipped"), ("PreError", "error")],
+            time="0.250",
+            skipped=1,
+            errors=1,
+        )
+        out = tmp_path / "merged.xml"
+
+        _merge_junit_xmls([pytest_xml, stub_xml], out)
+
+        root = ET.parse(out).getroot()
+        suites = root.findall("testsuite")
+        assert len(suites) == 1
+        suite = suites[0]
+        assert suite.get("name") == "kubernetes/test"
+        assert {case.get("name") for case in suite.findall("testcase")} == {"Ran", "PreSkipped", "PreError"}
+        assert suite.get("tests") == "3"
+        assert suite.get("skipped") == "1"
+        assert suite.get("errors") == "1"
+        assert suite.get("failures") == "0"
+        assert suite.get("time") == "1.750"
+
+    def test_skips_unparseable_phase_files(self, tmp_path: Path) -> None:
+        """A corrupt per-phase XML is logged and skipped, not fatal."""
+        good = tmp_path / "good.xml"
+        bad = tmp_path / "bad.xml"
+        self._write_suite(good, "kubernetes/test", [("OK", None)])
+        bad.write_text("<not-valid")
+        out = tmp_path / "merged.xml"
+
+        _merge_junit_xmls([good, bad], out)
+
+        root = ET.parse(out).getroot()
+        suites = root.findall("testsuite")
+        assert [s.get("name") for s in suites] == ["kubernetes/test"]
+        assert {case.get("name") for case in suites[0].findall("testcase")} == {"OK"}
+
+    def test_name_order_interleaves_stub_and_pytest_testcases(self, tmp_path: Path) -> None:
+        """With name_order, skipped stubs slot in beside pytest results per YAML order."""
+        stub_xml = tmp_path / "stub.xml"
+        pytest_xml = tmp_path / "pytest.xml"
+        # Stub gets the marker-excluded entry that lives third in the YAML.
+        self._write_suite(stub_xml, "kubernetes/test", [("MidSkipped", "skipped")], skipped=1)
+        # Pytest emits the two ready entries that flank it; subtest also present.
+        self._write_suite(
+            pytest_xml,
+            "kubernetes/test",
+            [("First", None), ("First::sub", None), ("Last", None)],
+        )
+        out = tmp_path / "merged.xml"
+
+        _merge_junit_xmls(
+            [stub_xml, pytest_xml],
+            out,
+            name_order=["First", "MidSkipped", "Last"],
+        )
+
+        suite = ET.parse(out).getroot().find("testsuite")
+        names = [case.get("name") for case in suite.findall("testcase")]
+        assert names == ["First", "First::sub", "MidSkipped", "Last"]
+
+    def test_name_order_keeps_unknown_testcases_at_end(self, tmp_path: Path) -> None:
+        """Testcases not mentioned in name_order land after the known ones."""
+        xml = tmp_path / "phase.xml"
+        self._write_suite(xml, "kubernetes/test", [("Unknown", None), ("Known", None)])
+        out = tmp_path / "merged.xml"
+
+        _merge_junit_xmls([xml], out, name_order=["Known"])
+
+        suite = ET.parse(out).getroot().find("testsuite")
+        assert [case.get("name") for case in suite.findall("testcase")] == ["Known", "Unknown"]
+
+
+class TestEntriesMissingFromJunit:
+    """Diff helper that finds executed entries pytest didn't write to XML."""
+
+    @staticmethod
+    def _entry(name: str) -> ResolvedEntry:
+        return ResolvedEntry(
+            entry=ValidationEntry(name=name, category="cluster", params_template={}),
+            state=State.SKIPPED,
+            skip_reason=SkipReason.OPERATOR,
+            message="not selected by pytest arguments",
+        )
+
+    @staticmethod
+    def _write_junit(path: Path, names: list[str]) -> None:
+        suite = ET.Element("testsuite", attrib={"name": "test"})
+        for name in names:
+            ET.SubElement(suite, "testcase", attrib={"name": name})
+        ET.ElementTree(suite).write(path, encoding="utf-8", xml_declaration=True)
+
+    def test_returns_executed_entries_not_in_junit(self, tmp_path: Path) -> None:
+        """Entries deselected by pytest -k surface here so they can be stubbed."""
+        junit = tmp_path / "junit.xml"
+        self._write_junit(junit, ["RanCheck"])
+
+        missing = _entries_missing_from_junit(
+            [self._entry("RanCheck"), self._entry("DeselectedCheck")],
+            junit,
+        )
+
+        assert [m.entry.name for m in missing] == ["DeselectedCheck"]
+
+    def test_empty_when_all_executed_entries_are_in_junit(self, tmp_path: Path) -> None:
+        """No stub needed when pytest wrote every executed entry."""
+        junit = tmp_path / "junit.xml"
+        self._write_junit(junit, ["A", "B"])
+
+        assert _entries_missing_from_junit([self._entry("A"), self._entry("B")], junit) == []
+
+    def test_returns_all_entries_when_junit_missing(self, tmp_path: Path) -> None:
+        """If pytest never produced an XML, treat every executed entry as missing."""
+        missing = _entries_missing_from_junit(
+            [self._entry("Solo")],
+            tmp_path / "does-not-exist.xml",
+        )
+        assert [m.entry.name for m in missing] == ["Solo"]
+
+    def test_returns_all_entries_when_junit_unparseable(self, tmp_path: Path) -> None:
+        """A corrupt pytest XML doesn't suppress entries from the merged report."""
+        junit = tmp_path / "broken.xml"
+        junit.write_text("<not-valid-xml")
+
+        missing = _entries_missing_from_junit([self._entry("Solo")], junit)
+        assert [m.entry.name for m in missing] == ["Solo"]
+
+    def test_returns_all_entries_when_junit_path_is_none(self) -> None:
+        """A None path (pytest skipped because no ready entries) returns the full list."""
+        assert _entries_missing_from_junit([self._entry("A")], None) == [self._entry("A")]

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -1016,8 +1016,8 @@ class TestEntriesMissingFromJunit:
         return ResolvedEntry(
             entry=ValidationEntry(name=name, category="cluster", params_template={}),
             state=State.SKIPPED,
-            skip_reason=SkipReason.OPERATOR,
-            message="not selected by pytest arguments",
+            skip_reason=SkipReason.EXCLUDED,
+            message="excluded by pytest -k/-m filter",
         )
 
     @staticmethod

--- a/isvtest/src/isvtest/core/resolution.py
+++ b/isvtest/src/isvtest/core/resolution.py
@@ -1,0 +1,421 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Validation entry parsing and resolution."""
+
+import copy
+import json
+from collections.abc import Iterable, Mapping
+from collections.abc import Set as AbstractSet
+from dataclasses import dataclass
+from enum import StrEnum
+from functools import cache
+from typing import Any
+
+from jinja2 import ChainableUndefined, Environment
+
+from isvtest.config.loader import _ternary
+from isvtest.core.discovery import discover_all_tests
+
+ADAPTER_HANDLED_CATEGORIES = {"reframe"}
+DEFAULT_VALIDATION_PHASE = "test"
+RESOLVED_ENTRIES_FLAG = "_isvtest_resolved_entries"
+
+
+class State(StrEnum):
+    """Terminal state of a validation in the report."""
+
+    PASSED = "passed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    ERROR = "error"
+
+
+class SkipReason(StrEnum):
+    """Why a skipped validation did not run."""
+
+    STEP_NOT_CONFIGURED = "step_not_configured"
+    STEP_NO_OUTPUT = "step_no_output"
+    PHASE_NOT_REQUESTED = "phase_not_requested"
+    UNRELEASED = "unreleased"
+    MARKER_EXCLUDED = "marker_excluded"
+    NAME_EXCLUDED = "name_excluded"
+    OPERATOR = "operator"
+
+
+class ErrorReason(StrEnum):
+    """Why an error validation could not be processed or executed."""
+
+    TEMPLATE_RENDER_FAILED = "template_render_failed"
+    INVALID_CONFIG = "invalid_config"
+    RUNTIME_EXCEPTION = "runtime_exception"
+
+
+@dataclass(frozen=True)
+class ValidationEntry:
+    """A validation declared in configuration before resolution."""
+
+    name: str
+    category: str
+    params_template: dict[str, Any]
+    step: str | None = None
+    phase: str | None = None
+    markers: tuple[str, ...] = ()
+
+
+@dataclass
+class ResolvedEntry:
+    """Lifecycle record for a single validation entry."""
+
+    entry: ValidationEntry
+    rendered_params: dict[str, Any] | None = None
+    state: State | None = None
+    skip_reason: SkipReason | None = None
+    error_reason: ErrorReason | None = None
+    message: str = ""
+    duration_seconds: float = 0.0
+
+    @property
+    def is_ready(self) -> bool:
+        """Return whether the entry is ready for runtime execution."""
+        return self.state is None and self.skip_reason is None and self.error_reason is None
+
+
+def parse_validations(raw_config: Mapping[str, Any]) -> list[ValidationEntry]:
+    """Parse raw validation config into ordered validation entries.
+
+    Args:
+        raw_config: The ``tests.validations`` mapping from isvctl config.
+
+    Returns:
+        Ordered validation entries. Adapter-handled categories are ignored
+        because they are not BaseValidation pytest entries.
+    """
+    markers_by_name = _validation_markers_by_name()
+    entries: list[ValidationEntry] = []
+
+    for category, category_config in raw_config.items():
+        if category in ADAPTER_HANDLED_CATEGORIES:
+            continue
+        if not isinstance(category, str):
+            entries.append(_invalid_entry(str(category), "invalid", "validation category must be a string"))
+            continue
+
+        for name, params, group_step, group_phase in _iter_validation_items(category, category_config):
+            entry_step = group_step
+            entry_phase = group_phase
+            params_template = params
+
+            if isinstance(params_template, dict):
+                params_template = copy.deepcopy(params_template)
+                if entry_step is None and "step" in params_template:
+                    entry_step = params_template.get("step")
+                if entry_phase is None and "phase" in params_template:
+                    entry_phase = params_template.get("phase")
+            else:
+                params_template = copy.deepcopy(params_template)
+
+            entries.append(
+                ValidationEntry(
+                    name=name,
+                    category=category,
+                    params_template=params_template,
+                    step=entry_step if isinstance(entry_step, str) else None,
+                    phase=entry_phase if isinstance(entry_phase, str) else None,
+                    markers=markers_by_name.get(_base_validation_name(name, markers_by_name), ()),
+                )
+            )
+
+    return entries
+
+
+def resolve_entries(
+    entries: list[ValidationEntry],
+    *,
+    step_outputs: Mapping[str, dict[str, Any]],
+    step_phases: Mapping[str, str],
+    requested_phases: AbstractSet[str],
+    exclude_markers: AbstractSet[str],
+    exclude_tests: AbstractSet[str],
+    released_tests: AbstractSet[str] | None,
+    render_context: Mapping[str, Any],
+) -> list[ResolvedEntry]:
+    """Resolve validation entries into ready or terminal outcomes.
+
+    Args:
+        entries: Parsed validation entries.
+        step_outputs: Step outputs accumulated so far.
+        step_phases: Mapping of configured, non-skipped step names to phases.
+        requested_phases: Phase names requested by the invocation.
+        exclude_markers: Validation markers excluded by config.
+        exclude_tests: Validation names excluded by config.
+        released_tests: Released test manifest, or None when unreleased checks are included.
+        render_context: Jinja context for validation parameter rendering.
+
+    Returns:
+        A resolved entry for every input entry, in input order.
+    """
+    resolved: list[ResolvedEntry] = []
+    env = _create_jinja_env()
+
+    for entry in entries:
+        config_error = _validate_entry_shape(entry)
+        if config_error:
+            resolved.append(_error(entry, ErrorReason.INVALID_CONFIG, config_error))
+            continue
+
+        if released_tests is not None and entry.name not in released_tests:
+            resolved.append(
+                _skip(
+                    entry,
+                    SkipReason.UNRELEASED,
+                    f"validation '{entry.name}' is not in released_tests.json",
+                )
+            )
+            continue
+
+        if entry.name in exclude_tests:
+            resolved.append(_skip(entry, SkipReason.NAME_EXCLUDED, f"validation '{entry.name}' is excluded by name"))
+            continue
+
+        marker_matches = sorted(set(entry.markers).intersection(exclude_markers))
+        if marker_matches:
+            marker_list = ", ".join(marker_matches)
+            resolved.append(
+                _skip(
+                    entry,
+                    SkipReason.MARKER_EXCLUDED,
+                    f"validation '{entry.name}' is excluded by marker: {marker_list}",
+                )
+            )
+            continue
+
+        if entry.step and entry.step not in step_phases:
+            resolved.append(
+                _skip(
+                    entry,
+                    SkipReason.STEP_NOT_CONFIGURED,
+                    f"step '{entry.step}' is not configured for this run",
+                )
+            )
+            continue
+
+        if entry.step and entry.step not in step_outputs:
+            resolved.append(
+                _skip(
+                    entry,
+                    SkipReason.STEP_NO_OUTPUT,
+                    f"step '{entry.step}' did not produce output",
+                )
+            )
+            continue
+
+        validation_phase = get_entry_phase(entry, step_phases)
+        if validation_phase not in requested_phases:
+            resolved.append(
+                _skip(
+                    entry,
+                    SkipReason.PHASE_NOT_REQUESTED,
+                    f"phase '{validation_phase}' was not requested",
+                )
+            )
+            continue
+
+        try:
+            rendered_params = _render_params(env, entry.params_template, render_context)
+        except Exception as exc:
+            resolved.append(
+                _error(
+                    entry,
+                    ErrorReason.TEMPLATE_RENDER_FAILED,
+                    f"failed to render validation parameters: {exc}",
+                )
+            )
+            continue
+
+        if not isinstance(rendered_params, dict):
+            resolved.append(
+                _error(
+                    entry,
+                    ErrorReason.INVALID_CONFIG,
+                    f"validation '{entry.name}' parameters must render to a mapping",
+                )
+            )
+            continue
+
+        if entry.step:
+            rendered_params.pop("step", None)
+            rendered_params["step_output"] = copy.deepcopy(step_outputs[entry.step])
+        rendered_params.pop("phase", None)
+        rendered_params["_category"] = entry.category
+
+        resolved.append(ResolvedEntry(entry=entry, rendered_params=rendered_params))
+
+    return resolved
+
+
+def get_entry_phase(entry: ValidationEntry, step_phases: Mapping[str, str]) -> str:
+    """Return the phase a validation entry belongs to."""
+    if entry.phase:
+        return entry.phase
+    if entry.step:
+        return step_phases.get(entry.step, DEFAULT_VALIDATION_PHASE)
+    return DEFAULT_VALIDATION_PHASE
+
+
+def format_resolution_message(entry: ResolvedEntry) -> str:
+    """Return the operator-facing message for a resolved entry."""
+    if entry.message:
+        return entry.message
+    if entry.skip_reason:
+        return entry.skip_reason.value
+    if entry.error_reason:
+        return entry.error_reason.value
+    return ""
+
+
+@cache
+def _validation_markers_by_name() -> dict[str, tuple[str, ...]]:
+    """Return discovered validation markers keyed by class name."""
+    markers: dict[str, tuple[str, ...]] = {}
+    for cls in discover_all_tests():
+        cls_markers = getattr(cls, "markers", None) or []
+        markers[cls.__name__] = tuple(str(marker) for marker in cls_markers)
+    return markers
+
+
+def resolve_class_key(name: str, keys: Iterable[str]) -> str | None:
+    """Resolve a configured validation name to its discovered class key.
+
+    Returns the input name if it matches a key directly, otherwise the
+    longest key matching a ``ClassName-Variant`` prefix, or None when no
+    candidate matches.
+    """
+    keys_tuple = tuple(keys)
+    if name in keys_tuple:
+        return name
+    matches = [candidate for candidate in keys_tuple if name.startswith(f"{candidate}-")]
+    if not matches:
+        return None
+    return max(matches, key=len)
+
+
+def _base_validation_name(name: str, markers_by_name: Mapping[str, tuple[str, ...]]) -> str:
+    """Return the discovered base class name for a configured validation name."""
+    return resolve_class_key(name, markers_by_name) or name
+
+
+def _iter_validation_items(category: str, category_config: Any) -> list[tuple[str, Any, Any, Any]]:
+    """Return parsed ``(name, params, group_step, group_phase)`` tuples."""
+    if isinstance(category_config, dict) and "checks" in category_config:
+        group_step = category_config.get("step")
+        group_phase = category_config.get("phase")
+        checks_val = category_config.get("checks", {})
+        if isinstance(checks_val, dict):
+            return [(str(name), params or {}, group_step, group_phase) for name, params in checks_val.items()]
+        if isinstance(checks_val, list):
+            return [
+                (str(name), params or {}, group_step, group_phase)
+                for item in checks_val
+                if isinstance(item, dict)
+                for name, params in item.items()
+            ]
+        return [
+            (
+                "<invalid>",
+                {"_invalid_config": f"checks for category '{category}' must be a mapping or list"},
+                None,
+                None,
+            )
+        ]
+
+    if isinstance(category_config, list):
+        return [
+            (str(name), params or {}, None, None)
+            for item in category_config
+            if isinstance(item, dict)
+            for name, params in item.items()
+        ]
+
+    if isinstance(category_config, dict):
+        return [(str(name), params or {}, None, None) for name, params in category_config.items()]
+
+    return [
+        ("<invalid>", {"_invalid_config": f"category '{category}' validations must be a mapping or list"}, None, None)
+    ]
+
+
+def _invalid_entry(name: str, category: str, message: str) -> ValidationEntry:
+    """Build a validation entry that resolves to INVALID_CONFIG."""
+    return ValidationEntry(name=name, category=category, params_template={"_invalid_config": message})
+
+
+def _validate_entry_shape(entry: ValidationEntry) -> str | None:
+    """Return an invalid-config message, or None when the entry shape is valid."""
+    if not isinstance(entry.name, str) or not entry.name:
+        return "validation name must be a non-empty string"
+    if not isinstance(entry.category, str) or not entry.category:
+        return f"validation '{entry.name}' category must be a non-empty string"
+    if not isinstance(entry.params_template, dict):
+        return f"validation '{entry.name}' parameters must be a mapping"
+    invalid_message = entry.params_template.get("_invalid_config")
+    if invalid_message:
+        return str(invalid_message)
+    return None
+
+
+def _render_params(env: Environment, params: dict[str, Any], render_context: Mapping[str, Any]) -> dict[str, Any]:
+    """Render validation parameters recursively."""
+    return {key: _render_value(env, value, render_context) for key, value in params.items()}
+
+
+def _render_value(env: Environment, value: Any, render_context: Mapping[str, Any]) -> Any:
+    """Render a nested validation parameter value."""
+    if isinstance(value, str):
+        return _render_string(env, value, render_context)
+    if isinstance(value, dict):
+        return {key: _render_value(env, item, render_context) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_render_value(env, item, render_context) for item in value]
+    return value
+
+
+def _render_string(env: Environment, value: str, render_context: Mapping[str, Any]) -> str:
+    """Render a single string if it contains a Jinja template."""
+    if "{{" not in value or "}}" not in value:
+        return value
+    return env.from_string(value).render(**render_context)
+
+
+@cache
+def _create_jinja_env() -> Environment:
+    """Return the strict Jinja environment used by resolution."""
+    env = Environment(undefined=ChainableStrictUndefined)
+    env.filters["tojson"] = lambda value: json.dumps(value)
+    env.filters["ternary"] = _ternary
+    return env
+
+
+class ChainableStrictUndefined(ChainableUndefined):
+    """Undefined value that supports ``default`` but errors when emitted."""
+
+    __str__ = ChainableUndefined._fail_with_undefined_error
+    __iter__ = ChainableUndefined._fail_with_undefined_error
+    __bool__ = ChainableUndefined._fail_with_undefined_error
+
+
+def _skip(entry: ValidationEntry, reason: SkipReason, message: str) -> ResolvedEntry:
+    """Build a skipped resolved entry."""
+    return ResolvedEntry(entry=entry, state=State.SKIPPED, skip_reason=reason, message=message)
+
+
+def _error(entry: ValidationEntry, reason: ErrorReason, message: str) -> ResolvedEntry:
+    """Build an error resolved entry."""
+    return ResolvedEntry(entry=entry, state=State.ERROR, error_reason=reason, message=message)

--- a/isvtest/src/isvtest/core/resolution.py
+++ b/isvtest/src/isvtest/core/resolution.py
@@ -12,6 +12,7 @@
 
 import copy
 import json
+import logging
 from collections.abc import Iterable, Mapping
 from collections.abc import Set as AbstractSet
 from dataclasses import dataclass
@@ -19,10 +20,12 @@ from enum import StrEnum
 from functools import cache
 from typing import Any
 
-from jinja2 import ChainableUndefined, Environment
+from jinja2 import ChainableUndefined, Environment, Undefined
 
 from isvtest.config.loader import _ternary
 from isvtest.core.discovery import discover_all_tests
+
+logger = logging.getLogger(__name__)
 
 ADAPTER_HANDLED_CATEGORIES = {"reframe"}
 DEFAULT_VALIDATION_PHASE = "test"
@@ -418,12 +421,29 @@ def _render_string(env: Environment, value: str, render_context: Mapping[str, An
     return env.from_string(value).render(**render_context)
 
 
+def _warning_default(value: Any, default_value: Any = "", boolean: bool = False) -> Any:
+    """Drop-in replacement for Jinja's ``default`` filter that warns when it
+    catches an Undefined value. Without this, a typo like
+    ``{{ steps.setup.node_count_invalid | default(1) }}`` silently substitutes
+    the default for the missing field instead of surfacing the mistake.
+    """
+    if isinstance(value, Undefined):
+        if value._undefined_message:
+            logger.warning(f"default(...) masked: {value._undefined_message}")
+        return default_value
+    if boolean and not value:
+        return default_value
+    return value
+
+
 @cache
 def _create_jinja_env() -> Environment:
     """Return the strict Jinja environment used by resolution."""
     env = Environment(undefined=ChainableStrictUndefined)
     env.filters["tojson"] = lambda value: json.dumps(value)
     env.filters["ternary"] = _ternary
+    env.filters["default"] = _warning_default
+    env.filters["d"] = _warning_default
     return env
 
 

--- a/isvtest/src/isvtest/core/resolution.py
+++ b/isvtest/src/isvtest/core/resolution.py
@@ -41,21 +41,20 @@ class State(StrEnum):
 class SkipReason(StrEnum):
     """Why a skipped validation did not run."""
 
-    STEP_NOT_CONFIGURED = "step_not_configured"
-    STEP_NO_OUTPUT = "step_no_output"
-    PHASE_NOT_REQUESTED = "phase_not_requested"
-    UNRELEASED = "unreleased"
-    MARKER_EXCLUDED = "marker_excluded"
-    NAME_EXCLUDED = "name_excluded"
-    OPERATOR = "operator"
+    EXCLUDED = "excluded"  # explicitly excluded by user (YAML markers/tests OR CLI -k/-m)
+    PHASE_NOT_REQUESTED = "phase_not_requested"  # entry's phase wasn't in the requested phase set
+    RUNTIME_SKIP = "runtime_skip"  # validation called pytest.skip(...) at runtime
+    STEP_NO_OUTPUT = "step_no_output"  # step ran but produced no JSON output
+    STEP_NOT_CONFIGURED = "step_not_configured"  # step the entry binds to isn't in the platform's step list
+    UNRELEASED = "unreleased"  # not in released_tests.json (gated until release)
 
 
 class ErrorReason(StrEnum):
     """Why an error validation could not be processed or executed."""
 
-    TEMPLATE_RENDER_FAILED = "template_render_failed"
     INVALID_CONFIG = "invalid_config"
     RUNTIME_EXCEPTION = "runtime_exception"
+    TEMPLATE_RENDER_FAILED = "template_render_failed"
 
 
 @dataclass(frozen=True)
@@ -182,7 +181,7 @@ def resolve_entries(
             continue
 
         if entry.name in exclude_tests:
-            resolved.append(_skip(entry, SkipReason.NAME_EXCLUDED, f"validation '{entry.name}' is excluded by name"))
+            resolved.append(_skip(entry, SkipReason.EXCLUDED, f"validation '{entry.name}' is excluded by name"))
             continue
 
         marker_matches = sorted(set(entry.markers).intersection(exclude_markers))
@@ -191,7 +190,7 @@ def resolve_entries(
             resolved.append(
                 _skip(
                     entry,
-                    SkipReason.MARKER_EXCLUDED,
+                    SkipReason.EXCLUDED,
                     f"validation '{entry.name}' is excluded by marker: {marker_list}",
                 )
             )

--- a/isvtest/src/isvtest/core/resolution.py
+++ b/isvtest/src/isvtest/core/resolution.py
@@ -41,7 +41,7 @@ class State(StrEnum):
 class SkipReason(StrEnum):
     """Why a skipped validation did not run."""
 
-    EXCLUDED = "excluded"  # explicitly excluded by user (YAML markers/tests OR CLI -k/-m)
+    EXCLUDED = "test_excluded"  # explicitly excluded by user (YAML markers/tests OR CLI -k/-m)
     PHASE_NOT_REQUESTED = "phase_not_requested"  # entry's phase wasn't in the requested phase set
     RUNTIME_SKIP = "runtime_skip"  # validation called pytest.skip(...) at runtime
     STEP_NO_OUTPUT = "step_no_output"  # step ran but produced no JSON output

--- a/isvtest/src/isvtest/core/resolution.py
+++ b/isvtest/src/isvtest/core/resolution.py
@@ -170,7 +170,10 @@ def resolve_entries(
             resolved.append(_error(entry, ErrorReason.INVALID_CONFIG, config_error))
             continue
 
-        if released_tests is not None and entry.name not in released_tests:
+        # Variant-aware match: a configured ``ClassName-Variant`` is considered
+        # released when the bare ``ClassName`` is in the manifest, mirroring the
+        # pytest-discovery path (``_is_released_validation`` in test_validations).
+        if released_tests is not None and resolve_class_key(entry.name, released_tests) is None:
             resolved.append(
                 _skip(
                     entry,
@@ -320,12 +323,12 @@ def _iter_validation_items(category: str, category_config: Any) -> list[tuple[st
         if isinstance(checks_val, dict):
             return [(str(name), params or {}, group_step, group_phase) for name, params in checks_val.items()]
         if isinstance(checks_val, list):
-            return [
-                (str(name), params or {}, group_step, group_phase)
-                for item in checks_val
-                if isinstance(item, dict)
-                for name, params in item.items()
-            ]
+            return _expand_check_list(
+                checks_val,
+                group_step,
+                group_phase,
+                f"each item in category '{category}.checks' must be a mapping",
+            )
         return [
             (
                 "<invalid>",
@@ -336,12 +339,12 @@ def _iter_validation_items(category: str, category_config: Any) -> list[tuple[st
         ]
 
     if isinstance(category_config, list):
-        return [
-            (str(name), params or {}, None, None)
-            for item in category_config
-            if isinstance(item, dict)
-            for name, params in item.items()
-        ]
+        return _expand_check_list(
+            category_config,
+            None,
+            None,
+            f"each item in category '{category}' must be a mapping",
+        )
 
     if isinstance(category_config, dict):
         return [(str(name), params or {}, None, None) for name, params in category_config.items()]
@@ -349,6 +352,28 @@ def _iter_validation_items(category: str, category_config: Any) -> list[tuple[st
     return [
         ("<invalid>", {"_invalid_config": f"category '{category}' validations must be a mapping or list"}, None, None)
     ]
+
+
+def _expand_check_list(
+    items: list[Any],
+    group_step: Any,
+    group_phase: Any,
+    invalid_message: str,
+) -> list[tuple[str, Any, Any, Any]]:
+    """Expand a list of ``[{Name: params}, ...]`` entries to parsed tuples.
+
+    Non-dict items become ``<invalid>`` placeholders that resolve to
+    ``ERROR(invalid_config)`` so malformed YAML surfaces in the report instead
+    of being silently dropped.
+    """
+    result: list[tuple[str, Any, Any, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            result.append(("<invalid>", {"_invalid_config": invalid_message}, None, None))
+            continue
+        for name, params in item.items():
+            result.append((str(name), params or {}, group_step, group_phase))
+    return result
 
 
 def _invalid_entry(name: str, category: str, message: str) -> ValidationEntry:

--- a/isvtest/src/isvtest/core/validation.py
+++ b/isvtest/src/isvtest/core/validation.py
@@ -204,8 +204,10 @@ class BaseValidation(ABC):
 
         # Report via subtests fixture if available
         if self._subtests is not None:
-            # Use skipped=skipped parameter to avoid pytest.skip() adding markers to parent
-            with self._subtests.test(msg=name, duration=duration, skipped=skipped):
+            # Use skipped=skipped parameter to avoid pytest.skip() adding markers to parent.
+            # message= surfaces in the report's <skipped> body when skipped=True;
+            # the failure path uses pytest.fail(message) below.
+            with self._subtests.test(msg=name, duration=duration, skipped=skipped, message=message or None):
                 if not skipped and not passed:
                     pytest.fail(message or f"Subtest {name} failed")
                 # If passed or skipped, just exit the context successfully

--- a/isvtest/src/isvtest/core/validation.py
+++ b/isvtest/src/isvtest/core/validation.py
@@ -226,11 +226,15 @@ class BaseValidation(ABC):
                 - description: Validation description from class metadata
                 - subtests: List of subtest results (if any)
         """
+        from isvtest.core.resolution import ErrorReason
+
         start_time = time.time()
+        error_reason: str | None = None
         try:
             self.run()
         except Exception as e:
             self.set_failed(f"Validation raised exception: {e}")
+            error_reason = ErrorReason.RUNTIME_EXCEPTION.value
             self.log.exception("Validation execution failed")
 
         duration = time.time() - start_time
@@ -243,6 +247,7 @@ class BaseValidation(ABC):
             "duration": duration,
             "description": self.description,
             "subtests": self._subtest_results,
+            "error_reason": error_reason,
         }
 
     @property

--- a/isvtest/src/isvtest/main.py
+++ b/isvtest/src/isvtest/main.py
@@ -204,8 +204,8 @@ def _apply_pytest_results(entries: list[ResolvedEntry], results: list[dict[str, 
                     entry=entry.entry,
                     rendered_params=entry.rendered_params,
                     state=State.SKIPPED,
-                    skip_reason=SkipReason.OPERATOR,
-                    message="not selected by pytest arguments",
+                    skip_reason=SkipReason.EXCLUDED,
+                    message="excluded by pytest -k/-m filter",
                 )
             )
             continue
@@ -222,7 +222,7 @@ def _result_to_resolved_entry(entry: ResolvedEntry, result: dict[str, Any]) -> R
             entry=entry.entry,
             rendered_params=entry.rendered_params,
             state=State.SKIPPED,
-            skip_reason=SkipReason.OPERATOR,
+            skip_reason=SkipReason.RUNTIME_SKIP,
             message=message,
             duration_seconds=duration,
         )

--- a/isvtest/src/isvtest/main.py
+++ b/isvtest/src/isvtest/main.py
@@ -14,10 +14,11 @@ Note: For cluster lifecycle management, use isvctl instead:
     isvctl test run -f isvctl/configs/suites/k8s.yaml
 """
 
+import copy
 import json
 import os
 import tempfile
-from collections.abc import Collection
+from dataclasses import replace
 from enum import StrEnum
 from pathlib import Path
 from typing import Annotated, Any
@@ -29,55 +30,34 @@ from isvreporter.version import get_version
 from isvtest.config.loader import ConfigLoader
 from isvtest.core import runners as reframe_runner
 from isvtest.core.logger import setup_logger
-from isvtest.release_manifest import INCLUDE_UNRELEASED_ENV, load_released_test_filter, load_released_tests
+from isvtest.core.resolution import RESOLVED_ENTRIES_FLAG, ErrorReason, ResolvedEntry, SkipReason, State
 from isvtest.tests.test_validations import (
-    ADAPTER_HANDLED_CATEGORIES,
     clear_validation_results,
     get_validation_results,
 )
 
 logger = setup_logger()
 
-# Process-level dedup so manifest-gate logs fire once per invocation
-# rather than once per phase (run_validations_via_pytest is called for
-# setup/test/teardown).
-_MANIFEST_GATE_ANNOUNCED = False
-_SKIPPED_UNRELEASED_LOGGED: set[str] = set()
-
 
 def run_validations_via_pytest(
-    validations: dict[str, list[dict[str, Any]] | dict[str, Any]],
-    step_outputs: dict[str, dict[str, Any]],
-    step_phases: dict[str, str] | None = None,
-    phase: str = "test",
+    entries: list[ResolvedEntry],
     extra_pytest_args: list[str] | None = None,
-    exclude_markers: list[str] | None = None,
-    exclude_tests: list[str] | None = None,
     settings: dict[str, Any] | None = None,
+    inventory: dict[str, Any] | None = None,
     verbose: bool = False,
     junitxml: str | None = None,
     suite_name: str | None = None,
-) -> tuple[int, list[dict[str, Any]]]:
-    """Run validations via pytest with step outputs available as context.
+) -> tuple[int, list[ResolvedEntry]]:
+    """Run ready validation entries via pytest.
 
-    This function bridges step-based execution with pytest-based validation.
-    It transforms the new config format (tests.validations) into a format
-    pytest can use, and passes step outputs for template rendering.
-
-    Results are captured in-memory via test_validations module, giving you
-    both full pytest features AND detailed validation messages.
+    Resolution decisions happen before this function. This bridge only executes
+    ready entries and maps pytest results back to the ResolvedEntry channel.
 
     Args:
-        validations: Validation config from tests.validations, grouped by category.
-            Format: {category: [{CheckName: {params...}}, ...] | {step, phase, checks}}
-        step_outputs: Accumulated step outputs from previous phases.
-            Format: {step_name: {output_dict}}
-        step_phases: Mapping of step names to their phases (for phase inference).
-            Format: {step_name: phase}
-        phase: Current phase to run validations for (filters by phase field).
+        entries: Ready resolved entries to execute.
         extra_pytest_args: Additional pytest arguments (-k, -m, -v, etc.).
-        exclude_markers: Markers to exclude from validation runs.
         settings: Test settings dict (e.g., show_skipped_tests).
+        inventory: Inventory passed to validations.
         verbose: Enable verbose output.
         junitxml: Path to write JUnit XML report.
         suite_name: Name for the JUnit XML test suite (defaults to pytest's "pytest").
@@ -85,98 +65,32 @@ def run_validations_via_pytest(
     Returns:
         Tuple of (exit_code, validation_results).
         exit_code: 0 if all validations passed, non-zero otherwise.
-        validation_results: List of validation result dicts with name, passed, message, category.
+        validation_results: Updated resolved entries with terminal states.
     """
-    # Transform validations into the format expected by test_validations.py
-    # The test_validations.py expects a "validations" dict at config root
-    released_tests = load_released_test_filter()
-    global _MANIFEST_GATE_ANNOUNCED
-    if not _MANIFEST_GATE_ANNOUNCED:
-        if released_tests is None:
-            # Env override is set: enumerate which configured validations are being included that would
-            # otherwise be gated, so it's obvious in the log which unreleased checks are actually running.
-            logger.info(f"Including unreleased validations because {INCLUDE_UNRELEASED_ENV} is enabled")
-            # Manifest read is for log diffing only; failure must not abort the unreleased run since
-            # that's the path that exists precisely to bypass the gate.
-            try:
-                manifest = load_released_tests()
-            except (FileNotFoundError, ValueError) as exc:
-                logger.warning(f"Could not diff against released_tests.json: {exc}")
-                manifest = set()
-            for name in _iter_configured_validation_names(validations):
-                if name not in manifest:
-                    logger.info(f"Including unreleased validation '{name}' (not in manifest)")
-        else:
-            # Env override is not set: announce the gate (with a count of unreleased configured validations)
-            # so it's obvious why newly-added validations may show up as 'Skipping unreleased ...' below.
-            unreleased_count = sum(
-                1 for name in _iter_configured_validation_names(validations) if name not in released_tests
-            )
-            logger.info(
-                f"Release manifest gate active: {unreleased_count} configured validation(s) unreleased "
-                f"(set {INCLUDE_UNRELEASED_ENV}=1 to include them)"
-            )
-        _MANIFEST_GATE_ANNOUNCED = True
-
-    transformed_validations = _transform_validations_for_pytest(
-        validations,
-        step_outputs,
-        step_phases or {},
-        phase,
-        released_tests=released_tests,
-    )
+    execution_entries = _entries_with_pytest_names(entries)
+    transformed_validations = _resolved_entries_to_pytest_validations(execution_entries)
 
     if not transformed_validations:
-        logger.info(f"No validations to run for phase '{phase}'")
+        logger.info("No ready validations to run")
         return 0, []
 
-    # Build inventory by merging step outputs
-    # This allows templates like {{ inventory.kubernetes.runtime_class }} to work
-    # by extracting platform sections (kubernetes, slurm, etc.) from step outputs
-    inventory: dict[str, Any] = {"steps": step_outputs}  # Keep steps available too
-    logger.debug(f"Building inventory from step_outputs: {list(step_outputs.keys())}")
-    for step_name, output in step_outputs.items():
-        logger.debug(f"Step '{step_name}' output keys: {list(output.keys()) if output else 'None'}")
-        for key, value in output.items():
-            if isinstance(value, dict):
-                # Merge nested dicts (e.g., kubernetes, slurm sections)
-                if key not in inventory:
-                    inventory[key] = {}
-                if isinstance(inventory[key], dict):
-                    inventory[key].update(value)
-                    logger.debug(f"Merged '{key}' section with {len(value)} keys")
-            else:
-                # Top-level fields go to inventory root
-                inventory[key] = value
+    effective_inventory = _build_inventory(execution_entries, inventory)
 
-    # Create a temporary config file with transformed validations
     temp_config: dict[str, Any] = {
+        RESOLVED_ENTRIES_FLAG: True,
         "validations": {"phase_validations": transformed_validations},
-        "inventory": inventory,
+        "inventory": effective_inventory,
     }
-
-    # Include exclude config so conftest.py can filter tests
-    exclude_config: dict[str, list[str]] = {}
-    if exclude_markers:
-        exclude_config["markers"] = exclude_markers
-    if exclude_tests:
-        exclude_config["tests"] = exclude_tests
-    if exclude_config:
-        temp_config["exclude"] = exclude_config
-
-    # Include settings (e.g., show_skipped_tests)
     if settings:
         temp_config["settings"] = settings
 
-    # Create temp file for the config
-    # Use JSON format (valid YAML) to avoid YAML's quote escaping issues that break
-    # Jinja2 template parsing (single quotes become ''nvidia'', backslashes added)
+    # JSON (valid YAML) avoids YAML quote-escaping that breaks Jinja2 templates
+    # (single quotes become ''nvidia'', backslashes are added).
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
         json.dump(temp_config, f, indent=2)
         temp_config_path = f.name
 
     try:
-        # Get the tests directory relative to this module
         tests_dir = Path(__file__).parent / "tests"
 
         pytest_args = [
@@ -198,24 +112,19 @@ def run_validations_via_pytest(
         if suite_name:
             pytest_args.extend(["-o", f"junit_suite_name={suite_name}"])
 
-        # Note: exclude_markers from YAML are handled by conftest.py which reads them
-        # directly from the config file. We don't add them as -m args here because
-        # that would trigger conftest.py's "explicit marker selection" detection.
-
-        # Add extra pytest args
+        # exclude_markers from YAML are read directly by conftest.py; passing them
+        # as -m args would flip conftest's "explicit marker selection" branch.
         if extra_pytest_args:
             pytest_args.extend(extra_pytest_args)
 
-        # Clear previous results before running
         clear_validation_results()
 
         logger.info(f"Running validations via pytest: {' '.join(pytest_args)}")
         exit_code = pytest.main(pytest_args)
 
-        # Get detailed results captured during test execution
-        results = get_validation_results()
+        raw_results = get_validation_results()
 
-        if not results and extra_pytest_args:
+        if not raw_results and extra_pytest_args:
             k_filters = [
                 extra_pytest_args[i + 1]
                 for i, a in enumerate(extra_pytest_args)
@@ -226,172 +135,29 @@ def run_validations_via_pytest(
                     f"No tests matched -k '{k_filters[0]}' - check spelling or run without -k to see available tests"
                 )
 
-        return exit_code, results
+        return exit_code, _apply_pytest_results(execution_entries, raw_results)
 
     finally:
-        # Clean up temp file
-        try:
-            os.unlink(temp_config_path)
-        except OSError:
-            pass
+        Path(temp_config_path).unlink(missing_ok=True)
 
 
-def _iter_configured_validation_names(
-    validations: dict[str, list[dict[str, Any]] | dict[str, Any]],
-) -> list[str]:
-    """Return the validation class names referenced by ``validations``.
-
-    Used purely for logging: walks both supported config shapes (group
-    defaults with ``checks`` key, and flat list-of-dicts) and yields the
-    class name of every configured check.
-    """
-    names: list[str] = []
-    for category, category_config in validations.items():
-        if category in ADAPTER_HANDLED_CATEGORIES:
-            continue
-        if isinstance(category_config, dict) and "checks" in category_config:
-            checks_val = category_config.get("checks", {})
-            if isinstance(checks_val, dict):
-                names.extend(checks_val.keys())
-            else:
-                names.extend(n for item in checks_val for n in item)
-        elif isinstance(category_config, list):
-            names.extend(n for item in category_config for n in item)
-    return names
+def _resolved_entries_to_pytest_validations(entries: list[ResolvedEntry]) -> list[dict[str, dict[str, Any]]]:
+    """Return pytest config validations for already-named resolved entries."""
+    return [{entry.entry.name: copy.deepcopy(entry.rendered_params or {})} for entry in entries]
 
 
-def _transform_validations_for_pytest(
-    validations: dict[str, list[dict[str, Any]] | dict[str, Any]],
-    step_outputs: dict[str, dict[str, Any]],
-    step_phases: dict[str, str],
-    phase: str,
-    released_tests: Collection[str] | None = None,
-) -> list[dict[str, Any]]:
-    """Transform new-format validations into pytest-compatible format.
-
-    The new format supports:
-    - step: shorthand for referencing step output
-    - phase: explicit phase filtering (or inferred from step's phase)
-    - checks: list of validation checks
-
-    Phase determination priority:
-    1. Explicit `phase` field on the validation
-    2. Inferred from `step` - uses the step's phase from step_phases
-    3. Default: 'test' phase
-
-    The pytest format expects:
-    - List of {ValidationName: {params with step_output resolved}}
-
-    Args:
-        validations: New-format validations grouped by category
-        step_outputs: Step outputs for resolving step references
-        step_phases: Mapping of step names to their phases
-        phase: Current phase to filter validations for
-        released_tests: Optional released validation names. When provided,
-            configured validations not in this set are skipped.
-
-    Returns:
-        List of validation dicts in pytest-compatible format
-    """
-    # Two-pass approach: collect entries first, then qualify duplicate class
-    # names with a "-category" suffix so each becomes a unique pytest param.
-    # Without this, get_validations_for_category collapses them into a dict
-    # and only the last occurrence survives (e.g. InstanceStateCheck on
-    # launch_instance vs describe_instance vs reboot_instance).
-    entries: list[tuple[str, str, dict[str, Any]]] = []  # (class_name, category, params)
-
-    for category, category_config in validations.items():
-        if category in ADAPTER_HANDLED_CATEGORIES:
-            continue
-
-        # Determine format: group defaults (with checks key) or flat list
-        if isinstance(category_config, dict) and "checks" in category_config:
-            # Group defaults format
-            group_step = category_config.get("step")
-            group_phase = category_config.get("phase")  # Don't default - let inference handle it
-            checks_val = category_config.get("checks", {})
-            if isinstance(checks_val, dict):
-                # Dict-based checks: {CheckName: {params}, ...}
-                checks_iter: list[tuple[str, Any]] = list(checks_val.items())
-            else:
-                # List-based checks: [{CheckName: {params}}, ...]
-                checks_iter = [(n, p) for item in checks_val for n, p in item.items()]
-        elif isinstance(category_config, list):
-            # List format (no group defaults)
-            group_step = None
-            group_phase = None
-            checks_iter = [(n, p) for item in category_config for n, p in item.items()]
-        else:
-            logger.warning(f"Unknown validation format for category '{category}'")
-            continue
-
-        for name, params in checks_iter:
-            if released_tests is not None and name not in released_tests:
-                key = f"{category}:{name}"
-                if key not in _SKIPPED_UNRELEASED_LOGGED:
-                    logger.info(f"Skipping unreleased validation '{name}' in [{category}]")
-                    _SKIPPED_UNRELEASED_LOGGED.add(key)
-                continue
-
-            if params is None:
-                params = {}
-
-            # Apply group defaults
-            if group_step and "step" not in params:
-                params = {"step": group_step, **params}
-            if group_phase and "phase" not in params:
-                params = {"phase": group_phase, **params}
-
-            # Determine validation phase (priority: explicit > infer from step > default)
-            # If a step is referenced but has no registered phase, it was skipped
-            if "phase" in params:
-                validation_phase = params["phase"]
-            elif "step" in params:
-                step_name = params["step"]
-                if step_name not in step_phases:
-                    logger.info(f"Skipping validation '{name}' in [{category}]: step '{step_name}' is skipped")
-                    continue
-                validation_phase = step_phases[step_name]
-            else:
-                validation_phase = "test"  # Default to test phase
-
-            # Filter by phase
-            if validation_phase != phase:
-                continue
-
-            # Resolve step to actual step output
-            resolved_params = dict(params)
-            if "step" in resolved_params:
-                step_name = resolved_params.pop("step")
-                if step_name not in step_outputs:
-                    logger.info(
-                        f"Skipping validation '{name}' in [{category}]: step '{step_name}' did not produce output"
-                    )
-                    continue
-                step_output = step_outputs[step_name]
-                resolved_params["step_output"] = step_output
-
-            # Remove phase from params (not needed by validation)
-            resolved_params.pop("phase", None)
-
-            # Add category for result reporting
-            resolved_params["_category"] = category
-
-            entries.append((name, category, resolved_params))
-
-    # Detect class names that appear more than once and qualify them with
-    # "-category" so downstream dict-keyed storage keeps every instance.
-    # Uses the existing ClassName-variant convention that pytest_generate_tests
-    # already supports via suffix matching.
-    # When the same class appears twice in the same category (e.g. legacy list
-    # format), append a counter: ClassName-category-2, ClassName-category-3, etc.
+def _entries_with_pytest_names(entries: list[ResolvedEntry]) -> list[ResolvedEntry]:
+    """Return ready entries with duplicate names qualified for pytest config storage."""
+    ready_entries = [entry for entry in entries if entry.is_ready]
     name_counts: dict[str, int] = {}
-    for class_name, _, _ in entries:
-        name_counts[class_name] = name_counts.get(class_name, 0) + 1
+    for entry in ready_entries:
+        name_counts[entry.entry.name] = name_counts.get(entry.entry.name, 0) + 1
 
     pair_counts: dict[tuple[str, str], int] = {}
-    result: list[dict[str, Any]] = []
-    for class_name, category, resolved_params in entries:
+    named_entries: list[ResolvedEntry] = []
+    for entry in ready_entries:
+        class_name = entry.entry.name
+        category = entry.entry.category
         if name_counts[class_name] == 1:
             key = class_name
         else:
@@ -399,9 +165,91 @@ def _transform_validations_for_pytest(
             pair_counts[pair] = pair_counts.get(pair, 0) + 1
             suffix = category if pair_counts[pair] == 1 else f"{category}-{pair_counts[pair]}"
             key = f"{class_name}-{suffix}"
-        result.append({key: resolved_params})
+        named_entries.append(ResolvedEntry(entry=replace(entry.entry, name=key), rendered_params=entry.rendered_params))
+    return named_entries
 
+
+def _build_inventory(entries: list[ResolvedEntry], inventory: dict[str, Any] | None) -> dict[str, Any]:
+    """Build pytest inventory from supplied inventory and ready entry step outputs."""
+    result = copy.deepcopy(inventory or {})
+    steps = result.setdefault("steps", {})
+    if not isinstance(steps, dict):
+        steps = {}
+        result["steps"] = steps
+
+    for entry in entries:
+        params = entry.rendered_params or {}
+        step_output = params.get("step_output")
+        if entry.entry.step and isinstance(step_output, dict):
+            steps[entry.entry.step] = copy.deepcopy(step_output)
+            for key, value in step_output.items():
+                if isinstance(value, dict):
+                    existing = result.setdefault(key, {})
+                    if isinstance(existing, dict):
+                        existing.update(copy.deepcopy(value))
+                else:
+                    result[key] = copy.deepcopy(value)
     return result
+
+
+def _apply_pytest_results(entries: list[ResolvedEntry], results: list[dict[str, Any]]) -> list[ResolvedEntry]:
+    """Apply captured pytest results to ready execution entries."""
+    by_name = {result.get("name"): result for result in results}
+    updated: list[ResolvedEntry] = []
+    for entry in entries:
+        result = by_name.get(entry.entry.name)
+        if result is None:
+            updated.append(
+                ResolvedEntry(
+                    entry=entry.entry,
+                    rendered_params=entry.rendered_params,
+                    state=State.SKIPPED,
+                    skip_reason=SkipReason.OPERATOR,
+                    message="not selected by pytest arguments",
+                )
+            )
+            continue
+        updated.append(_result_to_resolved_entry(entry, result))
+    return updated
+
+
+def _result_to_resolved_entry(entry: ResolvedEntry, result: dict[str, Any]) -> ResolvedEntry:
+    """Convert a captured pytest validation result to a terminal resolved entry."""
+    message = str(result.get("message", ""))
+    duration = float(result.get("duration", 0.0) or 0.0)
+    if result.get("skipped"):
+        return ResolvedEntry(
+            entry=entry.entry,
+            rendered_params=entry.rendered_params,
+            state=State.SKIPPED,
+            skip_reason=SkipReason.OPERATOR,
+            message=message,
+            duration_seconds=duration,
+        )
+    if result.get("passed", False):
+        return ResolvedEntry(
+            entry=entry.entry,
+            rendered_params=entry.rendered_params,
+            state=State.PASSED,
+            message=message,
+            duration_seconds=duration,
+        )
+    if result.get("error_reason") == ErrorReason.RUNTIME_EXCEPTION.value:
+        return ResolvedEntry(
+            entry=entry.entry,
+            rendered_params=entry.rendered_params,
+            state=State.ERROR,
+            error_reason=ErrorReason.RUNTIME_EXCEPTION,
+            message=message,
+            duration_seconds=duration,
+        )
+    return ResolvedEntry(
+        entry=entry.entry,
+        rendered_params=entry.rendered_params,
+        state=State.FAILED,
+        message=message,
+        duration_seconds=duration,
+    )
 
 
 class Platform(StrEnum):

--- a/isvtest/src/isvtest/testing/subtests.py
+++ b/isvtest/src/isvtest/testing/subtests.py
@@ -123,6 +123,7 @@ class SubTests:
         *,
         duration: float | None = None,
         skipped: bool = False,
+        message: str | None = None,
         **kwargs: Any,
     ) -> _SubTestContextManager:
         """Context manager for a subtest.
@@ -134,6 +135,9 @@ class SubTests:
                 Useful for reporting results from tests that already ran (e.g., Go tests).
             skipped: If True, mark the subtest as skipped. This avoids using
                 pytest.skip() which would add skip markers to the parent test.
+            message: Optional human-readable reason. When ``skipped=True``, this
+                is what surfaces in the report (e.g., "no CSIDriver objects
+                present") instead of the canned "Subtest <name> skipped".
             **kwargs: Additional parameters for the subtest.
 
         Returns:
@@ -150,7 +154,7 @@ class SubTests:
                     raise AssertionError("Go test failed")
 
             # Mark as skipped without calling pytest.skip():
-            with subtests.test(msg="TestOptional", skipped=True):
+            with subtests.test(msg="TestOptional", skipped=True, message="not configured"):
                 pass  # Nothing to run, just recording the skip
         """
         is_first = self._first_subtest
@@ -164,6 +168,7 @@ class SubTests:
             terminal_writer=self._terminal_writer,
             provided_duration=duration,
             skipped=skipped,
+            message=message,
         )
 
 
@@ -196,6 +201,7 @@ class _SubTestContextManager:
         terminal_writer: Any | None = None,
         provided_duration: float | None = None,
         skipped: bool = False,
+        message: str | None = None,
     ) -> None:
         self._request = request
         self._msg = msg
@@ -205,6 +211,7 @@ class _SubTestContextManager:
         self._terminal_writer = terminal_writer
         self._provided_duration = provided_duration
         self._skipped = skipped
+        self._message = message
         self._start: float = 0
         self._precise_start: float = 0
 
@@ -268,7 +275,7 @@ class _SubTestContextManager:
             sub_report.longrepr = (
                 __file__,
                 0,
-                f"Subtest {self._msg} skipped",
+                self._message or f"Subtest {self._msg} skipped",
             )
 
         # Print the subtest result ourselves for consistent formatting
@@ -539,7 +546,14 @@ def _inject_subtests_into_junit(junit_path: Path, reports: list[SubTestReport]) 
                 elif report.skipped:
                     added_skipped += 1
                     skipped_elem = ET.SubElement(testcase, "skipped")
-                    skipped_elem.set("message", f"Skipped: Subtest {subtest_desc} skipped")
+                    # longrepr from both our skipped-flag path and pytest.skip()
+                    # is a (file, line, msg) tuple; surface the msg so the
+                    # report carries the actual reason instead of a canned line.
+                    if isinstance(report.longrepr, tuple) and len(report.longrepr) >= 3:
+                        skip_text = str(report.longrepr[2])
+                    else:
+                        skip_text = f"Subtest {subtest_desc} skipped"
+                    skipped_elem.set("message", skip_text)
 
                 subtest_elements.append(testcase)
 

--- a/isvtest/src/isvtest/tests/test_validations.py
+++ b/isvtest/src/isvtest/tests/test_validations.py
@@ -16,15 +16,13 @@ import pytest
 
 from isvtest.config.loader import ConfigLoader
 from isvtest.core.discovery import discover_all_tests
+from isvtest.core.resolution import ADAPTER_HANDLED_CATEGORIES, RESOLVED_ENTRIES_FLAG, resolve_class_key
 from isvtest.core.runners import LocalRunner
 from isvtest.core.validation import BaseValidation
 from isvtest.release_manifest import INCLUDE_UNRELEASED_ENV, load_released_test_filter
 
 if TYPE_CHECKING:
     from isvtest.testing.subtests import SubTests
-
-# Categories handled by specialized adapters (not standard BaseValidation discovery)
-ADAPTER_HANDLED_CATEGORIES = {"reframe"}
 
 # In-memory storage for validation results (used by isvctl integration)
 # This allows capturing detailed results without temp files
@@ -46,18 +44,8 @@ def _resolve_validation_class(
     test_classes_map: dict[str, type[BaseValidation]],
 ) -> type[BaseValidation] | None:
     """Resolve a configured validation name to a discovered validation class."""
-    if validation_name in test_classes_map:
-        return test_classes_map[validation_name]
-
-    # Suffix match (e.g. ClassName-Variant). Generated duplicate keys use the
-    # same convention, but release filtering decides whether that suffix is an
-    # internal disambiguator or a literal configured variant.
-    possible_matches = [name for name in test_classes_map if validation_name.startswith(f"{name}-")]
-    if not possible_matches:
-        return None
-
-    longest_match = max(possible_matches, key=len)
-    return test_classes_map[longest_match]
+    key = resolve_class_key(validation_name, test_classes_map)
+    return test_classes_map[key] if key is not None else None
 
 
 def _is_released_validation(
@@ -103,11 +91,6 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     """Generate tests for all BaseValidation and BaseWorkloadCheck subclasses."""
     if "validation_class" in metafunc.fixturenames and "validation_config" in metafunc.fixturenames:
         test_classes = list(discover_all_tests())
-        released_tests = load_released_test_filter()
-        if released_tests is None:
-            sys.stderr.write(
-                f"\n\033[33mInfo:\033[0m Including unreleased validations because {INCLUDE_UNRELEASED_ENV} is enabled.\n"
-            )
 
         if not test_classes:
             return
@@ -116,7 +99,9 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         enabled_validations_config = {}
         cluster_inventory: dict[str, Any] = {}
         filtering_enabled = False
+        resolution_preapplied = False
         show_skipped = False
+        released_tests: set[str] | None = None
 
         try:
             config_file_arg = metafunc.config.getoption("--config", default=None)
@@ -132,6 +117,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
                 # Extract inventory - contains dynamic info about resources created during setup
                 # (e.g., instance IPs, SSH keys) needed by remote validations like AWS EC2
                 cluster_inventory = cluster_config.get("inventory", {})
+                resolution_preapplied = bool(cluster_config.get(RESOLVED_ENTRIES_FLAG))
                 # Get all validation categories, excluding adapter-handled ones
                 all_categories = list((cluster_config.get("validations") or {}).keys())
                 standard_categories = [c for c in all_categories if c not in ADAPTER_HANDLED_CATEGORIES]
@@ -140,6 +126,13 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
                 show_skipped = cluster_config.get("settings", {}).get("show_skipped_tests", False)
         except (ImportError, FileNotFoundError, ValueError, AttributeError, OSError):
             pass
+
+        if not resolution_preapplied:
+            released_tests = load_released_test_filter()
+            if released_tests is None:
+                sys.stderr.write(
+                    f"\n\033[33mInfo:\033[0m Including unreleased validations because {INCLUDE_UNRELEASED_ENV} is enabled.\n"
+                )
 
         # Create parameters with markers
         params = []
@@ -157,7 +150,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
                 if target_class is not None:
                     configured_classes.add(target_class.__name__)
 
-                if target_class is not None and released_tests is not None:
+                if target_class is not None and released_tests is not None and not resolution_preapplied:
                     if not _is_released_validation(validation_name, validation_config, target_class, released_tests):
                         sys.stderr.write(
                             f"\n\033[33mInfo:\033[0m Skipping unreleased validation: '{validation_name}'.\n"
@@ -192,7 +185,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
                     sys.stderr.write(f"\n\033[33mWarning:\033[0m Validation not found: '{validation_name}'. {hint}\n")
 
             # 2. Add skipped tests for classes NOT in config (if show_skipped)
-            if show_skipped:
+            if show_skipped and not resolution_preapplied:
                 for cls_name, cls in test_classes_map.items():
                     if released_tests is not None and cls_name not in released_tests:
                         continue
@@ -272,6 +265,7 @@ def test_validation(
                 "skipped": True,
                 "message": skip_reason,
                 "category": category,
+                "duration": 0.0,
             }
         )
         raise
@@ -283,6 +277,8 @@ def test_validation(
             "skipped": False,
             "message": result["output"] if result["passed"] else result["error"],
             "category": category,
+            "duration": result.get("duration", 0.0),
+            "error_reason": result.get("error_reason"),
         }
     )
 

--- a/isvtest/src/isvtest/validations/k8s_network_policy.py
+++ b/isvtest/src/isvtest/validations/k8s_network_policy.py
@@ -396,7 +396,7 @@ class K8sDualStackNodeCheck(BaseValidation):
                 self.report_subtest(
                     f"node/{name}",
                     passed=True,
-                    message=_family_summary(has_v4, has_v6),
+                    message=f"single-stack cluster (auto mode); node has {_family_summary(has_v4, has_v6)}",
                     skipped=True,
                 )
             self.set_passed("Skipped: cluster is single-stack (auto mode)")

--- a/isvtest/tests/test_main.py
+++ b/isvtest/tests/test_main.py
@@ -10,12 +10,13 @@
 
 """Tests for isvtest.main module."""
 
-from typing import Any
-
-import pytest
-
 import isvtest.main
-from isvtest.main import _transform_validations_for_pytest
+from isvtest.core.resolution import ErrorReason, ResolvedEntry, SkipReason, State, ValidationEntry
+from isvtest.main import (
+    _entries_with_pytest_names,
+    _resolved_entries_to_pytest_validations,
+    run_validations_via_pytest,
+)
 
 
 def test_dummy() -> None:
@@ -28,344 +29,97 @@ def test_main_module_exists() -> None:
     assert isvtest.main is not None
 
 
-# ---------------------------------------------------------------------------
-# _transform_validations_for_pytest
-# ---------------------------------------------------------------------------
+def _ready(name: str, category: str, params: dict[str, object]) -> ResolvedEntry:
+    """Build a ready resolved entry for main-module tests."""
+    return ResolvedEntry(
+        entry=ValidationEntry(name=name, category=category, params_template={}),
+        rendered_params={**params, "_category": category},
+    )
 
 
-class TestTransformValidationsForPytest:
-    """Tests for the validation transform that feeds pytest parametrization."""
+def _keys(result: list[dict[str, dict[str, object]]]) -> list[str]:
+    """Extract validation keys from pytest config entries."""
+    return [next(iter(entry)) for entry in result]
 
-    # Shared fixtures ---------------------------------------------------------
 
-    @pytest.fixture()
-    def step_outputs(self) -> dict[str, dict[str, Any]]:
-        """Simulated step outputs keyed by step name."""
-        return {
-            "launch_instance": {"instance_id": "i-abc", "state": "running"},
-            "describe_instance": {"instance_id": "i-abc", "state": "running"},
-            "reboot_instance": {"instance_id": "i-abc", "state": "running"},
-        }
-
-    @pytest.fixture()
-    def step_phases(self) -> dict[str, str]:
-        """Mapping of step names to the phase they belong to."""
-        return {
-            "launch_instance": "setup",
-            "describe_instance": "test",
-            "reboot_instance": "test",
-        }
-
-    # Helpers -----------------------------------------------------------------
-
-    @staticmethod
-    def _keys(result: list[dict[str, Any]]) -> list[str]:
-        """Extract the validation key from each entry."""
-        return [next(iter(d)) for d in result]
-
-    # Tests -------------------------------------------------------------------
-
-    def test_unique_checks_keep_bare_name(
-        self,
-        step_outputs: dict[str, dict[str, Any]],
-        step_phases: dict[str, str],
-    ) -> None:
-        """When each class name is unique, no suffix is added."""
-        validations: dict[str, Any] = {
-            "ssh": {
-                "step": "describe_instance",
-                "checks": {"ConnectivityCheck": {}, "OsCheck": {}},
-            },
-        }
-        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
-        keys = self._keys(result)
-        assert keys == ["ConnectivityCheck", "OsCheck"]
-
-    def test_duplicate_checks_get_category_suffix(
-        self,
-        step_outputs: dict[str, dict[str, Any]],
-        step_phases: dict[str, str],
-    ) -> None:
-        """Same class in multiple categories gets '-category' suffix."""
-        validations: dict[str, Any] = {
-            "instance_info": {
-                "step": "describe_instance",
-                "checks": {"InstanceStateCheck": {"expected_state": "running"}},
-            },
-            "reboot_state": {
-                "step": "reboot_instance",
-                "checks": {"InstanceStateCheck": {"expected_state": "running"}},
-            },
-        }
-        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
-        keys = self._keys(result)
-        assert "InstanceStateCheck-instance_info" in keys
-        assert "InstanceStateCheck-reboot_state" in keys
-        assert len(keys) == 2
-
-    def test_duplicate_checks_preserve_params(
-        self,
-        step_outputs: dict[str, dict[str, Any]],
-        step_phases: dict[str, str],
-    ) -> None:
-        """Qualified entries keep correct step_output and _category."""
-        validations: dict[str, Any] = {
-            "instance_info": {
-                "step": "describe_instance",
-                "checks": {"InstanceStateCheck": {"expected_state": "running"}},
-            },
-            "reboot_state": {
-                "step": "reboot_instance",
-                "checks": {"InstanceStateCheck": {"expected_state": "running"}},
-            },
-        }
-        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
-        by_key = {next(iter(d)): next(iter(d.values())) for d in result}
-
-        info = by_key["InstanceStateCheck-instance_info"]
-        assert info["_category"] == "instance_info"
-        assert info["step_output"] == step_outputs["describe_instance"]
-
-        reboot = by_key["InstanceStateCheck-reboot_state"]
-        assert reboot["_category"] == "reboot_state"
-        assert reboot["step_output"] == step_outputs["reboot_instance"]
-
-    def test_mixed_unique_and_duplicate(
-        self,
-        step_outputs: dict[str, dict[str, Any]],
-        step_phases: dict[str, str],
-    ) -> None:
-        """Unique checks stay bare; only duplicates get the suffix."""
-        validations: dict[str, Any] = {
-            "ssh": {
-                "step": "describe_instance",
-                "checks": {"ConnectivityCheck": {}, "GpuCheck": {}},
-            },
-            "reboot_ssh": {
-                "step": "reboot_instance",
-                "checks": {"ConnectivityCheck": {}, "DriverCheck": {}},
-            },
-        }
-        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
-        keys = self._keys(result)
-        assert "ConnectivityCheck-ssh" in keys
-        assert "ConnectivityCheck-reboot_ssh" in keys
-        assert "GpuCheck" in keys
-        assert "DriverCheck" in keys
-
-    def test_phase_filtering_excludes_other_phases(
-        self,
-        step_outputs: dict[str, dict[str, Any]],
-        step_phases: dict[str, str],
-    ) -> None:
-        """Checks in a different phase are not emitted."""
-        validations: dict[str, Any] = {
-            "setup_checks": {
-                "step": "launch_instance",
-                "checks": {"InstanceStateCheck": {"expected_state": "running"}},
-            },
-            "instance_info": {
-                "step": "describe_instance",
-                "checks": {"InstanceStateCheck": {"expected_state": "running"}},
-            },
-        }
-        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
-        keys = self._keys(result)
-        # Only the test-phase entry should appear, and since it's the only one
-        # for this phase, it keeps the bare class name.
-        assert keys == ["InstanceStateCheck"]
-
-    def test_list_entries_infer_distinct_phases_from_steps(self) -> None:
-        """Repeated checks can validate separate lifecycle operations."""
-        step_outputs = {
-            "create_test_node_pool": {"expected_replicas": 1},
-            "update_test_node_pool": {"expected_replicas": 2},
-        }
-        step_phases = {
-            "create_test_node_pool": "setup",
-            "update_test_node_pool": "test",
-        }
-        validations: dict[str, Any] = {
-            "k8s_node_pools": [
-                {
-                    "K8sNodePoolCheck": {
-                        "step": "create_test_node_pool",
-                        "expected_replicas": 1,
-                    }
-                },
-                {
-                    "K8sNodePoolCheck": {
-                        "step": "update_test_node_pool",
-                        "expected_replicas": 2,
-                    }
-                },
-            ],
-        }
-
-        setup_result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "setup")
-        test_result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
-
-        setup_params = setup_result[0]["K8sNodePoolCheck"]
-        test_params = test_result[0]["K8sNodePoolCheck"]
-        assert setup_params["expected_replicas"] == 1
-        assert setup_params["step_output"] == step_outputs["create_test_node_pool"]
-        assert test_params["expected_replicas"] == 2
-        assert test_params["step_output"] == step_outputs["update_test_node_pool"]
-
-    def test_step_scoped_checks_preserve_order_before_default_test_checks(self) -> None:
-        """A phase-scoped convergence check can gate later default test checks."""
-        step_outputs = {
-            "update_test_node_pool": {"expected_replicas": 2},
-        }
-        step_phases = {
-            "update_test_node_pool": "test",
-        }
-        validations: dict[str, Any] = {
-            "k8s_node_pools": [
-                {
-                    "K8sNodePoolCheck": {
-                        "step": "update_test_node_pool",
-                        "expected_replicas": 2,
-                    }
-                }
-            ],
-            "k8s_workloads": {
-                "checks": {
-                    "K8sGpuStressWorkload": {
-                        "timeout": 300,
-                    }
-                }
-            },
-        }
-
-        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
-
-        assert self._keys(result) == ["K8sNodePoolCheck", "K8sGpuStressWorkload"]
-
-    def test_missing_step_output_skips_validation(
-        self,
-        step_outputs: dict[str, dict[str, Any]],
-        step_phases: dict[str, str],
-    ) -> None:
-        """A step that was registered but never executed does not emit a validation."""
-        step_phases = {**step_phases, "cert_rotation_test": "test"}
-        validations: dict[str, Any] = {
-            "cert_rotation": {
-                "step": "cert_rotation_test",
-                "checks": {"CertRotationCycleCheck": {}},
-            },
-        }
-
-        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
-
-        assert result == []
-
-    def test_existing_failed_step_output_keeps_validation(
-        self,
-        step_phases: dict[str, str],
-    ) -> None:
-        """Failed command output is still passed through when the step produced JSON."""
-        step_outputs = {"cert_rotation_test": {"success": False, "error": "AWS credentials expired"}}
-        step_phases = {**step_phases, "cert_rotation_test": "test"}
-        validations: dict[str, Any] = {
-            "cert_rotation": {
-                "step": "cert_rotation_test",
-                "checks": {"CertRotationCycleCheck": {}},
-            },
-        }
-
-        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
-
-        assert result == [
-            {
-                "CertRotationCycleCheck": {
-                    "step_output": step_outputs["cert_rotation_test"],
-                    "_category": "cert_rotation",
-                }
-            }
-        ]
-
-    def test_empty_validations(self) -> None:
-        """Empty input returns empty list."""
-        assert _transform_validations_for_pytest({}, {}, {}, "test") == []
-
-    def test_unreleased_checks_are_skipped(
-        self,
-        step_outputs: dict[str, dict[str, Any]],
-        step_phases: dict[str, str],
-    ) -> None:
-        """Configured checks not in the release manifest are not emitted."""
-        validations: dict[str, Any] = {
-            "ssh": {
-                "step": "describe_instance",
-                "checks": {"ConnectivityCheck": {}, "NewMainOnlyCheck": {}},
-            },
-        }
-        result = _transform_validations_for_pytest(
-            validations,
-            step_outputs,
-            step_phases,
-            "test",
-            released_tests={"ConnectivityCheck"},
+def test_resolved_entries_to_pytest_validations_keeps_unique_names() -> None:
+    """Unique ready entries keep their configured validation names."""
+    result = _resolved_entries_to_pytest_validations(
+        _entries_with_pytest_names(
+            [
+                _ready("StepSuccessCheck", "setup_checks", {"step_output": {"success": True}}),
+                _ready("FieldExistsCheck", "setup_checks", {"step_output": {"id": "x"}, "field": "id"}),
+            ]
         )
-        assert self._keys(result) == ["ConnectivityCheck"]
+    )
 
-    def test_disabled_release_filter_includes_all_checks(
-        self,
-        step_outputs: dict[str, dict[str, Any]],
-        step_phases: dict[str, str],
-    ) -> None:
-        """A disabled release filter emits configured checks regardless of manifest membership."""
-        validations: dict[str, Any] = {
-            "ssh": {
-                "step": "describe_instance",
-                "checks": {"ConnectivityCheck": {}, "NewMainOnlyCheck": {}},
-            },
-        }
-        result = _transform_validations_for_pytest(
-            validations,
-            step_outputs,
-            step_phases,
-            "test",
-            released_tests=None,
+    assert _keys(result) == ["StepSuccessCheck", "FieldExistsCheck"]
+
+
+def test_resolved_entries_to_pytest_validations_disambiguates_duplicates() -> None:
+    """Duplicate ready entries receive category and counter suffixes."""
+    result = _resolved_entries_to_pytest_validations(
+        _entries_with_pytest_names(
+            [
+                _ready("StepSuccessCheck", "setup_checks", {"step_output": {"success": True}}),
+                _ready("StepSuccessCheck", "teardown_checks", {"step_output": {"success": True}}),
+                _ready("StepSuccessCheck", "teardown_checks", {"step_output": {"success": True}}),
+            ]
         )
-        assert self._keys(result) == ["ConnectivityCheck", "NewMainOnlyCheck"]
+    )
 
-    def test_list_format_dedup(self) -> None:
-        """Duplicate class names in legacy list format also get qualified."""
-        step_outputs = {
-            "step_a": {"ok": True},
-            "step_b": {"ok": True},
-        }
-        step_phases = {"step_a": "test", "step_b": "test"}
-        validations: dict[str, Any] = {
-            "cat_a": [
-                {"StepSuccessCheck": {"step": "step_a"}},
-            ],
-            "cat_b": [
-                {"StepSuccessCheck": {"step": "step_b"}},
-            ],
-        }
-        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
-        keys = self._keys(result)
-        assert "StepSuccessCheck-cat_a" in keys
-        assert "StepSuccessCheck-cat_b" in keys
+    assert _keys(result) == [
+        "StepSuccessCheck-setup_checks",
+        "StepSuccessCheck-teardown_checks",
+        "StepSuccessCheck-teardown_checks-2",
+    ]
 
-    def test_same_class_same_category_gets_counter(self) -> None:
-        """Same class repeated in one category gets a numeric disambiguator."""
-        step_outputs = {
-            "step_a": {"ok": True},
-            "step_b": {"ok": True},
-        }
-        step_phases = {"step_a": "test", "step_b": "test"}
-        validations: dict[str, Any] = {
-            "checks": [
-                {"StepSuccessCheck": {"step": "step_a"}},
-                {"StepSuccessCheck": {"step": "step_b"}},
-            ],
-        }
-        result = _transform_validations_for_pytest(validations, step_outputs, step_phases, "test")
-        keys = self._keys(result)
-        assert "StepSuccessCheck-checks" in keys
-        assert "StepSuccessCheck-checks-2" in keys
-        assert len(keys) == 2
+
+def test_run_validations_via_pytest_updates_ready_entries() -> None:
+    """The pytest bridge returns terminal states on the same resolved-entry channel."""
+    entries = [
+        _ready("StepSuccessCheck", "setup_checks", {"step_output": {"success": True, "message": "ok"}}),
+        _ready(
+            "NimHealthCheck",
+            "nim",
+            {"step_output": {"skipped": True, "skip_reason": "NIM was not deployed"}},
+        ),
+    ]
+
+    exit_code, results = run_validations_via_pytest(entries=entries)
+
+    assert exit_code == 0
+    assert [result.state for result in results] == [State.PASSED, State.SKIPPED]
+    assert results[0].message == "ok"
+    assert results[1].skip_reason == SkipReason.OPERATOR
+    assert results[1].message == "NIM was not deployed"
+
+
+def test_run_validations_via_pytest_marks_runtime_exception() -> None:
+    """A validation that raises during run() surfaces as ERROR(RUNTIME_EXCEPTION)."""
+    # step_output=None makes StepSuccessCheck.run() crash on the first .get() call.
+    entries = [_ready("StepSuccessCheck", "setup_checks", {"step_output": None})]
+
+    exit_code, results = run_validations_via_pytest(entries=entries)
+
+    assert exit_code != 0
+    assert len(results) == 1
+    assert results[0].state == State.ERROR
+    assert results[0].error_reason == ErrorReason.RUNTIME_EXCEPTION
+
+
+def test_run_validations_via_pytest_marks_unselected_entries_as_operator_skipped() -> None:
+    """Entries filtered out by pytest -k surface as SKIPPED(OPERATOR)."""
+    entries = [
+        _ready("StepSuccessCheck", "setup_checks", {"step_output": {"success": True}}),
+        _ready("NimHealthCheck", "nim", {"step_output": {"healthy": True}}),
+    ]
+
+    _exit_code, results = run_validations_via_pytest(entries=entries, extra_pytest_args=["-k", "StepSuccessCheck"])
+
+    by_name = {result.entry.name: result for result in results}
+    assert by_name["StepSuccessCheck"].state == State.PASSED
+    nim = by_name["NimHealthCheck"]
+    assert nim.state == State.SKIPPED
+    assert nim.skip_reason == SkipReason.OPERATOR
+    assert nim.message == "not selected by pytest arguments"

--- a/isvtest/tests/test_main.py
+++ b/isvtest/tests/test_main.py
@@ -91,7 +91,7 @@ def test_run_validations_via_pytest_updates_ready_entries() -> None:
     assert exit_code == 0
     assert [result.state for result in results] == [State.PASSED, State.SKIPPED]
     assert results[0].message == "ok"
-    assert results[1].skip_reason == SkipReason.OPERATOR
+    assert results[1].skip_reason == SkipReason.RUNTIME_SKIP
     assert results[1].message == "NIM was not deployed"
 
 
@@ -108,8 +108,8 @@ def test_run_validations_via_pytest_marks_runtime_exception() -> None:
     assert results[0].error_reason == ErrorReason.RUNTIME_EXCEPTION
 
 
-def test_run_validations_via_pytest_marks_unselected_entries_as_operator_skipped() -> None:
-    """Entries filtered out by pytest -k surface as SKIPPED(OPERATOR)."""
+def test_run_validations_via_pytest_marks_unselected_entries_as_excluded() -> None:
+    """Entries filtered out by pytest -k surface as SKIPPED(EXCLUDED)."""
     entries = [
         _ready("StepSuccessCheck", "setup_checks", {"step_output": {"success": True}}),
         _ready("NimHealthCheck", "nim", {"step_output": {"healthy": True}}),
@@ -121,5 +121,5 @@ def test_run_validations_via_pytest_marks_unselected_entries_as_operator_skipped
     assert by_name["StepSuccessCheck"].state == State.PASSED
     nim = by_name["NimHealthCheck"]
     assert nim.state == State.SKIPPED
-    assert nim.skip_reason == SkipReason.OPERATOR
-    assert nim.message == "not selected by pytest arguments"
+    assert nim.skip_reason == SkipReason.EXCLUDED
+    assert nim.message == "excluded by pytest -k/-m filter"

--- a/isvtest/tests/test_pytest_generation.py
+++ b/isvtest/tests/test_pytest_generation.py
@@ -13,6 +13,7 @@
 from typing import Any
 from unittest.mock import patch
 
+from isvtest.core.resolution import RESOLVED_ENTRIES_FLAG
 from isvtest.core.validation import BaseValidation
 from isvtest.tests import test_validations as validation_tests
 
@@ -107,6 +108,17 @@ class ShowSkippedLiteralVariantLoader(LiteralVariantLoader):
         return config
 
 
+class ResolvedEntriesLoader(FakeLoader):
+    """ConfigLoader replacement for orchestrator-resolved temp configs."""
+
+    def load_cluster_config(self, config_file: str, inventory_path: str | None = None) -> dict[str, Any]:
+        """Return a config whose validation entries were resolved upstream."""
+        config = super().load_cluster_config(config_file=config_file, inventory_path=inventory_path)
+        config[RESOLVED_ENTRIES_FLAG] = True
+        config["settings"] = {"show_skipped_tests": True}
+        return config
+
+
 def test_release_filter_allows_synthesized_key_when_base_is_released() -> None:
     """Synthesized duplicate keys are kept when their base class is released."""
     metafunc = FakeMetafunc()
@@ -133,6 +145,20 @@ def test_unreleased_configured_variant_is_not_labeled_not_configured() -> None:
         validation_tests.pytest_generate_tests(metafunc)
 
     assert metafunc.ids == ["NO_VALIDATIONS"]
+
+
+def test_resolved_entries_bypass_pytest_release_filter_and_show_skipped() -> None:
+    """Resolved temp configs execute exactly the entries already selected upstream."""
+    metafunc = FakeMetafunc()
+
+    with (
+        patch.object(validation_tests, "ConfigLoader", ResolvedEntriesLoader),
+        patch.object(validation_tests, "discover_all_tests", return_value=[ReleasedValidation, UnreleasedValidation]),
+        patch.object(validation_tests, "load_released_test_filter", return_value={"ReleasedValidation"}),
+    ):
+        validation_tests.pytest_generate_tests(metafunc)
+
+    assert metafunc.ids == ["ReleasedValidation-start_checks", "UnreleasedValidation"]
 
 
 def test_release_filter_allows_synthesized_key_when_full_key_is_released() -> None:

--- a/isvtest/tests/test_resolution.py
+++ b/isvtest/tests/test_resolution.py
@@ -286,3 +286,42 @@ def test_parse_validations_preserves_list_order(monkeypatch: pytest.MonkeyPatch)
     entries = parse_validations(raw_config)
 
     assert [entry.step for entry in entries] == ["first", "second"]
+
+
+def test_parse_validations_emits_invalid_for_non_dict_list_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stray scalars/lists in YAML produce ERROR(invalid_config) instead of vanishing."""
+    monkeypatch.setattr(
+        "isvtest.core.resolution.discover_all_tests",
+        lambda: [PlainCheck],
+    )
+    raw_config: dict[str, Any] = {
+        "cluster": {
+            "checks": [
+                {"PlainCheck": {}},
+                "this-is-not-a-mapping",  # malformed
+            ],
+        },
+        "top_level_list": [
+            {"PlainCheck": {}},
+            ["also-not-a-mapping"],  # malformed
+        ],
+    }
+
+    entries = parse_validations(raw_config)
+
+    invalid = [entry for entry in entries if "_invalid_config" in entry.params_template]
+    assert len(invalid) == 2, "both malformed list items must surface as <invalid> entries"
+    assert all(entry.name == "<invalid>" for entry in invalid)
+
+
+def test_resolve_entries_treats_variant_names_as_released() -> None:
+    """``ClassName-Variant`` resolves against the bare ClassName in the manifest.
+
+    Mirrors the pytest-discovery path's ``_is_released_validation`` so the
+    pre-resolution gate doesn't diverge from runtime test discovery.
+    """
+    entry = _entry("PlainCheck-myCustomVariant")
+
+    resolved = _resolve(entry, released_tests={"PlainCheck"})
+
+    assert resolved.skip_reason is None, "variant of a released class must not be marked UNRELEASED"

--- a/isvtest/tests/test_resolution.py
+++ b/isvtest/tests/test_resolution.py
@@ -10,6 +10,7 @@
 
 """Tests for validation resolution."""
 
+import logging
 from typing import Any, ClassVar, cast
 
 import pytest
@@ -325,3 +326,36 @@ def test_resolve_entries_treats_variant_names_as_released() -> None:
     resolved = _resolve(entry, released_tests={"PlainCheck"})
 
     assert resolved.skip_reason is None, "variant of a released class must not be marked UNRELEASED"
+
+
+def test_resolve_entries_warns_when_default_filter_masks_missing_step_field(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A typo'd step-output field surfaces a WARNING even when default(...) catches it.
+
+    Regression coverage for the silent-default-fallback bug from PR #191:
+    without this, a missing field reads as a passing test instead of a
+    visible mistake. The warning surfaces the failing reference name.
+    """
+    # ``isvtest`` logger has propagate=False (see core/logger.py), so caplog's
+    # root handler doesn't see resolver warnings. Re-enable propagation here.
+    monkeypatch.setattr(logging.getLogger("isvtest"), "propagate", True)
+
+    entry = _entry(
+        params={"count": "{{ steps.setup.kubernetes.node_count_invalid | default(1, true) }}"},
+        step="setup",
+    )
+    step_output = {"kubernetes": {"node_count": 4}}
+
+    with caplog.at_level("WARNING", logger="isvtest.core.resolution"):
+        _resolve(
+            entry,
+            step_outputs={"setup": step_output},
+            step_phases={"setup": "setup"},
+            requested_phases={"setup", "test"},
+            render_context={"steps": {"setup": step_output}},
+        )
+
+    assert "default(" in caplog.text, "default(...) wrapper should log a warning when masking Undefined"
+    assert "node_count_invalid" in caplog.text, "warning must surface the missing field name"

--- a/isvtest/tests/test_resolution.py
+++ b/isvtest/tests/test_resolution.py
@@ -94,8 +94,8 @@ def _resolve(
     ("entry", "kwargs", "expected_reason"),
     [
         (_entry("NewCheck"), {"released_tests": {"PlainCheck"}}, SkipReason.UNRELEASED),
-        (_entry("PlainCheck"), {"exclude_tests": {"PlainCheck"}}, SkipReason.NAME_EXCLUDED),
-        (_entry("MarkerCheck", markers=("slow",)), {"exclude_markers": {"slow"}}, SkipReason.MARKER_EXCLUDED),
+        (_entry("PlainCheck"), {"exclude_tests": {"PlainCheck"}}, SkipReason.EXCLUDED),
+        (_entry("MarkerCheck", markers=("slow",)), {"exclude_markers": {"slow"}}, SkipReason.EXCLUDED),
         (_entry(step="create_cluster"), {"step_phases": {}}, SkipReason.STEP_NOT_CONFIGURED),
         (
             _entry(step="create_cluster"),

--- a/isvtest/tests/test_resolution.py
+++ b/isvtest/tests/test_resolution.py
@@ -1,0 +1,288 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Tests for validation resolution."""
+
+from typing import Any, ClassVar, cast
+
+import pytest
+
+from isvtest.core.resolution import (
+    ErrorReason,
+    ResolvedEntry,
+    SkipReason,
+    State,
+    ValidationEntry,
+    parse_validations,
+    resolve_entries,
+)
+from isvtest.core.validation import BaseValidation
+
+
+class MarkerCheck(BaseValidation):
+    """Validation with markers used by parser tests."""
+
+    markers: ClassVar[list[str]] = ["slow", "kubernetes"]
+
+    def run(self) -> None:
+        """Mark the validation passed."""
+        self.set_passed()
+
+
+class PlainCheck(BaseValidation):
+    """Validation without markers used by parser tests."""
+
+    def run(self) -> None:
+        """Mark the validation passed."""
+        self.set_passed()
+
+
+def _entry(
+    name: str = "PlainCheck",
+    *,
+    category: str = "cluster",
+    params: dict[str, Any] | None = None,
+    step: str | None = None,
+    phase: str | None = None,
+    markers: tuple[str, ...] = (),
+) -> ValidationEntry:
+    """Build a minimal validation entry."""
+    return ValidationEntry(
+        name=name,
+        category=category,
+        params_template={} if params is None else params,
+        step=step,
+        phase=phase,
+        markers=markers,
+    )
+
+
+def _resolve(
+    entry: ValidationEntry,
+    *,
+    step_outputs: dict[str, dict[str, Any]] | None = None,
+    step_phases: dict[str, str] | None = None,
+    requested_phases: set[str] | None = None,
+    exclude_markers: set[str] | None = None,
+    exclude_tests: set[str] | None = None,
+    released_tests: set[str] | None = None,
+    render_context: dict[str, Any] | None = None,
+) -> ResolvedEntry:
+    """Resolve one entry and return the single result."""
+    results = resolve_entries(
+        [entry],
+        step_outputs={} if step_outputs is None else step_outputs,
+        step_phases={} if step_phases is None else step_phases,
+        requested_phases={"test"} if requested_phases is None else requested_phases,
+        exclude_markers=set() if exclude_markers is None else exclude_markers,
+        exclude_tests=set() if exclude_tests is None else exclude_tests,
+        released_tests=released_tests,
+        render_context={} if render_context is None else render_context,
+    )
+    assert len(results) == 1
+    return results[0]
+
+
+@pytest.mark.parametrize(
+    ("entry", "kwargs", "expected_reason"),
+    [
+        (_entry("NewCheck"), {"released_tests": {"PlainCheck"}}, SkipReason.UNRELEASED),
+        (_entry("PlainCheck"), {"exclude_tests": {"PlainCheck"}}, SkipReason.NAME_EXCLUDED),
+        (_entry("MarkerCheck", markers=("slow",)), {"exclude_markers": {"slow"}}, SkipReason.MARKER_EXCLUDED),
+        (_entry(step="create_cluster"), {"step_phases": {}}, SkipReason.STEP_NOT_CONFIGURED),
+        (
+            _entry(step="create_cluster"),
+            {"step_phases": {"create_cluster": "test"}, "step_outputs": {}},
+            SkipReason.STEP_NO_OUTPUT,
+        ),
+        (_entry(phase="teardown"), {"requested_phases": {"setup"}}, SkipReason.PHASE_NOT_REQUESTED),
+    ],
+)
+def test_resolve_entries_returns_typed_skip_reasons(
+    entry: ValidationEntry,
+    kwargs: dict[str, Any],
+    expected_reason: SkipReason,
+) -> None:
+    """Each decisive skip path returns a terminal skipped entry with a reason."""
+    resolved = _resolve(entry, **kwargs)
+
+    assert resolved.state == State.SKIPPED
+    assert resolved.skip_reason == expected_reason
+    assert resolved.error_reason is None
+    assert not resolved.is_ready
+    assert resolved.message
+
+
+@pytest.mark.parametrize(
+    ("entry", "expected_reason"),
+    [
+        (
+            _entry(params={"expected": "{{ missing.value }}"}),
+            ErrorReason.TEMPLATE_RENDER_FAILED,
+        ),
+        (
+            ValidationEntry(
+                name="PlainCheck",
+                category="cluster",
+                params_template=cast(dict[str, Any], ["not", "a", "dict"]),
+            ),
+            ErrorReason.INVALID_CONFIG,
+        ),
+    ],
+)
+def test_resolve_entries_returns_typed_error_reasons(
+    entry: ValidationEntry,
+    expected_reason: ErrorReason,
+) -> None:
+    """Template and config failures are terminal errors, not dropped entries."""
+    resolved = _resolve(entry)
+
+    assert resolved.state == State.ERROR
+    assert resolved.error_reason == expected_reason
+    assert resolved.skip_reason is None
+    assert not resolved.is_ready
+    assert resolved.message
+
+
+def test_resolve_entries_renders_ready_params_and_adds_step_output() -> None:
+    """A ready entry carries rendered params and the referenced step output."""
+    entry = _entry(
+        params={"expected": "{{ steps.create_cluster.node_count }}"},
+        step="create_cluster",
+    )
+    step_output = {"node_count": 4, "success": True}
+
+    resolved = _resolve(
+        entry,
+        step_outputs={"create_cluster": step_output},
+        step_phases={"create_cluster": "test"},
+        render_context={"steps": {"create_cluster": step_output}},
+    )
+
+    assert resolved.is_ready
+    assert resolved.state is None
+    assert resolved.rendered_params == {
+        "expected": "4",
+        "step_output": step_output,
+        "_category": "cluster",
+    }
+
+
+def test_resolve_entries_allows_default_filter_for_missing_optional_values() -> None:
+    """Missing optional values can be handled intentionally with Jinja default."""
+    entry = _entry(
+        params={"exclude_label_selector": "{{ steps.update_test_node_pool.label_selector | default('', true) }}"},
+    )
+
+    resolved = _resolve(entry, render_context={"steps": {}})
+
+    assert resolved.is_ready
+    assert resolved.rendered_params == {
+        "exclude_label_selector": "",
+        "_category": "cluster",
+    }
+
+
+def test_resolve_entries_does_not_mutate_input_params() -> None:
+    """Resolution copies params before adding step_output and category metadata."""
+    params = {"expected": "{{ steps.create_cluster.node_count }}"}
+    entry = _entry(params=params, step="create_cluster")
+    step_output = {"node_count": 4}
+
+    _resolve(
+        entry,
+        step_outputs={"create_cluster": step_output},
+        step_phases={"create_cluster": "test"},
+        render_context={"steps": {"create_cluster": step_output}},
+    )
+
+    assert params == {"expected": "{{ steps.create_cluster.node_count }}"}
+    assert entry.params_template == params
+
+
+def test_resolve_entries_is_idempotent_from_original_entries() -> None:
+    """Resolved entries can be reduced to entries and resolved again deterministically."""
+    entries = [
+        _entry("PlainCheck", params={"value": "static"}),
+        _entry("MarkerCheck", markers=("slow",)),
+    ]
+    kwargs: dict[str, Any] = {
+        "step_outputs": {},
+        "step_phases": {},
+        "requested_phases": {"test"},
+        "exclude_markers": {"slow"},
+        "exclude_tests": set(),
+        "released_tests": None,
+        "render_context": {},
+    }
+
+    first = resolve_entries(entries, **kwargs)
+    second = resolve_entries([resolved.entry for resolved in first], **kwargs)
+
+    assert second == first
+
+
+def test_parse_validations_supports_group_defaults_and_markers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parser expands config groups and populates markers from discovered classes."""
+    monkeypatch.setattr(
+        "isvtest.core.resolution.discover_all_tests",
+        lambda: [MarkerCheck, PlainCheck],
+    )
+    raw_config: dict[str, Any] = {
+        "cluster": {
+            "step": "create_cluster",
+            "phase": "setup",
+            "checks": {
+                "MarkerCheck": {"expected": 4},
+                "PlainCheck": {},
+            },
+        },
+    }
+
+    entries = parse_validations(raw_config)
+
+    assert entries == [
+        ValidationEntry(
+            name="MarkerCheck",
+            category="cluster",
+            params_template={"expected": 4},
+            step="create_cluster",
+            phase="setup",
+            markers=("slow", "kubernetes"),
+        ),
+        ValidationEntry(
+            name="PlainCheck",
+            category="cluster",
+            params_template={},
+            step="create_cluster",
+            phase="setup",
+            markers=(),
+        ),
+    ]
+
+
+def test_parse_validations_preserves_list_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Parser keeps list-format validation order for report and execution order."""
+    monkeypatch.setattr(
+        "isvtest.core.resolution.discover_all_tests",
+        lambda: [PlainCheck],
+    )
+    raw_config: dict[str, Any] = {
+        "checks": [
+            {"PlainCheck": {"step": "first"}},
+            {"PlainCheck": {"step": "second"}},
+        ],
+    }
+
+    entries = parse_validations(raw_config)
+
+    assert [entry.step for entry in entries] == ["first", "second"]

--- a/isvtest/tests/test_subtests_junit.py
+++ b/isvtest/tests/test_subtests_junit.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Tests for subtest -> JUnit XML injection."""
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+from isvtest.testing.subtests import SubTestReport, _inject_subtests_into_junit
+
+
+def _parent_junit(tmp_path: Path, parent_name: str) -> Path:
+    """Write a minimal pytest-style JUnit with a single parent testcase."""
+    suite = ET.Element("testsuite", attrib={"name": "phase", "tests": "1", "skipped": "0", "failures": "0"})
+    ET.SubElement(suite, "testcase", attrib={"name": parent_name, "classname": "", "time": "0.000"})
+    path = tmp_path / "junit.xml"
+    ET.ElementTree(suite).write(path, encoding="utf-8", xml_declaration=True)
+    return path
+
+
+def _stub_report(
+    parent_nodeid: str,
+    subtest_msg: str,
+    *,
+    skipped: bool = False,
+    failed: bool = False,
+    longrepr: object | None = None,
+    duration: float = 0.0,
+) -> SimpleNamespace:
+    """Build the minimum surface that ``_inject_subtests_into_junit`` reads.
+
+    The real ``SubTestReport`` is a pytest TestReport subclass that's awkward
+    to construct in isolation; the injector only touches a handful of fields.
+    """
+    return SimpleNamespace(
+        nodeid=parent_nodeid,
+        duration=duration,
+        failed=failed,
+        skipped=skipped,
+        longrepr=longrepr,
+        context=SimpleNamespace(msg=subtest_msg),
+    )
+
+
+def test_skipped_subtest_uses_real_message_from_longrepr(tmp_path: Path) -> None:
+    """The injector pulls the human reason out of longrepr, not a canned line."""
+    junit = _parent_junit(tmp_path, "K8sCsiTenantScopedCredentialsCheck")
+    real_message = "No CSIDriver objects present"
+    report = _stub_report(
+        "::K8sCsiTenantScopedCredentialsCheck",
+        "serviceaccount-rbac-scoped",
+        skipped=True,
+        longrepr=("/some/file.py", 0, real_message),
+    )
+
+    _inject_subtests_into_junit(junit, cast(list[SubTestReport], [report]))
+
+    cases = list(ET.parse(junit).iter("testcase"))
+    subtest_case = next(c for c in cases if "::serviceaccount-rbac-scoped" in (c.get("name") or ""))
+    skipped = subtest_case.find("skipped")
+    assert skipped is not None
+    assert skipped.get("message") == real_message
+
+
+def test_skipped_subtest_falls_back_when_longrepr_is_missing(tmp_path: Path) -> None:
+    """No longrepr -> fall back to the canned 'Subtest X skipped' string."""
+    junit = _parent_junit(tmp_path, "ParentCheck")
+    report = _stub_report(
+        "::ParentCheck",
+        "noisy-subtest",
+        skipped=True,
+        longrepr=None,
+    )
+
+    _inject_subtests_into_junit(junit, cast(list[SubTestReport], [report]))
+
+    subtest_case = next(c for c in ET.parse(junit).iter("testcase") if "::noisy-subtest" in (c.get("name") or ""))
+    skipped = subtest_case.find("skipped")
+    assert skipped is not None
+    assert skipped.get("message") == "Subtest noisy-subtest skipped"

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -155,6 +155,7 @@ class TestBaseValidation:
 
         assert result["passed"] is False
         assert "Unexpected error" in result["error"]
+        assert result["error_reason"] == "runtime_exception"
 
     def test_run_command(self) -> None:
         """Test run_command method."""


### PR DESCRIPTION
## Summary

Replaces the ad-hoc validation drop/skip/warn machinery with a single channel where every config-declared validation produces exactly one terminal outcome — `PASSED`, `FAILED`, `ERROR(reason)`, or `SKIPPED(reason)` — and reaches the JUnit report.

Previously an entry could disappear silently in seven places across three layers; operators couldn't answer "did `K8sNodePoolCheck` run, and if not, why?" from the report alone.

## Design

`config → ValidationEntry → resolve_entries() → ResolvedEntry → pytest (READY only) → report`

- `resolve_entries` decides skip/error/ready in priority order: released-gate → name/marker exclusion → step configured/produced output → phase scope → template render → param shape.
- READY entries run through pytest; SKIPPED/ERROR entries are already terminal.
- One JUnit emitter drives display and report. Per-phase XMLs (pytest output + pre-resolved/deselected stubs) collapse into a single suite per phase, ordered by YAML config.

## Behavior delta

Validation param templates now **hard-fail on unresolved references** (typos surface as `ERROR(template_render_failed)` instead of silently rendering empty). Use `default()` filters or `step:` gating where missing values are intentional. Step-argument templates retain the old lenient behavior.

JUnit XML now includes `<skipped>` testcases for entries that previously vanished silently — count delta is real but format-compatible. No changes to `BaseValidation`, YAML schema, `released_tests.json`, provider configs, or isvreporter ingestion.

## Test plan

- [x] `make lint` / `make test` (691 passed) / `make demo-test`
- [x] Live `isvctl deploy run` against reference cluster — every config-declared entry appears with a typed reason
- [x] Verify isvreporter ingests JUnit output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation results now derive status from full state/error/skip fields (including explicit ERROR) and produce clearer combined detail messages. Templates using defaults no longer emit spurious missing-step warnings.

* **Refactor**
  * Validation resolution was centralized to determine ready vs terminal outcomes before execution; reporting and JUnit merging now ensure all configured validations appear in final reports.

* **Tests**
  * Expanded coverage for resolution, JUnit merging, terminal handling, and skipped-subtest reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->