### PR TITLE
feat: add per-host status log validation (BMAAS-XX-07 M1-P1)

### DIFF
--- a/isvctl/configs/providers/aws/config/bare_metal.yaml
+++ b/isvctl/configs/providers/aws/config/bare_metal.yaml
@@ -225,7 +225,7 @@ commands:
           - "{{steps.describe_instance.public_ip}}"
           - "--max-age-minutes"
           - "5"
-        timeout: 120
+        timeout: 300
 
       # Reinstall instance from stock OS (stop + swap root volume + start)
       # Skipped by default: ~30-45 min on AWS metal, and CreateReplaceRootVolumeTask

--- a/isvctl/configs/providers/aws/config/bare_metal.yaml
+++ b/isvctl/configs/providers/aws/config/bare_metal.yaml
@@ -211,6 +211,22 @@ commands:
           - "{{steps.launch_instance.key_file}}"
         timeout: 120
 
+      - name: host_status_log
+        phase: test
+        command: "python3 ../scripts/bare_metal/host_status_log.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+          - "--key-file"
+          - "{{steps.launch_instance.key_file}}"
+          - "--public-ip"
+          - "{{steps.describe_instance.public_ip}}"
+          - "--max-age-minutes"
+          - "5"
+        timeout: 120
+
       # Reinstall instance from stock OS (stop + swap root volume + start)
       # Skipped by default: ~30-45 min on AWS metal, and CreateReplaceRootVolumeTask
       # is not supported. The script performs a manual root volume swap instead.

--- a/isvctl/configs/providers/aws/scripts/bare_metal/host_status_log.py
+++ b/isvctl/configs/providers/aws/scripts/bare_metal/host_status_log.py
@@ -38,6 +38,17 @@ DMESG_ISO_TS = re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:,\d+)?(?:[+\
 
 
 def _build_result(entry_count: int, latest_ts: str, max_age_minutes: int) -> dict[str, Any]:
+    """Build a per-source status log result.
+
+    Args:
+        entry_count: Number of recent log entries found.
+        latest_ts: Timestamp string from the most recent matching entry.
+        max_age_minutes: Recency window used for the sample.
+
+    Returns:
+        A result payload with pass/fail state, message, entry count, and
+        latest timestamp.
+    """
     passed = entry_count >= 1
     msg = (
         f"{entry_count} entries in last {max_age_minutes}min, latest {latest_ts}"
@@ -53,10 +64,21 @@ def _build_result(entry_count: int, latest_ts: str, max_age_minutes: int) -> dic
 
 
 def _ssh_error_result(source: str, exit_code: int, stderr: str) -> dict[str, Any]:
+    """Build a failed per-source result for an SSH command error.
+
+    Args:
+        source: Log source name, such as ``journalctl`` or ``dmesg``.
+        exit_code: SSH command exit code.
+        stderr: SSH command standard error text.
+
+    Returns:
+        A failed result payload matching the successful result shape.
+    """
     return {
         "passed": False,
         "message": f"{source} exited {exit_code}: {stderr.strip()[:200] or 'no stderr'}",
         "entry_count": 0,
+        "latest_timestamp": "",
     }
 
 
@@ -127,6 +149,12 @@ def _sample_dmesg(host: str, user: str, key_file: str, max_age_minutes: int) -> 
 
 @handle_aws_errors
 def main() -> int:
+    """Sample host status logs and emit the validation JSON payload.
+
+    Returns:
+        Process exit code, where 0 means at least one status log source has
+        fresh entries and 1 means the check failed.
+    """
     parser = argparse.ArgumentParser(description="Sample per-host status log on AWS bare metal")
     parser.add_argument("--instance-id", required=True, help="EC2 instance ID")
     parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
@@ -144,7 +172,7 @@ def main() -> int:
     result: dict[str, Any] = {
         "success": False,
         "platform": "bm",
-        "instance_id": args.instance_id,
+        "test_name": "host_status_log",
         "tests": {},
     }
 

--- a/isvctl/configs/providers/aws/scripts/bare_metal/host_status_log.py
+++ b/isvctl/configs/providers/aws/scripts/bare_metal/host_status_log.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Per-host status log sampler for AWS bare-metal.
+
+SSHes to the BM host and samples journalctl + dmesg to confirm at least
+one Linux status log is producing fresh entries within the configured
+recency window. Output is consumed by isvtest.validations.bm_host_status.BmHostStatusLog.
+
+Usage:
+    python host_status_log.py --instance-id i-xxx --region us-west-2 \\
+        --key-file /tmp/key.pem --public-ip 54.x.x.x [--max-age-minutes 5]
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from common.errors import handle_aws_errors
+from common.ssh_utils import ssh_run, wait_for_ssh
+
+JOURNALCTL_ISO_TS = re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+\-]\d{4})")
+DMESG_ISO_TS = re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:,\d+)?(?:[+\-]\d{2}:?\d{2}|Z)?)")
+
+
+def _build_result(entry_count: int, latest_ts: str, max_age_minutes: int) -> dict[str, Any]:
+    passed = entry_count >= 1
+    msg = (
+        f"{entry_count} entries in last {max_age_minutes}min, latest {latest_ts}"
+        if passed
+        else f"no entries in last {max_age_minutes}min"
+    )
+    return {
+        "passed": passed,
+        "message": msg,
+        "entry_count": entry_count,
+        "latest_timestamp": latest_ts,
+    }
+
+
+def _ssh_error_result(source: str, exit_code: int, stderr: str) -> dict[str, Any]:
+    return {
+        "passed": False,
+        "message": f"{source} exited {exit_code}: {stderr.strip()[:200] or 'no stderr'}",
+        "entry_count": 0,
+    }
+
+
+def _sample_journalctl(host: str, user: str, key_file: str, max_age_minutes: int) -> dict[str, Any]:
+    """Sample journalctl for entries within the last `max_age_minutes`."""
+    cmd = f"journalctl --since '{max_age_minutes} minutes ago' --no-pager -o short-iso 2>/dev/null | tail -n 500"
+    exit_code, stdout, stderr = ssh_run(host, user, key_file, cmd)
+    if exit_code != 0:
+        return _ssh_error_result("journalctl", exit_code, stderr)
+
+    last_match = None
+    entry_count = 0
+    for line in stdout.splitlines():
+        if m := JOURNALCTL_ISO_TS.match(line):
+            entry_count += 1
+            last_match = m
+    latest_ts = last_match.group(1) if last_match else ""
+    return _build_result(entry_count, latest_ts, max_age_minutes)
+
+
+def _parse_dmesg_timestamp(line: str) -> tuple[datetime, str] | None:
+    """Parse the dmesg ISO timestamp prefix; returns (datetime, raw_string).
+
+    util-linux's `dmesg --time-format=iso` emits e.g. `2024-01-15T10:30:45,123456+0000`.
+    Python 3.12+ `fromisoformat` accepts that shape (comma-fractional, `Z`, and
+    `+HHMM` offsets) natively, so no normalization is needed.
+    """
+    match = DMESG_ISO_TS.match(line)
+    if not match:
+        return None
+    raw = match.group(1)
+    try:
+        return datetime.fromisoformat(raw), raw
+    except ValueError:
+        return None
+
+
+def _sample_dmesg(host: str, user: str, key_file: str, max_age_minutes: int) -> dict[str, Any]:
+    """Sample dmesg for entries within the last `max_age_minutes`.
+
+    Filters in-process so we don't depend on dmesg --since (stricter timestamp
+    formats). Falls back to sudo when unprivileged dmesg is restricted.
+    """
+    cmd = "dmesg --time-format=iso 2>/dev/null | tail -n 1000"
+    exit_code, stdout, stderr = ssh_run(host, user, key_file, cmd)
+    if exit_code != 0 or not stdout.strip():
+        cmd_fallback = "sudo -n dmesg --time-format=iso 2>/dev/null | tail -n 1000"
+        exit_code, stdout, stderr = ssh_run(host, user, key_file, cmd_fallback)
+    if exit_code != 0:
+        return _ssh_error_result("dmesg", exit_code, stderr)
+
+    cutoff = datetime.now(UTC) - timedelta(minutes=max_age_minutes)
+    entry_count = 0
+    latest_ts = ""
+    for line in stdout.splitlines():
+        parsed = _parse_dmesg_timestamp(line)
+        if parsed is None:
+            continue
+        ts, raw = parsed
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
+        if ts >= cutoff:
+            entry_count += 1
+            latest_ts = raw
+
+    return _build_result(entry_count, latest_ts, max_age_minutes)
+
+
+@handle_aws_errors
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Sample per-host status log on AWS bare metal")
+    parser.add_argument("--instance-id", required=True, help="EC2 instance ID")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--key-file", required=True, help="Path to SSH private key")
+    parser.add_argument("--public-ip", required=True, help="Public IP of the host")
+    parser.add_argument("--ssh-user", default="ubuntu", help="SSH username")
+    parser.add_argument(
+        "--max-age-minutes",
+        type=int,
+        default=5,
+        help="Maximum age of the most recent log entry, in minutes",
+    )
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "bm",
+        "instance_id": args.instance_id,
+        "tests": {},
+    }
+
+    if not wait_for_ssh(args.public_ip, args.ssh_user, args.key_file, max_attempts=20, interval=10):
+        result["error"] = f"SSH did not become ready on {args.public_ip}"
+        print(json.dumps(result, indent=2))
+        return 1
+
+    journalctl_result = _sample_journalctl(args.public_ip, args.ssh_user, args.key_file, args.max_age_minutes)
+    dmesg_result = _sample_dmesg(args.public_ip, args.ssh_user, args.key_file, args.max_age_minutes)
+
+    result["tests"] = {
+        "journalctl_recent": journalctl_result,
+        "dmesg_recent": dmesg_result,
+    }
+    result["success"] = journalctl_result["passed"] or dmesg_result["passed"]
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/aws/scripts/bare_metal/host_status_log.py
+++ b/isvctl/configs/providers/aws/scripts/bare_metal/host_status_log.py
@@ -37,6 +37,14 @@ JOURNALCTL_ISO_TS = re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+\-]\d{4}
 DMESG_ISO_TS = re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:,\d+)?(?:[+\-]\d{2}:?\d{2}|Z)?)")
 
 
+def _positive_int(value: str) -> int:
+    """Parse a strictly positive integer argument."""
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
 def _build_result(entry_count: int, latest_ts: str, max_age_minutes: int) -> dict[str, Any]:
     """Build a per-source status log result.
 
@@ -163,7 +171,7 @@ def main() -> int:
     parser.add_argument("--ssh-user", default="ubuntu", help="SSH username")
     parser.add_argument(
         "--max-age-minutes",
-        type=int,
+        type=_positive_int,
         default=5,
         help="Maximum age of the most recent log entry, in minutes",
     )

--- a/isvctl/configs/providers/aws/scripts/common/ssh_utils.py
+++ b/isvctl/configs/providers/aws/scripts/common/ssh_utils.py
@@ -31,28 +31,33 @@ def ssh_run(
     connect_timeout: int = 10,
 ) -> tuple[int, str, str]:
     """Run a single command over SSH. Returns (exit_code, stdout, stderr)."""
-    proc = subprocess.run(
-        [
-            "ssh",
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "UserKnownHostsFile=/dev/null",
-            "-o",
-            f"ConnectTimeout={connect_timeout}",
-            "-o",
-            "BatchMode=yes",
-            "-i",
-            key_file,
-            f"{user}@{host}",
-            "--",
-            command,
-        ],
-        capture_output=True,
-        timeout=timeout,
-        text=True,
-        check=False,
-    )
+    try:
+        proc = subprocess.run(
+            [
+                "ssh",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                f"ConnectTimeout={connect_timeout}",
+                "-o",
+                "BatchMode=yes",
+                "-i",
+                key_file,
+                f"{user}@{host}",
+                "--",
+                command,
+            ],
+            capture_output=True,
+            timeout=timeout,
+            text=True,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as err:
+        return 124, "", f"TimeoutExpired: {err}"
+    except OSError as err:
+        return 255, "", f"OSError: {err}"
     return proc.returncode, proc.stdout, proc.stderr
 
 

--- a/isvctl/configs/providers/aws/scripts/common/ssh_utils.py
+++ b/isvctl/configs/providers/aws/scripts/common/ssh_utils.py
@@ -13,12 +13,47 @@
 
 Provides wait_for_ssh() used by bare-metal and VM stubs that need to
 poll for SSH readiness after instance state changes (start, reboot,
-power-cycle, reinstall).
+power-cycle, reinstall), and ssh_run() for one-shot commands.
 """
 
 import subprocess
 import sys
 import time
+
+
+def ssh_run(
+    host: str,
+    user: str,
+    key_file: str,
+    command: str,
+    *,
+    timeout: int = 30,
+    connect_timeout: int = 10,
+) -> tuple[int, str, str]:
+    """Run a single command over SSH. Returns (exit_code, stdout, stderr)."""
+    proc = subprocess.run(
+        [
+            "ssh",
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "-o",
+            f"ConnectTimeout={connect_timeout}",
+            "-o",
+            "BatchMode=yes",
+            "-i",
+            key_file,
+            f"{user}@{host}",
+            "--",
+            command,
+        ],
+        capture_output=True,
+        timeout=timeout,
+        text=True,
+        check=False,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
 
 
 def wait_for_ssh(

--- a/isvctl/configs/providers/my-isv/config/bare_metal.yaml
+++ b/isvctl/configs/providers/my-isv/config/bare_metal.yaml
@@ -181,6 +181,22 @@ commands:
           - "{{steps.launch_instance.key_file}}"
         timeout: 60
 
+      - name: host_status_log
+        phase: test
+        command: "python ../scripts/bare_metal/host_status_log.py"
+        args:
+          - "--instance-id"
+          - "{{steps.launch_instance.instance_id}}"
+          - "--region"
+          - "{{region}}"
+          - "--key-file"
+          - "{{steps.launch_instance.key_file}}"
+          - "--public-ip"
+          - "{{steps.describe_instance.public_ip}}"
+          - "--max-age-minutes"
+          - "5"
+        timeout: 60
+
       - name: reinstall_instance
         phase: test
         skip: true

--- a/isvctl/configs/providers/my-isv/scripts/bare_metal/host_status_log.py
+++ b/isvctl/configs/providers/my-isv/scripts/bare_metal/host_status_log.py
@@ -19,7 +19,7 @@ Required JSON output fields:
   {
     "success": true,
     "platform": "bm",
-    "instance_id": "<id>",
+    "test_name": "host_status_log",
     "tests": {
       "journalctl_recent": {
         "passed": true,
@@ -53,6 +53,12 @@ DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
 
 
 def main() -> int:
+    """Emit template per-host status log results.
+
+    Returns:
+        Process exit code, where 0 means the demo or implementation reported
+        fresh status log entries and 1 means it did not.
+    """
     parser = argparse.ArgumentParser(description="Per-host status log sampler (template)")
     parser.add_argument("--instance-id", required=True, help="Instance ID")
     parser.add_argument("--region", required=True, help="Cloud region")
@@ -70,7 +76,7 @@ def main() -> int:
     result: dict[str, Any] = {
         "success": False,
         "platform": "bm",
-        "instance_id": args.instance_id,
+        "test_name": "host_status_log",
         "tests": {},
     }
 

--- a/isvctl/configs/providers/my-isv/scripts/bare_metal/host_status_log.py
+++ b/isvctl/configs/providers/my-isv/scripts/bare_metal/host_status_log.py
@@ -52,6 +52,14 @@ from typing import Any
 DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
 
 
+def _positive_int(value: str) -> int:
+    """Parse a strictly positive integer argument."""
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
 def main() -> int:
     """Emit template per-host status log results.
 
@@ -67,7 +75,7 @@ def main() -> int:
     parser.add_argument("--ssh-user", default="ubuntu", help="SSH username")
     parser.add_argument(
         "--max-age-minutes",
-        type=int,
+        type=_positive_int,
         default=5,
         help="Maximum age of the most recent log entry, in minutes",
     )

--- a/isvctl/configs/providers/my-isv/scripts/bare_metal/host_status_log.py
+++ b/isvctl/configs/providers/my-isv/scripts/bare_metal/host_status_log.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Per-host status log sampler for bare-metal - TEMPLATE.
+
+Samples journalctl and dmesg on the BM host and emits per-source status
+so the BmHostStatusLog validation can assert that at least one status
+log is producing fresh entries within the configured recency window.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "bm",
+    "instance_id": "<id>",
+    "tests": {
+      "journalctl_recent": {
+        "passed": true,
+        "message": "<count> entries in last <N>min, latest <timestamp>",
+        "entry_count": <int>,
+        "latest_timestamp": "<iso8601>"
+      },
+      "dmesg_recent": {
+        "passed": true,
+        "message": "...",
+        "entry_count": <int>,
+        "latest_timestamp": "<iso8601>"
+      }
+    }
+  }
+
+Usage:
+    python host_status_log.py --instance-id <id> --region <region> \\
+        --key-file <path> --public-ip <ip> [--max-age-minutes 5]
+
+Reference implementation: ../../aws/bare_metal/host_status_log.py
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Per-host status log sampler (template)")
+    parser.add_argument("--instance-id", required=True, help="Instance ID")
+    parser.add_argument("--region", required=True, help="Cloud region")
+    parser.add_argument("--key-file", required=True, help="Path to SSH private key")
+    parser.add_argument("--public-ip", required=True, help="Public IP of the host")
+    parser.add_argument("--ssh-user", default="ubuntu", help="SSH username")
+    parser.add_argument(
+        "--max-age-minutes",
+        type=int,
+        default=5,
+        help="Maximum age of the most recent log entry, in minutes",
+    )
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "bm",
+        "instance_id": args.instance_id,
+        "tests": {},
+    }
+
+    # TODO: Replace with your platform's per-host status log sampling.
+    # Real implementations should SSH to the host, run journalctl and dmesg
+    # filtered by --max-age-minutes, and populate the `tests` block.
+    if DEMO_MODE:
+        result["tests"] = {
+            "journalctl_recent": {
+                "passed": True,
+                "message": f"42 entries in last {args.max_age_minutes}min, latest 2026-05-12T09:14:03",
+                "entry_count": 42,
+                "latest_timestamp": "2026-05-12T09:14:03",
+            },
+            "dmesg_recent": {
+                "passed": True,
+                "message": f"7 entries in last {args.max_age_minutes}min, latest 2026-05-12T09:13:58",
+                "entry_count": 7,
+                "latest_timestamp": "2026-05-12T09:13:58",
+            },
+        }
+        result["success"] = True
+    else:
+        result["error"] = "Not implemented - replace with your platform's per-host log fetch logic"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -105,6 +105,15 @@ tests:
           expected_gpus: 8
         HostSoftwareCheck: {}
 
+    # Per-host status log sampling: verify journalctl/dmesg
+    # are emitting fresh entries within max_age_minutes. Pass if at least
+    # one source has recent entries (set required_sources to enforce all).
+    host_status_logs:
+      step: host_status_log
+      checks:
+        StepSuccessCheck: {}
+        BmHostStatusLog: {}
+
     # GPU stress test - PyTorch matrix multiplications on all GPUs
     gpu_stress:
       step: describe_instance

--- a/isvctl/tests/test_aws_ssh_utils.py
+++ b/isvctl/tests/test_aws_ssh_utils.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Tests for AWS provider SSH helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+AWS_COMMON_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "common"
+
+
+def _load_ssh_utils() -> ModuleType:
+    """Load the AWS SSH utilities module for direct helper testing."""
+    script_path = AWS_COMMON_SCRIPTS / "ssh_utils.py"
+    spec = importlib.util.spec_from_file_location("test_aws_ssh_utils_module", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ssh_run_returns_tuple_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Timeouts return the ssh_run tuple contract instead of raising."""
+    module = _load_ssh_utils()
+
+    def fake_run(*_args: Any, **_kwargs: Any) -> None:
+        """Raise a subprocess timeout."""
+        raise subprocess.TimeoutExpired(cmd="ssh", timeout=30)
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    exit_code, stdout, stderr = module.ssh_run("host", "user", "key.pem", "true")
+
+    assert exit_code == 124
+    assert stdout == ""
+    assert "TimeoutExpired:" in stderr
+
+
+def test_ssh_run_returns_tuple_on_spawn_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Spawn failures return the ssh_run tuple contract instead of raising."""
+    module = _load_ssh_utils()
+
+    def fake_run(*_args: Any, **_kwargs: Any) -> None:
+        """Raise an operating system error."""
+        raise OSError("ssh missing")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    exit_code, stdout, stderr = module.ssh_run("host", "user", "key.pem", "true")
+
+    assert exit_code == 255
+    assert stdout == ""
+    assert "OSError: ssh missing" in stderr

--- a/isvtest/src/isvtest/validations/bm_host_status.py
+++ b/isvtest/src/isvtest/validations/bm_host_status.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Bare metal per-host status log validations."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from isvtest.core.validation import BaseValidation
+
+DEFAULT_SOURCES: tuple[str, ...] = ("journalctl_recent", "dmesg_recent")
+
+
+class BmHostStatusLog(BaseValidation):
+    """Verify the BM host emits a per-host status log over time.
+
+    Default: pass if at least one configured source has fresh entries.
+    Strict (``required_sources`` non-empty): every named source must pass.
+
+    Config:
+        required_sources: Optional list of source keys (e.g.
+            ``["journalctl_recent"]``) that must all pass.
+    """
+
+    description: ClassVar[str] = "Verify per-host status log (journalctl/dmesg) is producing fresh entries"
+    timeout: ClassVar[int] = 60
+    markers: ClassVar[list[str]] = ["bare_metal"]
+
+    def run(self) -> None:
+        step_output = self.config.get("step_output", {})
+        tests: dict[str, Any] = step_output.get("tests", {}) or {}
+
+        required_raw = self.config.get("required_sources", []) or []
+        if not isinstance(required_raw, list) or not all(isinstance(s, str) and s for s in required_raw):
+            self.set_failed(f"`required_sources` must be a list of non-empty strings, got {required_raw!r}")
+            return
+
+        strict = bool(required_raw)
+        sources: tuple[str, ...] = tuple(required_raw) if strict else DEFAULT_SOURCES
+
+        if not tests:
+            self.set_failed("No 'tests' in step output; the host_status_log step did not emit per-source results")
+            return
+
+        passed_sources: list[str] = []
+        failed_sources: list[str] = []
+        missing_sources: list[str] = []
+        summaries: list[str] = []
+
+        for source in sources:
+            entry = tests.get(source)
+            if entry is None:
+                missing_sources.append(source)
+                self.report_subtest(source, False, "source not reported")
+                continue
+            if entry.get("passed"):
+                passed_sources.append(source)
+                self.report_subtest(source, True, entry.get("message", ""))
+                summaries.append(f"{source}: {entry.get('message', 'ok')}")
+            else:
+                failed_sources.append(source)
+                msg = entry.get("message") or entry.get("error") or "no recent entries"
+                self.report_subtest(source, False, msg)
+                summaries.append(f"{source}: {msg}")
+
+        if strict:
+            if failed_sources or missing_sources:
+                problems = failed_sources + [f"{s} (missing)" for s in missing_sources]
+                self.set_failed(
+                    f"Strict mode: required sources did not all pass ({', '.join(problems)})",
+                    output="\n".join(summaries),
+                )
+                return
+            self.set_passed(f"All required sources passed: {', '.join(passed_sources)}")
+            return
+
+        if not passed_sources:
+            details = "; ".join(summaries) or "no sources reported"
+            self.set_failed(f"No status log source has fresh entries: {details}")
+            return
+
+        self.set_passed(
+            f"Fresh entries from {len(passed_sources)}/{len(sources)} source(s): {', '.join(passed_sources)}"
+        )

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -25,6 +25,7 @@ from isvtest.tests.test_validations import (
 from isvtest.tests.test_validations import (
     test_validation as run_validation_entry_point,
 )
+from isvtest.validations.bm_host_status import BmHostStatusLog
 from isvtest.validations.instance import (
     InstanceListCheck,
     InstancePowerCycleCheck,
@@ -1665,3 +1666,113 @@ class TestK8sApiServerMetricsCheck:
         assert result["passed"] is False
         assert "expected_metrics" in result["error"]
         mock_runner.run.assert_not_called()
+
+
+def _host_status_log_output(tests: dict[str, Any] | None = None) -> dict:
+    """Build a minimal BmHostStatusLog config (mirrors the script's JSON contract)."""
+    step_output: dict[str, Any] = {
+        "success": True,
+        "platform": "bm",
+        "instance_id": "i-abc123",
+        "tests": tests
+        if tests is not None
+        else {
+            "journalctl_recent": {
+                "passed": True,
+                "message": "42 entries in last 5min, latest 2026-05-12T09:14:03",
+                "entry_count": 42,
+                "latest_timestamp": "2026-05-12T09:14:03",
+            },
+            "dmesg_recent": {
+                "passed": True,
+                "message": "7 entries in last 5min",
+                "entry_count": 7,
+                "latest_timestamp": "2026-05-12T09:13:58",
+            },
+        },
+    }
+    return {"step_output": step_output}
+
+
+class TestBmHostStatusLog:
+    """Tests for BmHostStatusLog validation."""
+
+    def test_both_sources_pass(self) -> None:
+        v = BmHostStatusLog(config=_host_status_log_output())
+        result = v.execute()
+        assert result["passed"] is True
+        assert "journalctl_recent" in result["output"]
+        assert "dmesg_recent" in result["output"]
+
+    def test_any_source_passing_is_sufficient(self) -> None:
+        """Default 'any' semantic: pass if at least one source has fresh entries."""
+        tests = {
+            "journalctl_recent": {"passed": True, "message": "10 entries"},
+            "dmesg_recent": {"passed": False, "message": "no entries in last 5min"},
+        }
+        v = BmHostStatusLog(config=_host_status_log_output(tests=tests))
+        result = v.execute()
+        assert result["passed"] is True
+        assert "journalctl_recent" in result["output"]
+
+    def test_no_source_passing_fails(self) -> None:
+        tests = {
+            "journalctl_recent": {"passed": False, "message": "no entries in last 5min"},
+            "dmesg_recent": {"passed": False, "message": "no entries in last 5min"},
+        }
+        v = BmHostStatusLog(config=_host_status_log_output(tests=tests))
+        result = v.execute()
+        assert result["passed"] is False
+        assert "No status log source" in result["error"]
+
+    def test_empty_tests_block_fails(self) -> None:
+        v = BmHostStatusLog(config={"step_output": {"success": True}})
+        result = v.execute()
+        assert result["passed"] is False
+        assert "tests" in result["error"]
+
+    def test_strict_mode_passes_when_all_required_pass(self) -> None:
+        v = BmHostStatusLog(
+            config={
+                **_host_status_log_output(),
+                "required_sources": ["journalctl_recent", "dmesg_recent"],
+            }
+        )
+        result = v.execute()
+        assert result["passed"] is True
+        assert "All required sources" in result["output"]
+
+    def test_strict_mode_fails_when_any_required_fails(self) -> None:
+        tests = {
+            "journalctl_recent": {"passed": True, "message": "ok"},
+            "dmesg_recent": {"passed": False, "message": "no entries"},
+        }
+        v = BmHostStatusLog(
+            config={
+                **_host_status_log_output(tests=tests),
+                "required_sources": ["journalctl_recent", "dmesg_recent"],
+            }
+        )
+        result = v.execute()
+        assert result["passed"] is False
+        assert "dmesg_recent" in result["error"]
+        assert "Strict mode" in result["error"]
+
+    def test_strict_mode_fails_when_required_source_missing(self) -> None:
+        tests = {"journalctl_recent": {"passed": True, "message": "ok"}}
+        v = BmHostStatusLog(
+            config={
+                **_host_status_log_output(tests=tests),
+                "required_sources": ["journalctl_recent", "dmesg_recent"],
+            }
+        )
+        result = v.execute()
+        assert result["passed"] is False
+        assert "dmesg_recent" in result["error"]
+        assert "missing" in result["error"]
+
+    def test_invalid_required_sources_rejected(self) -> None:
+        v = BmHostStatusLog(config={**_host_status_log_output(), "required_sources": "journalctl_recent"})
+        result = v.execute()
+        assert result["passed"] is False
+        assert "required_sources" in result["error"]

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -1673,7 +1673,7 @@ def _host_status_log_output(tests: dict[str, Any] | None = None) -> dict:
     step_output: dict[str, Any] = {
         "success": True,
         "platform": "bm",
-        "instance_id": "i-abc123",
+        "test_name": "host_status_log",
         "tests": tests
         if tests is not None
         else {


### PR DESCRIPTION
## Summary

Adds `BmHostStatusLog` (P1) to the bare-metal suite. The check asserts at least one universal Linux status log on the BM host — `journalctl` or `dmesg` — has produced a fresh entry within a configurable recency window (default 5 min). A silently broken `systemd-journald` or kernel log otherwise masks every other operational signal the suite relies on.

## Changes

- Adds `BmHostStatusLog` validation (`isvtest/src/isvtest/validations/bm_host_status.py`) with two pass semantics: default `any` (pass if at least one configured source has fresh entries) and `strict` when `required_sources` is set (every named source must pass).
- Adds AWS reference script `isvctl/configs/providers/aws/scripts/bare_metal/host_status_log.py` that SSHes to the host (via `common.ssh_utils.wait_for_ssh`), samples `journalctl --since` and `dmesg --time-format=iso` (filtering in-process), and emits per-source `passed`/`message`/`entry_count`/`latest_timestamp`.
- Adds `my-isv` scaffold `isvctl/configs/providers/my-isv/scripts/bare_metal/host_status_log.py` with a `DEMO_MODE` gate that returns dummy success so `make demo-test` exercises the wiring end-to-end.
- Wires a new `host_status_logs` validation block into the canonical bare-metal suite contract and registers the `host_status_log` step in both AWS and my-isv provider configs (after `describe_instance`, so it inherits the post-power-cycle public IP).
- Adds focused unit tests covering both/any/none-passing cases, strict mode, missing sources, and config validation (8 new tests).
- The new validation ships **unreleased**; `isvtest/src/isvtest/released_tests.json` is intentionally untouched and will be updated in the next release commit. Exercise locally via `ISVTEST_INCLUDE_UNRELEASED=1`.

## Validation

- [x] `make test` — 736 passed, 123 deselected (8 new `TestBmHostStatusLog` cases included)
- [x] `make pre-commit` — all checks pass across `isvctl`, `isvreporter`, `isvtest`
- [x] `make demo-bare_metal` — `host_status_log` step runs; `BmHostStatusLog` correctly skipped as unreleased
- [x] `ISVCTL_DEMO_MODE=1 ISVTEST_INCLUDE_UNRELEASED=1 uv run isvctl test run -f isvctl/configs/providers/my-isv/config/bare_metal.yaml` — `BmHostStatusLog: PASSED - Fresh entries from 2/2 source(s): journalctl_recent, dmesg_recent`
- [x] Live testing on AWS EC2 (not BM) and negative testing by stopping journald and clearing the dmesg buffer (`sudo dmesg -C`)

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host status log sampling for bare-metal hosts: checks journalctl/dmesg for recent entries (default 5 minutes), demo-mode output, and integration with AWS and custom providers.
  * One-shot SSH helper to run remote commands with robust timeout/error behavior.

* **Tests**
  * Unit tests for the new validation and SSH helper covering pass/fail semantics, missing outputs, and strict vs permissive source requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/ISV-NCP-Validation-Suite/pull/407)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->