### PR TITLE
fix: skip Jinja re-rendering of pre-resolved configs

### DIFF
--- a/isvtest/src/isvtest/config/constants.py
+++ b/isvtest/src/isvtest/config/constants.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Shared configuration constants."""
+
+RESOLVED_ENTRIES_FLAG = "_isvtest_resolved_entries"

--- a/isvtest/src/isvtest/config/loader.py
+++ b/isvtest/src/isvtest/config/loader.py
@@ -29,6 +29,7 @@ from typing import Any
 import yaml
 from jinja2 import BaseLoader, ChainableUndefined, Environment
 
+from isvtest.config.constants import RESOLVED_ENTRIES_FLAG
 from isvtest.config.inventory import ClusterInventory, inventory_to_dict, parse_inventory
 
 
@@ -105,6 +106,10 @@ class ConfigLoader:
         with open(config_path) as f:
             config_content = f.read()
 
+        pre_rendered_config = self._load_pre_rendered_config(config_content)
+        if pre_rendered_config is not None:
+            return pre_rendered_config
+
         # Check for inventory path from argument or environment variable
         effective_inventory_path = inventory_path or os.environ.get("ISV_INVENTORY_PATH")
         inventory_dict: dict[str, Any] = {}
@@ -137,6 +142,18 @@ class ConfigLoader:
                     )
                 config["cluster_name"] = inventory_cluster_name
 
+        return config
+
+    def _load_pre_rendered_config(self, content: str) -> dict[str, Any] | None:
+        """Return an already-resolved JSON config without applying Jinja rendering."""
+        if not content.lstrip().startswith("{") or RESOLVED_ENTRIES_FLAG not in content:
+            return None
+        try:
+            config = json.loads(content)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(config, dict) or config.get(RESOLVED_ENTRIES_FLAG) is not True:
+            return None
         return config
 
     def _render_template(self, content: str, context: dict[str, Any]) -> str:

--- a/isvtest/src/isvtest/core/resolution.py
+++ b/isvtest/src/isvtest/core/resolution.py
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 
 ADAPTER_HANDLED_CATEGORIES = {"reframe"}
 DEFAULT_VALIDATION_PHASE = "test"
-RESOLVED_ENTRIES_FLAG = "_isvtest_resolved_entries"
 
 
 class State(StrEnum):

--- a/isvtest/src/isvtest/main.py
+++ b/isvtest/src/isvtest/main.py
@@ -27,10 +27,11 @@ import pytest
 import typer
 from isvreporter.version import get_version
 
+from isvtest.config.constants import RESOLVED_ENTRIES_FLAG
 from isvtest.config.loader import ConfigLoader
 from isvtest.core import runners as reframe_runner
 from isvtest.core.logger import setup_logger
-from isvtest.core.resolution import RESOLVED_ENTRIES_FLAG, ErrorReason, ResolvedEntry, SkipReason, State
+from isvtest.core.resolution import ErrorReason, ResolvedEntry, SkipReason, State
 from isvtest.tests.test_validations import (
     clear_validation_results,
     get_validation_results,

--- a/isvtest/src/isvtest/tests/test_validations.py
+++ b/isvtest/src/isvtest/tests/test_validations.py
@@ -14,9 +14,10 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from isvtest.config.constants import RESOLVED_ENTRIES_FLAG
 from isvtest.config.loader import ConfigLoader
 from isvtest.core.discovery import discover_all_tests
-from isvtest.core.resolution import ADAPTER_HANDLED_CATEGORIES, RESOLVED_ENTRIES_FLAG, resolve_class_key
+from isvtest.core.resolution import ADAPTER_HANDLED_CATEGORIES, resolve_class_key
 from isvtest.core.runners import LocalRunner
 from isvtest.core.validation import BaseValidation
 from isvtest.release_manifest import INCLUDE_UNRELEASED_ENV, load_released_test_filter

--- a/isvtest/tests/test_main.py
+++ b/isvtest/tests/test_main.py
@@ -95,6 +95,28 @@ def test_run_validations_via_pytest_updates_ready_entries() -> None:
     assert results[1].message == "NIM was not deployed"
 
 
+def test_run_validations_via_pytest_does_not_rerender_resolved_config_strings() -> None:
+    """Resolved temp configs may contain literal Jinja-looking strings from step output."""
+    jsonpath_probe = "kubectl get pods -o jsonpath='{{\"\\t\"}}'"
+    entries = [
+        _ready(
+            "StepSuccessCheck",
+            "setup_checks",
+            {"step_output": {"success": True, "message": jsonpath_probe, "probe": jsonpath_probe}},
+        ),
+    ]
+
+    exit_code, results = run_validations_via_pytest(
+        entries=entries,
+        inventory={"steps": {"setup": {"unauthorized_probe_cmd": jsonpath_probe}}},
+    )
+
+    assert exit_code == 0
+    assert len(results) == 1
+    assert results[0].state == State.PASSED
+    assert results[0].message == jsonpath_probe
+
+
 def test_run_validations_via_pytest_marks_runtime_exception() -> None:
     """A validation that raises during run() surfaces as ERROR(RUNTIME_EXCEPTION)."""
     # step_output=None makes StepSuccessCheck.run() crash on the first .get() call.

--- a/isvtest/tests/test_pytest_generation.py
+++ b/isvtest/tests/test_pytest_generation.py
@@ -13,7 +13,7 @@
 from typing import Any
 from unittest.mock import patch
 
-from isvtest.core.resolution import RESOLVED_ENTRIES_FLAG
+from isvtest.config.constants import RESOLVED_ENTRIES_FLAG
 from isvtest.core.validation import BaseValidation
 from isvtest.tests import test_validations as validation_tests
 


### PR DESCRIPTION
## Summary

Stops `ConfigLoader.load` from re-rendering pre-resolved configs through Jinja2 when `isvctl` hands a fully-resolved JSON config to `isvtest`. Step outputs and environment variables can legitimately contain literal `{{...}}` or `{%...%}` (for example kubectl jsonpath probes, or a `PS1` that uses `{%` glyphs), and re-rendering either mangles those braces or raises `TemplateSyntaxError` during pytest collection. The loader now detects the resolved-config sentinel up-front and returns the parsed JSON as-is.

Regression from #405 (unified validation resolution pipeline), which introduced the temp-file JSON roundtrip between `isvctl` and `isvtest`; only surfaces when step output or env contains a Jinja metacharacter. The `{{...}}` jsonpath case is the more obvious one, but a zsh `PS1` containing `{%` repros it too because `Context` snapshots `os.environ` into the JSON dump.

Example error:

```bash
collecting ... 2026-05-12 13:32:53 [WARNING] isvtest: Failed to load exclusion config: unexpected char '\\' at 4851
collected 0 items / 1 error

========================================================== ERRORS ===========================================================
___________________________________________ ERROR collecting test_validations.py ____________________________________________
isvtest/src/isvtest/tests/test_validations.py:113: in pytest_generate_tests
cluster_config = loader.load_cluster_config(
isvtest/src/isvtest/config/loader.py:117: in load_cluster_config
config_content = self._render_template(config_content, inventory_dict)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
isvtest/src/isvtest/config/loader.py:159: in _render_template
template = env.from_string(content)
           ^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/jinja2/environment.py:1111: in from_string
return cls.from_code(self, self.compile(source), gs, None)
                           ^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/jinja2/environment.py:771: in compile
self.handle_exception(source=source_hint)
.venv/lib/python3.12/site-packages/jinja2/environment.py:942: in handle_exception
raise rewrite_traceback_stack(source=source)
<unknown>:90: in template
???
E   jinja2.exceptions.TemplateSyntaxError: unexpected char '\\' at 4851
```

## Changes

- Adds `isvtest.config.constants` with the shared `RESOLVED_ENTRIES_FLAG` sentinel so `config.loader` and `core.resolution` can both reference it without the previous import cycle.
- Teaches `ConfigLoader.load` to short-circuit when the file is a JSON object carrying `_isvtest_resolved_entries: true` — it parses the JSON and returns immediately, skipping the inventory wiring and Jinja render pass.
- Updates `core.resolution`, `main`, and `tests/test_validations.py` to import `RESOLVED_ENTRIES_FLAG` from the new module.
- Adds a regression test in `isvtest/tests/test_main.py` covering a resolved config whose step output contains literal `{{...}}`, asserting the loader returns the value untouched.

## Test plan

- [x] `make test`
- [x] `make format`
- [x] `make demo-test`
- [x] Repro: `PS1='{% ' uv run isvctl test run -f ...` — confirm pytest collection no longer fails with `TemplateSyntaxError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loader detects pre-resolved configuration payloads and skips inventory loading and template rendering for them.

* **Bug Fixes**
  * Prevents already-resolved configuration strings from being re-rendered during validation runs.

* **Tests**
  * Added a test ensuring pre-resolved configurations retain their original values through the validation pipeline.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/ISV-NCP-Validation-Suite/pull/408)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->