### PR TITLE
feat: add isvctl provider scaffold command

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,6 +41,22 @@ No credentials, no cloud resources created. Great sanity check after
 install, and the starting point if you're adding a new platform --
 see [`providers/my-isv/scripts/`](../isvctl/configs/providers/my-isv/scripts/).
 
+Create a ready-to-edit scaffold for your own provider:
+
+```bash
+uv run isvctl provider scaffold acme
+```
+
+Provider implementations can live in private repositories and be run by path;
+see the [my-isv scaffold README](../isvctl/configs/providers/my-isv/scripts/README.md#private-provider-repositories)
+for the current workflow.
+
+Then preview the generated VM flow without cloud access:
+
+```bash
+ISVCTL_DEMO_MODE=1 uv run isvctl test run -f isvctl/configs/providers/acme/config/vm.yaml
+```
+
 ### Running Validation Tests
 
 **From source (development):**
@@ -133,7 +149,7 @@ See [Remote Deployment Guide](guides/remote-deployment.md) for details.
 
 ## Next Steps
 
-- [my-isv Scaffold](../isvctl/configs/providers/my-isv/scripts/README.md) - Adding your own platform? Start here
+- [my-isv Scaffold](../isvctl/configs/providers/my-isv/scripts/README.md) - Adding your own platform? Start with `isvctl provider scaffold`
 - [Validation Test Suites](../isvctl/configs/suites/README.md) - The platform-agnostic validation contract
 - [AWS Reference Implementation](references/aws.md) - Working AWS examples to study
 - [Configuration Guide](guides/configuration.md) - Config file format and options

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -50,7 +50,7 @@ Pre-built configs are provided in `isvctl/configs/`:
 
 | Config | Description |
 | ------ | ----------- |
-| `providers/my-isv/config/*.yaml` | [my-isv scaffold](../../isvctl/configs/providers/my-isv/scripts/README.md) - copy-and-fill-in for your own platform (runs end-to-end under `ISVCTL_DEMO_MODE=1`) |
+| `providers/my-isv/config/*.yaml` | [my-isv scaffold](../../isvctl/configs/providers/my-isv/scripts/README.md) - source template for `isvctl provider scaffold <provider-name>` (runs end-to-end under `ISVCTL_DEMO_MODE=1`) |
 | `providers/aws/config/control-plane.yaml` | AWS API health, access key lifecycle, tenant management |
 | `providers/aws/config/network.yaml` | AWS VPC network validation (6 test suites) |
 | `providers/aws/config/vm.yaml` | AWS EC2 GPU instance tests |
@@ -62,6 +62,9 @@ Pre-built configs are provided in `isvctl/configs/`:
 ## Basic Usage
 
 ```bash
+# Generate a provider scaffold
+isvctl provider scaffold acme
+
 # Run a config
 isvctl test run -f isvctl/configs/providers/aws/config/control-plane.yaml
 

--- a/docs/packages/isvctl.md
+++ b/docs/packages/isvctl.md
@@ -39,6 +39,9 @@ isvctl test run -f isvctl/configs/providers/k3s.yaml
 # Validate a Slurm cluster
 isvctl test run -f isvctl/configs/suites/slurm.yaml
 
+# Create a provider scaffold
+isvctl provider scaffold acme
+
 # Pass extra pytest args
 isvctl test run -f isvctl/configs/suites/k8s.yaml -- -v -s -k "NodeCount"
 ```
@@ -167,11 +170,11 @@ This output is validated and becomes the `{{inventory.*}}` available in template
 
 ### Directory Organization
 
-Place your provider-specific lifecycle scripts under `configs/providers/<your-isv-name>/scripts/`, mirroring the structure of the `providers/my-isv/scripts/` scaffold (e.g. `configs/providers/acme/scripts/k8s/setup.sh`). The providers directory contains:
+Generate provider-specific lifecycle scripts with `isvctl provider scaffold <your-isv-name>`, then implement the TODO blocks under `isvctl/configs/providers/<your-isv-name>/scripts/` (e.g. `isvctl/configs/providers/acme/scripts/k8s/setup.sh`). The providers directory contains:
 
-- `providers/my-isv/scripts/` - copy-and-fill-in template scripts for every domain
-- `providers/aws/scripts/` - fully-implemented AWS reference (follow its layout and JSON output contracts)
-- `providers/shared/` - cross-provider YAML-invoked scripts (`deploy_nim.py`, `teardown_nim.py`)
+- `isvctl/configs/providers/my-isv/scripts/` - source template scripts for every scaffolded domain
+- `isvctl/configs/providers/aws/scripts/` - fully-implemented AWS reference (follow its layout and JSON output contracts)
+- `isvctl/configs/providers/shared/` - cross-provider YAML-invoked scripts (`deploy_nim.py`, `teardown_nim.py`)
 
 Stubs can be written in any language. They must:
 

--- a/isvctl/configs/providers/my-isv/scripts/README.md
+++ b/isvctl/configs/providers/my-isv/scripts/README.md
@@ -16,13 +16,12 @@ suites/*.yaml                    <- contract   (what to validate; platform-agnos
 providers/my-isv/config/*.yaml   <- wiring     (which scripts implement each step)
                   │
                   ▼ invokes
-providers/my-isv/scripts/<domain>/*.py  <- scaffold   (copy these; fill in TODO blocks)
+providers/my-isv/scripts/<domain>/*.py  <- scaffold   (generated for you; fill in TODO blocks)
 ```
 
 The `suites/` layer is the validation contract - you never modify it, you
-`import:` it from your provider config. You copy the `providers/my-isv/scripts/`
-and `providers/my-isv/config/` trees, rename them to your platform, and fill in
-the TODOs.
+`import:` it from your provider config. Generate a provider scaffold from this
+template, then fill in the TODOs.
 
 ## Domains
 
@@ -48,22 +47,63 @@ See [`suites/README.md`](../../../suites/README.md) for the per-step / per-field
 make demo-test
 ```
 
-**2. Copy the scaffold and the wiring to a new name:**
+**2. Generate the scaffold and wiring under your provider name:**
 
 ```bash
-cp -r isvctl/configs/providers/my-isv/scripts/ isvctl/configs/providers/acme/scripts/
-cp -r isvctl/configs/providers/my-isv/config/  isvctl/configs/providers/acme/config/
+uv run isvctl provider scaffold acme
 ```
 
-**3. Update `providers/acme/config/*.yaml` to point at `providers/acme/scripts/`** (search & replace `my-isv` -> `acme`).
+Use `--dry-run` to preview the destination and next commands, or `--output-dir`
+to generate outside `isvctl/configs/providers/`.
 
-**4. Implement each script** - each has a `TODO:` block with pseudocode and a link to the AWS reference implementation.
+**3. Implement each script** - each has a `TODO:` block with pseudocode and a link to the AWS reference implementation.
 
-**5. Run for real (no demo flag):**
+**4. Run for real (no demo flag):**
 
 ```bash
 uv run isvctl test run -f isvctl/configs/providers/acme/config/vm.yaml
 ```
+
+## Private provider repositories
+
+You do not need to contribute your provider scripts back to this repository,
+Today `isvctl` runs provider configs by path: this repository supplies the
+CLI, validation suites, and validation code; your private repository supplies
+the provider `config/` and `scripts/` files.
+
+Generate the scaffold directly into the private provider repository path you
+intend to keep:
+
+```bash
+git clone <ISV-NCP-Validation-Suite>
+cd ISV-NCP-Validation-Suite
+uv sync
+
+uv run isvctl provider scaffold acme --output-dir ../isvctl-provider-acme
+```
+
+Then initialize or connect that generated directory to your private Git repo
+and implement the scripts there:
+
+```bash
+cd ../isvctl-provider-acme
+git init
+git remote add origin git@github.com:acme/isvctl-provider-acme.git
+# implement scripts/*
+```
+
+Run the private provider from the validation suite checkout by passing its
+config path:
+
+```bash
+cd ../ISV-NCP-Validation-Suite
+uv run isvctl test run -f ../isvctl-provider-acme/config/vm.yaml
+```
+
+Current limitation: out-of-tree provider YAML assumes you run `isvctl` from
+the validation suite checkout root. Suite imports and shared scripts use paths
+relative to that checkout; provider-owned scripts stay relative to the generated
+provider `config/` directory.
 
 ## Anatomy of a script
 

--- a/isvctl/src/isvctl/cli/provider.py
+++ b/isvctl/src/isvctl/cli/provider.py
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provider scaffold commands."""
+
+import os
+import re
+import shlex
+import shutil
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+app = typer.Typer(
+    name="provider",
+    help="Manage provider scaffolds",
+    no_args_is_help=True,
+)
+
+PROVIDER_NAME_RE = re.compile(r"^[a-z0-9_-]+$")
+TEMPLATE_PROVIDER_NAME = "my-isv"
+TEMPLATE_PROVIDER_TOKEN_RE = re.compile(r"(?<!\w)" + re.escape(TEMPLATE_PROVIDER_NAME) + r"(?!\w)")
+IGNORE_NAMES = ("__pycache__", ".pytest_cache")
+SCAFFOLD_META_FILE = ".scaffold-meta"
+RELATIVE_PATH_RE = re.compile(r"\.\./[^\s\"',]+\.(?:yaml|yml|py|sh)")
+
+
+def _validate_provider_name(provider_name: str) -> str:
+    """Validate a provider scaffold name."""
+    if not PROVIDER_NAME_RE.fullmatch(provider_name):
+        raise typer.BadParameter("Provider name must contain only lowercase letters, numbers, '_' and '-'.")
+    return provider_name
+
+
+def _find_template_dir() -> Path:
+    """Find the source provider scaffold directory."""
+    repo_root = Path(__file__).resolve().parents[4]
+    template_dir = repo_root / "isvctl" / "configs" / "providers" / TEMPLATE_PROVIDER_NAME
+    if not template_dir.is_dir():
+        raise FileNotFoundError(f"Provider template not found at {template_dir}")
+    return template_dir.resolve()
+
+
+def _resolve_target_path(provider_name: str, output_dir: Path | None, template_dir: Path) -> Path:
+    """Resolve the scaffold destination path."""
+    if output_dir is None:
+        return (template_dir.parent / provider_name).resolve()
+    return output_dir.expanduser().resolve()
+
+
+def _display_path(path: Path) -> str:
+    """Format a path for CLI output."""
+    try:
+        return str(path.relative_to(Path.cwd().resolve()))
+    except ValueError:
+        return str(path)
+
+
+def _rewrite_text_files(target_dir: Path, provider_name: str) -> None:
+    """Rewrite UTF-8 text files from the template provider name to the requested name.
+
+    Matches `my-isv` only at token boundaries so compound forms like
+    `my-isv-vm-validation` and `my-isv.gpu.1x` are rewritten while embedded
+    occurrences (e.g. `my-isvfoo`, `xxxmy-isv`) are left alone.
+    """
+    for path in target_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        updated = TEMPLATE_PROVIDER_TOKEN_RE.sub(provider_name, content)
+        if updated != content:
+            path.write_text(updated, encoding="utf-8")
+
+
+def _relative_posix_path(path: Path, start: Path) -> str:
+    """Return a POSIX relative path for generated YAML references."""
+    try:
+        relative = Path(os.path.relpath(path, start=start))
+    except ValueError:
+        return path.as_posix()
+    return relative.as_posix()
+
+
+def _built_in_reference(path: Path, start: Path, target_dir: Path, template_dir: Path) -> str:
+    """Return a reference to a validation-suite-owned file.
+
+    In-tree provider scaffolds keep config-file-relative references. Out-of-tree
+    scaffolds are supported from the validation checkout root, so use paths
+    relative to that root instead of generating long ``../../Users/...`` paths.
+    """
+    providers_dir = template_dir.parent.resolve()
+    if target_dir.resolve().is_relative_to(providers_dir):
+        return _relative_posix_path(path, start=start)
+
+    repo_root = template_dir.parents[3]
+    return _relative_posix_path(path, start=repo_root)
+
+
+def _rewrite_config_paths(target_dir: Path, template_dir: Path) -> None:
+    """Rewrite generated YAML references that depend on provider-tree placement."""
+    config_dir = target_dir / "config"
+    if not config_dir.is_dir():
+        return
+
+    suites_dir = template_dir.parents[1] / "suites"
+    shared_dir = template_dir.parent / "shared"
+
+    for path in config_dir.glob("*.yaml"):
+        content = path.read_text(encoding="utf-8")
+        updated = re.sub(
+            r"\.\./\.\./\.\./suites/([A-Za-z0-9_.-]+\.yaml)",
+            lambda match: _built_in_reference(
+                suites_dir / match.group(1),
+                start=path.parent,
+                target_dir=target_dir,
+                template_dir=template_dir,
+            ),
+            content,
+        )
+        updated = re.sub(
+            r"\.\./\.\./shared/([A-Za-z0-9_./-]+\.py)",
+            lambda match: _built_in_reference(
+                shared_dir / match.group(1),
+                start=path.parent,
+                target_dir=target_dir,
+                template_dir=template_dir,
+            ),
+            updated,
+        )
+        if updated != content:
+            path.write_text(updated, encoding="utf-8")
+        _assert_relative_paths_resolve(path, updated)
+
+
+def _assert_relative_paths_resolve(yaml_path: Path, content: str) -> None:
+    """Fail loudly if any `../`-rooted reference in the rewritten YAML doesn't exist.
+
+    Catches silent breakage when a future template introduces a relative-path
+    pattern the rewriter doesn't know about, leaving a dangling reference in
+    the generated scaffold.
+    """
+    for match in RELATIVE_PATH_RE.finditer(content):
+        reference = match.group(0)
+        candidate = (yaml_path.parent / reference).resolve()
+        if not candidate.exists():
+            raise ValueError(
+                f"Generated scaffold {_display_path(yaml_path)} references {reference} "
+                f"which does not resolve (expected at {candidate}).",
+            )
+
+
+def _assert_target_outside_template(target_dir: Path, template_dir: Path) -> None:
+    """Refuse scaffold targets that would mutate the source template tree."""
+    if target_dir.resolve().is_relative_to(template_dir.resolve()):
+        raise ValueError("Target path points inside the provider template.")
+
+
+def _looks_like_scaffold(path: Path) -> bool:
+    """Return True if path was produced by this command (has the sentinel meta file)."""
+    return path.is_dir() and (path / SCAFFOLD_META_FILE).is_file()
+
+
+def _assert_safe_to_overwrite(target_dir: Path, template_dir: Path) -> None:
+    """Refuse to overwrite paths that don't look like a scaffold this command produced."""
+    if template_dir.resolve().is_relative_to(target_dir.resolve()):
+        raise ValueError(f"Refusing to overwrite {_display_path(target_dir)}: would delete the provider template.")
+    if not target_dir.is_dir():
+        raise ValueError(f"Refusing to overwrite {_display_path(target_dir)}: not a directory.")
+    if not _looks_like_scaffold(target_dir):
+        raise ValueError(
+            f"Refusing to overwrite {_display_path(target_dir)}: "
+            f"missing scaffold marker ({SCAFFOLD_META_FILE}). "
+            f"Remove the directory manually if you want to replace it.",
+        )
+
+
+def _copy_scaffold(template_dir: Path, target_dir: Path, provider_name: str) -> None:
+    """Copy the scaffold template into the target directory."""
+    if target_dir.exists():
+        _assert_safe_to_overwrite(target_dir, template_dir)
+        shutil.rmtree(target_dir)
+
+    shutil.copytree(
+        template_dir,
+        target_dir,
+        copy_function=shutil.copy2,
+        ignore=shutil.ignore_patterns(*IGNORE_NAMES),
+    )
+    _rewrite_text_files(target_dir, provider_name)
+    _rewrite_config_paths(target_dir, template_dir)
+    (target_dir / SCAFFOLD_META_FILE).write_text(f"provider_name={provider_name}\n", encoding="utf-8")
+
+
+def _print_next_steps(target_dir: Path, action: str) -> None:
+    """Print scaffold creation output and next commands."""
+    display_target = _display_path(target_dir)
+    demo_config = shlex.quote(f"{display_target}/config/vm.yaml")
+    launch_script = shlex.quote(f"{display_target}/scripts/vm/launch_instance.py")
+    typer.echo(f"{action} provider scaffold: {display_target}")
+    typer.echo()
+    typer.echo("Preview without cloud:")
+    typer.echo(f"  ISVCTL_DEMO_MODE=1 uv run isvctl test run -f {demo_config}")
+    typer.echo()
+    typer.echo("Start implementing:")
+    typer.echo(f"  {launch_script}")
+
+
+@app.command("scaffold")
+def scaffold(
+    provider_name: Annotated[
+        str,
+        typer.Argument(
+            help="Provider name to scaffold. Use lowercase letters, numbers, '_' or '-'.",
+        ),
+    ],
+    output_dir: Annotated[
+        Path | None,
+        typer.Option(
+            "--output-dir",
+            help="Destination directory. Defaults to isvctl/configs/providers/<provider-name>.",
+        ),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help="Show what would be created without writing files.",
+        ),
+    ] = False,
+    overwrite: Annotated[
+        bool,
+        typer.Option(
+            "--overwrite",
+            help="Replace the target directory if it already exists.",
+        ),
+    ] = False,
+) -> None:
+    """Create a ready-to-edit provider scaffold from the my-isv template."""
+    try:
+        provider_name = _validate_provider_name(provider_name)
+        template_dir = _find_template_dir()
+        target_dir = _resolve_target_path(provider_name, output_dir, template_dir)
+
+        _assert_target_outside_template(target_dir, template_dir)
+
+        if dry_run:
+            if target_dir.exists():
+                if overwrite:
+                    _assert_safe_to_overwrite(target_dir, template_dir)
+                else:
+                    typer.echo(f"Note: target exists; --overwrite would be required: {_display_path(target_dir)}")
+            _print_next_steps(target_dir, "Would create")
+            return
+
+        if target_dir.exists() and not overwrite:
+            raise FileExistsError(f"Target already exists: {_display_path(target_dir)}")
+
+        _copy_scaffold(template_dir, target_dir, provider_name)
+    except (FileExistsError, FileNotFoundError, ValueError) as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    _print_next_steps(target_dir, "Created")

--- a/isvctl/src/isvctl/config/merger.py
+++ b/isvctl/src/isvctl/config/merger.py
@@ -20,9 +20,11 @@ configuration files, similar to Helm's --values flag behavior.
 
 Later files override earlier ones. The --set flag can override individual values.
 
-Files may declare an ``import:`` key with a list of paths (resolved relative
-to the importing file) that are loaded and merged as a base before the
-importing file's own content is applied on top.
+Files may declare an ``import:`` key with a list of paths. The
+``_resolve_import_path`` helper resolves imports relative to the importing file,
+then searches the current working directory and its parents before falling back
+to the current working directory. Imported files are loaded and merged as a base
+before the importing file's own content is applied on top.
 """
 
 import copy
@@ -121,8 +123,10 @@ def _load_yaml_with_imports(
     """Load a YAML file and recursively resolve its ``import:`` directives.
 
     Imported files are merged in order to form a base, then the importing
-    file's own content is deep-merged on top.  Paths in ``import:`` are
-    resolved relative to the importing file's directory.
+    file's own content is deep-merged on top. Paths in ``import:`` are resolved
+    by ``_resolve_import_path`` relative to the importing file's directory, then
+    by searching the current working directory and its parents before falling
+    back to the current working directory.
 
     Args:
         path: Path to the YAML file.
@@ -168,13 +172,44 @@ def _load_yaml_with_imports(
     # ancestors (the copy includes everything on the current call stack).
     base: dict[str, Any] = {}
     for imp in import_list:
-        imp_path = (path.parent / imp).resolve()
+        imp_path = _resolve_import_path(path, imp)
         logger.debug("Resolving import %s -> %s", imp, imp_path)
         imported = _load_yaml_with_imports(Path(imp_path), _visited.copy())
         base = deep_merge(base, imported)
 
     # The importing file's content wins over the base
     return deep_merge(base, content)
+
+
+def _resolve_import_path(path: Path, imp: Any) -> Path:
+    """Resolve an import path.
+
+    Prefer paths relative to the importing file. If that does not exist, fall
+    back to the current working directory or one of its parents so out-of-tree
+    provider configs can import validation-suite files using checkout-root-relative
+    paths even when commands run from a package subdirectory.
+    """
+    if not isinstance(imp, (str, Path)):
+        raise ValueError(
+            f"Import entries must be strings or paths in {path}, got {type(imp).__name__}",
+        )
+
+    expanded = Path(imp).expanduser()
+
+    file_relative = (path.parent / expanded).resolve()
+    if file_relative.exists():
+        return file_relative
+
+    if expanded.is_absolute():
+        return expanded.resolve()
+
+    cwd = Path.cwd().resolve()
+    for root in (cwd, *cwd.parents):
+        candidate = root / expanded
+        if candidate.exists():
+            return candidate.resolve()
+
+    return (cwd / expanded).resolve()
 
 
 def merge_yaml_files(
@@ -185,7 +220,9 @@ def merge_yaml_files(
 
     Files are merged in order - later files override earlier ones.
     Each file may contain an ``import:`` key listing other YAML files
-    to load as a base (paths resolved relative to the importing file).
+    to load as a base. Imports are resolved relative to the importing file,
+    then by searching the current working directory and its parents before
+    falling back to the current working directory.
     --set values are applied after all files are merged.
 
     Args:

--- a/isvctl/src/isvctl/main.py
+++ b/isvctl/src/isvctl/main.py
@@ -21,7 +21,7 @@ import typer
 from isvreporter.main import app as report_app
 from isvreporter.version import get_version
 
-from isvctl.cli import catalog, clean, deploy, docs, test
+from isvctl.cli import catalog, clean, deploy, docs, provider, test
 
 app = typer.Typer(
     name="isvctl",
@@ -52,6 +52,7 @@ app.add_typer(catalog.app, name="catalog")
 app.add_typer(clean.app, name="clean")
 app.add_typer(deploy.app, name="deploy")
 app.add_typer(docs.app, name="docs")
+app.add_typer(provider.app, name="provider")
 app.add_typer(test.app, name="test")
 app.add_typer(report_app, name="report")
 

--- a/isvctl/src/isvctl/orchestrator/step_executor.py
+++ b/isvctl/src/isvctl/orchestrator/step_executor.py
@@ -117,6 +117,30 @@ def _write_full_stderr(step_name: str, stderr: str) -> None:
     sys.stderr.write(f"\n--- stderr from step '{step_name}' ---\n{redacted}\n--- end stderr ---\n")
 
 
+def _resolve_python_script_path(cmd_parts: list[str], cwd: Path) -> list[str]:
+    """Resolve repo-root-relative Python script paths before changing cwd."""
+    if len(cmd_parts) < 2:
+        return cmd_parts
+    if not Path(cmd_parts[0]).name.startswith("python"):
+        return cmd_parts
+
+    script_arg = cmd_parts[1]
+    if script_arg.startswith("-"):
+        return cmd_parts
+
+    script_path = Path(script_arg)
+    if script_path.is_absolute() or (cwd / script_path).exists():
+        return cmd_parts
+
+    cwd_relative = Path.cwd() / script_path
+    if not cwd_relative.exists():
+        return cmd_parts
+
+    updated = cmd_parts.copy()
+    updated[1] = str(cwd_relative.resolve())
+    return updated
+
+
 def _find_missing_step_path(arg: str, steps_data: dict[str, Any]) -> str | None:
     """Return the first ``steps.X.Y`` path in ``arg`` that is unresolved.
 
@@ -319,6 +343,7 @@ class StepExecutor:
 
         # Determine working directory
         cwd = Path(step.working_dir) if step.working_dir else self.working_dir
+        cmd_parts = _resolve_python_script_path(cmd_parts, cwd)
 
         # Build environment
         env = os.environ.copy()

--- a/isvctl/src/isvctl/orchestrator/step_executor.py
+++ b/isvctl/src/isvctl/orchestrator/step_executor.py
@@ -118,16 +118,38 @@ def _write_full_stderr(step_name: str, stderr: str) -> None:
 
 
 def _resolve_python_script_path(cmd_parts: list[str], cwd: Path) -> list[str]:
-    """Resolve repo-root-relative Python script paths before changing cwd."""
+    """Resolve repo-root-relative Python script paths before changing cwd.
+
+    Python interpreter options may precede the script argument, so this scans
+    past supported flags and only rewrites a relative script path when it is
+    missing from the step cwd but exists from the current process cwd.
+
+    Args:
+        cmd_parts: Parsed command tokens beginning with the Python interpreter.
+        cwd: Working directory where the step command will run.
+
+    Returns:
+        Command tokens with the script path resolved to an absolute path, or the
+        original tokens when no rewrite is needed or possible.
+    """
     if len(cmd_parts) < 2:
         return cmd_parts
     if not Path(cmd_parts[0]).name.startswith("python"):
         return cmd_parts
 
-    script_arg = cmd_parts[1]
-    if script_arg.startswith("-"):
+    script_idx = 1
+    while script_idx < len(cmd_parts) and cmd_parts[script_idx].startswith("-"):
+        opt = cmd_parts[script_idx]
+        if opt in {"-m", "-c"}:
+            return cmd_parts
+        if opt in {"-W", "-X"} and script_idx + 1 < len(cmd_parts):
+            script_idx += 2
+        else:
+            script_idx += 1
+    if script_idx >= len(cmd_parts):
         return cmd_parts
 
+    script_arg = cmd_parts[script_idx]
     script_path = Path(script_arg)
     if script_path.is_absolute() or (cwd / script_path).exists():
         return cmd_parts
@@ -137,7 +159,7 @@ def _resolve_python_script_path(cmd_parts: list[str], cwd: Path) -> list[str]:
         return cmd_parts
 
     updated = cmd_parts.copy()
-    updated[1] = str(cwd_relative.resolve())
+    updated[script_idx] = str(cwd_relative.resolve())
     return updated
 
 

--- a/isvctl/tests/test_merger.py
+++ b/isvctl/tests/test_merger.py
@@ -234,6 +234,33 @@ class TestImportDirective:
         result = merge_yaml_files([str(child)])
         assert result == {"val": "overridden"}
 
+    def test_import_falls_back_to_current_working_directory(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Checkout-root-relative imports work for out-of-tree provider configs."""
+        repo_root = tmp_path / "repo"
+        template = repo_root / "isvctl" / "configs" / "suites" / "vm.yaml"
+        template.parent.mkdir(parents=True)
+        template.write_text(
+            "tests:\n  cluster_name: template\n  suite_only: inherited\n",
+            encoding="utf-8",
+        )
+
+        provider_dir = tmp_path / "provider" / "config"
+        provider_dir.mkdir(parents=True)
+        provider = provider_dir / "vm.yaml"
+        provider.write_text(
+            "import:\n  - isvctl/configs/suites/vm.yaml\ntests:\n  cluster_name: provider\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.chdir(repo_root / "isvctl")
+
+        result = merge_yaml_files([str(provider)])
+        assert result == {"tests": {"cluster_name": "provider", "suite_only": "inherited"}}
+
     def test_multiple_imports(self, tmp_path: Path) -> None:
         """Multiple imports are merged in order, child wins."""
         (tmp_path / "a.yaml").write_text("x: 1\ny: from_a")
@@ -289,6 +316,14 @@ class TestImportDirective:
         child.write_text("import:\n  - missing.yaml\nx: 1")
 
         with pytest.raises(FileNotFoundError):
+            merge_yaml_files([str(child)])
+
+    def test_import_entry_must_be_string_or_path(self, tmp_path: Path) -> None:
+        """Invalid import entry types raise a config-specific ValueError."""
+        child = tmp_path / "child.yaml"
+        child.write_text("import:\n  - 123\nx: 1")
+
+        with pytest.raises(ValueError, match=r"Import entries must be strings or paths.*child\.yaml"):
             merge_yaml_files([str(child)])
 
     def test_import_with_f_flag_merge(self, tmp_path: Path) -> None:

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -83,6 +83,28 @@ def test_python_script_path_falls_back_to_current_working_directory(
     assert resolved[1] == str(script.resolve())
 
 
+def test_python_script_path_falls_back_after_interpreter_flags(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repo-root-relative Python commands still work after interpreter flags."""
+    repo_root = tmp_path / "repo"
+    script = repo_root / "isvctl" / "configs" / "providers" / "shared" / "deploy_nim.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("print('ok')\n", encoding="utf-8")
+    provider_config_dir = tmp_path / "provider" / "config"
+    provider_config_dir.mkdir(parents=True)
+
+    monkeypatch.chdir(repo_root)
+
+    resolved = _resolve_python_script_path(
+        ["python", "-u", "isvctl/configs/providers/shared/deploy_nim.py"],
+        provider_config_dir,
+    )
+    assert resolved[1] == "-u"
+    assert resolved[2] == str(script.resolve())
+
+
 def _write_script(tmp_path: Path, name: str, content: str) -> str:
     """Create an executable script file under tmp_path and return its path.
 

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -18,6 +18,7 @@
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+import pytest
 from isvtest.core.resolution import (
     ErrorReason,
     ResolvedEntry,
@@ -40,6 +41,7 @@ from isvctl.orchestrator.step_executor import (
     StepExecutor,
     _find_missing_step_path,
     _format_stderr_excerpt,
+    _resolve_python_script_path,
 )
 
 _INVENTORY_SCRIPT = (
@@ -58,6 +60,27 @@ done
 echo "AWS_SECRET_ACCESS_KEY=super-secret" >&2
 exit 7
 """
+
+
+def test_python_script_path_falls_back_to_current_working_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repo-root-relative Python commands still work with config-relative cwd."""
+    repo_root = tmp_path / "repo"
+    script = repo_root / "isvctl" / "configs" / "providers" / "shared" / "deploy_nim.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("print('ok')\n", encoding="utf-8")
+    provider_config_dir = tmp_path / "provider" / "config"
+    provider_config_dir.mkdir(parents=True)
+
+    monkeypatch.chdir(repo_root)
+
+    resolved = _resolve_python_script_path(
+        ["python", "isvctl/configs/providers/shared/deploy_nim.py"],
+        provider_config_dir,
+    )
+    assert resolved[1] == str(script.resolve())
 
 
 def _write_script(tmp_path: Path, name: str, content: str) -> str:

--- a/isvctl/tests/test_provider_scaffold_cli.py
+++ b/isvctl/tests/test_provider_scaffold_cli.py
@@ -1,0 +1,482 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for provider scaffold CLI commands."""
+
+import shlex
+import stat
+from pathlib import Path
+
+import pytest
+import yaml
+from click.utils import strip_ansi
+from typer.testing import CliRunner
+
+from isvctl.cli import provider as provider_cli
+from isvctl.cli import test as test_cli
+from isvctl.cli.provider import RELATIVE_PATH_RE, _rewrite_text_files
+from isvctl.config.merger import merge_yaml_files
+from isvctl.config.schema import RunConfig
+from isvctl.main import app as main_app
+
+runner = CliRunner()
+
+
+def test_provider_help_renders() -> None:
+    """Test provider command help."""
+    result = runner.invoke(main_app, ["provider", "--help"])
+
+    assert result.exit_code == 0
+    assert "Manage provider scaffolds" in result.output
+    assert "scaffold" in result.output
+
+
+def test_provider_scaffold_help_renders() -> None:
+    """Test provider scaffold command help."""
+    result = runner.invoke(main_app, ["provider", "scaffold", "--help"])
+    output = strip_ansi(result.output)
+
+    assert result.exit_code == 0
+    assert "Create a ready-to-edit provider scaffold" in output
+    assert "--output-dir" in output
+    assert "--dry-run" in output
+    assert "--overwrite" in output
+
+
+def test_successful_scaffold_into_output_dir(tmp_path: Path) -> None:
+    """Test creating a provider scaffold in a custom output directory."""
+    target = tmp_path / "acme"
+
+    result = runner.invoke(main_app, ["provider", "scaffold", "acme", "--output-dir", str(target)])
+
+    assert result.exit_code == 0
+    assert target.is_dir()
+    assert (target / "README.md").is_file()
+    assert (target / "config" / "vm.yaml").is_file()
+    assert (target / "scripts" / "vm" / "launch_instance.py").is_file()
+    assert "Created provider scaffold:" in result.output
+    assert "ISVCTL_DEMO_MODE=1 uv run isvctl test run -f" in result.output
+    assert "scripts/vm/launch_instance.py" in result.output
+
+
+def test_scaffold_next_steps_quote_paths_with_spaces(tmp_path: Path) -> None:
+    """Test generated shell snippets quote paths that contain spaces."""
+    target = tmp_path / "provider dir" / "acme"
+
+    result = runner.invoke(main_app, ["provider", "scaffold", "acme", "--output-dir", str(target), "--dry-run"])
+
+    assert result.exit_code == 0
+    assert f"uv run isvctl test run -f {shlex.quote(f'{target}/config/vm.yaml')}" in result.output
+    assert f"  {shlex.quote(f'{target}/scripts/vm/launch_instance.py')}" in result.output
+
+
+def test_scaffold_rewrites_my_isv_text(tmp_path: Path) -> None:
+    """Test generated text files are rewritten to the requested provider name."""
+    target = tmp_path / "acme"
+
+    result = runner.invoke(main_app, ["provider", "scaffold", "acme", "--output-dir", str(target)])
+
+    assert result.exit_code == 0
+    readme = (target / "scripts" / "README.md").read_text(encoding="utf-8")
+    config = (target / "config" / "vm.yaml").read_text(encoding="utf-8")
+    assert "acme scaffold" in readme
+    assert "providers/acme" in readme
+    assert "my-isv" not in readme
+    assert "acme VM Validation Configuration" in config
+    assert "my-isv" not in config
+
+
+def test_rewrite_skips_embedded_template_token(tmp_path: Path) -> None:
+    """Test the my-isv rewrite leaves embedded occurrences alone."""
+    target = tmp_path / "scaffold"
+    target.mkdir()
+    sample = target / "notes.txt"
+    sample.write_text(
+        "my-isv scaffold\nproviders/my-isv/config\nmy-isv-vm-validation\nmy-isv.gpu.1x\nmy-isvfoo bar\nxxxmy-isv yyy\n",
+        encoding="utf-8",
+    )
+
+    _rewrite_text_files(target, "acme")
+
+    rewritten = sample.read_text(encoding="utf-8")
+    assert "acme scaffold" in rewritten
+    assert "providers/acme/config" in rewritten
+    assert "acme-vm-validation" in rewritten
+    assert "acme.gpu.1x" in rewritten
+    assert "my-isvfoo bar" in rewritten
+    assert "xxxmy-isv yyy" in rewritten
+
+
+def test_invalid_provider_names_are_rejected(tmp_path: Path) -> None:
+    """Test path-like provider names are rejected."""
+    target = tmp_path / "bad"
+
+    result = runner.invoke(main_app, ["provider", "scaffold", "../bad", "--output-dir", str(target)])
+
+    assert result.exit_code != 0
+    assert "Provider name must contain only lowercase letters" in result.output
+    assert not target.exists()
+
+
+def test_scaffold_rejects_output_dir_nested_under_template(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test scaffold refuses targets inside the source template tree."""
+    template_dir = tmp_path / "providers" / "my-isv"
+    template_dir.mkdir(parents=True)
+    (template_dir / "README.md").write_text("my-isv scaffold\n", encoding="utf-8")
+    monkeypatch.setattr(provider_cli, "_find_template_dir", lambda: template_dir.resolve())
+
+    target = template_dir / "generated" / "acme"
+
+    result = runner.invoke(main_app, ["provider", "scaffold", "acme", "--output-dir", str(target)])
+
+    assert result.exit_code == 1
+    assert "Target path points inside the provider template" in result.output
+    assert not target.exists()
+
+
+def test_existing_target_rejected_without_overwrite(tmp_path: Path) -> None:
+    """Test existing targets are rejected unless overwrite is requested."""
+    target = tmp_path / "acme"
+    target.mkdir()
+    marker = target / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+
+    result = runner.invoke(main_app, ["provider", "scaffold", "acme", "--output-dir", str(target)])
+
+    assert result.exit_code == 1
+    assert "Target already exists" in result.output
+    assert marker.read_text(encoding="utf-8") == "keep"
+
+
+def test_overwrite_replaces_existing_scaffold(tmp_path: Path) -> None:
+    """Test overwrite replaces an existing scaffold target directory."""
+    target = tmp_path / "acme"
+
+    first = runner.invoke(main_app, ["provider", "scaffold", "acme", "--output-dir", str(target)])
+    assert first.exit_code == 0
+
+    stale_file = target / "scripts" / "stale.txt"
+    stale_file.write_text("old", encoding="utf-8")
+
+    result = runner.invoke(main_app, ["provider", "scaffold", "acme", "--output-dir", str(target), "--overwrite"])
+
+    assert result.exit_code == 0
+    assert not stale_file.exists()
+    assert (target / "README.md").is_file()
+    assert (target / "scripts" / "vm" / "launch_instance.py").is_file()
+
+
+def test_overwrite_refuses_non_scaffold_directory(tmp_path: Path) -> None:
+    """Test overwrite refuses directories that don't look like a scaffold."""
+    target = tmp_path / "unrelated"
+    target.mkdir()
+    keep = target / "important.txt"
+    keep.write_text("do not delete", encoding="utf-8")
+
+    result = runner.invoke(
+        main_app,
+        ["provider", "scaffold", "acme", "--output-dir", str(target), "--overwrite"],
+    )
+
+    assert result.exit_code == 1
+    assert "Refusing to overwrite" in result.output
+    assert "missing scaffold marker" in result.output
+    assert keep.read_text(encoding="utf-8") == "do not delete"
+
+
+def test_overwrite_refuses_when_marker_dirs_alone_present(tmp_path: Path) -> None:
+    """Test overwrite refuses a directory that mimics the layout but lacks the meta sentinel."""
+    target = tmp_path / "look-alike"
+    (target / "config").mkdir(parents=True)
+    (target / "scripts").mkdir()
+    keep = target / "config" / "important.yaml"
+    keep.write_text("preserve: true\n", encoding="utf-8")
+
+    result = runner.invoke(
+        main_app,
+        ["provider", "scaffold", "acme", "--output-dir", str(target), "--overwrite"],
+    )
+
+    assert result.exit_code == 1
+    assert "missing scaffold marker" in result.output
+    assert keep.read_text(encoding="utf-8") == "preserve: true\n"
+
+
+def test_overwrite_refuses_when_output_dir_is_a_file(tmp_path: Path) -> None:
+    """Test overwrite refuses a file path masquerading as a target directory."""
+    target = tmp_path / "not-a-dir"
+    target.write_text("just a file", encoding="utf-8")
+
+    result = runner.invoke(
+        main_app,
+        ["provider", "scaffold", "acme", "--output-dir", str(target), "--overwrite"],
+    )
+
+    assert result.exit_code == 1
+    assert "Refusing to overwrite" in result.output
+    assert "not a directory" in result.output
+    assert target.read_text(encoding="utf-8") == "just a file"
+
+
+def test_overwrite_refuses_template_ancestor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test overwrite refuses when the target contains the provider template."""
+    template_dir = tmp_path / "providers" / "my-isv"
+    template_dir.mkdir(parents=True)
+    (template_dir / "README.md").write_text("my-isv scaffold\n", encoding="utf-8")
+    monkeypatch.setattr(provider_cli, "_find_template_dir", lambda: template_dir.resolve())
+    providers_dir = template_dir.parent
+
+    result = runner.invoke(
+        main_app,
+        ["provider", "scaffold", "acme", "--output-dir", str(providers_dir), "--overwrite"],
+    )
+
+    assert result.exit_code == 1
+    assert "Refusing to overwrite" in result.output
+    assert "would delete the provider template" in result.output
+    assert template_dir.is_dir()
+
+
+def test_dry_run_warns_when_target_exists_without_overwrite(tmp_path: Path) -> None:
+    """Test dry-run flags an existing target instead of erroring."""
+    target = tmp_path / "acme"
+    target.mkdir()
+
+    result = runner.invoke(
+        main_app,
+        ["provider", "scaffold", "acme", "--output-dir", str(target), "--dry-run"],
+    )
+
+    assert result.exit_code == 0
+    assert "--overwrite would be required" in result.output
+    assert "Would create provider scaffold:" in result.output
+
+
+def test_executable_bits_are_preserved(tmp_path: Path) -> None:
+    """Test executable shell scripts stay executable in the scaffold."""
+    target = tmp_path / "acme"
+
+    result = runner.invoke(main_app, ["provider", "scaffold", "acme", "--output-dir", str(target)])
+
+    assert result.exit_code == 0
+    mode = (target / "scripts" / "k8s" / "setup.sh").stat().st_mode
+    assert mode & stat.S_IXUSR
+
+
+def test_generated_yaml_files_parse(tmp_path: Path) -> None:
+    """Test generated provider YAML files are valid YAML."""
+    target = tmp_path / "acme"
+
+    result = runner.invoke(main_app, ["provider", "scaffold", "acme", "--output-dir", str(target)])
+
+    assert result.exit_code == 0
+    for yaml_path in sorted((target / "config").glob("*.yaml")):
+        parsed = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+        assert isinstance(parsed, dict), yaml_path
+
+
+def test_output_dir_scaffold_keeps_config_references_resolvable(tmp_path: Path) -> None:
+    """Test generated provider configs still load from an out-of-tree directory."""
+    target = tmp_path / "acme"
+
+    result = runner.invoke(main_app, ["provider", "scaffold", "acme", "--output-dir", str(target)])
+
+    assert result.exit_code == 0
+    config_path = target / "config" / "vm.yaml"
+    config_text = config_path.read_text(encoding="utf-8")
+    merged = merge_yaml_files([config_path])
+    deploy_nim = next(step for step in merged["commands"]["vm"]["steps"] if step["name"] == "deploy_nim")
+    shared_script = deploy_nim["command"].removeprefix("python ")
+    repo_root = Path(__file__).resolve().parents[2]
+
+    assert merged["tests"]["cluster_name"] == "acme-vm-validation"
+    assert not Path(shared_script).is_absolute()
+    assert not shared_script.startswith("../")
+    assert (repo_root / shared_script).resolve().is_file()
+    assert "isvctl/configs/suites/vm.yaml" in config_text
+    assert "isvctl/configs/providers/shared/deploy_nim.py" in config_text
+    assert "/Users/" not in config_text
+    assert "../../.." not in config_text
+
+
+def test_output_dir_scaffold_imports_load_for_every_config(tmp_path: Path) -> None:
+    """Test every out-of-tree scaffold config can import its validation suite."""
+    target = tmp_path / "acme"
+
+    result = runner.invoke(main_app, ["provider", "scaffold", "acme", "--output-dir", str(target)])
+
+    assert result.exit_code == 0
+    config_files = sorted((target / "config").glob("*.yaml"))
+    assert config_files, "no generated config files"
+    for config_path in config_files:
+        config_text = config_path.read_text(encoding="utf-8")
+        merged = merge_yaml_files([config_path])
+
+        RunConfig.model_validate(merged)
+        assert "commands" in merged, config_path
+        assert "tests" in merged, config_path
+        assert "/Users/" not in config_text
+        assert "../../.." not in config_text
+
+
+def test_output_dir_scaffold_runs_external_provider_script_imports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test an out-of-tree scaffold can run provider-local imports from the checkout root."""
+    target = tmp_path / "external-provider" / "acme"
+    result = runner.invoke(main_app, ["provider", "scaffold", "acme", "--output-dir", str(target)])
+    assert result.exit_code == 0
+
+    common_dir = target / "scripts" / "common"
+    common_dir.mkdir()
+    (common_dir / "__init__.py").write_text("", encoding="utf-8")
+    (common_dir / "provider_ids.py").write_text(
+        "def instance_id() -> str:\n    return 'acme-external-vm-0001'\n",
+        encoding="utf-8",
+    )
+
+    marker_path = tmp_path / "provider-import-marker.txt"
+    (target / "scripts" / "vm" / "launch_instance.py").write_text(
+        """#!/usr/bin/env python3
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from common.provider_ids import instance_id
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--name", required=True)
+parser.add_argument("--instance-type", required=True)
+parser.add_argument("--region", required=True)
+args = parser.parse_args()
+
+marker = os.environ.get("ACME_IMPORT_MARKER")
+if marker:
+    Path(marker).write_text(instance_id(), encoding="utf-8")
+
+print(json.dumps({
+    "success": True,
+    "platform": "vm",
+    "instance_id": instance_id(),
+    "public_ip": "203.0.113.10",
+    "private_ip": "10.0.0.10",
+    "key_file": "/tmp/dummy-key.pem",
+    "vpc_id": "dummy-vpc-0001",
+    "state": "running",
+    "security_group_id": "dummy-sg-0001",
+    "requested_key_name": args.name,
+    "key_name": args.name,
+    "tests": {
+        "specified_key": {
+            "passed": True,
+            "message": "dummy provider preserved requested key name",
+            "probes": ["provider-local-common-import"],
+        },
+    },
+}))
+""",
+        encoding="utf-8",
+    )
+
+    def _test_output_dir(root: Path | None = None) -> Path:
+        output_dir = tmp_path / "run-output"
+        output_dir.mkdir(exist_ok=True)
+        return output_dir
+
+    monkeypatch.setattr(test_cli, "get_output_dir", _test_output_dir)
+    monkeypatch.setenv("ACME_IMPORT_MARKER", str(marker_path))
+    monkeypatch.setenv("ISVTEST_INCLUDE_UNRELEASED", "1")
+
+    run = runner.invoke(
+        main_app,
+        [
+            "test",
+            "run",
+            "-f",
+            str(target / "config" / "vm.yaml"),
+            "--phase",
+            "setup",
+            "--no-upload",
+            "--junitxml",
+            str(tmp_path / "junit.xml"),
+            "--",
+            "-k",
+            "InstanceStateCheck or InstanceCreatedCheck or InstanceSpecifiedKeyCheck",
+        ],
+    )
+
+    assert run.exit_code == 0, run.output
+    assert marker_path.read_text(encoding="utf-8") == "acme-external-vm-0001"
+
+
+def test_every_generated_config_relative_path_resolves(tmp_path: Path) -> None:
+    """Test every ../-rooted reference in generated configs points at a real file.
+
+    Catches silent breakage if a future template introduces a path pattern the
+    rewriter doesn't know about.
+    """
+    target = tmp_path / "acme"
+
+    result = runner.invoke(main_app, ["provider", "scaffold", "acme", "--output-dir", str(target)])
+    assert result.exit_code == 0
+
+    config_files = sorted((target / "config").glob("*.yaml"))
+    assert config_files, "no generated config files"
+
+    total_refs = 0
+    for yaml_path in config_files:
+        content = yaml_path.read_text(encoding="utf-8")
+        refs = RELATIVE_PATH_RE.findall(content)
+        assert refs, f"{yaml_path} has no relative references; template change?"
+        for ref in refs:
+            resolved = (yaml_path.parent / ref).resolve()
+            assert resolved.is_file(), f"{yaml_path} references missing file: {ref} -> {resolved}"
+            total_refs += 1
+
+    assert total_refs >= len(config_files), "expected at least one reference per config file"
+
+
+def test_meta_file_is_written_and_records_provider_name(tmp_path: Path) -> None:
+    """Test the scaffold sentinel file is created with the provider name."""
+    target = tmp_path / "acme"
+
+    result = runner.invoke(main_app, ["provider", "scaffold", "acme", "--output-dir", str(target)])
+
+    assert result.exit_code == 0
+    meta = target / ".scaffold-meta"
+    assert meta.is_file()
+    assert "provider_name=acme" in meta.read_text(encoding="utf-8")
+
+
+def test_dry_run_does_not_create_target(tmp_path: Path) -> None:
+    """Test dry-run prints next steps without creating files."""
+    target = tmp_path / "acme"
+
+    result = runner.invoke(main_app, ["provider", "scaffold", "acme", "--output-dir", str(target), "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "Would create provider scaffold:" in result.output
+    assert "Preview without cloud:" in result.output
+    assert not target.exists()


### PR DESCRIPTION
## Summary

Adds an `isvctl provider scaffold <name>` command so ISVs can generate a ready-to-edit provider tree from the `my-isv` template instead of hand-copying directories and search-replacing `my-isv` -> `<name>`. The command preserves executable bits, rewrites provider-name tokens, and supports both in-tree provider generation and out-of-tree private provider repositories.

For out-of-tree scaffolds, generated YAML references to validation-suite-owned files are rewritten to paths relative to the validation-suite checkout root. The PR also updates config import loading and Python step-command path resolution so those checkout-root-relative suite imports and shared scripts run correctly from an external provider config, including Python invocations with interpreter flags.

## TL;DR: external provider setup

From a validation-suite checkout, generate the provider scaffold directly into the private repository or working directory that will own the provider implementation:

```bash
uv sync
uv run isvctl provider scaffold acme --output-dir ../isvctl-provider-acme
```

Implement the generated `scripts/` files in that external directory, then run the provider config from the validation-suite checkout root:

```bash
uv run isvctl test run -f ../isvctl-provider-acme/config/vm.yaml
```

The public validation-suite checkout supplies `isvctl`, suite contracts, validations, and shared scripts; the external directory supplies provider-owned `config/` and `scripts/`.

## Changes

- Adds `isvctl/src/isvctl/cli/provider.py` with a `provider scaffold` subcommand (Typer), wired in `isvctl/src/isvctl/main.py`.
- Token-aware text rewrite: replaces `my-isv` only at word boundaries so `my-isv-vm-validation` and `my-isv.gpu.1x` rewrite while embedded forms (`my-isvfoo`, `xxxmy-isv`) are left alone.
- Out-of-tree scaffold path repair: in-tree scaffolds keep config-file-relative `../../../suites/*.yaml` and `../../shared/*.py` references; out-of-tree scaffolds rewrite those to paths relative to the validation-suite checkout root, avoiding long `../../Users/...` paths. After rewriting, asserts every `../`-rooted reference still resolves so a future template change doesn't silently leave dangling refs.
- Config import resolution fallback: `import:` entries now prefer paths relative to the importing file, then absolute paths, then the current working directory and its parents. This lets external provider configs import checkout-root-relative suite files when `isvctl` is run from the validation-suite checkout.
- Python step path repair: before executing a step in its config-relative working directory, repo-root-relative Python script arguments are resolved from the current process working directory when needed. The resolver skips supported interpreter flags (`-u`, `-W`, `-X`, etc.) and leaves `-m`/`-c` invocations untouched.
- Safety rails: validates provider names against `^[a-z0-9_-]+$`; refuses targets inside the template tree; `--overwrite` requires a `.scaffold-meta` sentinel in the target so the command never deletes hand-written directories; `--dry-run` previews the next commands and surfaces the overwrite requirement.
- Drops `__pycache__` and `.pytest_cache` while copying; preserves file mode (`copy2`) so script executable bits survive.
- Updates `docs/getting-started.md`, `docs/guides/configuration.md`, `docs/packages/isvctl.md`, and `isvctl/configs/providers/my-isv/scripts/README.md` to point users at the new command, plus a new "Private provider repositories" section walking through the out-of-tree workflow.
- Adds tests for scaffold generation, token-boundary rewriting, in-tree vs out-of-tree path resolution, overwrite safety (sentinel required), dry-run behavior, executable-bit preservation, config import fallback, and Python script path resolution with interpreter flags.

## Test plan

- [x] `make test`
- [x] `make format`
- [x] `make demo-test`
- [x] `uv run isvctl provider scaffold acme --dry-run`
- [x] `uv run isvctl provider scaffold acme` followed by `ISVCTL_DEMO_MODE=1 uv run isvctl test run -f isvctl/configs/providers/acme/config/vm.yaml`
- [x] `uv run isvctl provider scaffold acme --output-dir /tmp/isvctl-provider-acme` followed by running the generated config from the validation-suite checkout root

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New provider scaffold CLI with dry-run/overwrite and a demo-mode preview to run generated flows without cloud credentials.

* **Bug Fixes**
  * YAML import resolution now prefers the importing file’s location and falls back to the current working directory.
  * Python script invocation paths are resolved correctly when running step commands.

* **Documentation**
  * Quick Start, guides, and onboarding updated to document scaffolding and out-of-tree provider workflows.

* **Tests**
  * Added extensive tests covering scaffolding, import fallback, script/path resolution, and safety checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/ISV-NCP-Validation-Suite/pull/409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
