### PR TITLE
feat: add ATTEST-XX-02 BIOS baseline validation (ATTEST-XX-02 M1-P1)

### DIFF
--- a/isvctl/configs/providers/aws/scripts/vm/docs/aws-vm.md
+++ b/isvctl/configs/providers/aws/scripts/vm/docs/aws-vm.md
@@ -196,8 +196,19 @@ Validates the full software stack: kernel, libvirt/QEMU, SBIOS, NVIDIA drivers.
 | `expected_driver_version` | string | *(none)* | NVIDIA driver version substring |
 | `expected_libvirt_version` | string | *(none)* | libvirt version substring |
 | `expected_bios_vendor` | string | *(none)* | BIOS vendor name |
+| `bios_baselines` | mapping | *(none)* | Approved BIOS minimums keyed by `system_vendor|product_name` |
 
-When no `expected_*` parameter is set, the check **reports** the value without failing.
+When no `expected_*` parameter or `bios_baselines` policy is set, the check **reports**
+the value without failing. To build a BIOS policy, run once in report-only mode to
+capture `system_vendor`, `system_product`, and `bios_version`, then configure the
+approved baseline:
+
+```yaml
+HostSoftwareCheck:
+  bios_baselines:
+    "Dell Inc.|PowerEdge R760xa":
+      min_version: "2.4.8"
+```
 
 ### InstanceRebootCheck
 

--- a/isvtest/src/isvtest/validations/host.py
+++ b/isvtest/src/isvtest/validations/host.py
@@ -45,6 +45,47 @@ from isvtest.core.ssh import (
 )
 from isvtest.core.validation import BaseValidation
 
+
+def _extract_numeric_version_parts(version: object) -> list[int]:
+    """Extract comparable numeric components from vendor version strings."""
+    return [int(part) for part in re.findall(r"\d+", str(version).strip())]
+
+
+def _numeric_version_at_least(actual: object, minimum: object) -> bool | None:
+    """Return whether ``actual`` is >= ``minimum``, or None when either cannot be parsed."""
+    actual_parts = _extract_numeric_version_parts(actual)
+    minimum_parts = _extract_numeric_version_parts(minimum)
+    if not actual_parts or not minimum_parts:
+        return None
+
+    width = max(len(actual_parts), len(minimum_parts))
+    actual_parts.extend([0] * (width - len(actual_parts)))
+    minimum_parts.extend([0] * (width - len(minimum_parts)))
+    return actual_parts >= minimum_parts
+
+
+def _check_bios_baseline(bios_baselines: dict, system_vendor: str, product: str, bios_version: str) -> tuple[bool, str]:
+    """Evaluate a BIOS version against the configured baseline for the host's vendor/product."""
+    baseline_key = f"{system_vendor}|{product}"
+    baseline = bios_baselines.get(baseline_key)
+    if baseline is None:
+        available = ", ".join(sorted(str(key) for key in bios_baselines)) or "<none>"
+        return False, f"No BIOS baseline for {baseline_key}; available baselines: {available}"
+
+    min_version = baseline.get("min_version")
+    if not min_version:
+        return False, f"BIOS baseline for {baseline_key} missing min_version"
+
+    version_ok = _numeric_version_at_least(bios_version, min_version)
+    if version_ok is None:
+        return False, (
+            f"Could not parse BIOS version for {baseline_key}: actual={bios_version!r}, min_version={min_version!r}"
+        )
+    if not version_ok:
+        return False, f"BIOS version {bios_version} is below minimum required {min_version}"
+    return True, f"BIOS version {bios_version} >= minimum {min_version} for {baseline_key}"
+
+
 # =============================================================================
 # Connectivity Validations
 # =============================================================================
@@ -613,6 +654,8 @@ class HostSoftwareCheck(BaseValidation):
         expected_driver_version: Expected NVIDIA driver version (optional, e.g. "550")
         expected_libvirt_version: Expected libvirt version substring (optional, e.g. "10.0")
         expected_bios_vendor: Expected BIOS vendor substring (optional, e.g. "Amazon")
+        bios_baselines: Optional mapping of "system_vendor|product_name" to
+            {"min_version": "<approved BIOS version>"}
     """
 
     description: ClassVar[str] = "Validates kernel, libvirt, SBIOS, and NVIDIA drivers"
@@ -635,6 +678,7 @@ class HostSoftwareCheck(BaseValidation):
         expected_driver = self.config.get("expected_driver_version")
         expected_libvirt = self.config.get("expected_libvirt_version")
         expected_bios_vendor = self.config.get("expected_bios_vendor")
+        bios_baselines = self.config.get("bios_baselines")
 
         if not host or not key_path:
             self.set_failed("Missing host or key_file")
@@ -753,6 +797,25 @@ class HostSoftwareCheck(BaseValidation):
             else:
                 self.report_subtest("bios_vendor", True, f"BIOS vendor: {bios_vendor}")
 
+            # System vendor / product for model-aware BIOS baseline matching
+            exit_code, stdout, _ = run_ssh_command(
+                ssh,
+                "cat /sys/class/dmi/id/sys_vendor 2>/dev/null "
+                "|| dmidecode -s system-manufacturer 2>/dev/null "
+                "|| echo 'unknown'",
+            )
+            system_vendor = stdout.strip() if exit_code == 0 else "unknown"
+            self.report_subtest("system_vendor", True, f"System vendor: {system_vendor}")
+
+            exit_code, stdout, _ = run_ssh_command(
+                ssh,
+                "cat /sys/class/dmi/id/product_name 2>/dev/null "
+                "|| dmidecode -s system-product-name 2>/dev/null "
+                "|| echo 'unknown'",
+            )
+            product = stdout.strip() if exit_code == 0 else "unknown"
+            self.report_subtest("system_product", True, f"Platform: {product}")
+
             # BIOS version
             exit_code, stdout, _ = run_ssh_command(
                 ssh,
@@ -763,6 +826,12 @@ class HostSoftwareCheck(BaseValidation):
             bios_version = stdout.strip() if exit_code == 0 else "unknown"
             self.report_subtest("bios_version", True, f"BIOS version: {bios_version}")
 
+            if bios_baselines is not None:
+                passed, message = _check_bios_baseline(bios_baselines, system_vendor, product, bios_version)
+                self.report_subtest("bios_baseline", passed, message)
+                if not passed:
+                    failures.append(message)
+
             # BIOS release date
             exit_code, stdout, _ = run_ssh_command(
                 ssh,
@@ -772,16 +841,6 @@ class HostSoftwareCheck(BaseValidation):
             )
             bios_date = stdout.strip() if exit_code == 0 else "unknown"
             self.report_subtest("bios_date", True, f"BIOS date: {bios_date}")
-
-            # System product / platform
-            exit_code, stdout, _ = run_ssh_command(
-                ssh,
-                "cat /sys/class/dmi/id/product_name 2>/dev/null "
-                "|| dmidecode -s system-product-name 2>/dev/null "
-                "|| echo 'unknown'",
-            )
-            product = stdout.strip() if exit_code == 0 else "unknown"
-            self.report_subtest("system_product", True, f"Platform: {product}")
 
             # UEFI vs legacy BIOS
             exit_code, stdout, _ = run_ssh_command(

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -1425,6 +1425,163 @@ class TestValidationResultCapture:
         assert r["passed"] is False
 
 
+class TestHostSoftwareCheckBiosBaselines:
+    """Tests for HostSoftwareCheck BIOS baseline enforcement."""
+
+    @staticmethod
+    def _run_response(
+        *,
+        bios_version: str,
+        system_vendor: str = "Dell Inc.",
+        product_name: str = "PowerEdge R760xa",
+    ):
+        def _response(ssh: MagicMock, cmd: str) -> tuple[int, str, str]:
+            if cmd == "uname -r":
+                return (0, "6.8.0-nvidia\n", "")
+            if cmd == "uname -v":
+                return (0, "#1 SMP PREEMPT_DYNAMIC\n", "")
+            if "lsmod" in cmd:
+                return (0, "nvidia\nkvm\n", "")
+            if "libvirtd --version" in cmd:
+                return (0, "not_installed\n", "")
+            if "qemu-system-x86_64" in cmd:
+                return (0, "not_installed\n", "")
+            if "test -c /dev/kvm" in cmd:
+                return (0, "kvm_available\n", "")
+            if "virsh version" in cmd:
+                return (0, "not_available\n", "")
+            if "bios_vendor" in cmd:
+                return (0, "Dell Inc.\n", "")
+            if "sys_vendor" in cmd or "system-manufacturer" in cmd:
+                return (0, f"{system_vendor}\n", "")
+            if "product_name" in cmd or "system-product-name" in cmd:
+                return (0, f"{product_name}\n", "")
+            if "bios_version" in cmd:
+                return (0, f"{bios_version}\n", "")
+            if "bios_date" in cmd or "bios-release-date" in cmd:
+                return (0, "03/12/2026\n", "")
+            if "test -d /sys/firmware/efi" in cmd:
+                return (0, "UEFI\n", "")
+            if "--query-gpu=driver_version" in cmd:
+                return (0, "550.54.15\n", "")
+            if "grep 'CUDA Version'" in cmd:
+                return (0, "12.4\n", "")
+            if "/sys/module/nvidia/version" in cmd:
+                return (0, "550.54.15\n", "")
+            if "--query-gpu=persistence_mode" in cmd:
+                return (0, "Enabled\n", "")
+            raise AssertionError(f"Unexpected SSH command: {cmd}")
+
+        return _response
+
+    @staticmethod
+    def _execute(
+        mock_ssh_cfg: MagicMock,
+        mock_run: MagicMock,
+        mock_ssh: MagicMock,
+        *,
+        bios_version: str,
+        config: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        from isvtest.validations.host import HostSoftwareCheck
+
+        mock_ssh_cfg.return_value = {
+            "ssh_host": "10.0.0.1",
+            "ssh_user": "ubuntu",
+            "ssh_key_path": "/tmp/k.pem",
+        }
+        mock_ssh.return_value = MagicMock()
+        mock_run.side_effect = TestHostSoftwareCheckBiosBaselines._run_response(bios_version=bios_version)
+
+        return HostSoftwareCheck(config=config or {}).execute()
+
+    @patch("isvtest.validations.host.get_ssh_client")
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_matching_bios_baseline_equal_version_passes(
+        self, mock_ssh_cfg: MagicMock, mock_run: MagicMock, mock_ssh: MagicMock
+    ) -> None:
+        config = {"bios_baselines": {"Dell Inc.|PowerEdge R760xa": {"min_version": "2.4.8"}}}
+
+        result = self._execute(mock_ssh_cfg, mock_run, mock_ssh, bios_version="2.4.8", config=config)
+
+        assert result["passed"] is True
+        assert any(subtest["name"] == "bios_baseline" and subtest["passed"] for subtest in result["subtests"])
+
+    @patch("isvtest.validations.host.get_ssh_client")
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_matching_bios_baseline_greater_version_passes(
+        self, mock_ssh_cfg: MagicMock, mock_run: MagicMock, mock_ssh: MagicMock
+    ) -> None:
+        config = {"bios_baselines": {"Dell Inc.|PowerEdge R760xa": {"min_version": "2.4.8"}}}
+
+        result = self._execute(mock_ssh_cfg, mock_run, mock_ssh, bios_version="BIOS-2.4.10", config=config)
+        baseline = next(subtest for subtest in result["subtests"] if subtest["name"] == "bios_baseline")
+
+        assert result["passed"] is True
+        assert "BIOS version BIOS-2.4.10 >= minimum 2.4.8" in baseline["message"]
+
+    @patch("isvtest.validations.host.get_ssh_client")
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_matching_bios_baseline_lower_version_fails(
+        self, mock_ssh_cfg: MagicMock, mock_run: MagicMock, mock_ssh: MagicMock
+    ) -> None:
+        config = {"bios_baselines": {"Dell Inc.|PowerEdge R760xa": {"min_version": "2.4.8"}}}
+
+        result = self._execute(mock_ssh_cfg, mock_run, mock_ssh, bios_version="2.4.7", config=config)
+
+        assert result["passed"] is False
+        assert "BIOS version 2.4.7 is below minimum required 2.4.8" in result["error"]
+
+    @patch("isvtest.validations.host.get_ssh_client")
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_configured_bios_baselines_require_matching_dmi_key(
+        self, mock_ssh_cfg: MagicMock, mock_run: MagicMock, mock_ssh: MagicMock
+    ) -> None:
+        config = {"bios_baselines": {"Other Vendor|Other Model": {"min_version": "2.4.8"}}}
+
+        result = self._execute(mock_ssh_cfg, mock_run, mock_ssh, bios_version="2.4.8", config=config)
+
+        assert result["passed"] is False
+        assert "No BIOS baseline for Dell Inc.|PowerEdge R760xa" in result["error"]
+
+    @pytest.mark.parametrize(
+        ("bios_version", "min_version"),
+        [("unknown", "2.4.8"), ("2.4.8", "latest")],
+    )
+    @patch("isvtest.validations.host.get_ssh_client")
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_unparseable_bios_baseline_versions_fail(
+        self,
+        mock_ssh_cfg: MagicMock,
+        mock_run: MagicMock,
+        mock_ssh: MagicMock,
+        bios_version: str,
+        min_version: str,
+    ) -> None:
+        config = {"bios_baselines": {"Dell Inc.|PowerEdge R760xa": {"min_version": min_version}}}
+
+        result = self._execute(mock_ssh_cfg, mock_run, mock_ssh, bios_version=bios_version, config=config)
+
+        assert result["passed"] is False
+        assert "Could not parse BIOS version for Dell Inc.|PowerEdge R760xa" in result["error"]
+
+    @patch("isvtest.validations.host.get_ssh_client")
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_bios_version_remains_report_only_without_baselines(
+        self, mock_ssh_cfg: MagicMock, mock_run: MagicMock, mock_ssh: MagicMock
+    ) -> None:
+        result = self._execute(mock_ssh_cfg, mock_run, mock_ssh, bios_version="vendor-build-current")
+
+        assert result["passed"] is True
+        assert not any(subtest["name"] == "bios_baseline" for subtest in result["subtests"])
+
+
 class TestCloudInitCheckMetadataHeaders:
     """Tests for CloudInitCheck metadata_headers parameter."""
 


### PR DESCRIPTION
## Summary

Extends `HostSoftwareCheck` with an opt-in BIOS baseline policy (ATTEST-XX-02 / P1). When `bios_baselines` is configured, the check compares the live BIOS version against a per-platform minimum keyed by `system_vendor|product_name` and fails the host when it falls below the approved baseline. Without `bios_baselines`, BIOS version remains report-only and existing configs are unaffected.

## Changes

- `isvtest/src/isvtest/validations/host.py`: add `bios_baselines` parameter to `HostSoftwareCheck`. Collects `sys_vendor` / `product_name` via DMI sysfs (with `dmidecode` fallback) and evaluates `bios_version` against `bios_baselines["<system_vendor>|<product_name>"]["min_version"]`. Version comparison is numeric-component based so vendor-prefixed strings (e.g. `BIOS-2.4.10`) compare correctly. Missing baseline entry, missing `min_version`, or unparseable versions all yield typed failure messages; unrelated subtests (kernel, drivers, etc.) are unchanged.
- `isvtest/tests/test_validation.py`: add `TestHostSoftwareCheckBiosBaselines` covering equal/greater/lower version cases, mismatched DMI key, unparseable actual/min versions, and the report-only path when `bios_baselines` is absent.
- `isvctl/configs/providers/aws/scripts/vm/docs/aws-vm.md`: document the new `bios_baselines` parameter, the report-only → policy bootstrap flow, and the YAML shape.
- Ships **unreleased**; `isvtest/src/isvtest/released_tests.json` intentionally untouched. Exercise via `ISVTEST_INCLUDE_UNRELEASED=1`.

## Validation

- [x] `make test` — full unit suite passes (new `TestHostSoftwareCheckBiosBaselines` cases included)
- [x] `make pre-commit` — clean
- [x] Manually verified pass/fail/unparseable paths via the new unit cases

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)