### PR TITLE
refactor: convert k8s validations and helpers to JSON parsing

### DIFF
--- a/isvtest/src/isvtest/core/k8s.py
+++ b/isvtest/src/isvtest/core/k8s.py
@@ -292,6 +292,19 @@ def pod_status_reason(pod: dict[str, Any]) -> str:
     return str(status.get("reason") or phase)
 
 
+def job_terminal_status(payload: dict[str, Any]) -> str | None:
+    """Return ``"Complete"`` or ``"Failed"`` if either appears in ``.status.conditions[].type``.
+
+    Returns ``None`` if the job has not yet reached a terminal condition.
+    """
+    types = {c.get("type") for c in (payload.get("status") or {}).get("conditions") or [] if isinstance(c, dict)}
+    if "Complete" in types:
+        return "Complete"
+    if "Failed" in types:
+        return "Failed"
+    return None
+
+
 def render_k8s_manifest(
     path: Path,
     mutate: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
@@ -446,20 +459,51 @@ def is_k8s_available() -> bool:
         return False
 
 
+def _parse_run_kubectl_json(result: subprocess.CompletedProcess[Any]) -> dict[str, Any] | None:
+    """Best-effort ``json.loads`` for ``run_kubectl(... -o json)`` stdout.
+
+    Returns ``None`` on empty or malformed output - callers that fall back to
+    sentinels (empty lists, ``"Unknown"``, ``0``) keep their old behaviour
+    rather than raising, since they cannot surface a validation failure.
+    """
+    if not result.stdout:
+        return None
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _items_from_run_kubectl(result: subprocess.CompletedProcess[Any]) -> list[dict[str, Any]]:
+    """Return the ``items`` list from ``run_kubectl(... -o json)`` (empty on failure)."""
+    payload = _parse_run_kubectl_json(result)
+    if payload is None:
+        return []
+    items = payload.get("items")
+    return [item for item in items if isinstance(item, dict)] if isinstance(items, list) else []
+
+
+def _node_names_from_kubectl(result: subprocess.CompletedProcess[Any]) -> list[str]:
+    """Extract node names from a ``kubectl get nodes -o json`` result."""
+    names: list[str] = []
+    for item in _items_from_run_kubectl(result):
+        name = (item.get("metadata") or {}).get("name")
+        if name:
+            names.append(str(name))
+    return names
+
+
 def get_gpu_nodes() -> list[str]:
     """Get list of GPU-enabled nodes in the cluster.
 
     Returns:
         List of node names that have GPUs available.
     """
-    result = run_kubectl(
-        ["get", "nodes", "-l", "nvidia.com/gpu.present=true", "-o", "jsonpath={.items[*].metadata.name}"]
-    )
+    result = run_kubectl(["get", "nodes", "-l", "nvidia.com/gpu.present=true", "-o", "json"])
     if result.returncode != 0:
         return []
-
-    nodes = result.stdout.strip().split()
-    return [node for node in nodes if node]
+    return _node_names_from_kubectl(result)
 
 
 def get_node_gpu_count(node_name: str) -> int:
@@ -471,13 +515,16 @@ def get_node_gpu_count(node_name: str) -> int:
     Returns:
         Number of GPUs available on the node, or 0 if none or error.
     """
-    result = run_kubectl(["get", "node", node_name, "-o", "jsonpath={.status.capacity.nvidia\\.com/gpu}"])
-    if result.returncode != 0 or not result.stdout.strip():
+    result = run_kubectl(["get", "node", node_name, "-o", "json"])
+    if result.returncode != 0:
         return 0
-
+    payload = _parse_run_kubectl_json(result)
+    if payload is None:
+        return 0
+    capacity = (payload.get("status") or {}).get("capacity") or {}
     try:
-        return int(result.stdout.strip())
-    except ValueError:
+        return int(capacity.get("nvidia.com/gpu") or 0)
+    except (TypeError, ValueError):
         return 0
 
 
@@ -508,12 +555,10 @@ def wait_for_pod_status(
     start_time = time.time()
 
     while time.time() - start_time < timeout:
-        result = run_kubectl(["get", "pod", pod_name, "-n", namespace, "-o", "jsonpath={.status.phase}"])
-
-        if result.returncode == 0:
-            current_phase = result.stdout.strip()
-            if current_phase == desired_phase:
-                return True
+        result = run_kubectl(["get", "pod", pod_name, "-n", namespace, "-o", "json"])
+        phase, _reason, _message = pod_state_from_result(result)
+        if phase == desired_phase:
+            return True
 
         time.sleep(0.5)
 
@@ -552,15 +597,12 @@ def wait_for_pod_completion(
     last_phase = "Unknown"
 
     while time.time() - start_time < timeout:
-        result = run_kubectl(["get", "pod", pod_name, "-n", namespace, "-o", "jsonpath={.status.phase}"])
-
-        if result.returncode == 0:
-            current_phase = result.stdout.strip()
-            last_phase = current_phase
-
-            # Check if pod reached a terminal state
-            if current_phase in ["Succeeded", "Failed"]:
-                return True, current_phase
+        result = run_kubectl(["get", "pod", pod_name, "-n", namespace, "-o", "json"])
+        phase, _reason, _message = pod_state_from_result(result)
+        if phase not in ("Unknown", "NotFound"):
+            last_phase = phase
+        if phase in ("Succeeded", "Failed"):
+            return True, phase
 
         time.sleep(0.5)
 
@@ -728,68 +770,20 @@ def wait_for_job_completion(
 
     while time.time() - start_time < timeout:
         # Check job conditions for Complete or Failed status
-        result = run_kubectl(
-            [
-                "get",
-                "job",
-                job_name,
-                "-n",
-                namespace,
-                "-o",
-                "jsonpath={.status.conditions[*].type}",
-            ]
-        )
-
-        if result.returncode == 0 and result.stdout.strip():
-            conditions = result.stdout.strip().split()
-
-            # Check if job has Complete or Failed condition
-            if "Complete" in conditions:
-                return True, "Complete"
-            if "Failed" in conditions:
-                return True, "Failed"
-
-            last_status = "Running" if conditions else "Pending"
+        result = run_kubectl(["get", "job", job_name, "-n", namespace, "-o", "json"])
+        job_payload = _parse_run_kubectl_json(result) if result.returncode == 0 else None
+        if job_payload is not None:
+            terminal = job_terminal_status(job_payload)
+            if terminal is not None:
+                return True, terminal
+            has_conditions = bool((job_payload.get("status") or {}).get("conditions"))
+            last_status = "Running" if has_conditions else "Pending"
 
         # Get pod status for better visibility
-        pod_status_result = run_kubectl(
-            [
-                "get",
-                "pods",
-                "-l",
-                f"job-name={job_name}",
-                "-n",
-                namespace,
-                "-o",
-                "jsonpath={.items[0].status.phase} {.items[0].status.containerStatuses[*].state}",
-            ]
-        )
-
-        pod_info = "No pods"
-        if pod_status_result.returncode == 0 and pod_status_result.stdout.strip():
-            parts = pod_status_result.stdout.strip().split(maxsplit=1)
-            pod_phase = parts[0] if parts else "Unknown"
-
-            # Count running containers if we have container status
-            if len(parts) > 1:
-                container_states = parts[1]
-                running_count = container_states.count("map[running:")
-                waiting_count = container_states.count("map[waiting:")
-                terminated_count = container_states.count("map[terminated:")
-                total = running_count + waiting_count + terminated_count
-
-                if running_count > 0:
-                    pod_info = f"Pod: {pod_phase}, Containers: {running_count}/{total} running"
-                elif waiting_count > 0:
-                    pod_info = f"Pod: {pod_phase}, Containers: {waiting_count}/{total} waiting"
-                else:
-                    pod_info = f"Pod: {pod_phase}"
-            else:
-                pod_info = f"Pod: {pod_phase}"
-
-            # Update last_status based on pod phase if we don't have conditions
-            if not result.stdout.strip():
-                last_status = pod_phase
+        pod_status_result = run_kubectl(["get", "pods", "-l", f"job-name={job_name}", "-n", namespace, "-o", "json"])
+        pod_info, pod_phase = _format_job_pod_info(pod_status_result)
+        if job_payload is None and pod_phase:
+            last_status = pod_phase
 
         # Log status every 30 seconds
         current_time = time.time()
@@ -804,6 +798,36 @@ def wait_for_job_completion(
     return False, last_status
 
 
+def _format_job_pod_info(result: subprocess.CompletedProcess[Any]) -> tuple[str, str]:
+    """Render a "Pod: <phase>, Containers: <r>/<t> running" line plus the bare pod phase.
+
+    Returns ``(info_str, phase)`` - ``phase`` is empty when there is no first pod.
+    """
+    if result.returncode != 0:
+        return "No pods", ""
+    pods = _items_from_run_kubectl(result)
+    if not pods:
+        return "No pods", ""
+    first_status = pods[0].get("status") or {}
+    pod_phase = first_status.get("phase") or "Unknown"
+    container_statuses = first_status.get("containerStatuses") or []
+    if not container_statuses:
+        return f"Pod: {pod_phase}", pod_phase
+    counters = {"running": 0, "waiting": 0, "terminated": 0}
+    for status in container_statuses:
+        state = status.get("state") or {}
+        for key in counters:
+            if state.get(key):
+                counters[key] += 1
+                break
+    total = sum(counters.values())
+    if counters["running"]:
+        return f"Pod: {pod_phase}, Containers: {counters['running']}/{total} running", pod_phase
+    if counters["waiting"]:
+        return f"Pod: {pod_phase}, Containers: {counters['waiting']}/{total} waiting", pod_phase
+    return f"Pod: {pod_phase}", pod_phase
+
+
 def get_job_pods(job_name: str, namespace: str) -> list[str]:
     """Get list of pod names for a specific job.
 
@@ -814,24 +838,15 @@ def get_job_pods(job_name: str, namespace: str) -> list[str]:
     Returns:
         List of pod names belonging to the job.
     """
-    result = run_kubectl(
-        [
-            "get",
-            "pods",
-            "-n",
-            namespace,
-            "-l",
-            f"job-name={job_name}",
-            "-o",
-            "jsonpath={.items[*].metadata.name}",
-        ]
-    )
-
+    result = run_kubectl(["get", "pods", "-n", namespace, "-l", f"job-name={job_name}", "-o", "json"])
     if result.returncode != 0:
         return []
-
-    pods = result.stdout.strip().split()
-    return [pod for pod in pods if pod]
+    names: list[str] = []
+    for pod in _items_from_run_kubectl(result):
+        name = (pod.get("metadata") or {}).get("name")
+        if name:
+            names.append(str(name))
+    return names
 
 
 def delete_job(job_name: str, namespace: str, wait: bool = True) -> bool:
@@ -884,36 +899,22 @@ def wait_for_multiple_pods_completion(
     """
     start_time = time.time()
     results = {pod_name: (False, "Unknown") for pod_name in pod_names}
-    completed_pods = set()
+    wanted = set(pod_names)
+    completed_pods: set[str] = set()
 
     while time.time() - start_time < timeout:
-        # Check all pods at once using label selector or field selector
-        # Get status of all pods in one call
-        result = run_kubectl(
-            [
-                "get",
-                "pods",
-                "-n",
-                namespace,
-                "-o",
-                'jsonpath={range .items[*]}{.metadata.name}{"\\t"}{.status.phase}{"\\n"}{end}',
-            ]
-        )
+        result = run_kubectl(["get", "pods", "-n", namespace, "-o", "json"])
 
         if result.returncode == 0:
-            # Parse output: "pod-name\tPhase\n"
-            for line in result.stdout.strip().split("\n"):
-                if not line:
+            for pod in _items_from_run_kubectl(result):
+                name = (pod.get("metadata") or {}).get("name")
+                if name not in wanted:
                     continue
-                parts = line.split("\t")
-                if len(parts) == 2:
-                    pod_name, phase = parts
-                    if pod_name in pod_names:
-                        if phase in ["Succeeded", "Failed"]:
-                            results[pod_name] = (True, phase)
-                            completed_pods.add(pod_name)
+                phase = str((pod.get("status") or {}).get("phase") or "")
+                if phase in ("Succeeded", "Failed"):
+                    results[name] = (True, phase)
+                    completed_pods.add(name)
 
-        # Check if all pods completed
         if len(completed_pods) == len(pod_names):
             return results
 
@@ -929,12 +930,10 @@ def get_all_nodes() -> list[str]:
     Returns:
         List of all node names in the cluster.
     """
-    result = run_kubectl(["get", "nodes", "-o", "jsonpath={.items[*].metadata.name}"])
+    result = run_kubectl(["get", "nodes", "-o", "json"])
     if result.returncode != 0:
         return []
-
-    nodes = result.stdout.strip().split()
-    return [node for node in nodes if node]
+    return _node_names_from_kubectl(result)
 
 
 def get_node_status(node_name: str) -> str:
@@ -947,13 +946,16 @@ def get_node_status(node_name: str) -> str:
         Node status string (e.g., 'Ready', 'NotReady', 'Unknown').
         Returns 'Unknown' if unable to determine status.
     """
-    result = run_kubectl(["get", "node", node_name, "-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}"])
-    if result.returncode != 0 or not result.stdout.strip():
+    result = run_kubectl(["get", "node", node_name, "-o", "json"])
+    if result.returncode != 0:
         return "Unknown"
-
-    # Status will be "True" or "False" - convert to Ready/NotReady
-    status = result.stdout.strip()
-    return "Ready" if status == "True" else "NotReady"
+    payload = _parse_run_kubectl_json(result)
+    if payload is None:
+        return "Unknown"
+    for condition in (payload.get("status") or {}).get("conditions") or []:
+        if isinstance(condition, dict) and condition.get("type") == "Ready":
+            return "Ready" if condition.get("status") == "True" else "NotReady"
+    return "Unknown"
 
 
 def get_nodes_with_status() -> dict[str, str]:

--- a/isvtest/src/isvtest/core/k8s.py
+++ b/isvtest/src/isvtest/core/k8s.py
@@ -20,11 +20,15 @@ import subprocess
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
 from isvtest.core.logger import setup_logger
+from isvtest.core.runners import CommandResult
+
+if TYPE_CHECKING:
+    from isvtest.core.validation import BaseValidation
 
 logger = setup_logger(__name__)
 
@@ -198,6 +202,96 @@ def get_kubectl_base_shell(*args: str) -> str:
     return " ".join(shlex.quote(part) for part in (*get_kubectl_command(), *args))
 
 
+class KubectlParseError(Exception):
+    """Raised when ``kubectl ... -o json`` output cannot be parsed."""
+
+
+def parse_kubectl_json(
+    result: CommandResult,
+    resource: str = "kubectl JSON output",
+) -> dict[str, Any]:
+    """Parse ``kubectl ... -o json`` stdout into a JSON object.
+
+    Raises ``KubectlParseError`` on malformed output. Command exit-code
+    handling stays with callers so they can keep resource-specific
+    failure messages.
+    """
+    stdout = result.stdout.strip()
+    if not stdout:
+        raise KubectlParseError(f"Failed to parse {resource}: empty stdout")
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise KubectlParseError(f"Failed to parse {resource}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise KubectlParseError(f"Failed to parse {resource}: expected JSON object, got {type(payload).__name__}")
+    return payload
+
+
+def parse_kubectl_json_items(
+    result: CommandResult,
+    resource: str = "kubectl JSON list output",
+) -> list[dict[str, Any]]:
+    """Extract the ``items`` list from a ``kubectl get ... -o json`` result.
+
+    Raises ``KubectlParseError`` if the payload is malformed or ``items`` is
+    missing/wrongly typed.
+    """
+    payload = parse_kubectl_json(result, resource)
+    items = payload.get("items")
+    if not isinstance(items, list):
+        raise KubectlParseError(f"Failed to parse {resource}: expected 'items' list")
+    if any(not isinstance(item, dict) for item in items):
+        raise KubectlParseError(f"Failed to parse {resource}: expected object entries in 'items'")
+    return items
+
+
+def kubectl_items_or_fail(
+    validation: "BaseValidation",
+    result: CommandResult,
+    resource: str,
+    *,
+    exec_label: str | None = None,
+) -> list[dict[str, Any]] | None:
+    """Parse ``kubectl get ... -o json`` items, routing failures to ``validation.set_failed``.
+
+    Returns the items list on success, or ``None`` after marking the validation
+    failed when the command exited non-zero or returned unparseable JSON.
+
+    ``exec_label`` overrides the noun used in the exec-failure message
+    (``"Failed to get {label}: ..."``) when callers want wording other than the
+    parse-error ``resource`` (e.g. ``"node count"`` vs ``"node list"``).
+    """
+    if result.exit_code != 0:
+        label = exec_label or resource
+        validation.set_failed(f"Failed to get {label}: {result.stderr}")
+        return None
+    try:
+        return parse_kubectl_json_items(result, resource)
+    except KubectlParseError as exc:
+        validation.set_failed(str(exc))
+        return None
+
+
+def pod_status_reason(pod: dict[str, Any]) -> str:
+    """Return a kubectl-like pod status reason from structured pod JSON."""
+    status = pod.get("status") or {}
+    phase = status.get("phase") or "Unknown"
+    for key in ("initContainerStatuses", "containerStatuses"):
+        for container_status in status.get(key) or []:
+            state = container_status.get("state") or {}
+            waiting_reason = (state.get("waiting") or {}).get("reason")
+            if waiting_reason:
+                return waiting_reason
+            terminated_reason = (state.get("terminated") or {}).get("reason")
+            if terminated_reason and terminated_reason != "Completed":
+                return terminated_reason
+    # Fall back to ``.status.reason`` (e.g. "Evicted", "NodeLost", "Shutdown")
+    # before the bare phase so the kubectl STATUS column wording is preserved
+    # for pods without informative container state.
+    return str(status.get("reason") or phase)
+
+
 def render_k8s_manifest(
     path: Path,
     mutate: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
@@ -255,6 +349,25 @@ def parse_pod_state(stdout: str, stderr: str) -> tuple[str, str, str]:
     statuses = status.get("containerStatuses") or []
     waiting = ((statuses[0].get("state") if statuses else {}) or {}).get("waiting") or {}
     return phase, waiting.get("reason") or "", waiting.get("message") or ""
+
+
+def pod_state_from_result(
+    result: "CommandResult | subprocess.CompletedProcess[Any]",
+) -> tuple[str, str, str]:
+    """Parse pod state from a ``kubectl get pod -o json`` result.
+
+    Accepts either a ``CommandResult`` (validations) or a
+    ``subprocess.CompletedProcess`` (core helpers). Returns the same
+    ``(phase, waiting_reason, waiting_message)`` tuple as
+    ``parse_pod_state``: on failure only stderr is inspected (for NotFound
+    detection); on success only stdout is parsed.
+    """
+    exit_code = getattr(result, "exit_code", None)
+    if exit_code is None:
+        exit_code = result.returncode  # subprocess.CompletedProcess
+    if exit_code == 0:
+        return parse_pod_state(result.stdout, "")
+    return parse_pod_state("", result.stderr or "")
 
 
 def parse_server_version(stdout: str) -> str | None:

--- a/isvtest/src/isvtest/core/k8s.py
+++ b/isvtest/src/isvtest/core/k8s.py
@@ -915,7 +915,7 @@ def wait_for_multiple_pods_completion(
                     results[name] = (True, phase)
                     completed_pods.add(name)
 
-        if len(completed_pods) == len(pod_names):
+        if len(completed_pods) == len(wanted):
             return results
 
         time.sleep(0.5)

--- a/isvtest/src/isvtest/core/ngc.py
+++ b/isvtest/src/isvtest/core/ngc.py
@@ -22,7 +22,7 @@ import time
 import uuid
 from typing import Any
 
-from isvtest.core.k8s import get_kubectl_command, run_kubectl
+from isvtest.core.k8s import get_kubectl_command, job_terminal_status, run_kubectl
 from isvtest.core.logger import setup_logger
 
 logger = setup_logger(__name__)
@@ -232,17 +232,20 @@ spec:
 
         for _ in range(timeout // 5):
             time.sleep(5)
-            result = run_kubectl(
-                ["get", "job", job_name, "-n", namespace, "-o", "jsonpath={.status.conditions[*].type}"],
-                timeout=10,
-            )
-            if result.returncode == 0:
-                if "Complete" in result.stdout:
-                    job_completed = True
-                    break
-                if "Failed" in result.stdout:
-                    job_failed = True
-                    break
+            result = run_kubectl(["get", "job", job_name, "-n", namespace, "-o", "json"], timeout=10)
+            if result.returncode != 0:
+                continue
+            try:
+                payload = json.loads(result.stdout)
+            except json.JSONDecodeError:
+                continue
+            terminal = job_terminal_status(payload)
+            if terminal == "Complete":
+                job_completed = True
+                break
+            if terminal == "Failed":
+                job_failed = True
+                break
 
         if not job_completed and not job_failed:
             return False, f"Inference test timed out after {timeout}s"

--- a/isvtest/src/isvtest/core/workload.py
+++ b/isvtest/src/isvtest/core/workload.py
@@ -12,7 +12,14 @@ import subprocess
 import time
 from typing import Any, ClassVar
 
-from isvtest.core.k8s import get_kubectl_base_shell, get_kubectl_command
+from isvtest.core.k8s import (
+    KubectlParseError,
+    get_kubectl_base_shell,
+    get_kubectl_command,
+    job_terminal_status,
+    parse_kubectl_json,
+    parse_kubectl_json_items,
+)
 from isvtest.core.runners import CommandResult, Runner
 from isvtest.core.validation import BaseValidation
 
@@ -82,18 +89,17 @@ class BaseWorkloadCheck(BaseValidation):
         while time.time() < end_time:
             time.sleep(5)
 
-            # Check job conditions
-            cmd = f"{kubectl_base} get job {job_name} -n {namespace} -o jsonpath='{{.status.conditions[*].type}}'"
-            res = self.runner.run(cmd)
-
-            if res.exit_code == 0 and res.stdout:
-                conditions = res.stdout.strip().split()
-                if "Complete" in conditions:
-                    job_status = "Complete"
-                    break
-                if "Failed" in conditions:
-                    job_status = "Failed"
-                    break
+            res = self.runner.run(f"{kubectl_base} get job {job_name} -n {namespace} -o json")
+            if res.exit_code != 0:
+                continue
+            try:
+                payload = parse_kubectl_json(res, f"job {job_name!r}")
+            except KubectlParseError:
+                continue
+            terminal = job_terminal_status(payload)
+            if terminal is not None:
+                job_status = terminal
+                break
 
         duration = time.time() - start_time
 
@@ -117,16 +123,21 @@ class BaseWorkloadCheck(BaseValidation):
         self.log.info(f"Collecting logs for job {job_name}...")
 
         # Find pod
-        cmd = f"{kubectl_base} get pods -n {namespace} -l job-name={job_name} -o jsonpath='{{.items[0].metadata.name}}'"
-        pod_res = self.runner.run(cmd)
+        pod_res = self.runner.run(f"{kubectl_base} get pods -n {namespace} -l job-name={job_name} -o json")
 
         logs_stdout = ""
         logs_stderr = ""
+        pod_name = ""
+        if pod_res.exit_code == 0:
+            try:
+                pods = parse_kubectl_json_items(pod_res, f"pods for job {job_name!r}")
+            except KubectlParseError:
+                pods = []
+            if pods:
+                pod_name = str((pods[0].get("metadata") or {}).get("name") or "")
 
-        if pod_res.exit_code == 0 and pod_res.stdout:
-            pod_name = pod_res.stdout.strip()
-            logs_cmd = f"{kubectl_base} logs {pod_name} -n {namespace}"
-            logs_res = self.runner.run(logs_cmd)
+        if pod_name:
+            logs_res = self.runner.run(f"{kubectl_base} logs {pod_name} -n {namespace}")
             logs_stdout = logs_res.stdout
             logs_stderr = logs_res.stderr
         else:

--- a/isvtest/src/isvtest/validations/k8s_api_network_acl.py
+++ b/isvtest/src/isvtest/validations/k8s_api_network_acl.py
@@ -285,8 +285,10 @@ class K8sApiNetworkAclCheck(BaseValidation):
         except KubectlParseError as exc:
             self.log.warning("Failed to parse kubectl config JSON: %s", exc)
             return None
-        clusters = payload.get("clusters") or [{}]
-        server = (clusters[0].get("cluster") or {}).get("server") or ""
+        clusters = payload.get("clusters")
+        if not isinstance(clusters, list) or not clusters or not isinstance(clusters[0], dict):
+            return None
+        server = ((clusters[0].get("cluster") or {}).get("server")) or ""
         return server.strip() or None
 
     def _run_authorized_probe(self, authorized_probe_cmd: str, probe_timeout_s: int) -> bool:

--- a/isvtest/src/isvtest/validations/k8s_api_network_acl.py
+++ b/isvtest/src/isvtest/validations/k8s_api_network_acl.py
@@ -18,7 +18,7 @@ from urllib.parse import urlsplit
 
 import pytest
 
-from isvtest.core.k8s import get_kubectl_base_shell
+from isvtest.core.k8s import KubectlParseError, get_kubectl_base_shell, parse_kubectl_json
 from isvtest.core.validation import BaseValidation
 from isvtest.utils.checks import truncate
 
@@ -276,17 +276,18 @@ class K8sApiNetworkAclCheck(BaseValidation):
         check on its own; the auth probe already established that kubectl
         works.
         """
-        cmd = get_kubectl_base_shell(
-            "config",
-            "view",
-            "--minify",
-            "-o",
-            "jsonpath={.clusters[0].cluster.server}",
-        )
+        cmd = get_kubectl_base_shell("config", "view", "--minify", "-o", "json")
         result = self.run_command(cmd, timeout=probe_timeout_s)
         if result.exit_code != 0:
             return None
-        return result.stdout.strip() or None
+        try:
+            payload = parse_kubectl_json(result, "kubectl config view")
+        except KubectlParseError as exc:
+            self.log.warning("Failed to parse kubectl config JSON: %s", exc)
+            return None
+        clusters = payload.get("clusters") or [{}]
+        server = (clusters[0].get("cluster") or {}).get("server") or ""
+        return server.strip() or None
 
     def _run_authorized_probe(self, authorized_probe_cmd: str, probe_timeout_s: int) -> bool:
         """Run the authorized baseline probe and report failure on non-zero exit.

--- a/isvtest/src/isvtest/validations/k8s_cluster.py
+++ b/isvtest/src/isvtest/validations/k8s_cluster.py
@@ -10,7 +10,11 @@
 
 from typing import ClassVar
 
-from isvtest.core.k8s import get_kubectl_base_shell
+from isvtest.core.k8s import (
+    get_kubectl_base_shell,
+    kubectl_items_or_fail,
+    pod_status_reason,
+)
 from isvtest.core.validation import BaseValidation
 
 
@@ -24,27 +28,22 @@ class K8sPodHealthCheck(BaseValidation):
 
         kubectl_base = get_kubectl_base_shell()
 
-        # We generally query for everything NOT running/succeeded
-        cmd = f"{kubectl_base} get pods -A --no-headers --field-selector status.phase!=Running,status.phase!=Succeeded"
-        result = self.run_command(cmd)
-
-        if result.exit_code != 0:
-            self.set_failed(f"Failed to get pod status: {result.stderr}")
+        result = self.run_command(f"{kubectl_base} get pods -A -o json")
+        pods = kubectl_items_or_fail(self, result, "pod list", exec_label="pod status")
+        if pods is None:
             return
 
         unhealthy_pods = []
-        for line in result.stdout.splitlines():
-            if not line.strip():
+        for pod in pods:
+            metadata = pod.get("metadata") or {}
+            status = (pod.get("status") or {}).get("phase") or "Unknown"
+
+            if status in ignore_phases:
                 continue
-            parts = line.split()
-            if len(parts) >= 4:
-                namespace = parts[0]
-                name = parts[1]
-                status = parts[3]
 
-                if status in ignore_phases:
-                    continue
-
+            if status not in {"Running", "Succeeded"}:
+                namespace = metadata.get("namespace", "default")
+                name = metadata.get("name", "unknown")
                 unhealthy_pods.append(f"{namespace}/{name} ({status})")
 
         if unhealthy_pods:
@@ -64,19 +63,17 @@ class K8sNoPendingPodsCheck(BaseValidation):
     def run(self) -> None:
         kubectl_base = get_kubectl_base_shell()
 
-        cmd = f"{kubectl_base} get pods -A --field-selector status.phase=Pending --no-headers"
-        result = self.run_command(cmd)
-
-        if result.exit_code != 0:
-            self.set_failed(f"Failed to get pending pods: {result.stderr}")
+        result = self.run_command(f"{kubectl_base} get pods -A -o json")
+        pods = kubectl_items_or_fail(self, result, "pod list", exec_label="pending pods")
+        if pods is None:
             return
 
         pending_pods = []
-        for line in result.stdout.splitlines():
-            if line.strip():
-                parts = line.split()
-                if len(parts) >= 2:
-                    pending_pods.append(f"{parts[0]}/{parts[1]}")
+        for pod in pods:
+            if (pod.get("status") or {}).get("phase") != "Pending":
+                continue
+            metadata = pod.get("metadata") or {}
+            pending_pods.append(f"{metadata.get('namespace', 'default')}/{metadata.get('name', 'unknown')}")
 
         if pending_pods:
             self.set_failed(f"Found {len(pending_pods)} pending pods: {', '.join(pending_pods)}")
@@ -104,26 +101,20 @@ class K8sNoErrorPodsCheck(BaseValidation):
             ],
         )
 
-        cmd = f"{kubectl_base} get pods -A --no-headers"
-        result = self.run_command(cmd)
-
-        if result.exit_code != 0:
-            self.set_failed(f"Failed to get pods: {result.stderr}")
+        result = self.run_command(f"{kubectl_base} get pods -A -o json")
+        pods = kubectl_items_or_fail(self, result, "pod list", exec_label="pods")
+        if pods is None:
             return
 
         error_pods = []
-        for line in result.stdout.splitlines():
-            if not line.strip():
-                continue
-            # Output format: NAMESPACE NAME READY STATUS RESTARTS AGE
-            parts = line.split()
-            if len(parts) >= 4:
-                namespace = parts[0]
-                name = parts[1]
-                status = parts[3]
+        for pod in pods:
+            metadata = pod.get("metadata") or {}
+            status = pod_status_reason(pod)
 
-                if status in error_states:
-                    error_pods.append(f"{namespace}/{name} ({status})")
+            if status in error_states:
+                namespace = metadata.get("namespace", "default")
+                name = metadata.get("name", "unknown")
+                error_pods.append(f"{namespace}/{name} ({status})")
 
         if error_pods:
             self.set_failed(f"Found {len(error_pods)} pods in error state: {', '.join(error_pods)}")

--- a/isvtest/src/isvtest/validations/k8s_conformance.py
+++ b/isvtest/src/isvtest/validations/k8s_conformance.py
@@ -40,8 +40,8 @@ from isvtest.core.k8s import (
     TRANSIENT_WAITING_REASONS,
     get_kubectl_base_shell,
     is_k8s_available,
-    parse_pod_state,
     parse_server_version,
+    pod_state_from_result,
 )
 from isvtest.core.validation import BaseValidation
 
@@ -369,10 +369,7 @@ class K8sCncfConformanceCheck(BaseValidation):
     def _get_pod_state(self, namespace: str, pod_name: str) -> tuple[str, str, str]:
         """Fetch ``(phase, waiting_reason, waiting_message)`` in one kubectl call."""
         cmd = get_kubectl_base_shell("get", "pod", pod_name, "-n", namespace, "-o", "json")
-        result = self.run_command(cmd, timeout=self._AUX_CMD_TIMEOUT)
-        if result.exit_code != 0:
-            return parse_pod_state("", result.stderr or "")
-        return parse_pod_state(result.stdout, "")
+        return pod_state_from_result(self.run_command(cmd, timeout=self._AUX_CMD_TIMEOUT))
 
     def _exec_cat(
         self,

--- a/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
+++ b/isvtest/src/isvtest/validations/k8s_control_plane_logs.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import shlex
 from typing import Any, ClassVar
 
-from isvtest.core.k8s import get_kubectl_base_shell
+from isvtest.core.k8s import KubectlParseError, get_kubectl_base_shell, parse_kubectl_json_items
 from isvtest.core.validation import BaseValidation
 from isvtest.utils.checks import truncate
 
@@ -321,31 +321,34 @@ class K8sControlPlaneLogsCheck(BaseValidation):
     def _find_component_pods(self, namespace: str, components: list[str]) -> tuple[dict[str, str], str | None]:
         """Return ``({component: pod_name}, probe_error)`` for the namespace.
 
-        Resolution runs from a single ``kubectl get pods`` call that emits
-        ``<pod_name>\\t<component_label>`` per line - label matching and
-        the name-prefix fallback are both resolved client-side from that
-        one response, so the cost is one round-trip regardless of how
-        many components are requested.
+        Resolution runs from a single ``kubectl get pods -o json`` call.
+        Label matching and the name-prefix fallback are both resolved
+        client-side from that one response, so the cost is one round-trip
+        regardless of how many components are requested.
 
         ``probe_error`` carries the stderr when the call fails, so auto-
         mode can distinguish "cluster reachable but control plane is
         hidden" from "kubectl itself is broken".
         """
         kubectl_base = get_kubectl_base_shell()
-        jsonpath = r"""{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.component}{"\n"}{end}"""
-        cmd = f"{kubectl_base} get pods -n {shlex.quote(namespace)} -o jsonpath={shlex.quote(jsonpath)}"
+        cmd = f"{kubectl_base} get pods -n {shlex.quote(namespace)} -o json"
         result = self.run_command(cmd)
         if result.exit_code != 0:
             probe_error = result.stderr.strip() or result.stdout.strip() or f"exit code {result.exit_code}"
             return {}, probe_error
 
+        try:
+            items = parse_kubectl_json_items(result, f"pod list in namespace {namespace!r}")
+        except KubectlParseError as exc:
+            return {}, str(exc)
+
         pods: list[tuple[str, str]] = []
-        for line in result.stdout.splitlines():
-            if not line.strip():
-                continue
-            pod_name, _, label = line.partition("\t")
-            pod_name = pod_name.strip()
+        for item in items:
+            metadata = item.get("metadata") or {}
+            pod_name = str(metadata.get("name") or "").strip()
             if pod_name:
+                labels = metadata.get("labels") or {}
+                label = str(labels.get("component") or "") if isinstance(labels, dict) else ""
                 pods.append((pod_name, label.strip()))
 
         found: dict[str, str] = {}

--- a/isvtest/src/isvtest/validations/k8s_gpu.py
+++ b/isvtest/src/isvtest/validations/k8s_gpu.py
@@ -15,7 +15,11 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import ClassVar
 
 from isvtest.config.settings import get_k8s_namespace
-from isvtest.core.k8s import get_kubectl_base_shell
+from isvtest.core.k8s import (
+    get_kubectl_base_shell,
+    kubectl_items_or_fail,
+    pod_state_from_result,
+)
 from isvtest.core.nvidia import count_gpus_from_full_output, parse_driver_version
 from isvtest.core.validation import BaseValidation
 
@@ -28,6 +32,9 @@ class K8sNvidiaSmiCheck(BaseValidation):
         # Configurable timeout, defaulting to 60 seconds for robustness
         timeout = int(self.config.get("timeout", 60))
         results = self._run_ephemeral_pods(timeout=timeout)
+        if results is None:
+            # ``_run_ephemeral_pods`` already routed the failure via set_failed.
+            return
 
         failed_nodes = []
         for node, res in results.items():
@@ -47,20 +54,24 @@ class K8sNvidiaSmiCheck(BaseValidation):
         else:
             self.set_passed(f"nvidia-smi check passed on all {len(results)} GPU nodes")
 
-    def _run_ephemeral_pods(self, timeout: int = 60) -> dict[str, dict]:
-        """Run ephemeral pods on all GPU nodes and return results."""
+    def _run_ephemeral_pods(self, timeout: int = 60) -> dict[str, dict] | None:
+        """Run ephemeral pods on all GPU nodes and return results.
+
+        Returns ``None`` (after ``set_failed``) when the GPU-node lookup
+        fails, distinguishing it from an empty cluster which returns ``{}``.
+        """
         kubectl_base = get_kubectl_base_shell()
         namespace = get_k8s_namespace()
 
         # 1. Identify GPU nodes
-        cmd = f"{kubectl_base} get nodes -l nvidia.com/gpu.present=true -o jsonpath='{{.items[*].metadata.name}}'"
-        result = self.run_command(cmd)
+        result = self.run_command(f"{kubectl_base} get nodes -l nvidia.com/gpu.present=true -o json")
+        nodes = kubectl_items_or_fail(self, result, "GPU node list", exec_label="GPU nodes")
+        if nodes is None:
+            return None
 
-        if result.exit_code != 0:
-            self.set_failed(f"Failed to discover GPU nodes: {result.stderr}")
-            return {}
-
-        gpu_nodes = result.stdout.strip().split()
+        gpu_nodes = [
+            str((node.get("metadata") or {}).get("name")) for node in nodes if (node.get("metadata") or {}).get("name")
+        ]
         if not gpu_nodes:
             self.log.warning("No GPU nodes found with label nvidia.com/gpu.present=true")
             return {}
@@ -149,18 +160,21 @@ class K8sNvidiaSmiCheck(BaseValidation):
         while time.time() < end_time:
             time.sleep(1)
             wait_count += 1
-            get_pod_cmd = f"{kubectl_base} get pod {pod_name} -n {namespace} -o jsonpath='{{.status.phase}}'"
+            get_pod_cmd = f"{kubectl_base} get pod {pod_name} -n {namespace} -o json"
             status_res = self.run_command(get_pod_cmd)
 
-            phase = status_res.stdout.strip()
+            phase, waiting_reason, waiting_message = pod_state_from_result(status_res)
+            detail = f", waiting={waiting_reason}" if waiting_reason else ""
 
             # Log phase changes and periodic updates for stuck pods
-            if phase != last_logged_phase:
-                self.log.info(f"Pod {pod_name} on node {node}: phase={phase}")
-                last_logged_phase = phase
+            if (phase, waiting_reason) != last_logged_phase:
+                self.log.info(f"Pod {pod_name} on node {node}: phase={phase}{detail}")
+                if waiting_message:
+                    self.log.debug("Pod %s waiting message: %s", pod_name, waiting_message)
+                last_logged_phase = (phase, waiting_reason)
             elif wait_count % 30 == 0:  # Log every 30 seconds if stuck
                 elapsed = int(time.time() - start_time)
-                self.log.warning(f"Pod {pod_name} on node {node} still in phase={phase} after {elapsed}s")
+                self.log.warning(f"Pod {pod_name} on node {node} still in phase={phase}{detail} after {elapsed}s")
 
             if phase == "Succeeded":
                 logs_cmd = f"{kubectl_base} logs {pod_name} -n {namespace}"
@@ -182,9 +196,10 @@ class K8sNvidiaSmiCheck(BaseValidation):
                 break
         else:
             # Timed out - get more details for debugging
-            get_pod_cmd = f"{kubectl_base} get pod {pod_name} -n {namespace} -o jsonpath='{{.status.phase}}'"
+            get_pod_cmd = f"{kubectl_base} get pod {pod_name} -n {namespace} -o json"
             status_res = self.run_command(get_pod_cmd)
-            phase = status_res.stdout.strip()
+            phase, waiting_reason, _waiting_message = pod_state_from_result(status_res)
+            detail = f" ({waiting_reason})" if waiting_reason else ""
             self.log.error(f"Pod {pod_name} on node {node} TIMED OUT after {timeout}s in phase {phase}")
 
             # Get pod events for debugging stuck pods
@@ -193,7 +208,7 @@ class K8sNvidiaSmiCheck(BaseValidation):
             if events_res.stdout.strip():
                 self.log.error(f"Events for {pod_name}:\n{events_res.stdout}")
 
-            error = f"pod on node {node} timed out after {timeout}s in phase {phase}"
+            error = f"pod on node {node} timed out after {timeout}s in phase {phase}{detail}"
 
         # Cleanup
         # Force delete and wait for completion to avoid overwhelming containerd
@@ -215,6 +230,8 @@ class K8sDriverVersionCheck(K8sNvidiaSmiCheck):
         # Inherit timeout from config if present, else default to 60
         timeout = int(self.config.get("timeout", 60))
         results = self._run_ephemeral_pods(timeout=timeout)
+        if results is None:
+            return
         mismatches = []
 
         for node, res in results.items():
@@ -264,6 +281,8 @@ class K8sGpuPodAccessCheck(K8sNvidiaSmiCheck):
         # Inherit timeout from config if present, else default to 60
         timeout = int(self.config.get("timeout", 60))
         results = self._run_ephemeral_pods(timeout=timeout)
+        if results is None:
+            return
         mismatches = []
         total_gpus_found = 0
 

--- a/isvtest/src/isvtest/validations/k8s_gpu_operator.py
+++ b/isvtest/src/isvtest/validations/k8s_gpu_operator.py
@@ -12,7 +12,7 @@ import shlex
 from typing import ClassVar
 
 from isvtest.config.settings import get_k8s_gpu_operator_namespace
-from isvtest.core.k8s import get_kubectl_base_shell
+from isvtest.core.k8s import get_kubectl_base_shell, kubectl_items_or_fail
 from isvtest.core.validation import BaseValidation
 
 
@@ -45,20 +45,15 @@ class K8sGpuOperatorPodsCheck(BaseValidation):
 
         kubectl_base = get_kubectl_base_shell()
 
-        result = self.run_command(f"{kubectl_base} get pods -n {shlex.quote(namespace)}")
-
-        if result.exit_code != 0:
-            self.set_failed(f"Failed to get GPU Operator pods: {result.stderr}")
+        result = self.run_command(f"{kubectl_base} get pods -n {shlex.quote(namespace)} -o json")
+        pods = kubectl_items_or_fail(self, result, "GPU Operator pod list", exec_label="GPU Operator pods")
+        if pods is None:
             return
 
-        # Parse kubectl output - STATUS is the 3rd column (index 2)
-        # Format: NAME  READY  STATUS  RESTARTS  AGE
         running_pods = []
-        for line in result.stdout.split("\n"):
-            columns = line.split()
-            # Skip header and empty lines, check STATUS column exactly equals "Running"
-            if len(columns) >= 3 and columns[2] == "Running":
-                running_pods.append(columns[0])  # Store pod name
+        for pod in pods:
+            if (pod.get("status") or {}).get("phase") == "Running":
+                running_pods.append((pod.get("metadata") or {}).get("name", "unknown"))
 
         if not running_pods:
             self.set_failed(f"No GPU Operator pods are running in namespace '{namespace}'")

--- a/isvtest/src/isvtest/validations/k8s_network_policy.py
+++ b/isvtest/src/isvtest/validations/k8s_network_policy.py
@@ -282,7 +282,7 @@ class K8sNetworkPolicyCheck(BaseValidation):
             self.log.error("Failed to read pod IPs for %s: %s", pod, exc)
             return []
         pod_ips = (payload.get("status") or {}).get("podIPs") or []
-        return [str(entry["ip"]) for entry in pod_ips if entry.get("ip")]
+        return [str(entry["ip"]) for entry in pod_ips if isinstance(entry, dict) and entry.get("ip")]
 
     def _probe(self, client: str, host: str) -> bool:
         """Run an ``agnhost connect`` probe from ``client`` to ``host:port``.

--- a/isvtest/src/isvtest/validations/k8s_network_policy.py
+++ b/isvtest/src/isvtest/validations/k8s_network_policy.py
@@ -38,7 +38,7 @@ from isvtest.config.settings import (
     get_k8s_network_policy_image,
     get_k8s_require_dual_stack,
 )
-from isvtest.core.k8s import get_kubectl_base_shell, get_kubectl_command
+from isvtest.core.k8s import KubectlParseError, get_kubectl_base_shell, get_kubectl_command, parse_kubectl_json
 from isvtest.core.validation import BaseValidation
 
 _MANIFEST_DIR = Path(__file__).parent / "manifests" / "k8s"
@@ -271,15 +271,18 @@ class K8sNetworkPolicyCheck(BaseValidation):
 
     def _get_pod_ips(self, pod: str) -> list[str]:
         """Return every IP assigned to ``pod`` via ``status.podIPs``."""
-        cmd = (
-            f"{self._kubectl_base} get pod {shlex.quote(pod)} -n {shlex.quote(self._namespace)} "
-            f"-o jsonpath='{{.status.podIPs[*].ip}}'"
-        )
+        cmd = f"{self._kubectl_base} get pod {shlex.quote(pod)} -n {shlex.quote(self._namespace)} -o json"
         result = self.run_command(cmd)
         if result.exit_code != 0:
             self.log.error("Failed to read pod IPs for %s: %s", pod, result.stderr)
             return []
-        return [ip for ip in result.stdout.strip().split() if ip]
+        try:
+            payload = parse_kubectl_json(result, f"pod {pod!r}")
+        except KubectlParseError as exc:
+            self.log.error("Failed to read pod IPs for %s: %s", pod, exc)
+            return []
+        pod_ips = (payload.get("status") or {}).get("podIPs") or []
+        return [str(entry["ip"]) for entry in pod_ips if entry.get("ip")]
 
     def _probe(self, client: str, host: str) -> bool:
         """Run an ``agnhost connect`` probe from ``client`` to ``host:port``.

--- a/isvtest/src/isvtest/validations/k8s_nodes.py
+++ b/isvtest/src/isvtest/validations/k8s_nodes.py
@@ -8,11 +8,10 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
-import json
 import shlex
-from typing import ClassVar
+from typing import Any, ClassVar
 
-from isvtest.core.k8s import get_kubectl_base_shell
+from isvtest.core.k8s import get_kubectl_base_shell, kubectl_items_or_fail
 from isvtest.core.validation import BaseValidation
 
 
@@ -99,14 +98,13 @@ class K8sNodeCountCheck(BaseValidation):
     def _get_node_names(self, label_selector: str | None) -> list[str] | None:
         """Return node names matching ``label_selector`` or set failure."""
         selector_args = f" -l {shlex.quote(label_selector)}" if label_selector else ""
-        cmd = f"{get_kubectl_base_shell()} get nodes{selector_args} -o name"
+        cmd = f"{get_kubectl_base_shell()} get nodes{selector_args} -o json"
 
         result = self.run_command(cmd)
-        if result.exit_code != 0:
-            self.set_failed(f"Failed to get node count: {result.stderr}")
+        items = kubectl_items_or_fail(self, result, "node list", exec_label="node count")
+        if items is None:
             return None
-
-        return _parse_kubectl_name_output(result.stdout)
+        return _node_names_from_items(items)
 
 
 def _optional_selector(value: object, field: str) -> str | None:
@@ -125,14 +123,14 @@ def _combine_label_selectors(*selectors: str | None) -> str | None:
     return ",".join(parts) if parts else None
 
 
-def _parse_kubectl_name_output(stdout: str) -> list[str]:
-    """Parse ``kubectl get nodes -o name`` output into bare node names."""
+def _node_names_from_items(items: list[dict[str, Any]]) -> list[str]:
+    """Extract node names from ``kubectl get nodes -o json`` items."""
     names: list[str] = []
-    for line in stdout.splitlines():
-        item = line.strip()
-        if not item:
-            continue
-        names.append(item.split("/", 1)[1] if "/" in item else item)
+    for item in items:
+        metadata = item.get("metadata") or {}
+        name = metadata.get("name") if isinstance(metadata, dict) else None
+        if name:
+            names.append(str(name))
     return names
 
 
@@ -154,20 +152,11 @@ class K8sNodeReadyCheck(BaseValidation):
         kubectl_base = get_kubectl_base_shell()
 
         # Use JSON output for safer parsing
-        cmd = f"{kubectl_base} get nodes -o json"
-        result = self.run_command(cmd)
-
-        if result.exit_code != 0:
-            self.set_failed(f"Failed to get nodes: {result.stderr}")
+        result = self.run_command(f"{kubectl_base} get nodes -o json")
+        items = kubectl_items_or_fail(self, result, "node list", exec_label="nodes")
+        if items is None:
             return
 
-        try:
-            nodes_data = json.loads(result.stdout)
-        except json.JSONDecodeError as e:
-            self.set_failed(f"Failed to parse kubectl JSON output: {e}")
-            return
-
-        items = nodes_data.get("items", [])
         if not items:
             self.set_passed("No nodes found in cluster")
             return
@@ -217,14 +206,12 @@ class K8sExpectedNodesCheck(BaseValidation):
 
         # Get actual nodes
         kubectl_base = get_kubectl_base_shell()
-        cmd = f"{kubectl_base} get nodes -o jsonpath='{{.items[*].metadata.name}}'"
-
-        result = self.run_command(cmd)
-        if result.exit_code != 0:
-            self.set_failed(f"Failed to get nodes: {result.stderr}")
+        result = self.run_command(f"{kubectl_base} get nodes -o json")
+        items = kubectl_items_or_fail(self, result, "node list", exec_label="nodes")
+        if items is None:
             return
 
-        actual_nodes = result.stdout.strip().split()
+        actual_nodes = _node_names_from_items(items)
         actual_nodes_set = set(actual_nodes)
         expected_names_set = set(expected_names)
 

--- a/isvtest/src/isvtest/validations/k8s_scheduling.py
+++ b/isvtest/src/isvtest/validations/k8s_scheduling.py
@@ -11,7 +11,7 @@
 import shlex
 from typing import ClassVar
 
-from isvtest.core.k8s import get_kubectl_base_shell
+from isvtest.core.k8s import get_kubectl_base_shell, kubectl_items_or_fail
 from isvtest.core.validation import BaseValidation
 
 
@@ -24,14 +24,12 @@ class K8sGpuLabelsCheck(BaseValidation):
 
         kubectl_base = get_kubectl_base_shell()
 
-        cmd = f"{kubectl_base} get nodes -l {shlex.quote(label_selector)} --no-headers"
+        cmd = f"{kubectl_base} get nodes -l {shlex.quote(label_selector)} -o json"
         result = self.run_command(cmd)
-
-        if result.exit_code != 0:
-            self.set_failed(f"Failed to query GPU nodes: {result.stderr}")
+        nodes = kubectl_items_or_fail(self, result, "GPU node list", exec_label="GPU nodes")
+        if nodes is None:
             return
 
-        nodes = [line for line in result.stdout.splitlines() if line.strip()]
         if not nodes:
             self.set_failed(f"No GPU nodes found with label '{label_selector}'")
             return
@@ -72,42 +70,30 @@ class K8sGpuCapacityCheck(BaseValidation):
             )
             return
 
-        # Need to escape dot for jsonpath if it exists (e.g. nvidia.com/gpu -> nvidia\.com/gpu)
-        escaped_resource = resource_name.replace(".", "\\.")
-
         kubectl_base = get_kubectl_base_shell()
 
-        # Check for resource in node capacity
-        cmd = f'{kubectl_base} get nodes -o jsonpath=\'{{range .items[*]}}{{.metadata.name}}{{"\\t"}}{{.status.capacity.{escaped_resource}}}{{"\\n"}}{{end}}\''
-        result = self.run_command(cmd)
-
-        if result.exit_code != 0:
-            self.set_failed(f"Failed to get node capacity: {result.stderr}")
+        result = self.run_command(f"{kubectl_base} get nodes -o json")
+        nodes = kubectl_items_or_fail(self, result, "node list", exec_label="node capacity")
+        if nodes is None:
             return
 
         gpu_nodes_count = 0
         total_gpus = 0
         per_node_mismatches = []
 
-        for line in result.stdout.splitlines():
-            if not line.strip():
+        for node in nodes:
+            capacity = (node.get("status") or {}).get("capacity") or {}
+            val_str = str(capacity.get(resource_name) or "")
+            if not val_str:
                 continue
-            parts = line.split("\t")
-            if len(parts) >= 2 and parts[1].strip():
-                try:
-                    # Handle "1" or "1Gi" (though GPU resources usually purely numeric)
-                    val_str = parts[1]
-                    if val_str.isdigit():
-                        count = int(val_str)
-                        if count > 0:
-                            gpu_nodes_count += 1
-                            total_gpus += count
-                            # Check per-node count if configured
-                            if expected_per_node is not None and count != expected_per_node:
-                                node_name = parts[0]
-                                per_node_mismatches.append(f"{node_name} ({count} != {expected_per_node})")
-                except ValueError:
-                    pass
+            if val_str.isdigit():
+                count = int(val_str)
+                if count > 0:
+                    gpu_nodes_count += 1
+                    total_gpus += count
+                    if expected_per_node is not None and count != expected_per_node:
+                        node_name = (node.get("metadata") or {}).get("name", "unknown")
+                        per_node_mismatches.append(f"{node_name} ({count} != {expected_per_node})")
 
         if gpu_nodes_count == 0:
             self.set_failed(f"No '{resource_name}' resources found in node capacity")

--- a/isvtest/src/isvtest/validations/k8s_storage.py
+++ b/isvtest/src/isvtest/validations/k8s_storage.py
@@ -43,8 +43,10 @@ from isvtest.config.settings import (
     get_k8s_csi_shared_fs_storage_class,
 )
 from isvtest.core.k8s import (
+    KubectlParseError,
     get_kubectl_base_shell,
     get_kubectl_command,
+    parse_kubectl_json,
     render_k8s_manifest,
 )
 from isvtest.core.validation import BaseValidation
@@ -85,13 +87,28 @@ def _apply_manifest(kubectl_parts: list[str], manifest: str, timeout: float) -> 
     return proc.returncode, proc.stderr or proc.stdout
 
 
+def _get_pvc_json(run_command, kubectl_base: str, namespace: str, pvc_name: str) -> tuple[dict[str, Any] | None, str]:
+    """Fetch and parse ``kubectl get pvc -o json``; return ``(payload, error)``.
+
+    ``error`` is empty on success and otherwise contains the kubectl stderr or
+    a ``KubectlParseError`` message - callers can surface it verbatim.
+    """
+    cmd = f"{kubectl_base} get pvc {shlex.quote(pvc_name)} -n {shlex.quote(namespace)} -o json"
+    result = run_command(cmd)
+    if result.exit_code != 0:
+        return None, result.stderr.strip() or result.stdout.strip() or f"exit code {result.exit_code}"
+    try:
+        return parse_kubectl_json(result, f"PVC {pvc_name!r}"), ""
+    except KubectlParseError as exc:
+        return None, str(exc)
+
+
 def _poll_pvc_bound(run_command, kubectl_base: str, namespace: str, pvc_name: str, timeout_s: int) -> bool:
     """Poll ``kubectl get pvc`` until ``status.phase == "Bound"`` or timeout."""
     deadline = time.time() + timeout_s
-    cmd = f"{kubectl_base} get pvc {shlex.quote(pvc_name)} -n {shlex.quote(namespace)} -o jsonpath='{{.status.phase}}'"
     while time.time() < deadline:
-        result = run_command(cmd)
-        if result.exit_code == 0 and result.stdout.strip().strip("'") == "Bound":
+        payload, _error = _get_pvc_json(run_command, kubectl_base, namespace, pvc_name)
+        if payload is not None and (payload.get("status") or {}).get("phase") == "Bound":
             return True
         time.sleep(2.0)
     return False
@@ -213,15 +230,21 @@ class K8sCsiStorageTypesCheck(BaseValidation):
                     )
                     continue
 
-                sc_result = self.run_command(f"{self._kubectl_base} get storageclass {shlex.quote(sc_name)} -o name")
-                sc_ok = sc_result.exit_code == 0
+                sc_result = self.run_command(f"{self._kubectl_base} get storageclass {shlex.quote(sc_name)} -o json")
+                sc_error = ""
+                if sc_result.exit_code != 0:
+                    sc_error = sc_result.stderr.strip() or sc_result.stdout.strip()
+                else:
+                    try:
+                        parse_kubectl_json(sc_result, f"StorageClass {sc_name!r}")
+                    except KubectlParseError as exc:
+                        sc_error = str(exc)
+                sc_ok = not sc_error
                 self.report_subtest(
                     f"sc-exists[{type_name}]",
                     passed=sc_ok,
                     message=(
-                        f"StorageClass {sc_name!r} found"
-                        if sc_ok
-                        else f"StorageClass {sc_name!r} missing: {sc_result.stderr.strip() or sc_result.stdout.strip()}"
+                        f"StorageClass {sc_name!r} found" if sc_ok else f"StorageClass {sc_name!r} missing: {sc_error}"
                     ),
                 )
                 if not sc_ok:
@@ -664,16 +687,20 @@ class K8sCsiStorageQuotaApiCheck(BaseValidation):
 
     def _run_pv_usage_api(self, pvc_name: str) -> bool:
         """Resolve the PVC's bound PV and assert ``spec.capacity/claimRef/csi.driver`` are populated."""
-        vol_name_result = self.run_command(
-            f"{self._kubectl_base} get pvc {shlex.quote(pvc_name)} "
-            f"-n {shlex.quote(self._namespace)} -o jsonpath='{{.spec.volumeName}}'"
-        )
-        pv_name = vol_name_result.stdout.strip().strip("'")
-        if vol_name_result.exit_code != 0 or not pv_name:
+        pvc_payload, error = _get_pvc_json(self.run_command, self._kubectl_base, self._namespace, pvc_name)
+        if pvc_payload is None:
             self.report_subtest(
                 "pv-usage-api",
                 passed=False,
-                message=f"Could not resolve volumeName for PVC {pvc_name!r}: {vol_name_result.stderr.strip()}",
+                message=f"Could not resolve volumeName for PVC {pvc_name!r}: {error}",
+            )
+            return False
+        pv_name = str((pvc_payload.get("spec") or {}).get("volumeName") or "")
+        if not pv_name:
+            self.report_subtest(
+                "pv-usage-api",
+                passed=False,
+                message=f"Could not resolve volumeName for PVC {pvc_name!r}: spec.volumeName is empty",
             )
             return False
 
@@ -746,15 +773,10 @@ class K8sCsiStorageQuotaApiCheck(BaseValidation):
 
     def _get_pvc_capacity(self, pvc_name: str) -> str:
         """Return ``.status.capacity.storage`` for ``pvc_name`` (empty string if unset)."""
-        cmd = (
-            f"{self._kubectl_base} get pvc {shlex.quote(pvc_name)} "
-            f"-n {shlex.quote(self._namespace)} "
-            f"-o jsonpath='{{.status.capacity.storage}}'"
-        )
-        result = self.run_command(cmd)
-        if result.exit_code != 0:
+        payload, _error = _get_pvc_json(self.run_command, self._kubectl_base, self._namespace, pvc_name)
+        if payload is None:
             return ""
-        return result.stdout.strip().strip("'")
+        return str(((payload.get("status") or {}).get("capacity") or {}).get("storage") or "")
 
     def _wait_quota_section(
         self,
@@ -1760,14 +1782,10 @@ class K8sCsiProvisioningModesCheck(BaseValidation):
 
     def _resolve_bound_pv_driver(self, pvc_name: str) -> tuple[str, str, str]:
         """Return ``(pv_name, csi_driver, error)`` - ``error`` is empty on success."""
-        vol_cmd = (
-            f"{self._kubectl_base} get pvc {shlex.quote(pvc_name)} "
-            f"-n {shlex.quote(self._namespace)} -o jsonpath='{{.spec.volumeName}}'"
-        )
-        vol_result = self.run_command(vol_cmd)
-        if vol_result.exit_code != 0:
-            return "", "", f"Failed to resolve volumeName for PVC {pvc_name!r}: {vol_result.stderr.strip()}"
-        pv_name = vol_result.stdout.strip().strip("'")
+        pvc_payload, error = _get_pvc_json(self.run_command, self._kubectl_base, self._namespace, pvc_name)
+        if pvc_payload is None:
+            return "", "", f"Failed to resolve volumeName for PVC {pvc_name!r}: {error}"
+        pv_name = str((pvc_payload.get("spec") or {}).get("volumeName") or "")
         if not pv_name:
             return "", "", f"PVC {pvc_name!r} bound but spec.volumeName is empty"
 

--- a/isvtest/tests/test_k8s.py
+++ b/isvtest/tests/test_k8s.py
@@ -12,6 +12,7 @@
 
 import json
 import os
+import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -19,12 +20,34 @@ import pytest
 from isvtest.core.k8s import (
     TERMINAL_WAITING_REASONS,
     TRANSIENT_WAITING_REASONS,
+    KubectlParseError,
     get_k8s_provider,
     get_kubectl_base_shell,
     get_kubectl_command,
+    kubectl_items_or_fail,
+    parse_kubectl_json,
+    parse_kubectl_json_items,
     parse_pod_state,
     parse_server_version,
+    pod_state_from_result,
+    pod_status_reason,
 )
+from isvtest.core.runners import CommandResult
+
+
+def _command_result(stdout: str, *, exit_code: int = 0, stderr: str = "") -> CommandResult:
+    """Return a command result for parser tests."""
+    return CommandResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+class _StubValidation:
+    """Minimal stand-in exposing ``set_failed`` for parser-helper tests."""
+
+    def __init__(self) -> None:
+        self.error: str | None = None
+
+    def set_failed(self, error: str, output: str = "") -> None:
+        self.error = error
 
 
 class TestGetKubectlCommandOverride:
@@ -147,6 +170,107 @@ class TestGetKubectlBaseShellArgs:
             result = get_kubectl_base_shell("label", "node", "n1", "app=foo bar")
         # The value with a space must be quoted so the shell sees it as one token.
         assert "'app=foo bar'" in result
+
+
+class TestKubectlJsonParsers:
+    """Tests for structured kubectl JSON parser helpers."""
+
+    def test_parse_kubectl_json_object(self) -> None:
+        payload = parse_kubectl_json(_command_result(json.dumps({"kind": "Pod"})), "pod")
+        assert payload == {"kind": "Pod"}
+
+    def test_parse_kubectl_json_reports_invalid_json(self) -> None:
+        with pytest.raises(KubectlParseError, match="Failed to parse pod"):
+            parse_kubectl_json(_command_result("not-json"), "pod")
+
+    def test_parse_kubectl_json_items_extracts_items(self) -> None:
+        payload = json.dumps({"items": [{"metadata": {"name": "n1"}}]})
+        items = parse_kubectl_json_items(_command_result(payload), "node list")
+        assert items == [{"metadata": {"name": "n1"}}]
+
+    def test_parse_kubectl_json_items_requires_items_list(self) -> None:
+        with pytest.raises(KubectlParseError, match="expected 'items' list"):
+            parse_kubectl_json_items(_command_result(json.dumps({"items": {}})), "node list")
+
+
+class TestKubectlItemsOrFail:
+    """Tests for the validation-aware ``kubectl_items_or_fail`` helper."""
+
+    def test_returns_items_on_success(self) -> None:
+        validation = _StubValidation()
+        payload = json.dumps({"items": [{"metadata": {"name": "n1"}}]})
+        items = kubectl_items_or_fail(validation, _command_result(payload), "node list")
+        assert items == [{"metadata": {"name": "n1"}}]
+        assert validation.error is None
+
+    def test_routes_exec_failure_to_set_failed(self) -> None:
+        validation = _StubValidation()
+        result = _command_result("", exit_code=1, stderr="cluster unavailable")
+        items = kubectl_items_or_fail(validation, result, "node list")
+        assert items is None
+        assert validation.error == "Failed to get node list: cluster unavailable"
+
+    def test_exec_label_overrides_failure_noun(self) -> None:
+        validation = _StubValidation()
+        result = _command_result("", exit_code=1, stderr="cluster unavailable")
+        items = kubectl_items_or_fail(validation, result, "node list", exec_label="node count")
+        assert items is None
+        assert validation.error == "Failed to get node count: cluster unavailable"
+
+    def test_routes_parse_failure_to_set_failed(self) -> None:
+        validation = _StubValidation()
+        items = kubectl_items_or_fail(validation, _command_result("not-json"), "node list")
+        assert items is None
+        assert validation.error is not None
+        assert "Failed to parse node list" in validation.error
+
+
+class TestPodStatusReason:
+    """Tests for ``pod_status_reason`` kubectl STATUS-column emulation."""
+
+    def test_container_waiting_reason_wins_over_phase(self) -> None:
+        pod = {
+            "status": {
+                "phase": "Pending",
+                "containerStatuses": [{"state": {"waiting": {"reason": "ImagePullBackOff"}}}],
+            }
+        }
+        assert pod_status_reason(pod) == "ImagePullBackOff"
+
+    def test_pod_level_reason_overrides_phase_when_no_container_state(self) -> None:
+        # Regression: evicted pods carry ``status.reason: Evicted`` but no
+        # informative container state; kubectl shows "Evicted" in STATUS so
+        # ``error_states: [Evicted]`` configs must still match.
+        pod = {"status": {"phase": "Failed", "reason": "Evicted"}}
+        assert pod_status_reason(pod) == "Evicted"
+
+    def test_falls_back_to_phase_when_reason_absent(self) -> None:
+        pod = {"status": {"phase": "Running"}}
+        assert pod_status_reason(pod) == "Running"
+
+    def test_returns_unknown_when_phase_missing(self) -> None:
+        assert pod_status_reason({}) == "Unknown"
+
+
+class TestPodStateFromResult:
+    """Tests for the result-aware ``pod_state_from_result`` wrapper."""
+
+    def test_parses_command_result_stdout_on_success(self) -> None:
+        payload = json.dumps({"status": {"phase": "Running"}})
+        assert pod_state_from_result(_command_result(payload)) == ("Running", "", "")
+
+    def test_inspects_stderr_on_command_result_failure(self) -> None:
+        result = _command_result("", exit_code=1, stderr='Error from server (NotFound): pods "x" not found')
+        assert pod_state_from_result(result) == ("NotFound", "", "")
+
+    def test_accepts_completed_process(self) -> None:
+        payload = json.dumps({"status": {"phase": "Succeeded"}})
+        completed = subprocess.CompletedProcess(args=["kubectl"], returncode=0, stdout=payload, stderr="")
+        assert pod_state_from_result(completed) == ("Succeeded", "", "")
+
+    def test_completed_process_failure_uses_stderr(self) -> None:
+        completed = subprocess.CompletedProcess(args=["kubectl"], returncode=1, stdout="", stderr="boom")
+        assert pod_state_from_result(completed) == ("Unknown", "", "")
 
 
 class TestParsePodState:

--- a/isvtest/tests/test_k8s.py
+++ b/isvtest/tests/test_k8s.py
@@ -31,6 +31,7 @@ from isvtest.core.k8s import (
     parse_server_version,
     pod_state_from_result,
     pod_status_reason,
+    wait_for_multiple_pods_completion,
 )
 from isvtest.core.runners import CommandResult
 
@@ -271,6 +272,31 @@ class TestPodStateFromResult:
     def test_completed_process_failure_uses_stderr(self) -> None:
         completed = subprocess.CompletedProcess(args=["kubectl"], returncode=1, stdout="", stderr="boom")
         assert pod_state_from_result(completed) == ("Unknown", "", "")
+
+
+class TestWaitForMultiplePodsCompletion:
+    def test_duplicate_targets_complete_after_unique_pods_finish(self) -> None:
+        payload = json.dumps(
+            {
+                "items": [
+                    {
+                        "metadata": {"name": "worker-0"},
+                        "status": {"phase": "Succeeded"},
+                    }
+                ]
+            }
+        )
+        completed = subprocess.CompletedProcess(args=["kubectl"], returncode=0, stdout=payload, stderr="")
+
+        with (
+            patch("isvtest.core.k8s.run_kubectl", return_value=completed),
+            patch("isvtest.core.k8s.time.time", side_effect=[0.0, 0.1]),
+            patch("isvtest.core.k8s.time.sleep") as sleep,
+        ):
+            result = wait_for_multiple_pods_completion(["worker-0", "worker-0"], "default", timeout=10)
+
+        assert result == {"worker-0": (True, "Succeeded")}
+        sleep.assert_not_called()
 
 
 class TestParsePodState:

--- a/isvtest/tests/test_k8s_api_network_acl.py
+++ b/isvtest/tests/test_k8s_api_network_acl.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -30,6 +31,11 @@ def _fail(stdout: str = "", stderr: str = "", exit_code: int = 1) -> CommandResu
 
 
 _DEFAULT_KUBECTL_SERVER = "https://api.example.com:6443"
+
+
+def _config_view_json(server: str = _DEFAULT_KUBECTL_SERVER) -> str:
+    """Return a minimal ``kubectl config view --minify -o json`` payload."""
+    return json.dumps({"clusters": [{"cluster": {"server": server}}]})
 
 
 def _minimal_config(**overrides: Any) -> dict[str, Any]:
@@ -62,7 +68,7 @@ def _make_fake(
     """Build a fake ``run_command`` that classifies by command shape."""
     auth = auth_result if auth_result is not None else _ok(stdout="ok")
     unauth = unauth_result if unauth_result is not None else _fail(stderr="connection timed out")
-    cv = config_view_result if config_view_result is not None else _ok(stdout=_DEFAULT_KUBECTL_SERVER)
+    cv = config_view_result if config_view_result is not None else _ok(stdout=_config_view_json())
 
     def fake(cmd: str, *_: Any, **__: Any) -> CommandResult:
         if calls is not None:
@@ -289,7 +295,7 @@ class TestAuthorizedProbe:
                 order.append("auth")
                 return _ok(stdout="ok")
             if kind == "config_view":
-                return _ok(stdout=_DEFAULT_KUBECTL_SERVER)
+                return _ok(stdout=_config_view_json())
             if kind == "unauthorized":
                 order.append("unauth")
                 return _fail(stderr="timed out")
@@ -369,7 +375,7 @@ class TestUnauthorizedProbe:
             if kind == "authorized":
                 return _ok(stdout="ok")
             if kind == "config_view":
-                return _ok(stdout=_DEFAULT_KUBECTL_SERVER)
+                return _ok(stdout=_config_view_json())
             if kind == "unauthorized":
                 return _fail(stderr="timed out", exit_code=124)
             raise AssertionError(f"unexpected {cmd}")
@@ -423,6 +429,15 @@ class TestEndpointVisibility:
         assert check.passed, check.message
         assert "authorized target (kubectl)" not in check.message
 
+    def test_kubectl_url_invalid_json_does_not_break_check(self) -> None:
+        check = K8sApiNetworkAclCheck(config=_minimal_config())
+        check.run_command = _make_fake(  # type: ignore[assignment]
+            config_view_result=_ok(stdout="not-json"),
+        )
+        check.run()
+        assert check.passed, check.message
+        assert "authorized target (kubectl)" not in check.message
+
 
 class TestEndpointConsistency:
     def test_unauth_probe_must_reference_api_endpoint_origin(self) -> None:
@@ -447,7 +462,7 @@ class TestEndpointConsistency:
         cfg["commands"]["unauthorized_probe"] = "ssh ext-host curl https://api.example.com/healthz"
         check = K8sApiNetworkAclCheck(config=cfg)
         check.run_command = _make_fake(  # type: ignore[assignment]
-            config_view_result=_ok(stdout="https://api.example.com"),
+            config_view_result=_ok(stdout=_config_view_json("https://api.example.com")),
         )
         check.run()
         assert check.passed, check.message
@@ -509,7 +524,7 @@ class TestEndpointConsistency:
         )
         calls: list[str] = []
         check.run_command = _make_fake(  # type: ignore[assignment]
-            config_view_result=_ok(stdout="https://other.example.com:6443"),
+            config_view_result=_ok(stdout=_config_view_json("https://other.example.com:6443")),
             calls=calls,
         )
         check.run()
@@ -524,7 +539,7 @@ class TestEndpointConsistency:
             config=_minimal_config(api_endpoint="https://api.example.com:6443"),
         )
         check.run_command = _make_fake(  # type: ignore[assignment]
-            config_view_result=_ok(stdout="https://api.example.com:443"),
+            config_view_result=_ok(stdout=_config_view_json("https://api.example.com:443")),
         )
         check.run()
         assert not check.passed
@@ -535,7 +550,7 @@ class TestEndpointConsistency:
         cfg["commands"]["unauthorized_probe"] = "ssh ext-host curl https://api.example.com/healthz"
         check = K8sApiNetworkAclCheck(config=cfg)
         check.run_command = _make_fake(  # type: ignore[assignment]
-            config_view_result=_ok(stdout="https://api.example.com"),
+            config_view_result=_ok(stdout=_config_view_json("https://api.example.com")),
         )
         check.run()
         assert check.passed, check.message
@@ -548,7 +563,7 @@ class TestEndpointConsistency:
             ),
         )
         check.run_command = _make_fake(  # type: ignore[assignment]
-            config_view_result=_ok(stdout="https://private.example.com:6443"),
+            config_view_result=_ok(stdout=_config_view_json("https://private.example.com:6443")),
         )
         check.run()
         assert check.passed, check.message

--- a/isvtest/tests/test_k8s_api_network_acl.py
+++ b/isvtest/tests/test_k8s_api_network_acl.py
@@ -438,6 +438,23 @@ class TestEndpointVisibility:
         assert check.passed, check.message
         assert "authorized target (kubectl)" not in check.message
 
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"clusters": {}},
+            {"clusters": []},
+            {"clusters": ["not-a-cluster"]},
+        ],
+    )
+    def test_kubectl_url_malformed_clusters_do_not_break_check(self, payload: dict[str, Any]) -> None:
+        check = K8sApiNetworkAclCheck(config=_minimal_config())
+        check.run_command = _make_fake(  # type: ignore[assignment]
+            config_view_result=_ok(stdout=json.dumps(payload)),
+        )
+        check.run()
+        assert check.passed, check.message
+        assert "authorized target (kubectl)" not in check.message
+
 
 class TestEndpointConsistency:
     def test_unauth_probe_must_reference_api_endpoint_origin(self) -> None:

--- a/isvtest/tests/test_k8s_cluster.py
+++ b/isvtest/tests/test_k8s_cluster.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Tests for cluster-wide pod-health validations in k8s_cluster.py."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+from isvtest.core.runners import CommandResult
+from isvtest.validations.k8s_cluster import K8sNoErrorPodsCheck, K8sPodHealthCheck
+
+
+def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    """Return a successful ``CommandResult``."""
+    return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _pod(name: str, phase: str = "Running", waiting_reason: str = "") -> dict[str, Any]:
+    """Return a minimal pod object."""
+    status: dict[str, Any] = {"phase": phase}
+    if waiting_reason:
+        status["containerStatuses"] = [{"state": {"waiting": {"reason": waiting_reason}}}]
+    return {"metadata": {"namespace": "default", "name": name}, "status": status}
+
+
+def _items_json(items: list[dict[str, Any]]) -> str:
+    """Wrap Kubernetes list items in a JSON payload."""
+    return json.dumps({"items": items})
+
+
+def test_pod_health_uses_json_and_passes_for_running_or_succeeded_pods() -> None:
+    """Verify the pod-health check reads structured pod JSON."""
+    check = K8sPodHealthCheck(config={})
+    payload = _items_json([_pod("running", "Running"), _pod("done", "Succeeded")])
+
+    with (
+        patch("isvtest.validations.k8s_cluster.get_kubectl_base_shell", return_value="kubectl"),
+        patch.object(check, "run_command", return_value=_ok(payload)) as mock_run,
+    ):
+        check.run()
+
+    assert check.passed
+    assert mock_run.call_args[0][0] == "kubectl get pods -A -o json"
+
+
+def test_pod_health_fails_on_invalid_json() -> None:
+    """Verify invalid pod JSON is surfaced as a validation failure."""
+    check = K8sPodHealthCheck(config={})
+    with patch.object(check, "run_command", return_value=_ok("not-json")):
+        check.run()
+    assert not check.passed
+    assert "Failed to parse pod list" in check.message
+
+
+def test_no_error_pods_detects_waiting_reason_from_json() -> None:
+    """Verify CrashLoopBackOff is detected from containerStatuses instead of table output."""
+    check = K8sNoErrorPodsCheck(config={})
+    payload = _items_json([_pod("bad", "Running", waiting_reason="CrashLoopBackOff")])
+
+    with patch.object(check, "run_command", return_value=_ok(payload)):
+        check.run()
+
+    assert not check.passed
+    assert "CrashLoopBackOff" in check.message
+
+
+def test_no_error_pods_detects_evicted_via_pod_level_reason() -> None:
+    """Regression: ``error_states: [Evicted]`` matches pods with status.reason set but no container state."""
+    check = K8sNoErrorPodsCheck(config={"error_states": ["Evicted"]})
+    evicted = {
+        "metadata": {"namespace": "default", "name": "doomed"},
+        "status": {"phase": "Failed", "reason": "Evicted"},
+    }
+    payload = _items_json([evicted])
+
+    with patch.object(check, "run_command", return_value=_ok(payload)):
+        check.run()
+
+    assert not check.passed
+    assert "Evicted" in check.message
+    assert "doomed" in check.message

--- a/isvtest/tests/test_k8s_control_plane_logs.py
+++ b/isvtest/tests/test_k8s_control_plane_logs.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -34,9 +35,12 @@ def _fail(stdout: str = "", stderr: str = "", exit_code: int = 1) -> CommandResu
 
 
 def _pod_list(*pairs: tuple[str, str]) -> str:
-    """Simulate ``kubectl get pods -o jsonpath='...'`` output: one
-    ``<pod_name>\\t<component_label>`` line per pod."""
-    return "".join(f"{pod}\t{label}\n" for pod, label in pairs)
+    """Simulate ``kubectl get pods -o json`` output for pod/component pairs."""
+    items = []
+    for pod, label in pairs:
+        labels = {"component": label} if label else {}
+        items.append({"metadata": {"name": pod, "labels": labels}})
+    return json.dumps({"items": items})
 
 
 class TestCountNonemptyLines:
@@ -138,7 +142,7 @@ class TestAutoDispatch:
 
         def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
             if "get pods" in cmd:
-                return _ok(stdout="")
+                return _ok(stdout=_pod_list())
             raise AssertionError(f"unexpected {cmd}")
 
         check.run_command = fake  # type: ignore[assignment]
@@ -163,6 +167,19 @@ class TestAutoDispatch:
         assert "Unable to list pods" in check.message
         assert "i/o timeout" in check.message
         assert "no `commands` entries configured" not in check.message
+
+    def test_auto_surfaces_invalid_pod_json(self) -> None:
+        check = K8sControlPlaneLogsCheck(config={"mode": "auto", "components": ["kube-apiserver"]})
+
+        def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
+            if "get pods" in cmd:
+                return _ok(stdout="not-json")
+            raise AssertionError(f"unexpected {cmd}")
+
+        check.run_command = fake  # type: ignore[assignment]
+        check.run()
+        assert not check.passed
+        assert "Failed to parse pod list" in check.message
 
     def test_auto_surfaces_kubectl_error_even_when_commands_cover_all_components(self) -> None:
         """A probe failure (kubeconfig/RBAC/context broken) must not be
@@ -218,7 +235,7 @@ class TestAutoDispatch:
 
         def fake(cmd: str, *a: Any, **kw: Any) -> CommandResult:
             if "get pods" in cmd:
-                return _ok(stdout="")
+                return _ok(stdout=_pod_list())
             if cmd.startswith("echo"):
                 return _ok(stdout="line1\nline2\nline3\n")
             raise AssertionError(f"unexpected {cmd}")

--- a/isvtest/tests/test_k8s_gpu.py
+++ b/isvtest/tests/test_k8s_gpu.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Tests for the nvidia-smi GPU validation."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from isvtest.core.runners import CommandResult
+from isvtest.validations.k8s_gpu import K8sNvidiaSmiCheck
+
+
+def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    """Return a successful ``CommandResult``."""
+    return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def test_gpu_node_discovery_fails_on_invalid_json() -> None:
+    """Verify GPU node discovery fails clearly when kubectl emits invalid JSON."""
+    check = K8sNvidiaSmiCheck(config={})
+    with (
+        patch("isvtest.validations.k8s_gpu.get_kubectl_base_shell", return_value="kubectl"),
+        patch.object(check, "run_command", return_value=_ok("not-json")),
+    ):
+        results = check._run_ephemeral_pods(timeout=1)
+
+    # ``None`` (not ``{}``) signals "hard failure already routed to set_failed"
+    # so the caller can distinguish it from "cluster has no GPU nodes".
+    assert results is None
+    assert not check.passed
+    assert "Failed to parse GPU node list" in check.message
+
+
+def test_run_does_not_overwrite_set_failed_when_node_discovery_fails() -> None:
+    """Regression: parse failure must not be clobbered by a trailing set_passed in run()."""
+    check = K8sNvidiaSmiCheck(config={})
+    with (
+        patch("isvtest.validations.k8s_gpu.get_kubectl_base_shell", return_value="kubectl"),
+        patch.object(check, "run_command", return_value=_ok("not-json")),
+    ):
+        check.run()
+
+    assert not check.passed
+    assert "Failed to parse GPU node list" in check.message

--- a/isvtest/tests/test_k8s_gpu_operator.py
+++ b/isvtest/tests/test_k8s_gpu_operator.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Tests for the GPU Operator pod-status validation."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from isvtest.core.runners import CommandResult
+from isvtest.validations.k8s_gpu_operator import K8sGpuOperatorPodsCheck
+
+
+def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    """Return a successful ``CommandResult``."""
+    return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def test_gpu_operator_pods_use_json_phase() -> None:
+    """Verify GPU Operator pod status is parsed from JSON."""
+    check = K8sGpuOperatorPodsCheck(config={"namespace": "gpu-operator"})
+    payload = json.dumps({"items": [{"metadata": {"name": "gpu-operator-1"}, "status": {"phase": "Running"}}]})
+
+    with (
+        patch("isvtest.validations.k8s_gpu_operator.get_kubectl_base_shell", return_value="kubectl"),
+        patch.object(check, "run_command", return_value=_ok(payload)) as mock_run,
+    ):
+        check.run()
+
+    assert check.passed
+    assert mock_run.call_args[0][0] == "kubectl get pods -n gpu-operator -o json"

--- a/isvtest/tests/test_k8s_network_policy.py
+++ b/isvtest/tests/test_k8s_network_policy.py
@@ -332,6 +332,13 @@ class TestNetworkPolicyCheckBehavior:
             ips = check._get_pod_ips("server")
         assert ips == ["10.0.0.1", "fd00::1"]
 
+    def test_get_pod_ips_ignores_malformed_entries(self) -> None:
+        check = _primed_check()
+        payload = json.dumps({"status": {"podIPs": [{"ip": "10.0.0.1"}, "bad", None, {"name": "missing-ip"}]}})
+        with patch.object(check, "run_command", return_value=_ok(stdout=payload)):
+            ips = check._get_pod_ips("server")
+        assert ips == ["10.0.0.1"]
+
     def test_get_pod_ips_returns_empty_on_invalid_json(self) -> None:
         check = _primed_check()
         with patch.object(check, "run_command", return_value=_ok(stdout="not-json")):

--- a/isvtest/tests/test_k8s_network_policy.py
+++ b/isvtest/tests/test_k8s_network_policy.py
@@ -327,9 +327,16 @@ class TestNetworkPolicyCheckBehavior:
 
     def test_get_pod_ips_parses_multiple_families(self) -> None:
         check = _primed_check()
-        with patch.object(check, "run_command", return_value=_ok(stdout="10.0.0.1 fd00::1")):
+        payload = json.dumps({"status": {"podIPs": [{"ip": "10.0.0.1"}, {"ip": "fd00::1"}]}})
+        with patch.object(check, "run_command", return_value=_ok(stdout=payload)):
             ips = check._get_pod_ips("server")
         assert ips == ["10.0.0.1", "fd00::1"]
+
+    def test_get_pod_ips_returns_empty_on_invalid_json(self) -> None:
+        check = _primed_check()
+        with patch.object(check, "run_command", return_value=_ok(stdout="not-json")):
+            ips = check._get_pod_ips("server")
+        assert ips == []
 
     def test_get_pod_ips_returns_empty_on_error(self) -> None:
         check = _primed_check()
@@ -431,10 +438,9 @@ class _NetPolStub:
             return _ok()
         if "wait --for=condition=Ready" in cmd:
             return _ok()
-        if "jsonpath" in cmd:
-            if "other-server" in cmd:
-                return _ok(stdout=" ".join(self.other_ips))
-            return _ok(stdout=" ".join(self.server_ips))
+        if "get pod" in cmd and "-o json" in cmd:
+            ips = self.other_ips if "other-server" in cmd else self.server_ips
+            return _ok(stdout=json.dumps({"status": {"podIPs": [{"ip": ip} for ip in ips]}}))
         if "/agnhost connect" in cmd:
             return self._probe(cmd)
         raise AssertionError(f"No scripted response for command: {cmd}")

--- a/isvtest/tests/test_k8s_nodes.py
+++ b/isvtest/tests/test_k8s_nodes.py
@@ -12,13 +12,15 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 from isvtest.core.runners import CommandResult, Runner
 from isvtest.validations.k8s_nodes import (
+    K8sExpectedNodesCheck,
     K8sNodeCountCheck,
     _combine_label_selectors,
-    _parse_kubectl_name_output,
+    _node_names_from_items,
 )
 
 
@@ -30,6 +32,11 @@ def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
 def _fail(stderr: str = "boom") -> CommandResult:
     """Return a failing ``CommandResult``."""
     return CommandResult(exit_code=1, stdout="", stderr=stderr, duration=0.0)
+
+
+def _nodes_json(*names: str) -> str:
+    """Return a ``kubectl get nodes -o json`` payload for node names."""
+    return json.dumps({"items": [{"metadata": {"name": name}} for name in names]})
 
 
 class StubRunner(Runner):
@@ -52,9 +59,12 @@ def _run_check(config: dict[str, object], responses: list[CommandResult]) -> tup
     return result, runner
 
 
-def test_parse_kubectl_name_output_strips_kind_prefix() -> None:
-    """Verify _parse_kubectl_name_output strips the 'kind/' prefix from names."""
-    assert _parse_kubectl_name_output("node/base-1\nnode/base-2\n\n") == ["base-1", "base-2"]
+def test_node_names_from_items_extracts_metadata_names() -> None:
+    """Verify _node_names_from_items reads names from node JSON items."""
+    assert _node_names_from_items([{"metadata": {"name": "base-1"}}, {"metadata": {"name": "base-2"}}]) == [
+        "base-1",
+        "base-2",
+    ]
 
 
 def test_combine_label_selectors_uses_and_semantics() -> None:
@@ -64,22 +74,22 @@ def test_combine_label_selectors_uses_and_semantics() -> None:
 
 def test_node_count_exact_count_passes() -> None:
     """Verify an exact node count match passes."""
-    result, runner = _run_check({"count": 2}, [_ok("node/base-1\nnode/base-2\n")])
+    result, runner = _run_check({"count": 2}, [_ok(_nodes_json("base-1", "base-2"))])
 
     assert result["passed"] is True
     assert result["output"] == "Node count matched: 2"
-    assert runner.commands == ["kubectl get nodes -o name"]
+    assert runner.commands == ["kubectl get nodes -o json"]
 
 
 def test_node_count_with_label_selector_counts_scoped_nodes() -> None:
     """Verify node counting honors the configured label selector."""
     result, runner = _run_check(
         {"count": 1, "label_selector": "nvidia.com/gpu.present=true"},
-        [_ok("node/gpu-1\n")],
+        [_ok(_nodes_json("gpu-1"))],
     )
 
     assert result["passed"] is True
-    assert runner.commands == ["kubectl get nodes -l nvidia.com/gpu.present=true -o name"]
+    assert runner.commands == ["kubectl get nodes -l nvidia.com/gpu.present=true -o json"]
 
 
 def test_node_count_excludes_matching_nodes() -> None:
@@ -87,16 +97,16 @@ def test_node_count_excludes_matching_nodes() -> None:
     result, runner = _run_check(
         {"count": 2, "exclude_label_selector": "isv.ncp.validation/workload=data-ingest"},
         [
-            _ok("node/base-1\nnode/base-2\nnode/test-1\nnode/test-2\n"),
-            _ok("node/test-1\nnode/test-2\n"),
+            _ok(_nodes_json("base-1", "base-2", "test-1", "test-2")),
+            _ok(_nodes_json("test-1", "test-2")),
         ],
     )
 
     assert result["passed"] is True
     assert result["output"] == "Node count matched (excluding='isv.ncp.validation/workload=data-ingest'): 2"
     assert runner.commands == [
-        "kubectl get nodes -o name",
-        "kubectl get nodes -l isv.ncp.validation/workload=data-ingest -o name",
+        "kubectl get nodes -o json",
+        "kubectl get nodes -l isv.ncp.validation/workload=data-ingest -o json",
     ]
 
 
@@ -109,21 +119,21 @@ def test_exclusion_is_intersected_with_label_selector() -> None:
             "exclude_label_selector": "pool=test",
         },
         [
-            _ok("node/worker-1\nnode/test-1\n"),
-            _ok("node/test-1\n"),
+            _ok(_nodes_json("worker-1", "test-1")),
+            _ok(_nodes_json("test-1")),
         ],
     )
 
     assert result["passed"] is True
     assert runner.commands == [
-        "kubectl get nodes -l node-role.kubernetes.io/worker=true -o name",
-        "kubectl get nodes -l node-role.kubernetes.io/worker=true,pool=test -o name",
+        "kubectl get nodes -l node-role.kubernetes.io/worker=true -o json",
+        "kubectl get nodes -l node-role.kubernetes.io/worker=true,pool=test -o json",
     ]
 
 
 def test_node_count_min_count_passes_when_actual_is_higher() -> None:
     """Verify min_count passes when the actual node count is higher."""
-    result, _runner = _run_check({"min_count": 2}, [_ok("node/base-1\nnode/base-2\nnode/extra\n")])
+    result, _runner = _run_check({"min_count": 2}, [_ok(_nodes_json("base-1", "base-2", "extra"))])
 
     assert result["passed"] is True
     assert result["output"] == "Node count matched: 3 >= 2"
@@ -131,7 +141,7 @@ def test_node_count_min_count_passes_when_actual_is_higher() -> None:
 
 def test_node_count_mismatch_fails() -> None:
     """Verify mismatched exact node counts fail with a clear error."""
-    result, _runner = _run_check({"count": 3}, [_ok("node/base-1\nnode/base-2\n")])
+    result, _runner = _run_check({"count": 3}, [_ok(_nodes_json("base-1", "base-2"))])
 
     assert result["passed"] is False
     assert result["error"] == "Node count mismatch: expected 3, found 2"
@@ -145,9 +155,38 @@ def test_node_count_fails_when_kubectl_fails() -> None:
     assert result["error"] == "Failed to get node count: cluster unavailable"
 
 
+def test_node_count_fails_on_invalid_json() -> None:
+    """Verify invalid kubectl JSON is reported as a parse failure."""
+    result, _runner = _run_check({"count": 1}, [_ok("not-json")])
+
+    assert result["passed"] is False
+    assert "Failed to parse node list" in str(result["error"])
+
+
 def test_node_count_rejects_count_and_min_count_together() -> None:
     """Verify count and min_count cannot be configured together."""
     result, _runner = _run_check({"count": 1, "min_count": 1}, [])
 
     assert result["passed"] is False
     assert result["error"] == "Configure only one of 'count' or 'min_count'"
+
+
+def test_expected_nodes_uses_node_json() -> None:
+    """Verify expected-node matching reads node names from JSON."""
+    check = K8sExpectedNodesCheck(config={"names": ["base-1", "base-2"]})
+    with (
+        patch("isvtest.validations.k8s_nodes.get_kubectl_base_shell", return_value="kubectl"),
+        patch.object(check, "run_command", return_value=_ok(_nodes_json("base-1", "base-2"))) as mock_run,
+    ):
+        check.run()
+    assert check.passed
+    assert mock_run.call_args[0][0] == "kubectl get nodes -o json"
+
+
+def test_expected_nodes_fails_on_invalid_json() -> None:
+    """Verify invalid node JSON fails expected-node matching."""
+    check = K8sExpectedNodesCheck(config={"names": ["base-1"]})
+    with patch.object(check, "run_command", return_value=_ok("not-json")):
+        check.run()
+    assert not check.passed
+    assert "Failed to parse node list" in check.message

--- a/isvtest/tests/test_k8s_scheduling.py
+++ b/isvtest/tests/test_k8s_scheduling.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Tests for k8s scheduling/capacity validations."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from isvtest.core.runners import CommandResult
+from isvtest.validations.k8s_scheduling import K8sGpuCapacityCheck
+
+
+def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    """Return a successful ``CommandResult``."""
+    return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def test_gpu_capacity_uses_node_json() -> None:
+    """Verify GPU capacity is summed from node JSON capacity fields."""
+    check = K8sGpuCapacityCheck(config={"expected_total": 4, "expected_per_node": 2})
+    payload = json.dumps(
+        {
+            "items": [
+                {"metadata": {"name": "gpu-1"}, "status": {"capacity": {"nvidia.com/gpu": "2"}}},
+                {"metadata": {"name": "gpu-2"}, "status": {"capacity": {"nvidia.com/gpu": "2"}}},
+            ]
+        }
+    )
+
+    with (
+        patch("isvtest.validations.k8s_scheduling.get_kubectl_base_shell", return_value="kubectl"),
+        patch.object(check, "run_command", return_value=_ok(payload)) as mock_run,
+    ):
+        check.run()
+
+    assert check.passed
+    assert mock_run.call_args[0][0] == "kubectl get nodes -o json"

--- a/isvtest/tests/test_k8s_storage.py
+++ b/isvtest/tests/test_k8s_storage.py
@@ -47,6 +47,27 @@ def _fail(stdout: str = "", stderr: str = "", exit_code: int = 1) -> CommandResu
     return CommandResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration=0.0)
 
 
+def _storage_class_json(name: str = "sc") -> str:
+    """Return a minimal StorageClass JSON payload."""
+    return json.dumps({"kind": "StorageClass", "metadata": {"name": name}})
+
+
+def _pvc_json(
+    *,
+    phase: str = "Bound",
+    capacity: str | None = "1Gi",
+    volume_name: str | None = "pv-123",
+) -> str:
+    """Return a minimal PVC JSON payload."""
+    status: dict[str, Any] = {"phase": phase}
+    if capacity is not None:
+        status["capacity"] = {"storage": capacity}
+    spec: dict[str, Any] = {}
+    if volume_name is not None:
+        spec["volumeName"] = volume_name
+    return json.dumps({"kind": "PersistentVolumeClaim", "status": status, "spec": spec})
+
+
 class _FakeProc:
     """Minimal stand-in for ``subprocess.CompletedProcess`` used by ``kubectl apply``."""
 
@@ -165,11 +186,11 @@ class TestK8sCsiStorageTypesCheck:
             if "create namespace" in cmd:
                 return _ok()
             if "get storageclass" in cmd:
-                return _ok(stdout="storageclass.storage.k8s.io/x\n")
+                return _ok(stdout=_storage_class_json("x"))
             if "wait --for=condition=Ready" in cmd:
                 return _ok()
             if "get pvc" in cmd:
-                return _ok(stdout="Bound")
+                return _ok(stdout=_pvc_json())
             if "delete namespace" in cmd:
                 return _ok()
             raise AssertionError(f"unexpected command: {cmd}")
@@ -201,11 +222,11 @@ class TestK8sCsiStorageTypesCheck:
             if "create namespace" in cmd:
                 return _ok()
             if "get storageclass" in cmd:
-                return _ok(stdout="storageclass.storage.k8s.io/gp3\n")
+                return _ok(stdout=_storage_class_json("gp3"))
             if "wait --for=condition=Ready" in cmd:
                 return _ok()
             if "get pvc" in cmd:
-                return _ok(stdout="Bound")
+                return _ok(stdout=_pvc_json())
             if "delete namespace" in cmd:
                 return _ok()
             raise AssertionError(f"unexpected command: {cmd}")
@@ -250,6 +271,27 @@ class TestK8sCsiStorageTypesCheck:
         # Paired PVC subtest must be marked skipped so the failure isn't double-counted.
         assert outcomes["pvc-binds[block]"]["skipped"]
 
+    def test_invalid_storageclass_json_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stub_env(monkeypatch)
+        check = self._make({"block_storage_class": "gp3", "bind_timeout_s": 5, "namespace_prefix": "ut"})
+
+        def fake_run(cmd: str, timeout: int | None = None) -> CommandResult:
+            if "create namespace" in cmd:
+                return _ok()
+            if "get storageclass" in cmd:
+                return _ok(stdout="not-json")
+            if "delete namespace" in cmd:
+                return _ok()
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with patch.object(check, "run_command", side_effect=fake_run):
+            check.run()
+
+        assert not check.passed
+        outcomes = {r["name"]: r for r in check._subtest_results}
+        assert not outcomes["sc-exists[block]"]["passed"]
+        assert "Failed to parse StorageClass" in outcomes["sc-exists[block]"]["message"]
+
     def test_pvc_never_binds_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._stub_env(monkeypatch)
         check = self._make({"block_storage_class": "gp3", "bind_timeout_s": 1, "namespace_prefix": "ut"})
@@ -258,13 +300,13 @@ class TestK8sCsiStorageTypesCheck:
             if "create namespace" in cmd:
                 return _ok()
             if "get storageclass" in cmd:
-                return _ok(stdout="storageclass.storage.k8s.io/gp3\n")
+                return _ok(stdout=_storage_class_json("gp3"))
             # Consumer pod never reaches Ready because the PVC stays Pending
             # under WaitForFirstConsumer with no provisioner available.
             if "wait --for=condition=Ready" in cmd:
                 return _fail(stderr="timed out waiting for the condition")
             if "get pvc" in cmd:
-                return _ok(stdout="Pending")
+                return _ok(stdout=_pvc_json(phase="Pending"))
             if "delete namespace" in cmd:
                 return _ok()
             raise AssertionError(f"unexpected command: {cmd}")
@@ -290,7 +332,7 @@ class TestK8sCsiStorageTypesCheck:
             if "create namespace" in cmd:
                 return _ok()
             if "get storageclass" in cmd:
-                return _ok(stdout="storageclass.storage.k8s.io/gp3\n")
+                return _ok(stdout=_storage_class_json("gp3"))
             if "delete namespace" in cmd:
                 return _ok()
             raise AssertionError(f"unexpected command: {cmd}")
@@ -318,7 +360,7 @@ class TestK8sCsiStorageTypesCheck:
             if "create namespace" in cmd:
                 return _ok()
             if "get storageclass" in cmd:
-                return _ok(stdout="storageclass.storage.k8s.io/gp3\n")
+                return _ok(stdout=_storage_class_json("gp3"))
             if "delete namespace" in cmd:
                 return _ok()
             raise AssertionError(f"unexpected command: {cmd}")
@@ -364,11 +406,11 @@ class TestK8sCsiStorageTypesCheck:
             if "create namespace" in cmd:
                 return _ok()
             if "get storageclass" in cmd:
-                return _ok(stdout="storageclass.storage.k8s.io/gp3-from-env\n")
+                return _ok(stdout=_storage_class_json("gp3-from-env"))
             if "wait --for=condition=Ready" in cmd:
                 return _ok()
             if "get pvc" in cmd:
-                return _ok(stdout="Bound")
+                return _ok(stdout=_pvc_json())
             if "delete namespace" in cmd:
                 return _ok()
             raise AssertionError(f"unexpected command: {cmd}")
@@ -401,11 +443,11 @@ class TestK8sCsiStorageTypesCheck:
             if "create namespace" in cmd:
                 return _ok()
             if "get storageclass" in cmd:
-                return _ok(stdout="storageclass.storage.k8s.io/efs-sc\n")
+                return _ok(stdout=_storage_class_json("efs-sc"))
             if "wait --for=condition=Ready" in cmd:
                 return _ok()
             if "get pvc" in cmd:
-                return _ok(stdout="Bound")
+                return _ok(stdout=_pvc_json())
             if "delete namespace" in cmd:
                 return _ok()
             raise AssertionError(f"unexpected command: {cmd}")
@@ -616,12 +658,8 @@ class TestK8sCsiStorageQuotaApiCheck:
                 # when the PVC stays Pending, the wait fails so the check
                 # reports the timeout correctly.
                 return _ok() if pvc_phase == "Bound" else _fail(stderr="timed out waiting for the condition")
-            if "get pvc" in cmd and "jsonpath='{.status.phase}'" in cmd:
-                return _ok(stdout=pvc_phase)
-            if "get pvc" in cmd and "jsonpath='{.status.capacity.storage}'" in cmd:
-                return _ok(stdout=pvc_capacity)
-            if "get pvc" in cmd and "jsonpath='{.spec.volumeName}'" in cmd:
-                return _ok(stdout=volume_name)
+            if "get pvc" in cmd and "-o json" in cmd:
+                return _ok(stdout=_pvc_json(phase=pvc_phase, capacity=pvc_capacity, volume_name=volume_name))
             if "get pv " in cmd and "-o json" in cmd:
                 return _ok(stdout=pv_json)
             if "delete namespace" in cmd:
@@ -909,12 +947,8 @@ class TestK8sCsiStorageQuotaApiCheck:
                 )
             if "wait --for=condition=Ready" in cmd:
                 return _ok()
-            if "get pvc" in cmd and "status.phase" in cmd:
-                return _ok(stdout="Bound")
-            if "get pvc" in cmd and "status.capacity.storage" in cmd:
-                return _ok(stdout="1Gi")
-            if "get pvc" in cmd and "spec.volumeName" in cmd:
-                return _ok(stdout="pv-123")
+            if "get pvc" in cmd and "-o json" in cmd:
+                return _ok(stdout=_pvc_json(volume_name="pv-123"))
             if "get pv " in cmd and "-o json" in cmd:
                 # Build PV payload; default claim ref matches usage PVC unless
                 # overridden by mutator_kwargs.
@@ -997,12 +1031,8 @@ class TestK8sCsiStorageQuotaApiCheck:
                 )
             if "wait --for=condition=Ready" in cmd:
                 return _ok()
-            if "get pvc" in cmd and "status.phase" in cmd:
-                return _ok(stdout="Bound")
-            if "get pvc" in cmd and "status.capacity.storage" in cmd:
-                return _ok(stdout="1Gi")
-            if "get pvc" in cmd and "spec.volumeName" in cmd:
-                return _ok(stdout="pv-env")
+            if "get pvc" in cmd and "-o json" in cmd:
+                return _ok(stdout=_pvc_json(volume_name="pv-env"))
             if "get pv " in cmd:
                 return _ok(
                     stdout=self._pv_json(
@@ -1873,10 +1903,8 @@ class TestK8sCsiProvisioningModesCheck:
                 return _ok()
             if "delete namespace" in cmd or "delete pv" in cmd:
                 return _ok()
-            if "get pvc" in cmd and ".status.phase" in cmd:
-                return _ok(stdout=phase)
-            if "get pvc" in cmd and ".spec.volumeName" in cmd:
-                return _ok(stdout=volume_name)
+            if "get pvc" in cmd and "-o json" in cmd:
+                return _ok(stdout=_pvc_json(phase=phase, volume_name=volume_name))
             if "get pv" in cmd and "-o json" in cmd:
                 return _ok(stdout=pv_json)
             if "wait --for=condition=Ready" in cmd:


### PR DESCRIPTION
## Summary

Moves the Kubernetes validation and core helper code off `kubectl` table/jsonpath text parsing and onto `kubectl -o json` + structured field access. Brittle patterns like dot-escaped resource names (`nvidia\.com/gpu`), jsonpath filter expressions for `Ready` conditions, and substring/`map[...]` matching on text output are replaced by `json.loads` and typed lookups. Public function signatures are unchanged, so workload callers (`k8s_nim`, `k8s_nccl`, `k8s_stress`, ...) are untouched.

## Changes

- Adds `parse_kubectl_json`, `parse_kubectl_json_items`, and `pod_status_reason` helpers in `core/k8s.py`; `KubectlParseError` surfaces malformed output with a resource-tagged message that callers can pass straight to `set_failed`.
- Converts k8s validations to structured JSON: pod health/pending/error checks, GPU node and pod discovery, scheduling labels and capacity, node listing, network-policy pod IPs, control-plane pod resolution, PVC/PV state, and the apiserver URL from `kubectl config view`. Text parsing remains only for genuinely textual protocols (`kubectl logs`, agnhost exit codes).
- Factors the PVC fetch+parse path in `k8s_storage` into a single `_get_pvc_json` helper shared by all four PVC consumers.
- Converts the remaining `wait_for_*` / `get_*` helpers in `core/k8s.py` to JSON (`get_node_gpu_count`, `get_node_status`, `wait_for_job_completion`, `wait_for_pod_status`/`completion` via `parse_pod_state`).
- Converts `core/workload.py` and `core/ngc.py` job-completion loops to `kubectl -o json` + structured condition parsing, tightening the previous `"Complete" in stdout` substring check that could match unrelated condition messages.
- Adds unit coverage for the new JSON paths in `tests/test_k8s.py`, `test_k8s_cluster.py`, `test_k8s_gpu.py`, `test_k8s_gpu_operator.py`, `test_k8s_nodes.py`, `test_k8s_scheduling.py`, `test_k8s_storage.py`, and refreshed expectations in the existing `test_k8s_*` files.

## Test plan

- [x] `make test`
- [x] `make lint`
- [x] `make demo-test`
- [x] Live `isvctl test run` against a real Kubernetes cluster covering GPU, scheduling, storage, and workload waits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cluster checks now use centralized JSON parsing with structured error handling instead of ad-hoc text/jsonpath parsing.
  * Pod, job and node state discovery rewritten to use normalized JSON-derived states, improving robustness and consistent handling of transient/parse failures.
  * Storage and networking checks updated to read resource JSON payloads for more reliable status extraction.

* **Tests**
  * Expanded unit tests covering JSON parsing, error routing, and pod/job/node/storage state handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/ISV-NCP-Validation-Suite/pull/415)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->