### PR TITLE
refactor: simplify k8s structured probe helpers

### DIFF
--- a/isvtest/src/isvtest/core/k8s.py
+++ b/isvtest/src/isvtest/core/k8s.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from isvtest.core.validation import BaseValidation
 
 logger = setup_logger(__name__)
+KubectlJsonResult = CommandResult | subprocess.CompletedProcess[Any]
 
 # Container waiting reasons that kubelet only reports after it has already
 # given up retrying - callers can fast-fail instead of waiting out a timeout.
@@ -212,7 +213,7 @@ class KubectlParseError(Exception):
 
 
 def parse_kubectl_json(
-    result: CommandResult,
+    result: KubectlJsonResult,
     resource: str = "kubectl JSON output",
 ) -> dict[str, Any]:
     """Parse ``kubectl ... -o json`` stdout into a JSON object.
@@ -234,7 +235,7 @@ def parse_kubectl_json(
 
 
 def parse_kubectl_json_items(
-    result: CommandResult,
+    result: KubectlJsonResult,
     resource: str = "kubectl JSON list output",
 ) -> list[dict[str, Any]]:
     """Extract the ``items`` list from a ``kubectl get ... -o json`` result.
@@ -255,27 +256,60 @@ def kubectl_items_or_fail(
     validation: "BaseValidation",
     result: CommandResult,
     resource: str,
-    *,
-    exec_label: str | None = None,
 ) -> list[dict[str, Any]] | None:
     """Parse ``kubectl get ... -o json`` items, routing failures to ``validation.set_failed``.
 
     Returns the items list on success, or ``None`` after marking the validation
     failed when the command exited non-zero or returned unparseable JSON.
-
-    ``exec_label`` overrides the noun used in the exec-failure message
-    (``"Failed to get {label}: ..."``) when callers want wording other than the
-    parse-error ``resource`` (e.g. ``"node count"`` vs ``"node list"``).
     """
     if result.exit_code != 0:
-        label = exec_label or resource
-        validation.set_failed(f"Failed to get {label}: {result.stderr}")
+        validation.set_failed(f"Failed to get {resource}: {result.stderr}")
         return None
     try:
         return parse_kubectl_json_items(result, resource)
     except KubectlParseError as exc:
         validation.set_failed(str(exc))
         return None
+
+
+def kubectl_payload_or_none(
+    result: KubectlJsonResult,
+) -> dict[str, Any] | None:
+    """Best-effort parse of ``kubectl ... -o json`` stdout into a JSON object.
+
+    Returns ``None`` on empty or malformed output - callers that fall back to
+    sentinels (empty lists, ``"Unknown"``, ``0``) keep their old behaviour
+    rather than raising, since they cannot surface a validation failure.
+    """
+    if not result.stdout:
+        return None
+    try:
+        return parse_kubectl_json(result)
+    except KubectlParseError:
+        return None
+
+
+def kubectl_items_or_empty(
+    result: KubectlJsonResult,
+) -> list[dict[str, Any]]:
+    """Best-effort items list; returns ``[]`` on empty or malformed output."""
+    if not result.stdout:
+        return []
+    try:
+        return parse_kubectl_json_items(result)
+    except KubectlParseError:
+        return []
+
+
+def names_from_items(items: list[dict[str, Any]]) -> list[str]:
+    """Extract ``.metadata.name`` values from a list of Kubernetes API objects."""
+    names: list[str] = []
+    for item in items:
+        metadata = item.get("metadata") or {}
+        name = metadata.get("name") if isinstance(metadata, dict) else None
+        if name:
+            names.append(str(name))
+    return names
 
 
 def pod_status_reason(pod: dict[str, Any]) -> str:
@@ -370,7 +404,7 @@ def parse_pod_state(stdout: str, stderr: str) -> tuple[str, str, str]:
 
 
 def pod_state_from_result(
-    result: "CommandResult | subprocess.CompletedProcess[Any]",
+    result: KubectlJsonResult,
 ) -> tuple[str, str, str]:
     """Parse pod state from a ``kubectl get pod -o json`` result.
 
@@ -380,9 +414,10 @@ def pod_state_from_result(
     ``parse_pod_state``: on failure only stderr is inspected (for NotFound
     detection); on success only stdout is parsed.
     """
-    exit_code = getattr(result, "exit_code", None)
-    if exit_code is None:
-        exit_code = result.returncode  # subprocess.CompletedProcess
+    if isinstance(result, CommandResult):
+        exit_code = result.exit_code
+    else:
+        exit_code = result.returncode
     if exit_code == 0:
         return parse_pod_state(result.stdout, "")
     return parse_pod_state("", result.stderr or "")
@@ -464,41 +499,6 @@ def is_k8s_available() -> bool:
         return False
 
 
-def _parse_run_kubectl_json(result: subprocess.CompletedProcess[Any]) -> dict[str, Any] | None:
-    """Best-effort ``json.loads`` for ``run_kubectl(... -o json)`` stdout.
-
-    Returns ``None`` on empty or malformed output - callers that fall back to
-    sentinels (empty lists, ``"Unknown"``, ``0``) keep their old behaviour
-    rather than raising, since they cannot surface a validation failure.
-    """
-    if not result.stdout:
-        return None
-    try:
-        payload = json.loads(result.stdout)
-    except json.JSONDecodeError:
-        return None
-    return payload if isinstance(payload, dict) else None
-
-
-def _items_from_run_kubectl(result: subprocess.CompletedProcess[Any]) -> list[dict[str, Any]]:
-    """Return the ``items`` list from ``run_kubectl(... -o json)`` (empty on failure)."""
-    payload = _parse_run_kubectl_json(result)
-    if payload is None:
-        return []
-    items = payload.get("items")
-    return [item for item in items if isinstance(item, dict)] if isinstance(items, list) else []
-
-
-def _node_names_from_kubectl(result: subprocess.CompletedProcess[Any]) -> list[str]:
-    """Extract node names from a ``kubectl get nodes -o json`` result."""
-    names: list[str] = []
-    for item in _items_from_run_kubectl(result):
-        name = (item.get("metadata") or {}).get("name")
-        if name:
-            names.append(str(name))
-    return names
-
-
 def get_gpu_nodes() -> list[str]:
     """Get list of GPU-enabled nodes in the cluster.
 
@@ -508,7 +508,7 @@ def get_gpu_nodes() -> list[str]:
     result = run_kubectl(["get", "nodes", "-l", "nvidia.com/gpu.present=true", "-o", "json"])
     if result.returncode != 0:
         return []
-    return _node_names_from_kubectl(result)
+    return names_from_items(kubectl_items_or_empty(result))
 
 
 def get_node_gpu_count(node_name: str) -> int:
@@ -523,7 +523,7 @@ def get_node_gpu_count(node_name: str) -> int:
     result = run_kubectl(["get", "node", node_name, "-o", "json"])
     if result.returncode != 0:
         return 0
-    payload = _parse_run_kubectl_json(result)
+    payload = kubectl_payload_or_none(result)
     if payload is None:
         return 0
     capacity = (payload.get("status") or {}).get("capacity") or {}
@@ -776,7 +776,7 @@ def wait_for_job_completion(
     while time.time() - start_time < timeout:
         # Check job conditions for Complete or Failed status
         result = run_kubectl(["get", "job", job_name, "-n", namespace, "-o", "json"])
-        job_payload = _parse_run_kubectl_json(result) if result.returncode == 0 else None
+        job_payload = kubectl_payload_or_none(result) if result.returncode == 0 else None
         if job_payload is not None:
             terminal = job_terminal_status(job_payload)
             if terminal is not None:
@@ -810,7 +810,7 @@ def _format_job_pod_info(result: subprocess.CompletedProcess[Any]) -> tuple[str,
     """
     if result.returncode != 0:
         return "No pods", ""
-    pods = _items_from_run_kubectl(result)
+    pods = kubectl_items_or_empty(result)
     if not pods:
         return "No pods", ""
     first_status = pods[0].get("status") or {}
@@ -846,12 +846,7 @@ def get_job_pods(job_name: str, namespace: str) -> list[str]:
     result = run_kubectl(["get", "pods", "-n", namespace, "-l", f"job-name={job_name}", "-o", "json"])
     if result.returncode != 0:
         return []
-    names: list[str] = []
-    for pod in _items_from_run_kubectl(result):
-        name = (pod.get("metadata") or {}).get("name")
-        if name:
-            names.append(str(name))
-    return names
+    return names_from_items(kubectl_items_or_empty(result))
 
 
 def delete_job(job_name: str, namespace: str, wait: bool = True) -> bool:
@@ -904,28 +899,26 @@ def wait_for_multiple_pods_completion(
     """
     start_time = time.time()
     results = {pod_name: (False, "Unknown") for pod_name in pod_names}
-    wanted = set(pod_names)
-    completed_pods: set[str] = set()
+    pending = set(pod_names)
 
     while time.time() - start_time < timeout:
         result = run_kubectl(["get", "pods", "-n", namespace, "-o", "json"])
 
         if result.returncode == 0:
-            for pod in _items_from_run_kubectl(result):
+            for pod in kubectl_items_or_empty(result):
                 name = (pod.get("metadata") or {}).get("name")
-                if name not in wanted:
+                if name not in pending:
                     continue
                 phase = str((pod.get("status") or {}).get("phase") or "")
                 if phase in ("Succeeded", "Failed"):
                     results[name] = (True, phase)
-                    completed_pods.add(name)
+                    pending.discard(name)
 
-        if len(completed_pods) == len(wanted):
+        if not pending:
             return results
 
         time.sleep(0.5)
 
-    # Timeout - return current status
     return results
 
 
@@ -938,7 +931,7 @@ def get_all_nodes() -> list[str]:
     result = run_kubectl(["get", "nodes", "-o", "json"])
     if result.returncode != 0:
         return []
-    return _node_names_from_kubectl(result)
+    return names_from_items(kubectl_items_or_empty(result))
 
 
 def get_node_status(node_name: str) -> str:
@@ -954,7 +947,7 @@ def get_node_status(node_name: str) -> str:
     result = run_kubectl(["get", "node", node_name, "-o", "json"])
     if result.returncode != 0:
         return "Unknown"
-    payload = _parse_run_kubectl_json(result)
+    payload = kubectl_payload_or_none(result)
     if payload is None:
         return "Unknown"
     for condition in (payload.get("status") or {}).get("conditions") or []:

--- a/isvtest/src/isvtest/validations/k8s_cluster.py
+++ b/isvtest/src/isvtest/validations/k8s_cluster.py
@@ -28,13 +28,13 @@ class K8sPodHealthCheck(BaseValidation):
     markers: ClassVar[list[str]] = ["kubernetes"]
 
     def run(self) -> None:
-        # Configurable ignore phases
         ignore_phases = self.config.get("ignore_phases", [])
 
         kubectl_base = get_kubectl_base_shell()
 
-        result = self.run_command(f"{kubectl_base} get pods -A -o json")
-        pods = kubectl_items_or_fail(self, result, "pod list", exec_label="pod status")
+        cmd = f"{kubectl_base} get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded -o json"
+        result = self.run_command(cmd)
+        pods = kubectl_items_or_fail(self, result, "pod list")
         if pods is None:
             return
 
@@ -46,10 +46,9 @@ class K8sPodHealthCheck(BaseValidation):
             if status in ignore_phases:
                 continue
 
-            if status not in {"Running", "Succeeded"}:
-                namespace = metadata.get("namespace", "default")
-                name = metadata.get("name", "unknown")
-                unhealthy_pods.append(f"{namespace}/{name} ({status})")
+            namespace = metadata.get("namespace", "default")
+            name = metadata.get("name", "unknown")
+            unhealthy_pods.append(f"{namespace}/{name} ({status})")
 
         if unhealthy_pods:
             self.set_failed(
@@ -68,15 +67,14 @@ class K8sNoPendingPodsCheck(BaseValidation):
     def run(self) -> None:
         kubectl_base = get_kubectl_base_shell()
 
-        result = self.run_command(f"{kubectl_base} get pods -A -o json")
-        pods = kubectl_items_or_fail(self, result, "pod list", exec_label="pending pods")
+        cmd = f"{kubectl_base} get pods -A --field-selector=status.phase=Pending -o json"
+        result = self.run_command(cmd)
+        pods = kubectl_items_or_fail(self, result, "pod list")
         if pods is None:
             return
 
         pending_pods = []
         for pod in pods:
-            if (pod.get("status") or {}).get("phase") != "Pending":
-                continue
             metadata = pod.get("metadata") or {}
             pending_pods.append(f"{metadata.get('namespace', 'default')}/{metadata.get('name', 'unknown')}")
 
@@ -107,7 +105,7 @@ class K8sNoErrorPodsCheck(BaseValidation):
         )
 
         result = self.run_command(f"{kubectl_base} get pods -A -o json")
-        pods = kubectl_items_or_fail(self, result, "pod list", exec_label="pods")
+        pods = kubectl_items_or_fail(self, result, "pod list")
         if pods is None:
             return
 

--- a/isvtest/src/isvtest/validations/k8s_gpu.py
+++ b/isvtest/src/isvtest/validations/k8s_gpu.py
@@ -23,6 +23,7 @@ from isvtest.config.settings import get_k8s_namespace
 from isvtest.core.k8s import (
     get_kubectl_base_shell,
     kubectl_items_or_fail,
+    names_from_items,
     pod_state_from_result,
 )
 from isvtest.core.nvidia import count_gpus_from_full_output, parse_driver_version
@@ -38,7 +39,6 @@ class K8sNvidiaSmiCheck(BaseValidation):
         timeout = int(self.config.get("timeout", 60))
         results = self._run_ephemeral_pods(timeout=timeout)
         if results is None:
-            # ``_run_ephemeral_pods`` already routed the failure via set_failed.
             return
 
         failed_nodes = []
@@ -68,15 +68,12 @@ class K8sNvidiaSmiCheck(BaseValidation):
         kubectl_base = get_kubectl_base_shell()
         namespace = get_k8s_namespace()
 
-        # 1. Identify GPU nodes
         result = self.run_command(f"{kubectl_base} get nodes -l nvidia.com/gpu.present=true -o json")
-        nodes = kubectl_items_or_fail(self, result, "GPU node list", exec_label="GPU nodes")
+        nodes = kubectl_items_or_fail(self, result, "GPU node list")
         if nodes is None:
             return None
 
-        gpu_nodes = [
-            str((node.get("metadata") or {}).get("name")) for node in nodes if (node.get("metadata") or {}).get("name")
-        ]
+        gpu_nodes = names_from_items(nodes)
         if not gpu_nodes:
             self.log.warning("No GPU nodes found with label nvidia.com/gpu.present=true")
             return {}

--- a/isvtest/src/isvtest/validations/k8s_gpu_operator.py
+++ b/isvtest/src/isvtest/validations/k8s_gpu_operator.py
@@ -17,7 +17,7 @@ import shlex
 from typing import ClassVar
 
 from isvtest.config.settings import get_k8s_gpu_operator_namespace
-from isvtest.core.k8s import get_kubectl_base_shell, kubectl_items_or_fail
+from isvtest.core.k8s import get_kubectl_base_shell, kubectl_items_or_fail, pod_status_reason
 from isvtest.core.validation import BaseValidation
 
 
@@ -51,13 +51,13 @@ class K8sGpuOperatorPodsCheck(BaseValidation):
         kubectl_base = get_kubectl_base_shell()
 
         result = self.run_command(f"{kubectl_base} get pods -n {shlex.quote(namespace)} -o json")
-        pods = kubectl_items_or_fail(self, result, "GPU Operator pod list", exec_label="GPU Operator pods")
+        pods = kubectl_items_or_fail(self, result, "GPU Operator pod list")
         if pods is None:
             return
 
         running_pods = []
         for pod in pods:
-            if (pod.get("status") or {}).get("phase") == "Running":
+            if pod_status_reason(pod) == "Running":
                 running_pods.append((pod.get("metadata") or {}).get("name", "unknown"))
 
         if not running_pods:

--- a/isvtest/src/isvtest/validations/k8s_nodes.py
+++ b/isvtest/src/isvtest/validations/k8s_nodes.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 import shlex
-from typing import Any, ClassVar
+from typing import ClassVar
 
-from isvtest.core.k8s import get_kubectl_base_shell, kubectl_items_or_fail
+from isvtest.core.k8s import get_kubectl_base_shell, kubectl_items_or_fail, names_from_items
 from isvtest.core.validation import BaseValidation
 
 
@@ -90,6 +90,9 @@ class K8sNodeCountCheck(BaseValidation):
         if isinstance(value, bool):
             self.set_failed(f"Invalid {field}: {value!r}")
             return 0
+        if not isinstance(value, int | str):
+            self.set_failed(f"Invalid {field}: {value}")
+            return 0
         try:
             parsed = int(value)
         except (ValueError, TypeError):
@@ -106,10 +109,10 @@ class K8sNodeCountCheck(BaseValidation):
         cmd = f"{get_kubectl_base_shell()} get nodes{selector_args} -o json"
 
         result = self.run_command(cmd)
-        items = kubectl_items_or_fail(self, result, "node list", exec_label="node count")
+        items = kubectl_items_or_fail(self, result, "node list")
         if items is None:
             return None
-        return _node_names_from_items(items)
+        return names_from_items(items)
 
 
 def _optional_selector(value: object, field: str) -> str | None:
@@ -126,17 +129,6 @@ def _combine_label_selectors(*selectors: str | None) -> str | None:
     """Combine label selectors with Kubernetes AND semantics."""
     parts = [selector.strip().strip(",") for selector in selectors if selector and selector.strip().strip(",")]
     return ",".join(parts) if parts else None
-
-
-def _node_names_from_items(items: list[dict[str, Any]]) -> list[str]:
-    """Extract node names from ``kubectl get nodes -o json`` items."""
-    names: list[str] = []
-    for item in items:
-        metadata = item.get("metadata") or {}
-        name = metadata.get("name") if isinstance(metadata, dict) else None
-        if name:
-            names.append(str(name))
-    return names
 
 
 def _scope_description(label_selector: str | None, exclude_selector: str | None) -> str:
@@ -156,9 +148,8 @@ class K8sNodeReadyCheck(BaseValidation):
     def run(self) -> None:
         kubectl_base = get_kubectl_base_shell()
 
-        # Use JSON output for safer parsing
         result = self.run_command(f"{kubectl_base} get nodes -o json")
-        items = kubectl_items_or_fail(self, result, "node list", exec_label="nodes")
+        items = kubectl_items_or_fail(self, result, "node list")
         if items is None:
             return
 
@@ -175,7 +166,6 @@ class K8sNodeReadyCheck(BaseValidation):
 
             # Find the Ready condition
             ready_condition = next((c for c in conditions if c.get("type") == "Ready"), None)
-
             if not ready_condition:
                 not_ready_nodes.append(f"{name} (No Ready condition found)")
                 continue
@@ -209,14 +199,13 @@ class K8sExpectedNodesCheck(BaseValidation):
             self.set_passed("Skipped: expected_nodes.names not configured")
             return
 
-        # Get actual nodes
         kubectl_base = get_kubectl_base_shell()
         result = self.run_command(f"{kubectl_base} get nodes -o json")
-        items = kubectl_items_or_fail(self, result, "node list", exec_label="nodes")
+        items = kubectl_items_or_fail(self, result, "node list")
         if items is None:
             return
 
-        actual_nodes = _node_names_from_items(items)
+        actual_nodes = names_from_items(items)
         actual_nodes_set = set(actual_nodes)
         expected_names_set = set(expected_names)
 

--- a/isvtest/src/isvtest/validations/k8s_scheduling.py
+++ b/isvtest/src/isvtest/validations/k8s_scheduling.py
@@ -31,7 +31,7 @@ class K8sGpuLabelsCheck(BaseValidation):
 
         cmd = f"{kubectl_base} get nodes -l {shlex.quote(label_selector)} -o json"
         result = self.run_command(cmd)
-        nodes = kubectl_items_or_fail(self, result, "GPU node list", exec_label="GPU nodes")
+        nodes = kubectl_items_or_fail(self, result, "GPU node list")
         if nodes is None:
             return
 
@@ -78,7 +78,7 @@ class K8sGpuCapacityCheck(BaseValidation):
         kubectl_base = get_kubectl_base_shell()
 
         result = self.run_command(f"{kubectl_base} get nodes -o json")
-        nodes = kubectl_items_or_fail(self, result, "node list", exec_label="node capacity")
+        nodes = kubectl_items_or_fail(self, result, "node list")
         if nodes is None:
             return
 

--- a/isvtest/tests/test_k8s.py
+++ b/isvtest/tests/test_k8s.py
@@ -216,13 +216,6 @@ class TestKubectlItemsOrFail:
         assert items is None
         assert validation.error == "Failed to get node list: cluster unavailable"
 
-    def test_exec_label_overrides_failure_noun(self) -> None:
-        validation = _StubValidation()
-        result = _command_result("", exit_code=1, stderr="cluster unavailable")
-        items = kubectl_items_or_fail(validation, result, "node list", exec_label="node count")
-        assert items is None
-        assert validation.error == "Failed to get node count: cluster unavailable"
-
     def test_routes_parse_failure_to_set_failed(self) -> None:
         validation = _StubValidation()
         items = kubectl_items_or_fail(validation, _command_result("not-json"), "node list")

--- a/isvtest/tests/test_k8s_cluster.py
+++ b/isvtest/tests/test_k8s_cluster.py
@@ -46,7 +46,7 @@ def _items_json(items: list[dict[str, Any]]) -> str:
 def test_pod_health_uses_json_and_passes_for_running_or_succeeded_pods() -> None:
     """Verify the pod-health check reads structured pod JSON."""
     check = K8sPodHealthCheck(config={})
-    payload = _items_json([_pod("running", "Running"), _pod("done", "Succeeded")])
+    payload = _items_json([])
 
     with (
         patch("isvtest.validations.k8s_cluster.get_kubectl_base_shell", return_value="kubectl"),
@@ -55,7 +55,12 @@ def test_pod_health_uses_json_and_passes_for_running_or_succeeded_pods() -> None
         check.run()
 
     assert check.passed
-    assert mock_run.call_args[0][0] == "kubectl get pods -A -o json"
+    # Field selector filters server-side, so the JSON output need only carry the
+    # unhealthy pods - here, none.
+    assert (
+        mock_run.call_args[0][0]
+        == "kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded -o json"
+    )
 
 
 def test_pod_health_fails_on_invalid_json() -> None:

--- a/isvtest/tests/test_k8s_gpu_operator.py
+++ b/isvtest/tests/test_k8s_gpu_operator.py
@@ -42,3 +42,30 @@ def test_gpu_operator_pods_use_json_phase() -> None:
 
     assert check.passed
     assert mock_run.call_args[0][0] == "kubectl get pods -n gpu-operator -o json"
+
+
+def test_gpu_operator_pods_reject_crashlooping_running_phase() -> None:
+    """Verify kubectl STATUS semantics are preserved for crashlooping pods."""
+    check = K8sGpuOperatorPodsCheck(config={"namespace": "gpu-operator"})
+    payload = json.dumps(
+        {
+            "items": [
+                {
+                    "metadata": {"name": "gpu-operator-1"},
+                    "status": {
+                        "phase": "Running",
+                        "containerStatuses": [{"state": {"waiting": {"reason": "CrashLoopBackOff"}}}],
+                    },
+                }
+            ]
+        }
+    )
+
+    with (
+        patch("isvtest.validations.k8s_gpu_operator.get_kubectl_base_shell", return_value="kubectl"),
+        patch.object(check, "run_command", return_value=_ok(payload)),
+    ):
+        check.run()
+
+    assert not check.passed
+    assert "No GPU Operator pods are running" in check.message

--- a/isvtest/tests/test_k8s_nodes.py
+++ b/isvtest/tests/test_k8s_nodes.py
@@ -20,12 +20,12 @@ from __future__ import annotations
 import json
 from unittest.mock import patch
 
+from isvtest.core.k8s import names_from_items
 from isvtest.core.runners import CommandResult, Runner
 from isvtest.validations.k8s_nodes import (
     K8sExpectedNodesCheck,
     K8sNodeCountCheck,
     _combine_label_selectors,
-    _node_names_from_items,
 )
 
 
@@ -64,9 +64,9 @@ def _run_check(config: dict[str, object], responses: list[CommandResult]) -> tup
     return result, runner
 
 
-def test_node_names_from_items_extracts_metadata_names() -> None:
-    """Verify _node_names_from_items reads names from node JSON items."""
-    assert _node_names_from_items([{"metadata": {"name": "base-1"}}, {"metadata": {"name": "base-2"}}]) == [
+def test_names_from_items_extracts_metadata_names() -> None:
+    """Verify names_from_items reads names from API object JSON items."""
+    assert names_from_items([{"metadata": {"name": "base-1"}}, {"metadata": {"name": "base-2"}}]) == [
         "base-1",
         "base-2",
     ]
@@ -157,7 +157,7 @@ def test_node_count_fails_when_kubectl_fails() -> None:
     result, _runner = _run_check({"count": 1}, [_fail("cluster unavailable")])
 
     assert result["passed"] is False
-    assert result["error"] == "Failed to get node count: cluster unavailable"
+    assert result["error"] == "Failed to get node list: cluster unavailable"
 
 
 def test_node_count_fails_on_invalid_json() -> None:


### PR DESCRIPTION
## Summary

Follow-up cleanup to #415. Consolidates the JSON-parsing helpers that landed alongside the k8s validation rewrite: the per-module `_parse_run_kubectl_json` / `_items_from_run_kubectl` / `_node_names_from_kubectl` private helpers in `core/k8s.py` and `_node_names_from_items` in `validations/k8s_nodes.py` are merged into a single public set on `core/k8s`. Also drops the `exec_label` override from `kubectl_items_or_fail` (callers now use a single resource noun for both exec and parse failures) and pushes pod-phase filtering server-side via `--field-selector` where the validation only cares about a subset.

## Changes

- Promotes the three `_parse_run_kubectl_json` / `_items_from_run_kubectl` / `_node_names_from_kubectl` private helpers to public `kubectl_payload_or_none`, `kubectl_items_or_empty`, and `names_from_items` on `core/k8s.py`, and routes `get_gpu_nodes`, `get_node_gpu_count`, `get_node_status`, `get_all_nodes`, `get_job_pods`, `wait_for_job_completion`, `wait_for_multiple_pods_completion`, and `_format_job_pod_info` through them.
- Removes the duplicate `_node_names_from_items` in `validations/k8s_nodes.py` and updates `K8sNodeCountCheck` / `K8sExpectedNodesCheck` to reuse the shared `names_from_items`. `validations/k8s_gpu.py` now uses it instead of an inline metadata-name comprehension.
- Drops the `exec_label` keyword from `kubectl_items_or_fail` and collapses every call site to the single resource noun (e.g. `"node list"`, `"pod list"`, `"GPU node list"`). Failure messages are now consistent with parse-error messages.
- Filters server-side in `K8sPodHealthCheck` (`status.phase!=Running,status.phase!=Succeeded`) and `K8sNoPendingPodsCheck` (`status.phase=Pending`) instead of fetching every pod and filtering in Python.
- Switches `K8sGpuOperatorPodsCheck` from a raw `status.phase == "Running"` read to `pod_status_reason`, so a pod in `CrashLoopBackOff` (which still reports `phase: Running`) is no longer counted as healthy. Adds a regression test covering that case.
- Simplifies `wait_for_multiple_pods_completion` to a single `pending` set instead of the parallel `wanted` / `completed_pods` bookkeeping.

## Test plan

- [x] `make test`
- [x] `make lint`
- [x] `make demo-test`
- [x] Live k8s.yaml test on a Kubernetes cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * GPU Operator pods in CrashLoopBackOff state are now correctly identified as failing health checks.

* **Refactor**
  * Kubernetes validation checks improved with server-side pod filtering for better efficiency.
  * Standardized pod identifier and node name extraction across validation checks.

* **Tests**
  * Added test coverage for CrashLoopBackOff pod detection.
  * Updated pod health validation tests to reflect improved filtering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/ISV-NCP-Validation-Suite/pull/417)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->