### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,3 +178,4 @@ forwarded env vars → optional isvreporter upload.
 - For linting, `make lint` uses `uvx` to run a pinned ruff version (no global install required).
 - No external services (databases, containers, clusters) are needed for local development or testing. All cloud-dependent tests require explicit credentials (`AWS_*`, `NGC_API_KEY`, etc.) and are skipped in demo mode.
 - **DCO sign-off required:** All commits must include a `Signed-off-by` line (enforced by the DCO Probot check on PRs). Use `git commit --signoff` or `git commit -s` for every commit.
+- **Pre-commit checks:** Run `uvx pre-commit run -a` before committing to catch formatting, linting, SPDX header, and link issues early.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,3 +177,4 @@ forwarded env vars → optional isvreporter upload.
 - For unit tests, `make test` runs all three packages plus `scripts/tests/`.
 - For linting, `make lint` uses `uvx` to run a pinned ruff version (no global install required).
 - No external services (databases, containers, clusters) are needed for local development or testing. All cloud-dependent tests require explicit credentials (`AWS_*`, `NGC_API_KEY`, etc.) and are skipped in demo mode.
+- **DCO sign-off required:** All commits must include a `Signed-off-by` line (enforced by the DCO Probot check on PRs). Use `git commit --signoff` or `git commit -s` for every commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,3 +167,13 @@ forwarded env vars → optional isvreporter upload.
 | `KUBECTL` | Optional kubectl-compatible CLI prefix (POSIX `shlex` in Python, word-split in shell; overrides `K8S_PROVIDER` detection) | isvtest `get_kubectl_command`, isvctl k8s scripts |
 | `ISVCTL_DEMO_MODE` | `"1"` makes `my-isv` scripts return dummy success | scripts |
 | `AWS_SKIP_TEARDOWN` | Skip teardown phase (run later with `--phase teardown`) | AWS configs |
+
+## Cursor Cloud specific instructions
+
+- **uv** is installed via `pip install uv` (the `~/.local/bin` path must be on `PATH`).
+- `uv sync` from the workspace root is the only install step; it creates `.venv/` with all three packages in editable mode.
+- The `uv-build` version warning during `uv sync`/`make build` is cosmetic and does not affect functionality.
+- `make demo-test` is the best quick E2E smoke test — it runs all `my-isv` provider configs in demo mode (~8 s, no cloud credentials needed).
+- For unit tests, `make test` runs all three packages plus `scripts/tests/`.
+- For linting, `make lint` uses `uvx` to run a pinned ruff version (no global install required).
+- No external services (databases, containers, clusters) are needed for local development or testing. All cloud-dependent tests require explicit credentials (`AWS_*`, `NGC_API_KEY`, etc.) and are skipped in demo mode.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,6 @@ forwarded env vars → optional isvreporter upload.
 - `make demo-test` is the best quick E2E smoke test — it runs all `my-isv` provider configs in demo mode (~8 s, no cloud credentials needed).
 - For unit tests, `make test` runs all three packages plus `scripts/tests/`.
 - For linting, `make lint` uses `uvx` to run a pinned ruff version (no global install required).
-- No external services (databases, containers, clusters) are needed for local development or testing. All cloud-dependent tests require explicit credentials (`AWS_*`, `NGC_API_KEY`, etc.) and are skipped in demo mode.
 - **DCO sign-off required:** All commits must include a `Signed-off-by` line (enforced by the DCO Probot check on PRs). Use `git commit --signoff` or `git commit -s` for every commit.
 - **Pre-commit checks:** Run `uvx pre-commit run -a` before committing to catch formatting, linting, SPDX header, and link issues early.
+- No external services (databases, containers, clusters) are needed for local development or testing. All cloud-dependent tests require explicit credentials (`AWS_*`, `NGC_API_KEY`, etc.) and are skipped in demo mode.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with durable context for future Cloud Agents:

- How `uv` is installed (pip, `~/.local/bin` on PATH)
- `uv sync` as the sole install step
- `make demo-test` as the quick E2E smoke test (~8s, no cloud creds)
- `make test` / `make lint` usage notes
- Confirmation that no external services are needed for local dev

This helps future agents start productive work immediately without re-discovering setup steps.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-224d6813-c2f5-4bbe-a857-8c5c18f29045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-224d6813-c2f5-4bbe-a857-8c5c18f29045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added development guidelines for workspace setup, testing commands, linting procedures, and commit requirements in the agent instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/ISV-NCP-Validation-Suite/pull/422)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->