### PR TITLE
feat: add TPM baseline policy to HostSoftwareCheck

### DIFF
--- a/isvctl/configs/providers/aws/scripts/vm/docs/aws-vm.md
+++ b/isvctl/configs/providers/aws/scripts/vm/docs/aws-vm.md
@@ -188,6 +188,7 @@ Validates the full software stack: kernel, libvirt/QEMU, SBIOS, NVIDIA drivers.
 | `kernel_modules` | GPU/virt modules: `nvidia`, `kvm`, `vfio`, `vhost` |
 | `libvirt`, `qemu`, `kvm` | Virtualization stack |
 | `bios_vendor`, `bios_version`, `bios_date` | System BIOS via `dmidecode` |
+| `tpm_present`, `tpm_version` | TPM device and major version via `/sys/class/tpm/tpm0` |
 | `nvidia_driver`, `cuda_version` | NVIDIA driver and CUDA versions |
 
 | Parameter | Type | Default | Description |
@@ -197,17 +198,21 @@ Validates the full software stack: kernel, libvirt/QEMU, SBIOS, NVIDIA drivers.
 | `expected_libvirt_version` | string | *(none)* | libvirt version substring |
 | `expected_bios_vendor` | string | *(none)* | BIOS vendor name |
 | `bios_baselines` | mapping | *(none)* | Approved BIOS minimums keyed by `system_vendor|product_name` |
+| `tpm_baselines` | mapping | *(none)* | Approved minimum TPM major version keyed by `system_vendor|product_name` (SEC22-02) |
 
-When no `expected_*` parameter or `bios_baselines` policy is set, the check **reports**
-the value without failing. To build a BIOS policy, run once in report-only mode to
-capture `system_vendor`, `system_product`, and `bios_version`, then configure the
-approved baseline:
+When no `expected_*` parameter or `*_baselines` policy is set, the check **reports**
+the value without failing. To build a BIOS or TPM policy, run once in report-only
+mode to capture `system_vendor`, `system_product`, `bios_version`, and
+`tpm_version`, then configure the approved baseline:
 
 ```yaml
 HostSoftwareCheck:
   bios_baselines:
     "Dell Inc.|PowerEdge R760xa":
       min_version: "2.4.8"
+  tpm_baselines:
+    "Dell Inc.|PowerEdge R760xa":
+      min_version: "2"
 ```
 
 ### InstanceRebootCheck

--- a/isvctl/configs/providers/aws/scripts/vm/docs/aws-vm.md
+++ b/isvctl/configs/providers/aws/scripts/vm/docs/aws-vm.md
@@ -198,7 +198,7 @@ Validates the full software stack: kernel, libvirt/QEMU, SBIOS, NVIDIA drivers.
 | `expected_libvirt_version` | string | *(none)* | libvirt version substring |
 | `expected_bios_vendor` | string | *(none)* | BIOS vendor name |
 | `bios_baselines` | mapping | *(none)* | Approved BIOS minimums keyed by `system_vendor|product_name` |
-| `tpm_baselines` | mapping | *(none)* | Approved minimum TPM major version keyed by `system_vendor|product_name` (SEC22-02) |
+| `tpm_baselines` | mapping | *(none)* | Approved minimum TPM major version keyed by `system_vendor\|product_name` (SEC22-02) |
 
 When no `expected_*` parameter or `*_baselines` policy is set, the check **reports**
 the value without failing. To build a BIOS or TPM policy, run once in report-only

--- a/isvtest/src/isvtest/validations/host.py
+++ b/isvtest/src/isvtest/validations/host.py
@@ -91,6 +91,33 @@ def _check_bios_baseline(bios_baselines: dict, system_vendor: str, product: str,
     return True, f"BIOS version {bios_version} >= minimum {min_version} for {baseline_key}"
 
 
+def _check_tpm_baseline(
+    tpm_baselines: dict, system_vendor: str, product: str, tpm_present: bool, tpm_version: str
+) -> tuple[bool, str]:
+    """Evaluate TPM presence and version against the configured baseline for the host's vendor/product."""
+    baseline_key = f"{system_vendor}|{product}"
+    baseline = tpm_baselines.get(baseline_key)
+    if baseline is None:
+        available = ", ".join(sorted(str(key) for key in tpm_baselines)) or "<none>"
+        return False, f"No TPM baseline for {baseline_key}; available baselines: {available}"
+
+    min_version = baseline.get("min_version")
+    if not min_version:
+        return False, f"TPM baseline for {baseline_key} missing min_version"
+
+    if not tpm_present:
+        return False, f"TPM device not present on host (required by baseline {baseline_key})"
+
+    version_ok = _numeric_version_at_least(tpm_version, min_version)
+    if version_ok is None:
+        return False, (
+            f"Could not parse TPM version for {baseline_key}: actual={tpm_version!r}, min_version={min_version!r}"
+        )
+    if not version_ok:
+        return False, f"TPM version {tpm_version} is below minimum required {min_version}"
+    return True, f"TPM version {tpm_version} >= minimum {min_version} for {baseline_key}"
+
+
 # =============================================================================
 # Connectivity Validations
 # =============================================================================
@@ -661,6 +688,10 @@ class HostSoftwareCheck(BaseValidation):
         expected_bios_vendor: Expected BIOS vendor substring (optional, e.g. "Amazon")
         bios_baselines: Optional mapping of "system_vendor|product_name" to
             {"min_version": "<approved BIOS version>"}
+        tpm_baselines: Optional mapping of "system_vendor|product_name" to
+            {"min_version": "<minimum TPM major version, e.g. 2>"}.
+            When configured, the host must expose a TPM device whose major
+            version is >= the configured minimum (SEC22-02).
     """
 
     description: ClassVar[str] = "Validates kernel, libvirt, SBIOS, and NVIDIA drivers"
@@ -684,6 +715,7 @@ class HostSoftwareCheck(BaseValidation):
         expected_libvirt = self.config.get("expected_libvirt_version")
         expected_bios_vendor = self.config.get("expected_bios_vendor")
         bios_baselines = self.config.get("bios_baselines")
+        tpm_baselines = self.config.get("tpm_baselines")
 
         if not host or not key_path:
             self.set_failed("Missing host or key_file")
@@ -853,6 +885,29 @@ class HostSoftwareCheck(BaseValidation):
             )
             boot_mode = stdout.strip() if exit_code == 0 else "unknown"
             self.report_subtest("boot_mode", True, f"Boot mode: {boot_mode}")
+
+            # TPM presence and version (SEC22-02). sysfs is unprivileged.
+            # tpm_version_major reports "1" or "2"; absence of the file
+            # (or the whole /sys/class/tpm/tpm0 directory) means no TPM.
+            exit_code, stdout, _ = run_ssh_command(
+                ssh,
+                "cat /sys/class/tpm/tpm0/tpm_version_major 2>/dev/null || echo 'absent'",
+            )
+            tpm_raw = stdout.strip() if exit_code == 0 else "absent"
+            tpm_present = tpm_raw != "absent" and tpm_raw != ""
+            tpm_version = tpm_raw if tpm_present else "absent"
+            self.report_subtest(
+                "tpm_present",
+                True,
+                f"TPM device: {'present' if tpm_present else 'absent'}",
+            )
+            self.report_subtest("tpm_version", True, f"TPM major version: {tpm_version}")
+
+            if tpm_baselines is not None:
+                passed, message = _check_tpm_baseline(tpm_baselines, system_vendor, product, tpm_present, tpm_version)
+                self.report_subtest("tpm_baseline", passed, message)
+                if not passed:
+                    failures.append(message)
 
             # ==============================================================
             # 4. NVIDIA Driver

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -1559,6 +1559,8 @@ class TestHostSoftwareCheckBiosBaselines:
                 return (0, "03/12/2026\n", "")
             if "test -d /sys/firmware/efi" in cmd:
                 return (0, "UEFI\n", "")
+            if "tpm_version_major" in cmd:
+                return (0, "2\n", "")
             if "--query-gpu=driver_version" in cmd:
                 return (0, "550.54.15\n", "")
             if "grep 'CUDA Version'" in cmd:
@@ -1677,6 +1679,168 @@ class TestHostSoftwareCheckBiosBaselines:
 
         assert result["passed"] is True
         assert not any(subtest["name"] == "bios_baseline" for subtest in result["subtests"])
+
+
+class TestHostSoftwareCheckTpmBaselines:
+    """Tests for HostSoftwareCheck TPM baseline enforcement (SEC22-02)."""
+
+    @staticmethod
+    def _run_response(
+        *,
+        tpm_output: str,
+        system_vendor: str = "Dell Inc.",
+        product_name: str = "PowerEdge R760xa",
+    ):
+        def _response(ssh: MagicMock, cmd: str) -> tuple[int, str, str]:
+            if cmd == "uname -r":
+                return (0, "6.8.0-nvidia\n", "")
+            if cmd == "uname -v":
+                return (0, "#1 SMP PREEMPT_DYNAMIC\n", "")
+            if "lsmod" in cmd:
+                return (0, "nvidia\nkvm\n", "")
+            if "libvirtd --version" in cmd:
+                return (0, "not_installed\n", "")
+            if "qemu-system-x86_64" in cmd:
+                return (0, "not_installed\n", "")
+            if "test -c /dev/kvm" in cmd:
+                return (0, "kvm_available\n", "")
+            if "virsh version" in cmd:
+                return (0, "not_available\n", "")
+            if "bios_vendor" in cmd:
+                return (0, "Dell Inc.\n", "")
+            if "sys_vendor" in cmd or "system-manufacturer" in cmd:
+                return (0, f"{system_vendor}\n", "")
+            if "product_name" in cmd or "system-product-name" in cmd:
+                return (0, f"{product_name}\n", "")
+            if "bios_version" in cmd:
+                return (0, "2.4.8\n", "")
+            if "bios_date" in cmd or "bios-release-date" in cmd:
+                return (0, "03/12/2026\n", "")
+            if "test -d /sys/firmware/efi" in cmd:
+                return (0, "UEFI\n", "")
+            if "tpm_version_major" in cmd:
+                return (0, f"{tpm_output}\n", "")
+            if "--query-gpu=driver_version" in cmd:
+                return (0, "550.54.15\n", "")
+            if "grep 'CUDA Version'" in cmd:
+                return (0, "12.4\n", "")
+            if "/sys/module/nvidia/version" in cmd:
+                return (0, "550.54.15\n", "")
+            if "--query-gpu=persistence_mode" in cmd:
+                return (0, "Enabled\n", "")
+            raise AssertionError(f"Unexpected SSH command: {cmd}")
+
+        return _response
+
+    @staticmethod
+    def _execute(
+        mock_ssh_cfg: MagicMock,
+        mock_run: MagicMock,
+        mock_ssh: MagicMock,
+        *,
+        tpm_output: str,
+        config: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        from isvtest.validations.host import HostSoftwareCheck
+
+        mock_ssh_cfg.return_value = {
+            "ssh_host": "10.0.0.1",
+            "ssh_user": "ubuntu",
+            "ssh_key_path": "/tmp/k.pem",
+        }
+        mock_ssh.return_value = MagicMock()
+        mock_run.side_effect = TestHostSoftwareCheckTpmBaselines._run_response(tpm_output=tpm_output)
+
+        return HostSoftwareCheck(config=config or {}).execute()
+
+    @patch("isvtest.validations.host.get_ssh_client")
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_matching_tpm_baseline_equal_version_passes(
+        self, mock_ssh_cfg: MagicMock, mock_run: MagicMock, mock_ssh: MagicMock
+    ) -> None:
+        config = {"tpm_baselines": {"Dell Inc.|PowerEdge R760xa": {"min_version": "2"}}}
+
+        result = self._execute(mock_ssh_cfg, mock_run, mock_ssh, tpm_output="2", config=config)
+
+        assert result["passed"] is True
+        assert any(subtest["name"] == "tpm_baseline" and subtest["passed"] for subtest in result["subtests"])
+
+    @patch("isvtest.validations.host.get_ssh_client")
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_tpm_absent_fails_when_baseline_configured(
+        self, mock_ssh_cfg: MagicMock, mock_run: MagicMock, mock_ssh: MagicMock
+    ) -> None:
+        config = {"tpm_baselines": {"Dell Inc.|PowerEdge R760xa": {"min_version": "2"}}}
+
+        result = self._execute(mock_ssh_cfg, mock_run, mock_ssh, tpm_output="absent", config=config)
+
+        assert result["passed"] is False
+        assert "TPM device not present" in result["error"]
+
+    @patch("isvtest.validations.host.get_ssh_client")
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_tpm_lower_version_fails(self, mock_ssh_cfg: MagicMock, mock_run: MagicMock, mock_ssh: MagicMock) -> None:
+        config = {"tpm_baselines": {"Dell Inc.|PowerEdge R760xa": {"min_version": "2"}}}
+
+        result = self._execute(mock_ssh_cfg, mock_run, mock_ssh, tpm_output="1", config=config)
+
+        assert result["passed"] is False
+        assert "TPM version 1 is below minimum required 2" in result["error"]
+
+    @patch("isvtest.validations.host.get_ssh_client")
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_configured_tpm_baselines_require_matching_dmi_key(
+        self, mock_ssh_cfg: MagicMock, mock_run: MagicMock, mock_ssh: MagicMock
+    ) -> None:
+        config = {"tpm_baselines": {"Other Vendor|Other Model": {"min_version": "2"}}}
+
+        result = self._execute(mock_ssh_cfg, mock_run, mock_ssh, tpm_output="2", config=config)
+
+        assert result["passed"] is False
+        assert "No TPM baseline for Dell Inc.|PowerEdge R760xa" in result["error"]
+
+    @patch("isvtest.validations.host.get_ssh_client")
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_tpm_baseline_missing_min_version_fails(
+        self, mock_ssh_cfg: MagicMock, mock_run: MagicMock, mock_ssh: MagicMock
+    ) -> None:
+        config = {"tpm_baselines": {"Dell Inc.|PowerEdge R760xa": {}}}
+
+        result = self._execute(mock_ssh_cfg, mock_run, mock_ssh, tpm_output="2", config=config)
+
+        assert result["passed"] is False
+        assert "missing min_version" in result["error"]
+
+    @patch("isvtest.validations.host.get_ssh_client")
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_tpm_remains_report_only_without_baselines(
+        self, mock_ssh_cfg: MagicMock, mock_run: MagicMock, mock_ssh: MagicMock
+    ) -> None:
+        result = self._execute(mock_ssh_cfg, mock_run, mock_ssh, tpm_output="2")
+
+        assert result["passed"] is True
+        subtest_names = {subtest["name"] for subtest in result["subtests"]}
+        assert "tpm_present" in subtest_names
+        assert "tpm_version" in subtest_names
+        assert "tpm_baseline" not in subtest_names
+
+    @patch("isvtest.validations.host.get_ssh_client")
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_tpm_absent_is_report_only_without_baselines(
+        self, mock_ssh_cfg: MagicMock, mock_run: MagicMock, mock_ssh: MagicMock
+    ) -> None:
+        result = self._execute(mock_ssh_cfg, mock_run, mock_ssh, tpm_output="absent")
+
+        assert result["passed"] is True
+        present_subtest = next(s for s in result["subtests"] if s["name"] == "tpm_present")
+        assert "absent" in present_subtest["message"]
 
 
 class TestCloudInitCheckMetadataHeaders:

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -1816,6 +1816,28 @@ class TestHostSoftwareCheckTpmBaselines:
         assert result["passed"] is False
         assert "missing min_version" in result["error"]
 
+    @pytest.mark.parametrize(
+        ("tpm_output", "min_version"),
+        [("unknown", "2"), ("2", "latest")],
+    )
+    @patch("isvtest.validations.host.get_ssh_client")
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_unparseable_tpm_baseline_versions_fail(
+        self,
+        mock_ssh_cfg: MagicMock,
+        mock_run: MagicMock,
+        mock_ssh: MagicMock,
+        tpm_output: str,
+        min_version: str,
+    ) -> None:
+        config = {"tpm_baselines": {"Dell Inc.|PowerEdge R760xa": {"min_version": min_version}}}
+
+        result = self._execute(mock_ssh_cfg, mock_run, mock_ssh, tpm_output=tpm_output, config=config)
+
+        assert result["passed"] is False
+        assert "Could not parse TPM version for Dell Inc.|PowerEdge R760xa" in result["error"]
+
     @patch("isvtest.validations.host.get_ssh_client")
     @patch("isvtest.validations.host.run_ssh_command")
     @patch("isvtest.validations.host.get_ssh_config")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends `HostSoftwareCheck` with an opt-in TPM baseline policy (SEC22-02 / P1). When `tpm_baselines` is configured, the check requires the host to expose a TPM device whose major version is >= the configured minimum, keyed by `system_vendor|product_name`. Without `tpm_baselines`, TPM presence and version remain report-only and existing configs are unaffected.

Mirrors the `bios_baselines` pattern from #410 so operators can build and maintain BIOS and TPM policies symmetrically per platform.

## Changes

- `isvtest/src/isvtest/validations/host.py`: add `tpm_baselines` parameter to `HostSoftwareCheck`. Probe `/sys/class/tpm/tpm0/tpm_version_major` from sysfs (unprivileged, no extra packages). Always report `tpm_present` and `tpm_version` subtests; when `tpm_baselines` is configured, evaluate against `tpm_baselines["<system_vendor>|<product_name>"]["min_version"]` and report a `tpm_baseline` subtest. Reuses the existing `_numeric_version_at_least` helper. Missing baseline entry, missing `min_version`, missing TPM device, and unparseable versions all yield typed failure messages; unrelated subtests are unchanged.
- `isvtest/tests/test_validation.py`: add `TestHostSoftwareCheckTpmBaselines` covering equal/lower-version pass/fail, absent-device fail, mismatched DMI key, missing `min_version`, and the report-only path when `tpm_baselines` is absent. Also extend the existing `TestHostSoftwareCheckBiosBaselines` SSH stub to answer the new TPM probe.
- `isvctl/configs/providers/aws/scripts/vm/docs/aws-vm.md`: document the new `tpm_present` / `tpm_version` subtests, the `tpm_baselines` parameter, and the report-only → policy bootstrap flow.
- Ships **unreleased**; `isvtest/src/isvtest/released_tests.json` intentionally untouched (`HostSoftwareCheck` is already released and the new path is an opt-in policy parameter, same convention as `bios_baselines` from #410).

## Validation

Exercised end-to-end on a real AWS g5.xlarge VM (Ubuntu, kernel `6.8.0-1055-aws`, NVIDIA driver `580.150`) via the full AWS VM suite. The new TPM subtests appear inside `HostSoftwareCheck` in the expected position between `boot_mode` and `nvidia_driver`:

```text
SUBTEST [boot_mode] PASSED
SUBTEST [tpm_present] PASSED       ← new
SUBTEST [tpm_version] PASSED       ← new
SUBTEST [nvidia_driver] PASSED
...
[host_os] HostSoftwareCheck: PASSED - Host software check on 44.250.67.122 OK (kernel=6.8.0-1055-aws, driver=580.150)
```

Full suite result: **26 passed, 4 skipped**. Command used:

```bash
ISVTEST_INCLUDE_UNRELEASED=1 AWS_PROFILE=ncp-isv-lab \
  uv run isvctl test run -f isvctl/configs/providers/aws/config/vm.yaml -- -v -s
```

Supporting checks:

- ✅ `make test` — 792 isvtest + 40 scripts unit tests pass, including the new `TestHostSoftwareCheckTpmBaselines` (7 scenarios)
- ✅ `make lint` / `uvx pre-commit run -a` / `make demo-test` — clean
- ✅ Standalone smoke harness drives `HostSoftwareCheck.execute()` through stubbed-SSH pass/fail/absent-device baseline paths

Closes #316

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f2783f8-e1e6-4e2f-b57a-58037674381f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f2783f8-e1e6-4e2f-b57a-58037674381f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added TPM (Trusted Platform Module) baseline validation to host software checks, enabling validation of TPM presence and version requirements against configured minimums.

* **Documentation**
  * Updated AWS VM validation guide with TPM validation details and baseline configuration examples.

* **Tests**
  * Added comprehensive test coverage for TPM baseline validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/ISV-NCP-Validation-Suite/pull/429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
