### PR TITLE
feat: add validation labels compatibility

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -480,7 +480,7 @@ EOF
 
 ## Available Validations
 
-For the full list of validations with descriptions and platform markers, see [isvtest package docs](../packages/isvtest.md#available-validations).
+For the full list of validations with descriptions and labels, see [isvtest package docs](../packages/isvtest.md#available-validations).
 
 Below is a summary by category.
 
@@ -607,20 +607,22 @@ Use the `tests.exclude` section to deselect tests before they run. Excluded test
 ```yaml
 tests:
   exclude:
-    platforms: []   # Deselect all tests with these platform markers
-    markers: []     # Deselect all tests with these markers
+    platforms: []   # Deselect all tests with these platform labels
+    labels: []      # Deselect all tests with these labels
     tests: []       # Deselect specific tests by name
     files: []       # Deselect all tests in these files
 ```
 
 ### Exclusion Types
 
-| Key | Behavior | Bypassed by `-k` / `-m`? |
-| --- | -------- | ------------------------ |
-| `platforms` | Removes tests whose markers include the listed platform (e.g., `bare_metal`, `kubernetes`) | No - always applied |
-| `markers` | Removes tests whose markers include any of the listed values (e.g., `workload`, `slow`) | Yes - explicit `-k` or `-m` overrides |
+| Key | Behavior | Bypassed by explicit selectors? |
+| --- | -------- | ------------------------------- |
+| `platforms` | Removes tests whose labels include the listed platform (e.g., `bare_metal`, `kubernetes`) | No - always applied |
+| `labels` | Removes tests whose labels include any of the listed values (e.g., `workload`, `slow`) | Yes - explicit `--label`, `-k`, or pytest `-m` overrides |
 | `tests` | Removes tests matching by exact name, prefix, or parametrized ID (e.g., `K8sNcclWorkload`, `K8sNimHelmWorkload-3b`) | No - always applied |
 | `files` | Removes tests whose source file matches (e.g., `test_host.py`) | No - always applied |
+
+`markers` is still accepted as a legacy alias for `labels`. If both are present, their values are combined for now.
 
 ### Examples
 
@@ -629,7 +631,7 @@ Skip all workload and slow tests (the most common use case):
 ```yaml
 tests:
   exclude:
-    markers:
+    labels:
       - workload
       - slow
 ```
@@ -654,30 +656,31 @@ isvctl test run -f isvctl/configs/suites/k8s.yaml -f my-overrides.yaml
 
 A template is provided in `isvctl/configs/overrides.yaml`. Note that `exclude` lists from later `-f` files **replace** earlier lists (they are not appended).
 
-### Interaction with `-k` and `-m`
+### Interaction with Explicit Selectors
 
-When you pass explicit pytest selectors via `--`:
+When you pass explicit selectors:
 
 ```bash
+isvctl test run -f config.yaml --label workload
 isvctl test run -f config.yaml -- -k "K8sNcclWorkload"
 isvctl test run -f config.yaml -- -m "workload"
 ```
 
-**Marker exclusions are bypassed**, allowing you to explicitly run tests that would normally be excluded. Platform, test name, and file exclusions still apply.
+**Label exclusions are bypassed**, allowing you to explicitly run tests that would normally be excluded. Platform, test name, and file exclusions still apply. Pytest `-m` remains available for advanced internal marker selection.
 
-## Test Markers
+## Test Labels
 
-Filter tests using pytest markers:
+Filter tests using labels:
 
 ```bash
 # Run only specific tests
 isvctl test run -f config.yaml -- -k "vpc_crud"
 
-# Run by marker
-isvctl test run -f config.yaml -- -m kubernetes
+# Run by label
+isvctl test run -f config.yaml --label kubernetes
 ```
 
-Available markers: `bare_metal`, `vm`, `kubernetes`, `slurm`, `gpu`, `network`, `ssh`, `security`, `iam`, `workload`, `slow`
+Available labels: `bare_metal`, `vm`, `kubernetes`, `slurm`, `gpu`, `network`, `ssh`, `security`, `iam`, `workload`, `slow`
 
 ## Related Documentation
 

--- a/docs/guides/external-validation-guide.md
+++ b/docs/guides/external-validation-guide.md
@@ -205,7 +205,7 @@ isvctl test run -f config.yaml --phase teardown
 isvctl test run -f base.yaml -f overrides.yaml
 
 # Filter validations with labels or advanced pytest args
-isvctl test run -f config.yaml -- -k "SshConnectivity"
+isvctl test run -f config.yaml -- -k "ConnectivityCheck"
 isvctl test run -f config.yaml --label gpu
 isvctl test run -f config.yaml -- -m "not slow"
 

--- a/docs/guides/external-validation-guide.md
+++ b/docs/guides/external-validation-guide.md
@@ -204,9 +204,9 @@ isvctl test run -f config.yaml --phase teardown
 # Merge configs (later overrides earlier)
 isvctl test run -f base.yaml -f overrides.yaml
 
-# Filter validations with pytest args
+# Filter validations with labels or advanced pytest args
 isvctl test run -f config.yaml -- -k "SshConnectivity"
-isvctl test run -f config.yaml -- -m gpu
+isvctl test run -f config.yaml --label gpu
 isvctl test run -f config.yaml -- -m "not slow"
 
 # Debug: full output on failure

--- a/docs/guides/troubleshooting-started-tests.md
+++ b/docs/guides/troubleshooting-started-tests.md
@@ -95,7 +95,7 @@ Ensure the step that runs **after** the tests **always** calls update, even when
   Increase job/container timeout so that the full suite (including setup/teardown) can finish. Long-running workload tests (e.g. NIM) can take 15-30+ minutes.
 
 - **Hangs**
-  Check which phase hangs (setup, test, or teardown) from logs. Common causes: waiting on a cluster resource, Slurm job that never completes, or a validation that blocks. Fix the stub or validation, or exclude slow tests during initial runs:
+  Check which phase hangs (setup, test, or teardown) from logs. Common causes: waiting on a cluster resource, Slurm job that never completes, or a validation that blocks. Fix the stub or validation, or exclude slow tests during initial runs. For one-off negative selection, use the underlying pytest marker expression:
 
   ```bash
   isvctl test run -f configs/suites/k8s.yaml --lab-id ${ISV_LAB_ID} -- -m "not workload"

--- a/docs/packages/isvtest.md
+++ b/docs/packages/isvtest.md
@@ -56,7 +56,7 @@ isvtest/src/isvtest/
 
 ## Available Validations
 
-Validations are platform-agnostic checks that inspect JSON step output. They are organized by category and referenced by class name in YAML test configs. Each validation has a `description` and `markers` that indicate which platforms it applies to.
+Validations are platform-agnostic checks that inspect JSON step output. They are organized by category and referenced by class name in YAML test configs. Each validation has a `description` and public labels that indicate which platforms and capabilities it applies to.
 
 ### Generic (`validations/generic.py`)
 
@@ -250,16 +250,20 @@ tests:
 
 Canonical test configs live in `isvctl/configs/suites/` (vm.yaml, bare_metal.yaml, network.yaml, etc.). Provider-specific configs in `isvctl/configs/providers/<provider>/` import the canonical config and override commands with platform stubs.
 
-## Test Markers
+## Test Labels
 
-Filter tests using pytest markers:
+Filter tests using labels:
 
 - `bare_metal`, `vm`, `kubernetes`, `slurm` - Platform-specific
 - `gpu`, `network`, `ssh`, `security`, `iam` - Component-specific
 - `workload` - Workload-based tests (longer running)
 - `slow` - Tests that take longer than 5 minutes
 
-**Note:** By default, `workload` and `slow` markers are excluded. Use `-k` to explicitly run them.
+```bash
+isvtest test --config tests.yaml --label gpu --label network
+```
+
+**Note:** By default, `workload` and `slow` labels are excluded. Use `--label workload` or another explicit selector to run them. Pytest markers remain supported internally and through `--markers` as a legacy alias.
 
 ## Development
 

--- a/isvctl/README.md
+++ b/isvctl/README.md
@@ -15,7 +15,7 @@ uv run isvctl docs -t getting-started        # view a specific topic
 
 # List all validation tests by category
 uv run isvctl docs tests
-uv run isvctl docs tests -m kubernetes                   # filter by marker
+uv run isvctl docs tests -l kubernetes                   # filter by label
 uv run isvctl docs tests -f isvctl/configs/suites/k8s.yaml      # show config test instances
 uv run isvctl docs tests -i StepSuccessCheck             # detailed info for a test
 ```

--- a/isvctl/configs/overrides.yaml
+++ b/isvctl/configs/overrides.yaml
@@ -29,7 +29,7 @@ tests:
     # - K8sNodeCountCheck
     # - K8sNcclWorkload
 
-    # Exclude by marker (e.g., skip slow or workload tests)
-    markers: []
+    # Exclude by label (e.g., skip slow or workload tests)
+    labels: []
     # - slow
     # - workload

--- a/isvctl/configs/providers/k3s.yaml
+++ b/isvctl/configs/providers/k3s.yaml
@@ -99,7 +99,7 @@ tests:
         GpuMemoryCheck: {}
 
   exclude:
-    markers:
+    labels:
       - slow
       - workload
       - reframe

--- a/isvctl/configs/providers/microk8s.yaml
+++ b/isvctl/configs/providers/microk8s.yaml
@@ -99,7 +99,7 @@ tests:
         GpuMemoryCheck: {}
 
   exclude:
-    markers:
+    labels:
       - slow
       - workload
       - reframe

--- a/isvctl/configs/providers/minikube.yaml
+++ b/isvctl/configs/providers/minikube.yaml
@@ -99,7 +99,7 @@ tests:
         GpuMemoryCheck: {}
 
   exclude:
-    markers:
+    labels:
       - slow
       - workload
       - reframe

--- a/isvctl/configs/providers/my-isv/README.md
+++ b/isvctl/configs/providers/my-isv/README.md
@@ -23,7 +23,7 @@ exercises.
 ## Coverage note
 
 These configs exclude validations that require SSH into a real host
-(`exclude.markers: [ssh]`) and skip steps that need real cloud APIs
+(`exclude.labels: [ssh]`) and skip steps that need real cloud APIs
 (e.g. `deploy_nim`), because dummy scripts can't spin up real hosts.
 Each YAML's header comment documents exactly which checks are excluded
 and why - remove those exclusions as your real scripts come online.

--- a/isvctl/configs/providers/my-isv/config/bare_metal.yaml
+++ b/isvctl/configs/providers/my-isv/config/bare_metal.yaml
@@ -28,12 +28,12 @@
 #    StableIdentifierCheck, StepSuccessCheck). SSH-based host checks
 #    (Connectivity, Os, Gpu, Driver, CpuInfo, HostSoftware, GpuStress,
 #    Nccl, Training, Nvlink, InfiniBand, Ethernet, ContainerRuntime,
-#    CloudInit, NIM*) are excluded via `exclude.markers: [ssh]` because
+#    CloudInit, NIM*) are excluded via `exclude.labels: [ssh]` because
 #    a dummy stub cannot spin up a real host to SSH into. The
 #    deploy_nim / teardown_nim / reinstall_instance steps are also
 #    skipped for the same reason.
 #
-# ACTION: Remove `exclude.markers: [ssh]` at the bottom once your
+# ACTION: Remove `exclude.labels: [ssh]` at the bottom once your
 #   stubs provision real instances with SSH access.
 #
 # Steps:
@@ -285,4 +285,4 @@ tests:
   # Ethernet, ContainerRuntime, CloudInit, NIM*). Real ISVs remove this
   # exclusion as their stubs come online.
   exclude:
-    markers: ["ssh"]
+    labels: ["ssh"]

--- a/isvctl/configs/providers/my-isv/config/image-registry.yaml
+++ b/isvctl/configs/providers/my-isv/config/image-registry.yaml
@@ -25,10 +25,10 @@
 #   (StepSuccessCheck, FieldExistsCheck, CrudOperationsCheck,
 #    InstanceStateCheck) on all 7 steps. The vm_ssh validation group
 #    (ConnectivityCheck + OsCheck on launch_instance) is excluded via
-#    `exclude.markers: [ssh]` because a dummy stub cannot stand up a
+#    `exclude.labels: [ssh]` because a dummy stub cannot stand up a
 #    real VM to SSH into.
 #
-# ACTION: Remove `exclude.markers: [ssh]` at the bottom once your
+# ACTION: Remove `exclude.labels: [ssh]` at the bottom once your
 #   stubs provision real instances with SSH access.
 #
 # Note on field names:
@@ -146,4 +146,4 @@ tests:
   # launch_instance) - would try to SSH into the dummy public_ip.
   # Real ISVs remove this exclusion as their stubs come online.
   exclude:
-    markers: ["ssh"]
+    labels: ["ssh"]

--- a/isvctl/configs/providers/my-isv/config/network.yaml
+++ b/isvctl/configs/providers/my-isv/config/network.yaml
@@ -31,7 +31,7 @@
 #    The NET01-01 and NET02-02 checks validate
 #    provider-reported fabric metadata only. The DhcpIpManagementCheck
 #    validation needs to SSH into a real instance, so it is excluded
-#    via `exclude.markers: [ssh]`; the dhcp_ip_test step is also
+#    via `exclude.labels: [ssh]`; the dhcp_ip_test step is also
 #    `skip: true` for the same reason.
 #
 # Usage:
@@ -341,4 +341,4 @@ tests:
   # Skip SSH-based DhcpIpManagementCheck - it'd try to SSH into the dummy
   # instance. Real ISVs remove this exclusion as their stubs come online.
   exclude:
-    markers: ["ssh"]
+    labels: ["ssh"]

--- a/isvctl/configs/providers/my-isv/config/vm.yaml
+++ b/isvctl/configs/providers/my-isv/config/vm.yaml
@@ -27,11 +27,11 @@
 #    StableIdentifierCheck, InstanceRebootCheck, SerialConsoleCheck,
 #    ConsoleRbacCheck, StepSuccessCheck). SSH-based host checks (ConnectivityCheck,
 #    GpuCheck, DriverCheck, CpuInfoCheck, NIM checks, etc.) are excluded
-#    via `exclude.markers: [ssh]` because a dummy-success stub cannot
+#    via `exclude.labels: [ssh]` because a dummy-success stub cannot
 #    spin up a real host to SSH into. The deploy_nim / teardown_nim
 #    steps are also skipped for the same reason.
 #
-# ACTION: Remove `exclude.markers: [ssh]` at the bottom once your
+# ACTION: Remove `exclude.labels: [ssh]` at the bottom once your
 #   stubs provision real instances with SSH access.
 #
 # Steps:
@@ -219,4 +219,4 @@ tests:
   # to the dummy public_ip. Pure JSON-contract checks still run.
   # Real ISVs remove this exclusion as their stubs come online.
   exclude:
-    markers: ["ssh"]
+    labels: ["ssh"]

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -318,4 +318,4 @@ tests:
         StepSuccessCheck: {}
 
   exclude:
-    markers: []
+    labels: []

--- a/isvctl/configs/suites/control-plane.yaml
+++ b/isvctl/configs/suites/control-plane.yaml
@@ -87,4 +87,4 @@ tests:
           step: delete_tenant
 
   exclude:
-    markers: []
+    labels: []

--- a/isvctl/configs/suites/iam.yaml
+++ b/isvctl/configs/suites/iam.yaml
@@ -68,4 +68,4 @@ tests:
         StepSuccessCheck: {}
 
   exclude:
-    markers: []
+    labels: []

--- a/isvctl/configs/suites/image-registry.yaml
+++ b/isvctl/configs/suites/image-registry.yaml
@@ -119,4 +119,4 @@ tests:
         StepSuccessCheck: {}
 
   exclude:
-    markers: []
+    labels: []

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -308,4 +308,4 @@ tests:
           api_endpoint: "{{ steps.setup.kubernetes.api_endpoint | default('', true) }}"
 
   exclude:
-    markers: []
+    labels: []

--- a/isvctl/configs/suites/network.yaml
+++ b/isvctl/configs/suites/network.yaml
@@ -133,4 +133,4 @@ tests:
         StepSuccessCheck: {}
 
   exclude:
-    markers: []
+    labels: []

--- a/isvctl/configs/suites/security.yaml
+++ b/isvctl/configs/suites/security.yaml
@@ -140,4 +140,4 @@ tests:
         StepSuccessCheck: {}
 
   exclude:
-    markers: []
+    labels: []

--- a/isvctl/configs/suites/slurm.yaml
+++ b/isvctl/configs/suites/slurm.yaml
@@ -132,4 +132,4 @@ tests:
           timeout: 60
 
   exclude:
-    markers: []
+    labels: []

--- a/isvctl/configs/suites/vm.yaml
+++ b/isvctl/configs/suites/vm.yaml
@@ -230,4 +230,4 @@ tests:
         StepSuccessCheck: {}
 
   exclude:
-    markers: []
+    labels: []

--- a/isvctl/schemas/config.schema.json
+++ b/isvctl/schemas/config.schema.json
@@ -257,7 +257,7 @@
         },
         "exclude": {
           "additionalProperties": true,
-          "description": "Exclusion rules",
+          "description": "Exclusion rules. Prefer labels; markers is legacy.",
           "title": "Exclude",
           "type": "object"
         }

--- a/isvctl/src/isvctl/cli/catalog.py
+++ b/isvctl/src/isvctl/cli/catalog.py
@@ -85,14 +85,14 @@ def list_cmd(
     )
     table.add_column("Test", style="green", no_wrap=True)
     table.add_column("Platforms", style="cyan")
-    table.add_column("Markers", style="dim")
+    table.add_column("Labels", style="dim")
     table.add_column("Description")
 
     for entry in sorted(catalog_entries, key=lambda e: e["name"]):
         table.add_row(
             entry["name"],
             ", ".join(entry.get("platforms") or []) or "-",
-            ", ".join(entry.get("markers") or []) or "-",
+            ", ".join(entry.get("labels") or entry.get("markers") or []) or "-",
             entry.get("description") or "-",
         )
 

--- a/isvctl/src/isvctl/cli/docs.py
+++ b/isvctl/src/isvctl/cli/docs.py
@@ -24,6 +24,7 @@ from typing import Any
 import typer
 import yaml
 from isvtest.core.discovery import discover_all_tests
+from isvtest.core.validation import get_validation_labels
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
@@ -134,11 +135,13 @@ def docs(
 
 @app.command()
 def tests(
-    marker: list[str] = typer.Option(
+    label: list[str] = typer.Option(
         None,
+        "--label",
+        "-l",
         "--marker",
         "-m",
-        help="Filter by marker (repeatable, e.g. -m kubernetes -m gpu)",
+        help="Filter by label (repeatable, e.g. -l kubernetes -l gpu; --marker is legacy)",
     ),
     config_file: Path | None = typer.Option(
         None,
@@ -150,7 +153,7 @@ def tests(
         dir_okay=False,
         readable=True,
     ),
-    flat: bool = typer.Option(False, "--flat", help="Flat list without grouping by marker"),
+    flat: bool = typer.Option(False, "--flat", help="Flat list without grouping by label"),
     info: str | None = typer.Option(
         None,
         "--info",
@@ -162,7 +165,7 @@ def tests(
 
     Examples:
         isvctl docs tests                          # All tests by category
-        isvctl docs tests -m kubernetes            # Only kubernetes tests
+        isvctl docs tests -l kubernetes            # Only kubernetes tests
         isvctl docs tests -f isvctl/configs/suites/k8s.yaml  # Tests from config file
         isvctl docs tests --flat                   # Flat alphabetical list
         isvctl docs tests -i GpuStressCheck     # Detailed info for a test
@@ -180,11 +183,11 @@ def tests(
         return
 
     if config_file:
-        _print_config_instances(all_classes, config_file, marker)
+        _print_config_instances(all_classes, config_file, label)
     elif flat:
-        _print_flat(all_classes, marker)
+        _print_flat(all_classes, label)
     else:
-        _print_grouped(all_classes, marker)
+        _print_grouped(all_classes, label)
 
 
 def _warn_duplicates(classes: list[type]) -> None:
@@ -227,7 +230,8 @@ def _print_test_info(classes: list[type], name: str) -> None:
     table = Table(show_header=False, box=None, padding=(0, 2))
     table.add_column(style="bold cyan")
     table.add_column()
-    table.add_row("Markers", ", ".join(cls.markers) if cls.markers else "(none)")
+    labels = get_validation_labels(cls)
+    table.add_row("Labels", ", ".join(labels) if labels else "(none)")
     table.add_row("Timeout", f"{cls.timeout}s")
     table.add_row("Source", source_display)
     console.print(table)
@@ -242,28 +246,28 @@ def _print_test_info(classes: list[type], name: str) -> None:
     console.print()
 
 
-def _print_grouped(classes: list[type], marker_filter: list[str] | None) -> None:
-    """Print tests grouped by marker category."""
-    by_marker: dict[str, list[type]] = defaultdict(list)
+def _print_grouped(classes: list[type], label_filter: list[str] | None) -> None:
+    """Print tests grouped by label category."""
+    by_label: dict[str, list[type]] = defaultdict(list)
 
     for cls in classes:
-        markers = cls.markers if cls.markers else ["uncategorized"]
-        for m in markers:
-            by_marker[m].append(cls)
+        labels = get_validation_labels(cls) or ("uncategorized",)
+        for item in labels:
+            by_label[item].append(cls)
 
-    if marker_filter:
-        by_marker = {k: v for k, v in by_marker.items() if k in marker_filter}
+    if label_filter:
+        by_label = {k: v for k, v in by_label.items() if k in label_filter}
 
-    if not by_marker:
-        console.print("[yellow]No tests found for the given markers.[/yellow]")
+    if not by_label:
+        console.print("[yellow]No tests found for the given labels.[/yellow]")
         raise typer.Exit(1)
 
-    total = len({cls.__name__ for group in by_marker.values() for cls in group})
-    console.print(f"\n[bold]Validation Tests[/bold] ({total} unique across {len(by_marker)} categories)\n")
+    total = len({cls.__name__ for group in by_label.values() for cls in group})
+    console.print(f"\n[bold]Validation Tests[/bold] ({total} unique across {len(by_label)} categories)\n")
 
-    for marker in sorted(by_marker):
+    for label_name in sorted(by_label):
         table = Table(
-            title=f"[bold cyan]{marker}[/bold cyan] ({len(by_marker[marker])})",
+            title=f"[bold cyan]{label_name}[/bold cyan] ({len(by_label[label_name])})",
             title_justify="left",
             show_header=True,
             header_style="bold",
@@ -272,13 +276,14 @@ def _print_grouped(classes: list[type], marker_filter: list[str] | None) -> None
         )
         table.add_column("Test", style="green", no_wrap=True)
         table.add_column("Description")
-        table.add_column("Markers", style="dim")
+        table.add_column("Labels", style="dim")
 
-        for cls in sorted(by_marker[marker], key=lambda c: c.__name__):
+        for cls in sorted(by_label[label_name], key=lambda c: c.__name__):
+            labels = get_validation_labels(cls)
             table.add_row(
                 cls.__name__,
                 cls.description or "-",
-                ", ".join(cls.markers) if cls.markers else "-",
+                ", ".join(labels) if labels else "-",
             )
 
         console.print(table)
@@ -342,7 +347,7 @@ def _resolve_class(instance_name: str, class_map: dict[str, type]) -> type | Non
     return None
 
 
-def _print_config_instances(classes: list[type], config_path: Path, marker_filter: list[str] | None) -> None:
+def _print_config_instances(classes: list[type], config_path: Path, label_filter: list[str] | None) -> None:
     """Print test instances as defined in a config file, grouped by config category."""
     class_map = {cls.__name__: cls for cls in classes}
     categories = _extract_config_instances(config_path)
@@ -351,20 +356,21 @@ def _print_config_instances(classes: list[type], config_path: Path, marker_filte
         console.print("[yellow]No validations found in config file.[/yellow]")
         raise typer.Exit(1)
 
-    if marker_filter:
+    if label_filter:
         filtered: dict[str, list[str]] = {}
         for cat, names in categories.items():
             matched = [
                 n
                 for n in names
-                if (cls := _resolve_class(n, class_map)) and any(m in (cls.markers or []) for m in marker_filter)
+                if (cls := _resolve_class(n, class_map))
+                and any(label in get_validation_labels(cls) for label in label_filter)
             ]
             if matched:
                 filtered[cat] = matched
         categories = filtered
 
     if not categories:
-        console.print("[yellow]No test instances match the given markers.[/yellow]")
+        console.print("[yellow]No test instances match the given labels.[/yellow]")
         raise typer.Exit(1)
 
     total = sum(len(names) for names in categories.values())
@@ -384,18 +390,19 @@ def _print_config_instances(classes: list[type], config_path: Path, marker_filte
         )
         table.add_column("Test", no_wrap=True)
         table.add_column("Description")
-        table.add_column("Markers", style="dim")
+        table.add_column("Labels", style="dim")
 
         for name in names:
             cls = _resolve_class(name, class_map)
             if cls:
+                labels = get_validation_labels(cls)
                 label = f"[green]{name}[/green]"
                 if cls.__name__ != name:
                     label += f" [dim]({cls.__name__})[/dim]"
                 table.add_row(
                     label,
                     cls.description or "-",
-                    ", ".join(cls.markers) if cls.markers else "-",
+                    ", ".join(labels) if labels else "-",
                 )
             else:
                 table.add_row(f"[green]{name}[/green]", "[red]not found[/red]", "-")
@@ -404,13 +411,13 @@ def _print_config_instances(classes: list[type], config_path: Path, marker_filte
         console.print()
 
 
-def _print_flat(classes: list[type], marker_filter: list[str] | None) -> None:
+def _print_flat(classes: list[type], label_filter: list[str] | None) -> None:
     """Print a flat alphabetical list of tests."""
-    if marker_filter:
-        classes = [cls for cls in classes if any(m in (cls.markers or []) for m in marker_filter)]
+    if label_filter:
+        classes = [cls for cls in classes if any(label in get_validation_labels(cls) for label in label_filter)]
 
     if not classes:
-        console.print("[yellow]No tests found for the given markers.[/yellow]")
+        console.print("[yellow]No tests found for the given labels.[/yellow]")
         raise typer.Exit(1)
 
     table = Table(
@@ -422,13 +429,14 @@ def _print_flat(classes: list[type], marker_filter: list[str] | None) -> None:
     )
     table.add_column("Test", style="green", no_wrap=True)
     table.add_column("Description")
-    table.add_column("Markers", style="dim")
+    table.add_column("Labels", style="dim")
 
     for cls in sorted(classes, key=lambda c: c.__name__):
+        labels = get_validation_labels(cls)
         table.add_row(
             cls.__name__,
             cls.description or "-",
-            ", ".join(cls.markers) if cls.markers else "-",
+            ", ".join(labels) if labels else "-",
         )
 
     console.print()

--- a/isvctl/src/isvctl/cli/test.py
+++ b/isvctl/src/isvctl/cli/test.py
@@ -101,6 +101,14 @@ def run(
             help="Run only a specific phase of the test lifecycle",
         ),
     ] = Phase.ALL,
+    labels: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--label",
+            "-l",
+            help="Label to filter validations (can be repeated; all selected labels must match)",
+        ),
+    ] = None,
     dry_run: Annotated[
         bool,
         typer.Option(
@@ -150,7 +158,6 @@ def run(
         int | None,
         typer.Option(
             "--lab-id",
-            "-l",
             help="ISV Lab ID for result upload (required if uploading)",
         ),
     ] = None,
@@ -181,6 +188,7 @@ def run(
         isvctl test run -f lab.yaml -f commands.yaml -f suites/k8s.yaml
         isvctl test run -f config.yaml --set context.node_count=8
         isvctl test run -f config.yaml --phase setup
+        isvctl test run -f config.yaml --label gpu --label slow
         isvctl test run -f config.yaml -- -v -s -k "test_name"
     """
     setup_logging(verbose)
@@ -319,6 +327,7 @@ def run(
             result = orchestrator.run(
                 phases=phases,
                 extra_pytest_args=extra_pytest_args,
+                include_labels=labels,
                 verbose=verbose,
                 junitxml=str(junitxml),
             )

--- a/isvctl/src/isvctl/config/schema.py
+++ b/isvctl/src/isvctl/config/schema.py
@@ -360,7 +360,9 @@ class ValidationConfig(BaseModel):
         default_factory=dict,
         description="Validation checks by category. Supports list format or group defaults with 'checks' key.",
     )
-    exclude: dict[str, Any] = Field(default_factory=dict, description="Exclusion rules")
+    exclude: dict[str, Any] = Field(
+        default_factory=dict, description="Exclusion rules. Prefer labels; markers is legacy."
+    )
 
 
 class RunConfig(BaseModel):

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -270,6 +270,8 @@ def _resolved_entry_to_result_dict(entry: ResolvedEntry) -> dict[str, Any]:
         "skipped": skipped,
         "message": entry.message,
         "category": entry.entry.category,
+        "labels": list(entry.entry.labels),
+        "markers": list(entry.entry.markers),
         "state": entry.state.value if entry.state else None,
         "skip_reason": entry.skip_reason.value if entry.skip_reason else None,
         "error_reason": entry.error_reason.value if entry.error_reason else None,
@@ -325,6 +327,7 @@ class Orchestrator:
         self.step_executor = StepExecutor(working_dir=working_dir)
         self._results: list[PhaseResult] = []
         self._extra_pytest_args: list[str] | None = None
+        self._include_labels: list[str] = []
         self._verbose: bool = False
         self._junitxml: str | None = None
 
@@ -333,6 +336,7 @@ class Orchestrator:
         phases: list[Phase] | None = None,
         teardown_on_failure: bool = True,
         extra_pytest_args: list[str] | None = None,
+        include_labels: list[str] | None = None,
         verbose: bool = False,
         junitxml: str | None = None,
     ) -> OrchestratorResult:
@@ -344,6 +348,7 @@ class Orchestrator:
             extra_pytest_args: Pytest arguments for validations (-k, -m, -v, etc.)
                 - `-k AccessKey`: Run only validations matching "AccessKey"
                 - `-m kubernetes`: Run only validations with kubernetes marker
+            include_labels: Labels that selected validations must all contain.
             verbose: Enable verbose output for validations
             junitxml: Path to write JUnit XML report for validations
 
@@ -355,6 +360,7 @@ class Orchestrator:
 
         self._results = []
         self._extra_pytest_args = extra_pytest_args
+        self._include_labels = include_labels or []
         self._verbose = verbose
         self._junitxml = junitxml
 
@@ -451,12 +457,18 @@ class Orchestrator:
         if released_tests is None:
             logger.info(f"Including unreleased validations because {INCLUDE_UNRELEASED_ENV} is enabled")
 
+        exclude_labels: list[str] = []
         exclude_markers: list[str] = []
         exclude_tests: list[str] = []
         if self.config.tests and self.config.tests.exclude:
+            exclude_labels = self.config.tests.exclude.get("labels", [])
             exclude_markers = self.config.tests.exclude.get("markers", [])
             exclude_tests = self.config.tests.exclude.get("tests", [])
-        resolution_exclude_markers = [] if _has_explicit_pytest_selection(self._extra_pytest_args) else exclude_markers
+        skip_config_label_exclusions = bool(self._include_labels) or _has_explicit_pytest_selection(
+            self._extra_pytest_args
+        )
+        resolution_exclude_labels = [] if skip_config_label_exclusions else exclude_labels
+        resolution_exclude_markers = [] if skip_config_label_exclusions else exclude_markers
 
         phase_results: list[PhaseResult] = []
         overall_success = True
@@ -536,6 +548,8 @@ class Orchestrator:
                 resolved_phase_entries = self._resolve_validation_entries(
                     phase_entries,
                     requested_phase_names if Phase.ALL not in requested_phases else set(config_phases),
+                    set(self._include_labels),
+                    set(resolution_exclude_labels),
                     set(resolution_exclude_markers),
                     set(exclude_tests),
                     released_tests,
@@ -604,6 +618,8 @@ class Orchestrator:
                 terminal_remaining = self._resolve_remaining_validation_entries(
                     remaining_entries,
                     requested_phase_names if Phase.ALL not in requested_phases else set(config_phases),
+                    set(self._include_labels),
+                    set(resolution_exclude_labels),
                     set(resolution_exclude_markers),
                     set(exclude_tests),
                     released_tests,
@@ -704,6 +720,8 @@ class Orchestrator:
         self,
         entries: list[ValidationEntry],
         requested_phase_names: set[str],
+        include_labels: set[str],
+        exclude_labels: set[str],
         exclude_markers: set[str],
         exclude_tests: set[str],
         released_tests: set[str] | None,
@@ -715,6 +733,8 @@ class Orchestrator:
             step_outputs=step_outputs,
             step_phases=self.context.get_all_step_phases(),
             requested_phases=requested_phase_names,
+            include_labels=include_labels,
+            exclude_labels=exclude_labels,
             exclude_markers=exclude_markers,
             exclude_tests=exclude_tests,
             released_tests=released_tests,
@@ -725,6 +745,8 @@ class Orchestrator:
         self,
         entries: list[tuple[int, ValidationEntry]],
         requested_phase_names: set[str],
+        include_labels: set[str],
+        exclude_labels: set[str],
         exclude_markers: set[str],
         exclude_tests: set[str],
         released_tests: set[str] | None,
@@ -734,6 +756,8 @@ class Orchestrator:
         resolved_entries = self._resolve_validation_entries(
             [entry for _, entry in entries],
             requested_phase_names,
+            include_labels,
+            exclude_labels,
             exclude_markers,
             exclude_tests,
             released_tests,

--- a/isvctl/tests/test_catalog_cli.py
+++ b/isvctl/tests/test_catalog_cli.py
@@ -28,6 +28,7 @@ _FAKE_ENTRIES = [
     {
         "name": "AlphaCheck",
         "description": "Alpha description",
+        "labels": ["kubernetes"],
         "markers": ["kubernetes"],
         "module": "isvtest.validations.alpha",
         "platforms": ["KUBERNETES"],
@@ -35,6 +36,7 @@ _FAKE_ENTRIES = [
     {
         "name": "BetaCheck",
         "description": "",
+        "labels": [],
         "markers": [],
         "module": "isvtest.validations.beta",
         "platforms": [],

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -428,6 +428,8 @@ EOF
                 "skipped": True,
                 "message": "step 'probe' did not produce output",
                 "category": "probe_checks",
+                "labels": [],
+                "markers": [],
                 "state": "skipped",
                 "skip_reason": "step_no_output",
                 "error_reason": None,

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -519,6 +519,102 @@ EOF
         assert cases["FieldExistsCheck"].find("error").attrib["type"] == "template_render_failed"
 
 
+class TestLabelFiltering:
+    """Tests for ``--label`` selection and its precedence over config exclusions.
+
+    These pin two non-obvious composition rules from ``Orchestrator.run``:
+    1. CLI labels (or pytest ``-k``/``-m``) bypass YAML
+       ``exclude.labels``/``exclude.markers`` for the same run.
+    2. CLI labels pre-filter entries by label first, then pytest's ``-k`` filter
+       applies on top - so a deselected entry shows the pytest-filter message,
+       not the label-mismatch message.
+
+    ``K8sNodeCountCheck`` is used as the test subject because it ships with
+    ``markers=["kubernetes"]`` (so labels fall back to ``("kubernetes",)``) and
+    short-circuits to ``set_passed`` when neither ``count`` nor ``min_count``
+    is configured - no kubectl invocation needed.
+    """
+
+    @staticmethod
+    def _config(*, exclude_labels: list[str] | None = None) -> RunConfig:
+        """Build a minimal config with one labeled validation.
+
+        ``K8sNodeCountCheck`` is configured without ``count``/``min_count`` so
+        it returns ``set_passed`` without touching kubectl.
+        """
+        return RunConfig(
+            commands={
+                "kubernetes": PlatformCommands(
+                    phases=["test"],
+                    steps=[StepConfig(name="probe", command="true", phase="test")],
+                )
+            },
+            tests=ValidationConfig(
+                platform="kubernetes",
+                validations={"cluster": {"checks": {"K8sNodeCountCheck": {}}}},
+                exclude={"labels": exclude_labels} if exclude_labels else {},
+            ),
+        )
+
+    def test_include_labels_bypass_config_label_exclusions(self) -> None:
+        """``--label X`` drops a config ``exclude.labels: [X]`` for that run.
+
+        Regression for the precedence rule wired in
+        ``Orchestrator._resolve_validation_entries``: without ``--label``, the
+        check is skipped pre-resolution by the config; with ``--label
+        kubernetes``, the same exclusion is bypassed and the check runs.
+        """
+        config = self._config(exclude_labels=["kubernetes"])
+
+        without_label = Orchestrator(config).run(phases=[Phase.TEST])
+        check = without_label.phases[0].details["validations"][0]
+        assert check["state"] == "skipped"
+        assert check["skip_reason"] == "test_excluded"
+        assert "excluded by label" in check["message"]
+
+        with_label = Orchestrator(config).run(phases=[Phase.TEST], include_labels=["kubernetes"])
+        bypassed = with_label.phases[0].details["validations"][0]
+        assert bypassed["state"] == "passed", bypassed
+        assert "excluded by label" not in bypassed["message"]
+
+    def test_pytest_k_filter_also_bypasses_config_label_exclusions(self) -> None:
+        """An explicit ``-k`` selection bypasses ``exclude.labels`` too.
+
+        The bypass branch in ``Orchestrator.run`` is
+        ``bool(include_labels) or _has_explicit_pytest_selection(args)``;
+        this covers the second leg so a future refactor can't drop it.
+        """
+        config = self._config(exclude_labels=["kubernetes"])
+
+        result = Orchestrator(config).run(
+            phases=[Phase.TEST],
+            extra_pytest_args=["-k", "K8sNodeCountCheck"],
+        )
+        check = result.phases[0].details["validations"][0]
+        assert check["state"] == "passed", check
+        assert "excluded by label" not in check["message"]
+
+    def test_include_labels_compose_with_pytest_k_deselection(self) -> None:
+        """``--label X -- -k "not Y"`` lets pytest deselect on top of label pre-filter.
+
+        Pins the layering: the orchestrator resolves labeled entries to
+        ``ready`` so pytest sees them, then pytest's ``-k`` deselects. The
+        terminal skip reason must be the pytest-filter message - not the
+        label-mismatch message - otherwise the layering is broken.
+        """
+        config = self._config()
+
+        result = Orchestrator(config).run(
+            phases=[Phase.TEST],
+            include_labels=["kubernetes"],
+            extra_pytest_args=["-k", "not K8sNodeCountCheck"],
+        )
+        check = result.phases[0].details["validations"][0]
+        assert check["state"] == "skipped"
+        assert check["skip_reason"] == "test_excluded"
+        assert check["message"] == "excluded by pytest -k/-m filter"
+
+
 class TestTeardownOnlyPhase:
     """Tests for running teardown as the only requested phase.
 

--- a/isvctl/tests/test_test_cli_labels.py
+++ b/isvctl/tests/test_test_cli_labels.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for isvctl test CLI label filtering."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+import isvctl.cli.test as test_cli
+from isvctl.orchestrator.loop import OrchestratorResult, Phase, PhaseResult
+
+runner = CliRunner()
+
+
+def _write_config(tmp_path: Path) -> Path:
+    """Write a minimal isvctl test config and return its path."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+commands:
+  kubernetes:
+    phases: [test]
+    steps:
+      - name: test_step
+        command: echo
+        args: ['{"success": true}']
+        phase: test
+tests:
+  platform: kubernetes
+  validations: {}
+""",
+        encoding="utf-8",
+    )
+    return config
+
+
+def test_test_run_forwards_label_filters(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """`isvctl test run -l/--label` passes requested labels to the orchestrator."""
+    config = _write_config(tmp_path)
+    captured: dict[str, Any] = {}
+
+    class FakeOrchestrator:
+        """Capture orchestrator options passed by the CLI."""
+
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def run(self, **kwargs: Any) -> OrchestratorResult:
+            captured.update(kwargs)
+            return OrchestratorResult(
+                success=True,
+                phases=[PhaseResult(phase=Phase.TEST, success=True, message="ok")],
+            )
+
+    monkeypatch.setattr(test_cli, "Orchestrator", FakeOrchestrator)
+
+    result = runner.invoke(test_cli.app, ["run", "-f", str(config), "--no-upload", "-l", "gpu", "--label", "slow"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["include_labels"] == ["gpu", "slow"]

--- a/isvctl/tests/test_test_cli_labels.py
+++ b/isvctl/tests/test_test_cli_labels.py
@@ -16,7 +16,7 @@
 """Tests for isvctl test CLI label filtering."""
 
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 from typer.testing import CliRunner
@@ -49,27 +49,48 @@ tests:
     return config
 
 
+class _FakeOrchestrator:
+    """Capture orchestrator options passed by the CLI for assertion in tests."""
+
+    captured: ClassVar[dict[str, Any]] = {}
+
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    def run(self, **kwargs: Any) -> OrchestratorResult:
+        type(self).captured.update(kwargs)
+        return OrchestratorResult(
+            success=True,
+            phases=[PhaseResult(phase=Phase.TEST, success=True, message="ok")],
+        )
+
+
 def test_test_run_forwards_label_filters(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """`isvctl test run -l/--label` passes requested labels to the orchestrator."""
     config = _write_config(tmp_path)
-    captured: dict[str, Any] = {}
-
-    class FakeOrchestrator:
-        """Capture orchestrator options passed by the CLI."""
-
-        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
-            pass
-
-        def run(self, **kwargs: Any) -> OrchestratorResult:
-            captured.update(kwargs)
-            return OrchestratorResult(
-                success=True,
-                phases=[PhaseResult(phase=Phase.TEST, success=True, message="ok")],
-            )
-
-    monkeypatch.setattr(test_cli, "Orchestrator", FakeOrchestrator)
+    _FakeOrchestrator.captured = {}
+    monkeypatch.setattr(test_cli, "Orchestrator", _FakeOrchestrator)
 
     result = runner.invoke(test_cli.app, ["run", "-f", str(config), "--no-upload", "-l", "gpu", "--label", "slow"])
 
     assert result.exit_code == 0, result.output
-    assert captured["include_labels"] == ["gpu", "slow"]
+    assert _FakeOrchestrator.captured["include_labels"] == ["gpu", "slow"]
+
+
+def test_short_l_flag_binds_to_label_not_lab_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """`-l` is the short flag for `--label`, not the legacy `--lab-id`.
+
+    Pre-PR, `-l 12345` mapped to `--lab-id 12345` (an int). This test pins the
+    rebinding so a future refactor can't silently restore the old mapping: an
+    all-digit value passed via `-l` must land in ``include_labels`` as a string,
+    and the orchestrator must run with the request (proving Typer did not reject
+    a non-int `--lab-id`).
+    """
+    config = _write_config(tmp_path)
+    _FakeOrchestrator.captured = {}
+    monkeypatch.setattr(test_cli, "Orchestrator", _FakeOrchestrator)
+
+    result = runner.invoke(test_cli.app, ["run", "-f", str(config), "--no-upload", "-l", "12345"])
+
+    assert result.exit_code == 0, result.output
+    assert _FakeOrchestrator.captured["include_labels"] == ["12345"]

--- a/isvreporter/src/isvreporter/client.py
+++ b/isvreporter/src/isvreporter/client.py
@@ -293,7 +293,7 @@ def upload_test_catalog(
         jwt_token: JWT access token
         isv_test_version: Test suite version string (e.g. "1.2.3")
         entries: List of catalog entry dicts with keys:
-            name, description, markers, module
+            name, description, labels, markers, module
 
     Returns:
         True if catalog was uploaded or already exists, False on error
@@ -318,6 +318,7 @@ def upload_test_catalog(
             {
                 "name": e["name"],
                 "description": e.get("description", ""),
+                "labels": e.get("labels", e.get("markers", [])),
                 "markers": e.get("markers", []),
                 "module": e.get("module", ""),
                 "platforms": e.get("platforms", []),

--- a/isvreporter/tests/test_catalog_upload.py
+++ b/isvreporter/tests/test_catalog_upload.py
@@ -43,7 +43,13 @@ class TestUploadTestCatalog:
         mock_urlopen.side_effect = [get_response, post_response]
 
         entries = [
-            {"name": "TestA", "description": "Test A", "markers": ["k8s"], "module": "mod.a"},
+            {
+                "name": "TestA",
+                "description": "Test A",
+                "labels": ["k8s"],
+                "markers": ["k8s"],
+                "module": "mod.a",
+            },
             {"name": "TestB", "description": "Test B", "markers": [], "module": "mod.b"},
         ]
 
@@ -66,6 +72,9 @@ class TestUploadTestCatalog:
         assert payload["isvTestVersion"] == "1.2.3"
         assert len(payload["entries"]) == 2
         assert payload["entries"][0]["name"] == "TestA"
+        assert payload["entries"][0]["labels"] == ["k8s"]
+        assert payload["entries"][0]["markers"] == ["k8s"]
+        assert payload["entries"][1]["labels"] == []
 
     @patch("isvreporter.client.urlopen")
     def test_skips_upload_when_version_exists(self, mock_urlopen: MagicMock) -> None:
@@ -165,5 +174,29 @@ class TestUploadTestCatalog:
 
         assert entry["name"] == "TestA"
         assert entry["description"] == ""
+        assert entry["labels"] == []
         assert entry["markers"] == []
         assert entry["module"] == ""
+
+    @patch("isvreporter.client.urlopen")
+    def test_legacy_markers_are_used_as_labels_when_labels_missing(self, mock_urlopen: MagicMock) -> None:
+        """Legacy catalog entries that only send markers still upload labels."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"status": "created"}).encode()
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        upload_test_catalog(
+            endpoint="https://api.example.com",
+            jwt_token="test-token",
+            isv_test_version="1.0.0",
+            entries=[{"name": "TestA", "markers": ["gpu"]}],
+        )
+
+        request = mock_urlopen.call_args[0][0]
+        payload = json.loads(request.data.decode())
+        entry = payload["entries"][0]
+
+        assert entry["labels"] == ["gpu"]
+        assert entry["markers"] == ["gpu"]

--- a/isvtest/src/isvtest/catalog.py
+++ b/isvtest/src/isvtest/catalog.py
@@ -35,6 +35,7 @@ import yaml
 from isvreporter.version import get_version
 
 from isvtest.core.discovery import discover_all_tests
+from isvtest.core.validation import get_validation_labels, get_validation_markers
 from isvtest.release_manifest import INCLUDE_UNRELEASED_ENV, load_released_test_filter
 
 logger = logging.getLogger(__name__)
@@ -155,6 +156,7 @@ def build_catalog(*, released_only: bool = True) -> list[dict[str, Any]]:
         List of catalog entry dicts, each containing:
             - name: Validation class name or variant name
             - description: Human-readable description from class metadata
+            - labels: List of public label strings (e.g. ["kubernetes", "gpu"])
             - markers: List of marker strings (e.g. ["kubernetes", "gpu"])
             - module: Fully qualified module path
             - platforms: List of platform strings (e.g. ["KUBERNETES"])
@@ -168,9 +170,11 @@ def build_catalog(*, released_only: bool = True) -> list[dict[str, Any]]:
         if getattr(cls, "catalog_exclude", False):
             excluded_names.add(cls.__name__)
             continue
-        markers = list(getattr(cls, "markers", []))
+        labels = list(get_validation_labels(cls))
+        markers = list(get_validation_markers(cls))
         class_meta[cls.__name__] = {
             "description": getattr(cls, "description", "") or "",
+            "labels": labels,
             "markers": markers,
             "module": cls.__module__,
         }
@@ -194,6 +198,7 @@ def build_catalog(*, released_only: bool = True) -> list[dict[str, Any]]:
             {
                 "name": name,
                 "description": meta["description"],
+                "labels": meta["labels"],
                 "markers": meta["markers"],
                 "module": meta["module"],
                 "platforms": sorted(platform_map.get(name, [])),
@@ -217,6 +222,7 @@ def build_catalog(*, released_only: bool = True) -> list[dict[str, Any]]:
             {
                 "name": name,
                 "description": desc,
+                "labels": meta.get("labels", []),
                 "markers": meta.get("markers", []),
                 "module": meta.get("module", ""),
                 "platforms": sorted(platforms),

--- a/isvtest/src/isvtest/core/resolution.py
+++ b/isvtest/src/isvtest/core/resolution.py
@@ -29,6 +29,7 @@ from jinja2 import ChainableUndefined, Environment, Undefined
 
 from isvtest.config.loader import _ternary
 from isvtest.core.discovery import discover_all_tests
+from isvtest.core.validation import get_validation_labels, get_validation_markers
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +49,7 @@ class State(StrEnum):
 class SkipReason(StrEnum):
     """Why a skipped validation did not run."""
 
-    EXCLUDED = "test_excluded"  # explicitly excluded by user (YAML markers/tests OR CLI -k/-m)
+    EXCLUDED = "test_excluded"  # explicitly excluded by user (YAML labels/markers/tests OR CLI -k/-m)
     PHASE_NOT_REQUESTED = "phase_not_requested"  # entry's phase wasn't in the requested phase set
     RUNTIME_SKIP = "runtime_skip"  # validation called pytest.skip(...) at runtime
     STEP_NO_OUTPUT = "step_no_output"  # step ran but produced no JSON output
@@ -73,6 +74,7 @@ class ValidationEntry:
     params_template: dict[str, Any]
     step: str | None = None
     phase: str | None = None
+    labels: tuple[str, ...] = ()
     markers: tuple[str, ...] = ()
 
 
@@ -104,7 +106,7 @@ def parse_validations(raw_config: Mapping[str, Any]) -> list[ValidationEntry]:
         Ordered validation entries. Adapter-handled categories are ignored
         because they are not BaseValidation pytest entries.
     """
-    markers_by_name = _validation_markers_by_name()
+    metadata_by_name = _validation_metadata_by_name()
     entries: list[ValidationEntry] = []
 
     for category, category_config in raw_config.items():
@@ -128,6 +130,8 @@ def parse_validations(raw_config: Mapping[str, Any]) -> list[ValidationEntry]:
             else:
                 params_template = copy.deepcopy(params_template)
 
+            base_name = _base_validation_name(name, metadata_by_name)
+            metadata = metadata_by_name.get(base_name, ((), ()))
             entries.append(
                 ValidationEntry(
                     name=name,
@@ -135,7 +139,8 @@ def parse_validations(raw_config: Mapping[str, Any]) -> list[ValidationEntry]:
                     params_template=params_template,
                     step=entry_step if isinstance(entry_step, str) else None,
                     phase=entry_phase if isinstance(entry_phase, str) else None,
-                    markers=markers_by_name.get(_base_validation_name(name, markers_by_name), ()),
+                    labels=metadata[0],
+                    markers=metadata[1],
                 )
             )
 
@@ -148,6 +153,8 @@ def resolve_entries(
     step_outputs: Mapping[str, dict[str, Any]],
     step_phases: Mapping[str, str],
     requested_phases: AbstractSet[str],
+    include_labels: AbstractSet[str],
+    exclude_labels: AbstractSet[str],
     exclude_markers: AbstractSet[str],
     exclude_tests: AbstractSet[str],
     released_tests: AbstractSet[str] | None,
@@ -160,7 +167,9 @@ def resolve_entries(
         step_outputs: Step outputs accumulated so far.
         step_phases: Mapping of configured, non-skipped step names to phases.
         requested_phases: Phase names requested by the invocation.
-        exclude_markers: Validation markers excluded by config.
+        include_labels: Validation labels required by CLI selection. All requested labels must be present.
+        exclude_labels: Validation labels excluded by config.
+        exclude_markers: Legacy validation markers excluded by config.
         exclude_tests: Validation names excluded by config.
         released_tests: Released test manifest, or None when unreleased checks are included.
         render_context: Jinja context for validation parameter rendering.
@@ -192,6 +201,30 @@ def resolve_entries(
 
         if entry.name in exclude_tests:
             resolved.append(_skip(entry, SkipReason.EXCLUDED, f"validation '{entry.name}' is excluded by name"))
+            continue
+
+        missing_include_labels = sorted(set(include_labels).difference(entry.labels))
+        if missing_include_labels:
+            label_list = ", ".join(sorted(include_labels))
+            resolved.append(
+                _skip(
+                    entry,
+                    SkipReason.EXCLUDED,
+                    f"validation '{entry.name}' does not match all selected labels: {label_list}",
+                )
+            )
+            continue
+
+        label_matches = sorted(set(entry.labels).intersection(exclude_labels))
+        if label_matches:
+            label_list = ", ".join(label_matches)
+            resolved.append(
+                _skip(
+                    entry,
+                    SkipReason.EXCLUDED,
+                    f"validation '{entry.name}' is excluded by label: {label_list}",
+                )
+            )
             continue
 
         marker_matches = sorted(set(entry.markers).intersection(exclude_markers))
@@ -291,13 +324,12 @@ def format_resolution_message(entry: ResolvedEntry) -> str:
 
 
 @cache
-def _validation_markers_by_name() -> dict[str, tuple[str, ...]]:
-    """Return discovered validation markers keyed by class name."""
-    markers: dict[str, tuple[str, ...]] = {}
+def _validation_metadata_by_name() -> dict[str, tuple[tuple[str, ...], tuple[str, ...]]]:
+    """Return discovered validation ``(labels, markers)`` metadata keyed by class name."""
+    metadata: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {}
     for cls in discover_all_tests():
-        cls_markers = getattr(cls, "markers", None) or []
-        markers[cls.__name__] = tuple(str(marker) for marker in cls_markers)
-    return markers
+        metadata[cls.__name__] = (get_validation_labels(cls), get_validation_markers(cls))
+    return metadata
 
 
 def resolve_class_key(name: str, keys: Iterable[str]) -> str | None:
@@ -316,9 +348,9 @@ def resolve_class_key(name: str, keys: Iterable[str]) -> str | None:
     return max(matches, key=len)
 
 
-def _base_validation_name(name: str, markers_by_name: Mapping[str, tuple[str, ...]]) -> str:
+def _base_validation_name(name: str, metadata_by_name: Mapping[str, object]) -> str:
     """Return the discovered base class name for a configured validation name."""
-    return resolve_class_key(name, markers_by_name) or name
+    return resolve_class_key(name, metadata_by_name) or name
 
 
 def _iter_validation_items(category: str, category_config: Any) -> list[tuple[str, Any, Any, Any]]:

--- a/isvtest/src/isvtest/core/validation.py
+++ b/isvtest/src/isvtest/core/validation.py
@@ -68,6 +68,7 @@ class BaseValidation(ABC):
     # Optional metadata
     description: ClassVar[str] = ""
     timeout: ClassVar[int] = 60
+    labels: ClassVar[list[str]] = []
     markers: ClassVar[list[str]] = []
     catalog_exclude: ClassVar[bool] = False
 
@@ -304,6 +305,35 @@ def get_validation_class(name: str) -> type[BaseValidation] | None:
     """
     cache = _discover_validation_classes()
     return cache.get(name)
+
+
+def _normalize_metadata_values(values: object) -> tuple[str, ...]:
+    """Return metadata values as a tuple of strings."""
+    if not values:
+        return ()
+    if isinstance(values, str):
+        return (values,)
+    try:
+        return tuple(str(value) for value in values)
+    except TypeError:
+        return (str(values),)
+
+
+def get_validation_markers(cls: type[BaseValidation]) -> tuple[str, ...]:
+    """Return legacy pytest markers for a validation class."""
+    return _normalize_metadata_values(getattr(cls, "markers", ()))
+
+
+def get_validation_labels(cls: type[BaseValidation]) -> tuple[str, ...]:
+    """Return public labels for a validation class.
+
+    During the labels transition, classes that do not define explicit labels
+    publish their existing pytest markers as labels.
+    """
+    labels = _normalize_metadata_values(getattr(cls, "labels", ()))
+    if labels:
+        return labels
+    return get_validation_markers(cls)
 
 
 def register_validation_class(cls: type[BaseValidation]) -> None:

--- a/isvtest/src/isvtest/core/validation.py
+++ b/isvtest/src/isvtest/core/validation.py
@@ -68,7 +68,7 @@ class BaseValidation(ABC):
     # Optional metadata
     description: ClassVar[str] = ""
     timeout: ClassVar[int] = 60
-    labels: ClassVar[list[str]] = []
+    labels: ClassVar[tuple[str, ...]] = ()
     markers: ClassVar[list[str]] = []
     catalog_exclude: ClassVar[bool] = False
 

--- a/isvtest/src/isvtest/main.py
+++ b/isvtest/src/isvtest/main.py
@@ -273,6 +273,7 @@ def run_pytest_tests(
     platform: str | None = None,
     config_file: str | None = None,
     inventory_path: str | None = None,
+    labels: list[str] | None = None,
     markers: list[str] | None = None,
     verbose: bool = False,
     extra_pytest_args: list[str] | None = None,
@@ -283,7 +284,8 @@ def run_pytest_tests(
         platform: Platform to validate (bare_metal, kubernetes, slurm, common, or all)
         config_file: Direct path to cluster configuration file
         inventory_path: Path to cluster inventory file (JSON or YAML)
-        markers: Pytest markers to filter tests (e.g., ['gpu', 'network'])
+        labels: Public labels to filter tests (e.g., ['gpu', 'network']). All must match.
+        markers: Legacy pytest markers to filter tests.
         verbose: Show verbose output
         extra_pytest_args: Additional arguments to pass to pytest
 
@@ -340,16 +342,17 @@ def run_pytest_tests(
     if inventory_path:
         pytest_args.extend(["--inventory", inventory_path])
 
+    marker_terms: list[str] = []
+
     # Add platform marker if specified
     if platform and platform != "all":
         normalized_platform = "bare_metal" if platform == "common" else platform
         if normalized_platform in ["bare_metal", "kubernetes", "slurm"]:
-            pytest_args.extend(["-m", normalized_platform])
+            marker_terms.append(normalized_platform)
 
-    # Add markers
-    if markers:
-        for marker in markers:
-            pytest_args.extend(["-m", marker])
+    marker_terms.extend([*(labels or []), *(markers or [])])
+    if marker_terms:
+        pytest_args.extend(["-m", " and ".join(marker_terms)])
 
     # Add any extra pytest arguments
     if extra_pytest_args:
@@ -390,12 +393,20 @@ def test_cmd(
             readable=True,
         ),
     ] = None,
+    labels: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--label",
+            "-l",
+            help="Label to filter tests (can be repeated; all selected labels must match)",
+        ),
+    ] = None,
     markers: Annotated[
         list[str] | None,
         typer.Option(
             "--markers",
             "-m",
-            help="Pytest markers to filter tests (can be repeated)",
+            help="Legacy alias for --label; pytest marker compatibility",
         ),
     ] = None,
     verbose: Annotated[
@@ -414,7 +425,7 @@ def test_cmd(
 
         isvtest test --platform bare_metal --config tests.yaml
 
-        isvtest test --config tests.yaml --markers gpu --markers network
+        isvtest test --config tests.yaml --label gpu --label network
 
         isvtest test --config tests.yaml -k test_gpu --maxfail=1
     """
@@ -424,6 +435,7 @@ def test_cmd(
     exit_code = run_pytest_tests(
         platform=platform.value,
         config_file=str(config) if config else None,
+        labels=labels,
         markers=markers,
         verbose=verbose,
         extra_pytest_args=extra_args,

--- a/isvtest/src/isvtest/tests/conftest.py
+++ b/isvtest/src/isvtest/tests/conftest.py
@@ -119,7 +119,7 @@ def _handle_test_exclusions(config: pytest.Config, items: list[pytest.Item]) -> 
 
     Deselects tests based on:
     - Excluded platforms
-    - Excluded markers (skipped if -k is used, allowing explicit test selection)
+    - Excluded labels (skipped if -k/-m is used, allowing explicit test selection)
     - Excluded test names
     - Excluded test file names
 
@@ -166,10 +166,11 @@ def _handle_test_exclusions(config: pytest.Config, items: list[pytest.Item]) -> 
             if any(platform in item_markers for platform in excluded_platforms):
                 should_exclude = True
 
-            # Exclude by marker (skipped if -k is used for explicit selection)
+            # Exclude by label (skipped if -k/-m is used for explicit selection).
+            # Legacy "markers" remains an alias during the labels transition.
             if not skip_marker_exclusions:
-                excluded_markers = exclude_config.get("markers", [])
-                if any(marker in item_markers for marker in excluded_markers):
+                excluded_labels = [*exclude_config.get("labels", []), *exclude_config.get("markers", [])]
+                if any(label in item_markers for label in excluded_labels):
                     should_exclude = True
 
             # Exclude by test name (supports exact match, prefix match, or parametrized ID match)

--- a/isvtest/src/isvtest/tests/test_validations.py
+++ b/isvtest/src/isvtest/tests/test_validations.py
@@ -24,7 +24,7 @@ from isvtest.config.loader import ConfigLoader
 from isvtest.core.discovery import discover_all_tests
 from isvtest.core.resolution import ADAPTER_HANDLED_CATEGORIES, resolve_class_key
 from isvtest.core.runners import LocalRunner
-from isvtest.core.validation import BaseValidation
+from isvtest.core.validation import BaseValidation, get_validation_labels, get_validation_markers
 from isvtest.release_manifest import INCLUDE_UNRELEASED_ENV, load_released_test_filter
 
 if TYPE_CHECKING:
@@ -43,6 +43,19 @@ def get_validation_results() -> list[dict[str, Any]]:
 def clear_validation_results() -> None:
     """Clear captured validation results before a new pytest run."""
     _validation_results.clear()
+
+
+def _pytest_marks_for_validation(
+    config: pytest.Config,
+    validation_class: type[BaseValidation],
+) -> list[Any]:
+    """Return pytest marks for a validation's labels and legacy markers."""
+    labels = get_validation_labels(validation_class)
+    markers = get_validation_markers(validation_class)
+    mark_names = tuple(dict.fromkeys([*markers, *labels]))
+    for mark_name in mark_names:
+        config.addinivalue_line("markers", f"{mark_name}: Validation label")
+    return [getattr(pytest.mark, mark_name) for mark_name in mark_names]
 
 
 def _resolve_validation_class(
@@ -164,9 +177,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
                         continue
 
                 if target_class:
-                    # Get markers from class, ensuring we handle inheritance correctly
-                    markers = getattr(target_class, "markers", [])
-                    pytest_marks = [getattr(pytest.mark, m) for m in markers]
+                    pytest_marks = _pytest_marks_for_validation(metafunc.config, target_class)
 
                     # Merge inventory into validation config for validations that need it.
                     # Most validations (k8s, slurm, bare_metal) run commands locally and don't need inventory.
@@ -198,8 +209,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
                     # If class was not configured by exact or variant match, treat it as skipped.
                     if cls_name not in configured_classes:
-                        markers = getattr(cls, "markers", [])
-                        pytest_marks = [getattr(pytest.mark, m) for m in markers]
+                        pytest_marks = _pytest_marks_for_validation(metafunc.config, cls)
                         pytest_marks.append(pytest.mark.skip(reason="Not configured in config YAML"))
 
                         # Include inventory even for skipped tests (for consistency)
@@ -212,8 +222,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
                 if released_tests is not None and cls.__name__ not in released_tests:
                     continue
 
-                markers = getattr(cls, "markers", [])
-                pytest_marks = [getattr(pytest.mark, m) for m in markers]
+                pytest_marks = _pytest_marks_for_validation(metafunc.config, cls)
                 params.append(pytest.param(cls, {"inventory": cluster_inventory}, cls.__name__, marks=pytest_marks))
                 ids.append(cls.__name__)
 

--- a/isvtest/tests/test_catalog.py
+++ b/isvtest/tests/test_catalog.py
@@ -15,9 +15,23 @@
 
 """Tests for the catalog module."""
 
+from typing import ClassVar
 from unittest.mock import patch
 
 from isvtest.catalog import build_catalog, get_catalog_version
+from isvtest.core.validation import BaseValidation
+
+
+class ExplicitLabelCatalogCheck(BaseValidation):
+    """Catalog fixture with labels that intentionally differ from markers."""
+
+    description = "Explicit labels"
+    markers: ClassVar[list[str]] = ["gpu"]
+    labels: ClassVar[list[str]] = ["accelerator", "long-running"]
+
+    def run(self) -> None:
+        """Mark the validation passed."""
+        self.set_passed()
 
 
 class TestBuildCatalog:
@@ -37,6 +51,7 @@ class TestBuildCatalog:
         for entry in catalog:
             assert "name" in entry
             assert "description" in entry
+            assert "labels" in entry
             assert "markers" in entry
             assert "module" in entry
 
@@ -46,6 +61,7 @@ class TestBuildCatalog:
         for entry in catalog:
             assert isinstance(entry["name"], str)
             assert isinstance(entry["description"], str)
+            assert isinstance(entry["labels"], list)
             assert isinstance(entry["markers"], list)
             assert isinstance(entry["module"], str)
 
@@ -84,6 +100,40 @@ class TestBuildCatalog:
         for entry in catalog:
             for marker in entry["markers"]:
                 assert isinstance(marker, str)
+
+    def test_labels_are_lists_of_strings(self) -> None:
+        """Test that labels are lists of strings."""
+        catalog = build_catalog()
+        for entry in catalog:
+            for label in entry["labels"]:
+                assert isinstance(label, str)
+
+    def test_labels_default_to_markers(self) -> None:
+        """Catalog entries expose labels even for legacy marker-only classes."""
+        catalog = build_catalog()
+
+        for entry in catalog:
+            assert entry["labels"] == entry["markers"]
+
+    def test_catalog_uses_explicit_labels_when_present(self) -> None:
+        """Explicit class labels are public metadata while markers remain for compatibility."""
+        with (
+            patch("isvtest.catalog.discover_all_tests", return_value=[ExplicitLabelCatalogCheck]),
+            patch("isvtest.catalog._build_platform_map", return_value={}),
+            patch("isvtest.catalog.load_released_test_filter", return_value=None),
+        ):
+            catalog = build_catalog()
+
+        assert catalog == [
+            {
+                "name": "ExplicitLabelCatalogCheck",
+                "description": "Explicit labels",
+                "labels": ["accelerator", "long-running"],
+                "markers": ["gpu"],
+                "module": __name__,
+                "platforms": [],
+            }
+        ]
 
     def test_modules_are_valid_python_paths(self) -> None:
         """Test that module paths look like valid Python module paths."""

--- a/isvtest/tests/test_main.py
+++ b/isvtest/tests/test_main.py
@@ -15,6 +15,8 @@
 
 """Tests for isvtest.main module."""
 
+import pytest
+
 import isvtest.main
 from isvtest.core.resolution import ErrorReason, ResolvedEntry, SkipReason, State, ValidationEntry
 from isvtest.main import (
@@ -150,3 +152,52 @@ def test_run_validations_via_pytest_marks_unselected_entries_as_excluded() -> No
     assert nim.state == State.SKIPPED
     assert nim.skip_reason == SkipReason.EXCLUDED
     assert nim.message == "excluded by pytest -k/-m filter"
+
+
+def test_run_pytest_tests_uses_all_selected_labels(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Label selection forwards one pytest marker expression with AND semantics."""
+    captured: dict[str, list[str]] = {}
+
+    def fake_pytest_main(args: list[str]) -> int:
+        captured["args"] = args
+        return 0
+
+    monkeypatch.setattr(isvtest.main.pytest, "main", fake_pytest_main)
+
+    exit_code = isvtest.main.run_pytest_tests(labels=["gpu", "slow"])
+
+    assert exit_code == 0
+    assert captured["args"][-2:] == ["-m", "gpu and slow"]
+
+
+def test_run_pytest_tests_combines_platform_and_labels(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Platform and label filters use one pytest marker expression."""
+    captured: dict[str, list[str]] = {}
+
+    def fake_pytest_main(args: list[str]) -> int:
+        captured["args"] = args
+        return 0
+
+    monkeypatch.setattr(isvtest.main.pytest, "main", fake_pytest_main)
+
+    exit_code = isvtest.main.run_pytest_tests(platform="bare_metal", labels=["gpu"])
+
+    assert exit_code == 0
+    assert captured["args"].count("-m") == 1
+    assert captured["args"][-2:] == ["-m", "bare_metal and gpu"]
+
+
+def test_run_pytest_tests_keeps_markers_as_legacy_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The legacy markers option still selects by the same expression path."""
+    captured: dict[str, list[str]] = {}
+
+    def fake_pytest_main(args: list[str]) -> int:
+        captured["args"] = args
+        return 0
+
+    monkeypatch.setattr(isvtest.main.pytest, "main", fake_pytest_main)
+
+    exit_code = isvtest.main.run_pytest_tests(markers=["gpu"])
+
+    assert exit_code == 0
+    assert captured["args"][-2:] == ["-m", "gpu"]

--- a/isvtest/tests/test_resolution.py
+++ b/isvtest/tests/test_resolution.py
@@ -42,6 +42,17 @@ class MarkerCheck(BaseValidation):
         self.set_passed()
 
 
+class LabelCheck(BaseValidation):
+    """Validation with labels that differ from markers used by parser tests."""
+
+    markers: ClassVar[list[str]] = ["gpu"]
+    labels: ClassVar[list[str]] = ["accelerator", "long-running"]
+
+    def run(self) -> None:
+        """Mark the validation passed."""
+        self.set_passed()
+
+
 class PlainCheck(BaseValidation):
     """Validation without markers used by parser tests."""
 
@@ -58,6 +69,7 @@ def _entry(
     step: str | None = None,
     phase: str | None = None,
     markers: tuple[str, ...] = (),
+    labels: tuple[str, ...] = (),
 ) -> ValidationEntry:
     """Build a minimal validation entry."""
     return ValidationEntry(
@@ -67,6 +79,7 @@ def _entry(
         step=step,
         phase=phase,
         markers=markers,
+        labels=labels,
     )
 
 
@@ -77,6 +90,8 @@ def _resolve(
     step_phases: dict[str, str] | None = None,
     requested_phases: set[str] | None = None,
     exclude_markers: set[str] | None = None,
+    include_labels: set[str] | None = None,
+    exclude_labels: set[str] | None = None,
     exclude_tests: set[str] | None = None,
     released_tests: set[str] | None = None,
     render_context: dict[str, Any] | None = None,
@@ -88,6 +103,8 @@ def _resolve(
         step_phases={} if step_phases is None else step_phases,
         requested_phases={"test"} if requested_phases is None else requested_phases,
         exclude_markers=set() if exclude_markers is None else exclude_markers,
+        include_labels=set() if include_labels is None else include_labels,
+        exclude_labels=set() if exclude_labels is None else exclude_labels,
         exclude_tests=set() if exclude_tests is None else exclude_tests,
         released_tests=released_tests,
         render_context={} if render_context is None else render_context,
@@ -102,6 +119,7 @@ def _resolve(
         (_entry("NewCheck"), {"released_tests": {"PlainCheck"}}, SkipReason.UNRELEASED),
         (_entry("PlainCheck"), {"exclude_tests": {"PlainCheck"}}, SkipReason.EXCLUDED),
         (_entry("MarkerCheck", markers=("slow",)), {"exclude_markers": {"slow"}}, SkipReason.EXCLUDED),
+        (_entry("LabelCheck", labels=("accelerator",)), {"exclude_labels": {"accelerator"}}, SkipReason.EXCLUDED),
         (_entry(step="create_cluster"), {"step_phases": {}}, SkipReason.STEP_NOT_CONFIGURED),
         (
             _entry(step="create_cluster"),
@@ -224,6 +242,8 @@ def test_resolve_entries_is_idempotent_from_original_entries() -> None:
         "step_phases": {},
         "requested_phases": {"test"},
         "exclude_markers": {"slow"},
+        "include_labels": set(),
+        "exclude_labels": set(),
         "exclude_tests": set(),
         "released_tests": None,
         "render_context": {},
@@ -235,13 +255,41 @@ def test_resolve_entries_is_idempotent_from_original_entries() -> None:
     assert second == first
 
 
-def test_parse_validations_supports_group_defaults_and_markers(
+def test_resolve_entries_requires_all_include_labels() -> None:
+    """Label selection is an AND filter across all requested labels."""
+    entries = [
+        _entry("GpuSlowCheck", labels=("gpu", "slow")),
+        _entry("GpuOnlyCheck", labels=("gpu",)),
+        _entry("SlowOnlyCheck", labels=("slow",)),
+    ]
+
+    results = resolve_entries(
+        entries,
+        step_outputs={},
+        step_phases={},
+        requested_phases={"test"},
+        include_labels={"gpu", "slow"},
+        exclude_labels=set(),
+        exclude_markers=set(),
+        exclude_tests=set(),
+        released_tests=None,
+        render_context={},
+    )
+
+    by_name = {result.entry.name: result for result in results}
+    assert by_name["GpuSlowCheck"].is_ready
+    assert by_name["GpuOnlyCheck"].skip_reason == SkipReason.EXCLUDED
+    assert by_name["SlowOnlyCheck"].skip_reason == SkipReason.EXCLUDED
+    assert "labels" in by_name["GpuOnlyCheck"].message
+
+
+def test_parse_validations_supports_group_defaults_and_labels(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Parser expands config groups and populates markers from discovered classes."""
+    """Parser expands config groups and populates labels from discovered classes."""
     monkeypatch.setattr(
         "isvtest.core.resolution.discover_all_tests",
-        lambda: [MarkerCheck, PlainCheck],
+        lambda: [MarkerCheck, LabelCheck, PlainCheck],
     )
     raw_config: dict[str, Any] = {
         "cluster": {
@@ -249,6 +297,7 @@ def test_parse_validations_supports_group_defaults_and_markers(
             "phase": "setup",
             "checks": {
                 "MarkerCheck": {"expected": 4},
+                "LabelCheck": {"expected": 8},
                 "PlainCheck": {},
             },
         },
@@ -264,6 +313,16 @@ def test_parse_validations_supports_group_defaults_and_markers(
             step="create_cluster",
             phase="setup",
             markers=("slow", "kubernetes"),
+            labels=("slow", "kubernetes"),
+        ),
+        ValidationEntry(
+            name="LabelCheck",
+            category="cluster",
+            params_template={"expected": 8},
+            step="create_cluster",
+            phase="setup",
+            markers=("gpu",),
+            labels=("accelerator", "long-running"),
         ),
         ValidationEntry(
             name="PlainCheck",
@@ -272,6 +331,7 @@ def test_parse_validations_supports_group_defaults_and_markers(
             step="create_cluster",
             phase="setup",
             markers=(),
+            labels=(),
         ),
     ]
 

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -16,13 +16,13 @@
 """Tests for validation module."""
 
 import json
-from typing import Any
+from typing import Any, ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from isvtest.core.runners import CommandResult
-from isvtest.core.validation import BaseValidation
+from isvtest.core.validation import BaseValidation, get_validation_labels
 from isvtest.tests.test_validations import (
     _validation_results,
     clear_validation_results,
@@ -59,6 +59,27 @@ class ConcreteValidation(BaseValidation):
 
     description = "Test validation"
     timeout = 30
+
+    def run(self) -> None:
+        """Simple run implementation."""
+        self.set_passed("Test passed")
+
+
+class MarkerOnlyValidation(BaseValidation):
+    """Validation with legacy markers only."""
+
+    markers: ClassVar[list[str]] = ["gpu", "slow"]
+
+    def run(self) -> None:
+        """Simple run implementation."""
+        self.set_passed("Test passed")
+
+
+class LabelledValidation(BaseValidation):
+    """Validation with public labels overriding legacy markers."""
+
+    markers: ClassVar[list[str]] = ["gpu"]
+    labels: ClassVar[list[str]] = ["accelerator", "long-running"]
 
     def run(self) -> None:
         """Simple run implementation."""
@@ -219,6 +240,14 @@ class TestBaseValidation:
         validation = ConcreteValidation()
         assert validation.log is not None
         assert validation.log.name == "ConcreteValidation"
+
+    def test_get_validation_labels_falls_back_to_markers(self) -> None:
+        """Validation labels default to legacy markers during the transition."""
+        assert get_validation_labels(MarkerOnlyValidation) == ("gpu", "slow")
+
+    def test_get_validation_labels_prefers_explicit_labels(self) -> None:
+        """Validation classes can publish labels without changing pytest markers."""
+        assert get_validation_labels(LabelledValidation) == ("accelerator", "long-running")
 
 
 class TestInstanceListCheck:


### PR DESCRIPTION
## Summary

- Introduce public validation labels while keeping pytest markers as a compatibility alias.
- Add `--label/-l` selection for `isvctl` and `isvtest`, plus `tests.exclude.labels` config support.
- Include both `labels` and legacy `markers` in catalog upload payloads and docs during the transition.

## Validation

- `git diff --check upstream/main...HEAD`
- `make test`
- `make lint`

Related: #412

This implements the labels-v1 compatibility slice but does not close #412.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added label-based filtering for validations via new --label/-l CLI flags and catalog/listing output showing Labels.

* **Documentation**
  * Updated guides and examples to use "labels" terminology and explain interaction with explicit selectors.

* **Configuration**
  * Exclusion rules now prefer labels (markers accepted as legacy alias; combined if both present).

* **Tests**
  * Added and extended tests to cover label selection, exclusion precedence, and legacy-marker compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/ISV-NCP-Validation-Suite/pull/434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->