### PR TITLE
feat: add K8s Cluster Autoscaler validation

### DIFF
--- a/isvctl/configs/providers/aws/scripts/eks/setup.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/setup.sh
@@ -480,6 +480,8 @@ cat << EOF
     "control_plane_address": "${CLUSTER_ENDPOINT}",
     "kubeconfig_path": "${KUBECONFIG_PATH}",
     "gpu_operator_namespace": "${GPU_OPERATOR_NS}",
+    "cluster_autoscaler_namespace": "kube-system",
+    "cluster_autoscaler_deployment": "cluster-autoscaler",
     "runtime_class": "${RUNTIME_CLASS}",
     "gpu_resource_name": "nvidia.com/gpu"
   },

--- a/isvctl/configs/providers/aws/scripts/eks/terraform/README.md
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform/README.md
@@ -7,11 +7,12 @@ This Terraform module deploys an AWS EKS cluster configured for GPU workloads an
 - **EKS Cluster** with configurable Kubernetes version
 - **GPU Node Group** with NVIDIA GPU instances (g4dn, g5, p4d, p5)
 - **System Node Group** for non-GPU workloads
+- **Upstream Kubernetes Cluster Autoscaler** installed via Helm with IRSA
 - **NVIDIA GPU Operator** installed via Helm
 - **EFS Storage** for ReadWriteMany PVCs (NIM model cache)
 - **gp3 StorageClass** as default for EBS volumes
 - **VPC** with public/private subnets and NAT Gateway
-- **IRSA** for EBS and EFS CSI drivers
+- **IRSA** for EBS CSI, EFS CSI, and Cluster Autoscaler
 
 ## Prerequisites
 
@@ -127,6 +128,18 @@ mig_strategy = "none"
 
 # For A100/H100 clusters with MIG enabled
 mig_strategy = "single"
+```
+
+### Cluster Autoscaler
+
+The module installs the upstream Kubernetes Cluster Autoscaler chart by default so the EKS provider satisfies the
+`K8sClusterAutoscalerCheck` integration validation. It is configured for AWS auto-discovery, uses IRSA for AWS API
+permissions, and disables scale-down by default to keep validation runs low-risk.
+
+```hcl
+install_cluster_autoscaler       = true
+cluster_autoscaler_chart_version = ""  # Empty uses the upstream chart repository default
+cluster_autoscaler_image_tag     = ""  # Empty derives v<kubernetes_version>.0
 ```
 
 ## Outputs

--- a/isvctl/configs/providers/aws/scripts/eks/terraform/main.tf
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform/main.tf
@@ -127,6 +127,11 @@ data "aws_ec2_instance_type_offerings" "gpu" {
 
 locals {
   cluster_name = "${var.cluster_name_prefix}-${var.environment}"
+  cluster_autoscaler_image_tag = (
+    var.cluster_autoscaler_image_tag != ""
+    ? var.cluster_autoscaler_image_tag
+    : "v${var.kubernetes_version}.0"
+  )
 
   # Filter AZs to only those that support the GPU instance type
   # This prevents NodeCreationFailure when EKS tries to launch GPU nodes in unsupported AZs
@@ -449,6 +454,29 @@ module "ebs_csi_irsa" {
 }
 
 # -----------------------------------------------------------------------------
+# Cluster Autoscaler IRSA
+# -----------------------------------------------------------------------------
+
+module "cluster_autoscaler_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.0"
+  count   = var.install_cluster_autoscaler ? 1 : 0
+
+  role_name                        = "${local.cluster_name}-cluster-autoscaler"
+  attach_cluster_autoscaler_policy = true
+  cluster_autoscaler_cluster_names = [local.cluster_name]
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:cluster-autoscaler"]
+    }
+  }
+
+  tags = local.tags
+}
+
+# -----------------------------------------------------------------------------
 # EFS for ReadWriteMany Storage (NIM model cache)
 # -----------------------------------------------------------------------------
 
@@ -561,6 +589,55 @@ resource "helm_release" "gpu_operator" {
   })]
 
   timeout = 900 # 15 minutes - GPU operator can take a while
+}
+
+# -----------------------------------------------------------------------------
+# Cluster Autoscaler (Helm)
+# -----------------------------------------------------------------------------
+
+resource "helm_release" "cluster_autoscaler" {
+  count = var.install_cluster_autoscaler ? 1 : 0
+
+  name       = "cluster-autoscaler"
+  repository = "https://kubernetes.github.io/autoscaler"
+  chart      = "cluster-autoscaler"
+  version    = var.cluster_autoscaler_chart_version != "" ? var.cluster_autoscaler_chart_version : null
+  namespace  = "kube-system"
+
+  depends_on = [
+    module.eks,
+    module.cluster_autoscaler_irsa,
+  ]
+
+  values = [yamlencode({
+    fullnameOverride = "cluster-autoscaler"
+    nameOverride     = "cluster-autoscaler"
+    cloudProvider    = "aws"
+    awsRegion        = var.region
+    autoDiscovery = {
+      clusterName = local.cluster_name
+    }
+    image = {
+      tag = local.cluster_autoscaler_image_tag
+    }
+    replicaCount = 1
+    rbac = {
+      serviceAccount = {
+        create = true
+        name   = "cluster-autoscaler"
+        annotations = {
+          "eks.amazonaws.com/role-arn" = module.cluster_autoscaler_irsa[0].iam_role_arn
+        }
+      }
+    }
+    extraArgs = {
+      "balance-similar-node-groups" = "true"
+      "scale-down-enabled"          = "false"
+      "skip-nodes-with-system-pods" = "true"
+    }
+  })]
+
+  timeout = 300
 }
 
 # -----------------------------------------------------------------------------

--- a/isvctl/configs/providers/aws/scripts/eks/terraform/terraform.tfvars.example
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform/terraform.tfvars.example
@@ -36,6 +36,14 @@ kubernetes_version = "1.32"
 cluster_endpoint_public_access_cidrs = ["YOUR.IP.ADDRESS/32"]
 
 # -----------------------------------------------------------------------------
+# Cluster Autoscaler
+# -----------------------------------------------------------------------------
+
+install_cluster_autoscaler       = true
+cluster_autoscaler_chart_version = ""  # Empty uses the upstream chart repository default
+cluster_autoscaler_image_tag     = ""  # Empty derives v<kubernetes_version>.0
+
+# -----------------------------------------------------------------------------
 # System Node Group (non-GPU control plane workloads)
 # -----------------------------------------------------------------------------
 

--- a/isvctl/configs/providers/aws/scripts/eks/terraform/variables.tf
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform/variables.tf
@@ -67,7 +67,29 @@ variable "kubernetes_version" {
 variable "cluster_endpoint_public_access_cidrs" {
   description = "List of CIDR blocks to allow access to the EKS API server endpoint. MUST be set to your IP address(es). Example: [\"YOUR.IP.ADDRESS/32\"]"
   type        = list(string)
-  default     = ["203.0.113.0/24"]  # RFC 5737 TEST-NET-3 - non-routable, must override with your IP
+  default     = ["203.0.113.0/24"] # RFC 5737 TEST-NET-3 - non-routable, must override with your IP
+}
+
+# -----------------------------------------------------------------------------
+# Cluster Autoscaler Configuration
+# -----------------------------------------------------------------------------
+
+variable "install_cluster_autoscaler" {
+  description = "Install upstream Kubernetes Cluster Autoscaler via Helm for integration validation"
+  type        = bool
+  default     = true
+}
+
+variable "cluster_autoscaler_chart_version" {
+  description = "Optional upstream Cluster Autoscaler Helm chart version. Leave empty to use the chart repository default."
+  type        = string
+  default     = ""
+}
+
+variable "cluster_autoscaler_image_tag" {
+  description = "Optional Cluster Autoscaler image tag. Leave empty to derive v<kubernetes_version>.0."
+  type        = string
+  default     = ""
 }
 
 # -----------------------------------------------------------------------------

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -135,6 +135,14 @@ tests:
             "nvidia.com/mig.strategy": "single"
         K8sDualStackNodeCheck:
           require_dual_stack: "auto" # true | false | "auto"
+        K8sClusterAutoscalerCheck:
+          namespace: "{{ steps.setup.kubernetes.cluster_autoscaler_namespace | default('kube-system', true) }}"
+          deployment_names:
+            - "{{ steps.setup.kubernetes.cluster_autoscaler_deployment | default('cluster-autoscaler', true) }}"
+          label_selectors:
+            - "app.kubernetes.io/name=cluster-autoscaler"
+            - "app=cluster-autoscaler"
+            - "k8s-app=cluster-autoscaler"
         K8sNetworkPolicyCheck:
           image: "registry.k8s.io/e2e-test-images/agnhost:2.47"
           probe_port: 8080

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -136,6 +136,7 @@ tests:
         K8sDualStackNodeCheck:
           require_dual_stack: "auto" # true | false | "auto"
         K8sClusterAutoscalerCheck:
+          require_autoscaler: false
           namespace: "{{ steps.setup.kubernetes.cluster_autoscaler_namespace | default('kube-system', true) }}"
           deployment_names:
             - "{{ steps.setup.kubernetes.cluster_autoscaler_deployment | default('cluster-autoscaler', true) }}"

--- a/isvctl/tests/test_aws_eks_autoscaler_config.py
+++ b/isvctl/tests/test_aws_eks_autoscaler_config.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for AWS EKS Cluster Autoscaler provider wiring."""
+
+from pathlib import Path
+
+AWS_EKS_DIR = Path(__file__).resolve().parents[1] / "configs" / "providers" / "aws" / "scripts" / "eks"
+
+
+def test_eks_terraform_installs_upstream_cluster_autoscaler_with_irsa() -> None:
+    """EKS Terraform should install upstream Cluster Autoscaler with scoped IRSA."""
+    terraform = (AWS_EKS_DIR / "terraform" / "main.tf").read_text(encoding="utf-8")
+
+    assert 'module "cluster_autoscaler_irsa"' in terraform
+    assert "attach_cluster_autoscaler_policy = true" in terraform
+    assert "cluster_autoscaler_cluster_names = [local.cluster_name]" in terraform
+    assert 'namespace_service_accounts = ["kube-system:cluster-autoscaler"]' in terraform
+
+    assert 'resource "helm_release" "cluster_autoscaler"' in terraform
+    assert 'repository = "https://kubernetes.github.io/autoscaler"' in terraform
+    assert 'chart      = "cluster-autoscaler"' in terraform
+    assert 'fullnameOverride = "cluster-autoscaler"' in terraform
+    assert 'nameOverride     = "cluster-autoscaler"' in terraform
+    assert '"scale-down-enabled"          = "false"' in terraform
+
+
+def test_eks_setup_output_exposes_autoscaler_validation_metadata() -> None:
+    """EKS setup output should tell the suite where to find Cluster Autoscaler."""
+    setup_script = (AWS_EKS_DIR / "setup.sh").read_text(encoding="utf-8")
+
+    assert '"cluster_autoscaler_namespace": "kube-system"' in setup_script
+    assert '"cluster_autoscaler_deployment": "cluster-autoscaler"' in setup_script

--- a/isvctl/tests/test_schema.py
+++ b/isvctl/tests/test_schema.py
@@ -373,6 +373,8 @@ class TestOutputSchemaValidation:
             "gpu_per_node": 4,
             "total_gpus": 8,
             "gpu_operator_namespace": "nvidia-gpu-operator",
+            "cluster_autoscaler_namespace": "kube-system",
+            "cluster_autoscaler_deployment": "cluster-autoscaler",
             "runtime_class": "nvidia",
             "gpu_resource_name": "nvidia.com/gpu",
         },

--- a/isvtest/src/isvtest/validations/k8s_autoscaler.py
+++ b/isvtest/src/isvtest/validations/k8s_autoscaler.py
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cluster Autoscaler integration check."""
+
+from __future__ import annotations
+
+import shlex
+from typing import Any, ClassVar
+
+from isvtest.core.k8s import (
+    KubectlParseError,
+    get_kubectl_base_shell,
+    parse_kubectl_json,
+    parse_kubectl_json_items,
+    pod_status_reason,
+)
+from isvtest.core.runners import CommandResult
+from isvtest.core.validation import BaseValidation
+
+DEFAULT_DEPLOYMENT_NAMES: tuple[str, ...] = ("cluster-autoscaler",)
+DEFAULT_LABEL_SELECTORS: tuple[str, ...] = (
+    "app.kubernetes.io/name=cluster-autoscaler",
+    "app=cluster-autoscaler",
+    "k8s-app=cluster-autoscaler",
+)
+
+
+class K8sClusterAutoscalerCheck(BaseValidation):
+    """Verify an upstream Cluster Autoscaler deployment is installed and running.
+
+    Config keys:
+
+    * ``namespaces`` - namespaces to probe by deployment name. Defaults to
+      ``["kube-system"]``. ``namespace`` is accepted as a single-value alias.
+    * ``deployment_names`` - deployment names to probe. Defaults to
+      ``["cluster-autoscaler"]``.
+    * ``label_selectors`` - label selectors used to discover deployments across
+      all namespaces. Defaults cover common upstream manifests and Helm charts.
+    """
+
+    description: ClassVar[str] = "Verify upstream Cluster Autoscaler integration is installed and running."
+    markers: ClassVar[list[str]] = ["kubernetes"]
+
+    def run(self) -> None:
+        """Find Cluster Autoscaler deployments and verify their replicas and pods are healthy."""
+        try:
+            namespaces = _coerce_str_list(
+                self.config.get("namespaces", self.config.get("namespace", ["kube-system"])),
+                "namespaces",
+            )
+            deployment_names = _coerce_str_list(
+                self.config.get("deployment_names", list(DEFAULT_DEPLOYMENT_NAMES)),
+                "deployment_names",
+            )
+            label_selectors = _coerce_str_list(
+                self.config.get("label_selectors", list(DEFAULT_LABEL_SELECTORS)),
+                "label_selectors",
+            )
+        except ValueError as exc:
+            self.set_failed(f"Invalid config: {exc}")
+            return
+
+        if not deployment_names and not label_selectors:
+            self.set_failed("Invalid config: deployment_names and label_selectors cannot both be empty")
+            return
+
+        kubectl_base = get_kubectl_base_shell()
+        deployments = self._discover_deployments(kubectl_base, namespaces, deployment_names, label_selectors)
+        if deployments is None:
+            return
+        if not deployments:
+            self.set_failed(
+                "No Cluster Autoscaler deployment found using "
+                f"names={deployment_names or '[]'} namespaces={namespaces or '[]'} selectors={label_selectors or '[]'}"
+            )
+            return
+
+        failures: list[str] = []
+        running_total = 0
+        for deployment in deployments:
+            namespace, name = _object_ref(deployment)
+            status = deployment.get("status") or {}
+            spec = deployment.get("spec") or {}
+            desired = _replica_count(spec.get("replicas"), default=1)
+            available = _replica_count(status.get("availableReplicas"), default=0)
+
+            if not _has_autoscaler_container(deployment):
+                failures.append(f"{namespace}/{name}: no container looks like Cluster Autoscaler")
+            if desired < 1:
+                failures.append(f"{namespace}/{name}: deployment is scaled to {desired} replicas")
+            if available < desired:
+                failures.append(f"{namespace}/{name}: {available}/{desired} replicas available")
+
+            pod_selector = _selector_from_deployment(deployment)
+            if not pod_selector:
+                failures.append(f"{namespace}/{name}: deployment selector has no matchLabels for pod verification")
+                continue
+            pods = self._pods_for_deployment(kubectl_base, namespace, pod_selector)
+            if pods is None:
+                return
+            running_pods = _running_pod_names(pods)
+            running_total += len(running_pods)
+            if len(running_pods) < desired:
+                failures.append(f"{namespace}/{name}: {len(running_pods)}/{desired} matching pods Running")
+
+        if failures:
+            self.set_failed("Cluster Autoscaler integration is not healthy: " + "; ".join(failures))
+            return
+
+        refs = ", ".join(f"{_object_ref(deployment)[0]}/{_object_ref(deployment)[1]}" for deployment in deployments)
+        self.set_passed(
+            f"Found {len(deployments)} healthy Cluster Autoscaler deployment(s): {refs}; "
+            f"{running_total} matching pod(s) Running"
+        )
+
+    def _discover_deployments(
+        self,
+        kubectl_base: str,
+        namespaces: list[str],
+        deployment_names: list[str],
+        label_selectors: list[str],
+    ) -> list[dict[str, Any]] | None:
+        """Discover deployments by upstream labels and configured names."""
+        deployments_by_ref: dict[tuple[str, str], dict[str, Any]] = {}
+        query_errors: list[str] = []
+        successful_queries = 0
+
+        for selector in label_selectors:
+            result = self.run_command(f"{kubectl_base} get deployments -A -l {shlex.quote(selector)} -o json")
+            if result.exit_code != 0:
+                query_errors.append(_format_error(f"selector {selector!r}", result))
+                continue
+            successful_queries += 1
+            try:
+                for deployment in parse_kubectl_json_items(result, f"deployments for selector {selector!r}"):
+                    deployments_by_ref[_object_ref(deployment)] = deployment
+            except KubectlParseError as exc:
+                self.set_failed(str(exc))
+                return None
+
+        for namespace in namespaces:
+            for name in deployment_names:
+                result = self.run_command(
+                    f"{kubectl_base} get deployment -n {shlex.quote(namespace)} {shlex.quote(name)} -o json"
+                )
+                if result.exit_code != 0:
+                    if not _is_not_found(result.stderr):
+                        query_errors.append(_format_error(f"deployment {namespace}/{name}", result))
+                    continue
+                successful_queries += 1
+                try:
+                    deployment = parse_kubectl_json(result, f"deployment {namespace}/{name}")
+                except KubectlParseError as exc:
+                    self.set_failed(str(exc))
+                    return None
+                deployments_by_ref[_object_ref(deployment)] = deployment
+
+        if successful_queries == 0 and query_errors:
+            self.set_failed("Unable to query Cluster Autoscaler deployments: " + "; ".join(query_errors))
+            return None
+        return list(deployments_by_ref.values())
+
+    def _pods_for_deployment(
+        self,
+        kubectl_base: str,
+        namespace: str,
+        pod_selector: str,
+    ) -> list[dict[str, Any]] | None:
+        """Return pods matching a deployment selector, or mark the validation failed."""
+        result = self.run_command(
+            f"{kubectl_base} get pods -n {shlex.quote(namespace)} -l {shlex.quote(pod_selector)} -o json"
+        )
+        if result.exit_code != 0:
+            self.set_failed(_format_error(f"pods for selector {pod_selector!r} in {namespace}", result))
+            return None
+        try:
+            return parse_kubectl_json_items(result, f"pods for selector {pod_selector!r} in {namespace}")
+        except KubectlParseError as exc:
+            self.set_failed(str(exc))
+            return None
+
+
+def _coerce_str_list(value: Any, field: str) -> list[str]:
+    """Coerce a scalar or list into a stripped ``list[str]``."""
+    if value is None or value == "":
+        return []
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else []
+    if not isinstance(value, list):
+        raise ValueError(f"{field} must be a string or list of strings")
+    values: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError(f"{field} entries must be strings, got {item!r}")
+        stripped = item.strip()
+        if stripped:
+            values.append(stripped)
+    return values
+
+
+def _object_ref(obj: dict[str, Any]) -> tuple[str, str]:
+    """Return ``(namespace, name)`` for a Kubernetes object."""
+    metadata = obj.get("metadata") or {}
+    return str(metadata.get("namespace") or "default"), str(metadata.get("name") or "unknown")
+
+
+def _replica_count(value: Any, default: int) -> int:
+    """Return a non-negative replica count from Kubernetes status/spec values."""
+    try:
+        replicas = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0, replicas)
+
+
+def _has_autoscaler_container(deployment: dict[str, Any]) -> bool:
+    """Return True when a pod template container identifies as Cluster Autoscaler."""
+    pod_spec = ((deployment.get("spec") or {}).get("template") or {}).get("spec") or {}
+    for container in pod_spec.get("containers") or []:
+        if not isinstance(container, dict):
+            continue
+        haystack = " ".join(
+            str(value)
+            for value in (
+                container.get("name", ""),
+                container.get("image", ""),
+                " ".join(container.get("command") or []),
+                " ".join(container.get("args") or []),
+            )
+        )
+        if "cluster-autoscaler" in haystack:
+            return True
+    return False
+
+
+def _selector_from_deployment(deployment: dict[str, Any]) -> str:
+    """Build a Kubernetes label selector from ``spec.selector.matchLabels``."""
+    match_labels = ((deployment.get("spec") or {}).get("selector") or {}).get("matchLabels") or {}
+    if not isinstance(match_labels, dict):
+        return ""
+    parts = []
+    for key, value in sorted(match_labels.items()):
+        if isinstance(key, str) and isinstance(value, str) and key and value:
+            parts.append(f"{key}={value}")
+    return ",".join(parts)
+
+
+def _running_pod_names(pods: list[dict[str, Any]]) -> list[str]:
+    """Return names of pods whose kubectl-like status is Running."""
+    names: list[str] = []
+    for pod in pods:
+        if pod_status_reason(pod) == "Running":
+            names.append(_object_ref(pod)[1])
+    return names
+
+
+def _is_not_found(stderr: str) -> bool:
+    """Return True when kubectl stderr is a normal NotFound response."""
+    lowered = stderr.lower().replace(" ", "")
+    return "notfound" in lowered or "notfound" in lowered.replace("(", "").replace(")", "")
+
+
+def _format_error(scope: str, result: CommandResult) -> str:
+    """Format a concise kubectl error."""
+    detail = (result.stderr or result.stdout or "").strip()
+    return f"Failed to get {scope}: {detail or f'exit {result.exit_code}'}"

--- a/isvtest/src/isvtest/validations/k8s_autoscaler.py
+++ b/isvtest/src/isvtest/validations/k8s_autoscaler.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import shlex
 from typing import Any, ClassVar
 
+import pytest
+
 from isvtest.core.k8s import (
     KubectlParseError,
     get_kubectl_base_shell,
@@ -49,6 +51,9 @@ class K8sClusterAutoscalerCheck(BaseValidation):
       ``["cluster-autoscaler"]``.
     * ``label_selectors`` - label selectors used to discover deployments across
       all namespaces. Defaults cover common upstream manifests and Helm charts.
+    * ``require_autoscaler`` - when ``False`` (default), absent deployments
+      cause the check to skip rather than fail. Set to ``True`` to require a
+      Cluster Autoscaler integration on the cluster.
     """
 
     description: ClassVar[str] = "Verify upstream Cluster Autoscaler integration is installed and running."
@@ -77,15 +82,22 @@ class K8sClusterAutoscalerCheck(BaseValidation):
             self.set_failed("Invalid config: deployment_names and label_selectors cannot both be empty")
             return
 
+        require_autoscaler = bool(self.config.get("require_autoscaler", False))
+
         kubectl_base = get_kubectl_base_shell()
         deployments = self._discover_deployments(kubectl_base, namespaces, deployment_names, label_selectors)
         if deployments is None:
             return
         if not deployments:
-            self.set_failed(
+            msg = (
                 "No Cluster Autoscaler deployment found using "
-                f"names={deployment_names or '[]'} namespaces={namespaces or '[]'} selectors={label_selectors or '[]'}"
+                f"names={deployment_names or '[]'} namespaces={namespaces or '[]'} "
+                f"selectors={label_selectors or '[]'}"
             )
+            if require_autoscaler:
+                self.set_failed(msg)
+            else:
+                pytest.skip(f"{msg} (require_autoscaler is false)")
             return
 
         failures: list[str] = []

--- a/isvtest/tests/test_k8s_autoscaler.py
+++ b/isvtest/tests/test_k8s_autoscaler.py
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Cluster Autoscaler integration validation."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from unittest.mock import patch
+
+from isvtest.core.runners import CommandResult
+from isvtest.validations.k8s_autoscaler import K8sClusterAutoscalerCheck
+
+
+def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    """Return a successful ``CommandResult``."""
+    return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _fail(stdout: str = "", stderr: str = "", exit_code: int = 1) -> CommandResult:
+    """Return a failed ``CommandResult``."""
+    return CommandResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _items_json(items: list[dict[str, object]]) -> str:
+    """Wrap Kubernetes list items in a JSON payload."""
+    return json.dumps({"items": items})
+
+
+def _deployment(
+    *,
+    namespace: str = "kube-system",
+    name: str = "cluster-autoscaler",
+    replicas: int = 1,
+    available: int = 1,
+    labels: dict[str, str] | None = None,
+    container_name: str = "cluster-autoscaler",
+) -> dict[str, object]:
+    """Build a minimal Deployment object."""
+    match_labels = labels or {"app.kubernetes.io/name": "cluster-autoscaler"}
+    return {
+        "metadata": {"namespace": namespace, "name": name, "labels": match_labels},
+        "spec": {
+            "replicas": replicas,
+            "selector": {"matchLabels": match_labels},
+            "template": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": container_name,
+                            "image": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0",
+                        }
+                    ]
+                }
+            },
+        },
+        "status": {"availableReplicas": available},
+    }
+
+
+def _pod(name: str = "cluster-autoscaler-abc", phase: str = "Running") -> dict[str, object]:
+    """Build a minimal Pod object."""
+    return {"metadata": {"namespace": "kube-system", "name": name}, "status": {"phase": phase}}
+
+
+def test_cluster_autoscaler_passes_with_labeled_available_deployment_and_running_pod() -> None:
+    """Verify the happy path discovers a standard upstream-labeled deployment."""
+    check = K8sClusterAutoscalerCheck(config={})
+    deployment = _deployment()
+    responses: Iterator[CommandResult] = iter(
+        [
+            _ok(_items_json([deployment])),
+            _ok(_items_json([])),
+            _ok(_items_json([])),
+            _fail(stderr='Error from server (NotFound): deployments.apps "cluster-autoscaler" not found'),
+            _ok(_items_json([_pod()])),
+        ]
+    )
+
+    with (
+        patch("isvtest.validations.k8s_autoscaler.get_kubectl_base_shell", return_value="kubectl"),
+        patch.object(check, "run_command", side_effect=lambda *a, **k: next(responses)) as mock_run,
+    ):
+        check.run()
+
+    assert check.passed, check.message
+    assert "healthy Cluster Autoscaler" in check.message
+    assert mock_run.call_args_list[0][0][0] == (
+        "kubectl get deployments -A -l app.kubernetes.io/name=cluster-autoscaler -o json"
+    )
+    assert mock_run.call_args_list[-1][0][0] == (
+        "kubectl get pods -n kube-system -l app.kubernetes.io/name=cluster-autoscaler -o json"
+    )
+
+
+def test_cluster_autoscaler_falls_back_to_configured_deployment_name() -> None:
+    """Verify name-based discovery catches installs without common upstream labels."""
+    check = K8sClusterAutoscalerCheck(config={"label_selectors": [], "namespace": "autoscaler-system"})
+    deployment = _deployment(namespace="autoscaler-system", labels={"app": "ca"})
+    responses: Iterator[CommandResult] = iter(
+        [
+            _ok(json.dumps(deployment)),
+            _ok(_items_json([_pod()])),
+        ]
+    )
+
+    with (
+        patch("isvtest.validations.k8s_autoscaler.get_kubectl_base_shell", return_value="kubectl"),
+        patch.object(check, "run_command", side_effect=lambda *a, **k: next(responses)) as mock_run,
+    ):
+        check.run()
+
+    assert check.passed, check.message
+    assert mock_run.call_args_list[0][0][0] == (
+        "kubectl get deployment -n autoscaler-system cluster-autoscaler -o json"
+    )
+
+
+def test_cluster_autoscaler_fails_when_no_deployment_is_found() -> None:
+    """Verify absent Cluster Autoscaler deployments fail clearly."""
+    check = K8sClusterAutoscalerCheck(config={"label_selectors": [], "namespaces": ["kube-system"]})
+    with (
+        patch("isvtest.validations.k8s_autoscaler.get_kubectl_base_shell", return_value="kubectl"),
+        patch.object(
+            check,
+            "run_command",
+            return_value=_fail(stderr='Error from server (NotFound): deployments.apps "cluster-autoscaler" not found'),
+        ),
+    ):
+        check.run()
+
+    assert not check.passed
+    assert "No Cluster Autoscaler deployment found" in check.message
+
+
+def test_cluster_autoscaler_fails_when_deployment_is_unavailable() -> None:
+    """Verify unavailable replicas are reported."""
+    check = K8sClusterAutoscalerCheck(config={"label_selectors": ["app=cluster-autoscaler"], "deployment_names": []})
+    deployment = _deployment(replicas=2, available=1)
+    responses: Iterator[CommandResult] = iter(
+        [
+            _ok(_items_json([deployment])),
+            _ok(_items_json([_pod("cluster-autoscaler-1"), _pod("cluster-autoscaler-2", phase="Pending")])),
+        ]
+    )
+
+    with (
+        patch("isvtest.validations.k8s_autoscaler.get_kubectl_base_shell", return_value="kubectl"),
+        patch.object(check, "run_command", side_effect=lambda *a, **k: next(responses)),
+    ):
+        check.run()
+
+    assert not check.passed
+    assert "1/2 replicas available" in check.message
+    assert "1/2 matching pods Running" in check.message
+
+
+def test_cluster_autoscaler_fails_without_match_labels_for_pod_check() -> None:
+    """Verify deployments without matchLabels do not pass without pod verification."""
+    check = K8sClusterAutoscalerCheck(config={"label_selectors": ["app=cluster-autoscaler"], "deployment_names": []})
+    deployment = _deployment()
+    spec = deployment["spec"]
+    assert isinstance(spec, dict)
+    spec["selector"] = {"matchExpressions": [{"key": "app", "operator": "In", "values": ["cluster-autoscaler"]}]}
+
+    with (
+        patch("isvtest.validations.k8s_autoscaler.get_kubectl_base_shell", return_value="kubectl"),
+        patch.object(check, "run_command", return_value=_ok(_items_json([deployment]))) as mock_run,
+    ):
+        check.run()
+
+    assert not check.passed
+    assert "selector has no matchLabels" in check.message
+    assert mock_run.call_count == 1
+
+
+def test_cluster_autoscaler_fails_on_invalid_deployment_json() -> None:
+    """Verify malformed kubectl JSON is surfaced as a validation failure."""
+    check = K8sClusterAutoscalerCheck(config={"label_selectors": ["app=cluster-autoscaler"], "deployment_names": []})
+    with (
+        patch("isvtest.validations.k8s_autoscaler.get_kubectl_base_shell", return_value="kubectl"),
+        patch.object(check, "run_command", return_value=_ok("not-json")),
+    ):
+        check.run()
+
+    assert not check.passed
+    assert "Failed to parse deployments" in check.message
+
+
+def test_cluster_autoscaler_rejects_bad_config() -> None:
+    """Verify bad config fails before invoking kubectl."""
+    check = K8sClusterAutoscalerCheck(config={"namespaces": [123]})
+    with patch.object(check, "run_command") as mock_run:
+        check.run()
+
+    assert not check.passed
+    assert "Invalid config" in check.message
+    mock_run.assert_not_called()

--- a/isvtest/tests/test_k8s_autoscaler.py
+++ b/isvtest/tests/test_k8s_autoscaler.py
@@ -21,6 +21,8 @@ import json
 from collections.abc import Iterator
 from unittest.mock import patch
 
+import pytest
+
 from isvtest.core.runners import CommandResult
 from isvtest.validations.k8s_autoscaler import K8sClusterAutoscalerCheck
 
@@ -129,9 +131,29 @@ def test_cluster_autoscaler_falls_back_to_configured_deployment_name() -> None:
     )
 
 
-def test_cluster_autoscaler_fails_when_no_deployment_is_found() -> None:
-    """Verify absent Cluster Autoscaler deployments fail clearly."""
+def test_cluster_autoscaler_skips_when_no_deployment_is_found_by_default() -> None:
+    """Verify absent Cluster Autoscaler is treated as 'feature not installed' (skip)."""
     check = K8sClusterAutoscalerCheck(config={"label_selectors": [], "namespaces": ["kube-system"]})
+    with (
+        patch("isvtest.validations.k8s_autoscaler.get_kubectl_base_shell", return_value="kubectl"),
+        patch.object(
+            check,
+            "run_command",
+            return_value=_fail(stderr='Error from server (NotFound): deployments.apps "cluster-autoscaler" not found'),
+        ),
+        pytest.raises(pytest.skip.Exception) as excinfo,
+    ):
+        check.run()
+
+    assert "No Cluster Autoscaler deployment found" in str(excinfo.value)
+    assert "require_autoscaler is false" in str(excinfo.value)
+
+
+def test_cluster_autoscaler_fails_when_no_deployment_is_found_and_required() -> None:
+    """Verify require_autoscaler=True turns an absent deployment into a failure."""
+    check = K8sClusterAutoscalerCheck(
+        config={"label_selectors": [], "namespaces": ["kube-system"], "require_autoscaler": True}
+    )
     with (
         patch("isvtest.validations.k8s_autoscaler.get_kubectl_base_shell", return_value="kubectl"),
         patch.object(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add `K8sClusterAutoscalerCheck` to discover upstream Cluster Autoscaler deployments by common labels or configured names, then verify Deployment availability and running pods from the Deployment selector.
- Wire the check into the Kubernetes suite.
- Add cluster-autoscaler setup for the EKS provider. 

Closes #267

## Verification

- [x] `make test`
- [x] `make demo-test`
- [x] `make lint`
- [x] `uvx pre-commit run -a`
- [x] `ISVTEST_INCLUDE_UNRELEASED=1 uv run isvctl test run \
    -f isvctl/configs/providers/aws/config/eks.yaml -v`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-611c60e3-65a4-4e2f-aa28-133c2810df6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-611c60e3-65a4-4e2f-aa28-133c2810df6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add support for deploying and managing the Kubernetes Cluster Autoscaler with configurable chart version and image tag; inventory output now includes autoscaler namespace and deployment identifiers.

* **Validation**
  * New runtime check to detect Cluster Autoscaler deployments and validate replicas, pod readiness, and health; configurable require/namespace/name behavior.

* **Documentation**
  * README expanded with autoscaler installation and configuration examples.

* **Tests**
  * Added tests and schema updates covering autoscaler wiring and output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/ISV-NCP-Validation-Suite/pull/435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->