### PR TITLE
feat: add DMS05-01 stable egress IP validation

### DIFF
--- a/isvctl/configs/providers/aws/config/network.yaml
+++ b/isvctl/configs/providers/aws/config/network.yaml
@@ -305,6 +305,24 @@ commands:
         timeout: 600
         output_schema: stable_ip
 
+      # Test 10b: Stable Egress IP for NVIDIA service allowlists (DMS05-01, ~3 min)
+      - name: stable_egress_ip_test
+        phase: test
+        command: "python3 ../scripts/network/stable_egress_ip_test.py"
+        args:
+          - "--region"
+          - "{{region}}"
+          - "--cidr"
+          - "10.100.0.0/16"
+          - "--probes"
+          - "3"
+          - "--interval-seconds"
+          - "2"
+          - "--endpoint"
+          - "https://api.ipify.org"
+        timeout: 600
+        output_schema: stable_egress_ip
+
       # Test 11: Floating IP Switch (~5 min)
       - name: floating_ip_test
         phase: test

--- a/isvctl/configs/providers/aws/scripts/network/stable_egress_ip_test.py
+++ b/isvctl/configs/providers/aws/scripts/network/stable_egress_ip_test.py
@@ -90,9 +90,7 @@ def derive_subnet_cidr(cidr: str) -> str:
     return str(network)
 
 
-def create_internet_routing(
-    ec2: Any, vpc_id: str, subnet_id: str, name: str, routing: dict[str, str]
-) -> None:
+def create_internet_routing(ec2: Any, vpc_id: str, subnet_id: str, name: str, routing: dict[str, str]) -> None:
     """Create IGW + route table + default route + association.
 
     Each created resource's ID is written into ``routing`` immediately so a
@@ -127,9 +125,7 @@ def create_internet_routing(
         DestinationCidrBlock="0.0.0.0/0",
         GatewayId=routing["igw_id"],
     )
-    assoc = ec2.associate_route_table(
-        RouteTableId=routing["route_table_id"], SubnetId=subnet_id
-    )
+    assoc = ec2.associate_route_table(RouteTableId=routing["route_table_id"], SubnetId=subnet_id)
     routing["association_id"] = assoc["AssociationId"]
 
 
@@ -226,9 +222,7 @@ def probe_egress_ip(
             time.sleep(interval_seconds)
         exit_code, stdout, stderr = ssh_run(public_ip, ssh_user, key_file, cmd, timeout=15)
         if exit_code != 0:
-            result["error"] = (
-                f"probe {attempt}/{probes} failed (exit={exit_code}): {stderr.strip() or stdout.strip()}"
-            )
+            result["error"] = f"probe {attempt}/{probes} failed (exit={exit_code}): {stderr.strip() or stdout.strip()}"
             return result
         ip = stdout.strip()
         if not ip:
@@ -269,9 +263,7 @@ def main() -> int:
     parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
     parser.add_argument("--cidr", default="10.100.0.0/16", help="CIDR for test VPC")
     parser.add_argument("--probes", type=int, default=3, help="Number of egress IP probes")
-    parser.add_argument(
-        "--interval-seconds", type=float, default=2.0, help="Delay between probes"
-    )
+    parser.add_argument("--interval-seconds", type=float, default=2.0, help="Delay between probes")
     parser.add_argument(
         "--endpoint",
         default="https://api.ipify.org",

--- a/isvctl/configs/providers/aws/scripts/network/stable_egress_ip_test.py
+++ b/isvctl/configs/providers/aws/scripts/network/stable_egress_ip_test.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test that the egress IP observed by external services is stable (DMS05-01).
+
+NVIDIA cloud services use IP allowlists, so workloads that call out to them
+must present a stable egress IP. This script launches a test instance with
+direct internet egress (auto-assigned public IP via IGW), probes
+``https://api.ipify.org`` (or a configurable endpoint) N times from the
+instance, and verifies every probe returned the same address.
+
+Usage:
+    python stable_egress_ip_test.py --region us-west-2 --cidr 10.100.0.0/16 \\
+        --probes 3 --interval-seconds 2 --endpoint https://api.ipify.org
+
+Output JSON:
+{
+    "success": true,
+    "platform": "network",
+    "test_name": "stable_egress_ip",
+    "tests": {
+        "create_instance":  {"passed": true},
+        "probe_egress_ip":  {"passed": true, "probes": 3},
+        "egress_ip_stable": {"passed": true}
+    }
+}
+"""
+
+import argparse
+import ipaddress
+import json
+import os
+import shlex
+import sys
+import time
+import uuid
+from typing import Any
+
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+
+import boto3
+from botocore.exceptions import ClientError, WaiterError
+from common.ec2 import create_key_pair, create_security_group, get_amazon_linux_ami
+from common.errors import delete_with_retry, handle_aws_errors
+from common.ssh_utils import ssh_run, wait_for_ssh
+from common.vpc import create_test_vpc, delete_vpc
+
+TEST_NAME = "stable_egress_ip"
+TEST_NAMES = ("create_instance", "probe_egress_ip", "egress_ip_stable")
+
+
+def base_result() -> dict[str, Any]:
+    """Build the minimal provider-neutral result skeleton."""
+    return {
+        "success": False,
+        "platform": "network",
+        "test_name": TEST_NAME,
+        "tests": {test_name: {"passed": False} for test_name in TEST_NAMES},
+    }
+
+
+def public_test_result(result: dict[str, Any]) -> dict[str, Any]:
+    """Return only validation-relevant fields from an internal subtest result."""
+    public: dict[str, Any] = {"passed": bool(result.get("passed", False))}
+    if "probes" in result:
+        public["probes"] = result["probes"]
+    if not public["passed"] and "error" in result:
+        public["error"] = result["error"]
+    return public
+
+
+def derive_subnet_cidr(cidr: str) -> str:
+    """Return the first subnet CIDR to create inside the requested VPC CIDR."""
+    network = ipaddress.ip_network(cidr)
+    if network.version == 4 and network.prefixlen < 24:
+        return str(next(network.subnets(new_prefix=24)))
+    return str(network)
+
+
+def create_internet_routing(
+    ec2: Any, vpc_id: str, subnet_id: str, name: str, routing: dict[str, str]
+) -> None:
+    """Create IGW + route table + default route + association.
+
+    Each created resource's ID is written into ``routing`` immediately so a
+    mid-function failure still leaves the caller's finally block able to
+    clean up everything that was created. A function that built and returned
+    the IDs only at the end would silently leak the IGW (and possibly the
+    route table) whenever a later step raised.
+    """
+    igw = ec2.create_internet_gateway(
+        TagSpecifications=[
+            {
+                "ResourceType": "internet-gateway",
+                "Tags": [{"Key": "Name", "Value": name}, {"Key": "CreatedBy", "Value": "isvtest"}],
+            }
+        ]
+    )
+    routing["igw_id"] = igw["InternetGateway"]["InternetGatewayId"]
+    ec2.attach_internet_gateway(InternetGatewayId=routing["igw_id"], VpcId=vpc_id)
+
+    rt = ec2.create_route_table(
+        VpcId=vpc_id,
+        TagSpecifications=[
+            {
+                "ResourceType": "route-table",
+                "Tags": [{"Key": "Name", "Value": name}, {"Key": "CreatedBy", "Value": "isvtest"}],
+            }
+        ],
+    )
+    routing["route_table_id"] = rt["RouteTable"]["RouteTableId"]
+    ec2.create_route(
+        RouteTableId=routing["route_table_id"],
+        DestinationCidrBlock="0.0.0.0/0",
+        GatewayId=routing["igw_id"],
+    )
+    assoc = ec2.associate_route_table(
+        RouteTableId=routing["route_table_id"], SubnetId=subnet_id
+    )
+    routing["association_id"] = assoc["AssociationId"]
+
+
+def launch_instance(
+    ec2: Any,
+    subnet_id: str,
+    sg_id: str,
+    key_name: str,
+    name: str,
+) -> dict[str, Any]:
+    """Launch an EC2 instance with an auto-assigned public IP."""
+    result: dict[str, Any] = {"passed": False}
+
+    ami_id = get_amazon_linux_ami(ec2)
+    if not ami_id:
+        result["error"] = "Could not find Amazon Linux AMI"
+        return result
+
+    try:
+        response = ec2.run_instances(
+            ImageId=ami_id,
+            InstanceType="t3.micro",
+            KeyName=key_name,
+            MinCount=1,
+            MaxCount=1,
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "Groups": [sg_id],
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {
+                    "ResourceType": "instance",
+                    "Tags": [
+                        {"Key": "Name", "Value": name},
+                        {"Key": "CreatedBy", "Value": "isvtest"},
+                    ],
+                }
+            ],
+        )
+        instance_id = response["Instances"][0]["InstanceId"]
+
+        ec2.get_waiter("instance_running").wait(InstanceIds=[instance_id])
+
+        desc = ec2.describe_instances(InstanceIds=[instance_id])
+        instance = desc["Reservations"][0]["Instances"][0]
+        public_ip = instance.get("PublicIpAddress")
+
+        if not public_ip:
+            result["error"] = "Instance running but no public IP assigned"
+            return result
+
+        result["passed"] = True
+        result["instance_id"] = instance_id
+        result["public_ip"] = public_ip
+        result["message"] = f"Launched instance {instance_id} with public IP {public_ip}"
+    except ClientError as e:
+        result["error"] = str(e)
+
+    return result
+
+
+def probe_egress_ip(
+    public_ip: str,
+    key_file: str,
+    endpoint: str,
+    probes: int,
+    interval_seconds: float,
+    ssh_user: str = "ec2-user",
+) -> dict[str, Any]:
+    """Probe the egress IP via SSH + curl, ``probes`` times, ``interval_seconds`` apart."""
+    result: dict[str, Any] = {
+        "passed": False,
+        "ips": [],
+        "endpoint": endpoint,
+        "probes": probes,
+    }
+
+    # max_attempts * (subprocess timeout 15s + interval 5s) must fit comfortably
+    # under the orchestrator step timeout (600s). On SIGKILL the finally block
+    # does not run and every AWS resource above this point leaks.
+    if not wait_for_ssh(public_ip, ssh_user, key_file, max_attempts=20, interval=5):
+        result["error"] = f"SSH not reachable on {public_ip} after 20 attempts"
+        return result
+
+    # endpoint is shlex-quoted so a malicious or typo'd --endpoint can't smuggle
+    # shell metachars onto the remote login shell ssh invokes for us.
+    cmd = f"curl -s --max-time 5 {shlex.quote(endpoint)}"
+    for attempt in range(1, probes + 1):
+        if attempt > 1:
+            time.sleep(interval_seconds)
+        exit_code, stdout, stderr = ssh_run(public_ip, ssh_user, key_file, cmd, timeout=15)
+        if exit_code != 0:
+            result["error"] = (
+                f"probe {attempt}/{probes} failed (exit={exit_code}): {stderr.strip() or stdout.strip()}"
+            )
+            return result
+        ip = stdout.strip()
+        if not ip:
+            result["error"] = f"probe {attempt}/{probes} returned empty response"
+            return result
+        try:
+            ipaddress.ip_address(ip)
+        except ValueError:
+            result["error"] = f"probe {attempt}/{probes} returned non-IP value: {ip!r}"
+            return result
+        result["ips"].append(ip)
+
+    result["passed"] = True
+    result["message"] = f"Collected {probes} egress IP probes from {endpoint}"
+    return result
+
+
+def check_egress_ip_stable(ips: list[str]) -> dict[str, Any]:
+    """Assert every probe returned the same egress IP."""
+    distinct = sorted(set(ips))
+    result: dict[str, Any] = {"passed": False, "distinct": len(distinct)}
+    if not ips:
+        result["error"] = "No probes collected"
+        return result
+    if len(distinct) == 1:
+        result["passed"] = True
+        result["ip"] = distinct[0]
+        result["message"] = f"Egress IP {distinct[0]} stable across {len(ips)} probes"
+    else:
+        result["error"] = f"Egress IP changed across probes: {', '.join(distinct)}"
+    return result
+
+
+@handle_aws_errors
+def main() -> int:
+    """Run the AWS stable egress IP test and print its JSON result."""
+    parser = argparse.ArgumentParser(description="Test stable egress IP (DMS05-01)")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--cidr", default="10.100.0.0/16", help="CIDR for test VPC")
+    parser.add_argument("--probes", type=int, default=3, help="Number of egress IP probes")
+    parser.add_argument(
+        "--interval-seconds", type=float, default=2.0, help="Delay between probes"
+    )
+    parser.add_argument(
+        "--endpoint",
+        default="https://api.ipify.org",
+        help="IP-discovery endpoint that echoes the caller's egress IP",
+    )
+    parser.add_argument("--ssh-user", default="ec2-user", help="SSH user for the AMI")
+    args = parser.parse_args()
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+    suffix = str(uuid.uuid4())[:8]
+    name = f"isv-stable-egress-ip-{suffix}"
+
+    result = base_result()
+
+    vpc_id = None
+    subnet_id = None
+    sg_id = None
+    instance_id = None
+    routing: dict[str, str] = {}
+    key_name: str | None = None
+    key_file: str | None = None
+
+    try:
+        vpc_result = create_test_vpc(ec2, args.cidr, name)
+        if not vpc_result["passed"]:
+            raise RuntimeError(vpc_result.get("error", "Failed to create VPC"))
+        vpc_id = vpc_result["vpc_id"]
+
+        azs = ec2.describe_availability_zones(Filters=[{"Name": "state", "Values": ["available"]}])
+        az = azs["AvailabilityZones"][0]["ZoneName"]
+        subnet_cidr = derive_subnet_cidr(args.cidr)
+        subnet = ec2.create_subnet(VpcId=vpc_id, CidrBlock=subnet_cidr, AvailabilityZone=az)
+        subnet_id = subnet["Subnet"]["SubnetId"]
+
+        create_internet_routing(ec2, vpc_id, subnet_id, name, routing)
+
+        sg_id = create_security_group(ec2, vpc_id, f"{name}-sg", description="Stable egress IP test SG")
+
+        key_name = f"{name}-key"
+        key_file = create_key_pair(ec2, key_name)
+
+        create_result = launch_instance(ec2, subnet_id, sg_id, key_name, name)
+        result["tests"]["create_instance"] = public_test_result(create_result)
+        if not create_result["passed"]:
+            raise RuntimeError("Failed to launch instance")
+        instance_id = create_result["instance_id"]
+        public_ip = create_result["public_ip"]
+
+        probe_result = probe_egress_ip(
+            public_ip=public_ip,
+            key_file=key_file,
+            endpoint=args.endpoint,
+            probes=args.probes,
+            interval_seconds=args.interval_seconds,
+            ssh_user=args.ssh_user,
+        )
+        result["tests"]["probe_egress_ip"] = public_test_result(probe_result)
+        if not probe_result["passed"]:
+            raise RuntimeError("Egress IP probing failed")
+
+        stable_result = check_egress_ip_stable(probe_result["ips"])
+        result["tests"]["egress_ip_stable"] = public_test_result(stable_result)
+
+        all_passed = all(t.get("passed", False) for t in result["tests"].values())
+        result["success"] = all_passed
+
+    except Exception as e:
+        result["error"] = str(e)
+    finally:
+        if instance_id:
+            if delete_with_retry(
+                ec2.terminate_instances,
+                InstanceIds=[instance_id],
+                resource_desc=f"instance {instance_id}",
+            ):
+                try:
+                    ec2.get_waiter("instance_terminated").wait(InstanceIds=[instance_id])
+                except (ClientError, WaiterError):
+                    pass
+            time.sleep(5)
+        if key_name:
+            delete_with_retry(
+                ec2.delete_key_pair,
+                KeyName=key_name,
+                resource_desc=f"key pair {key_name}",
+            )
+        if key_file and os.path.exists(key_file):
+            try:
+                os.remove(key_file)
+            except OSError:
+                pass
+        if sg_id:
+            delete_with_retry(
+                ec2.delete_security_group,
+                GroupId=sg_id,
+                resource_desc=f"security group {sg_id}",
+            )
+        if routing.get("association_id"):
+            delete_with_retry(
+                ec2.disassociate_route_table,
+                AssociationId=routing["association_id"],
+                resource_desc=f"route table association {routing['association_id']}",
+            )
+        if routing.get("route_table_id"):
+            delete_with_retry(
+                ec2.delete_route_table,
+                RouteTableId=routing["route_table_id"],
+                resource_desc=f"route table {routing['route_table_id']}",
+            )
+        if routing.get("igw_id") and vpc_id:
+            delete_with_retry(
+                ec2.detach_internet_gateway,
+                InternetGatewayId=routing["igw_id"],
+                VpcId=vpc_id,
+                resource_desc=f"detach IGW {routing['igw_id']}",
+            )
+            delete_with_retry(
+                ec2.delete_internet_gateway,
+                InternetGatewayId=routing["igw_id"],
+                resource_desc=f"internet gateway {routing['igw_id']}",
+            )
+        if subnet_id:
+            delete_with_retry(
+                ec2.delete_subnet,
+                SubnetId=subnet_id,
+                resource_desc=f"subnet {subnet_id}",
+            )
+        if vpc_id:
+            delete_vpc(ec2, vpc_id)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/my-isv/config/network.yaml
+++ b/isvctl/configs/providers/my-isv/config/network.yaml
@@ -25,7 +25,7 @@
 #   (NetworkProvisionedCheck, VpcCrudCheck, SubnetConfigCheck,
 #    VpcIsolationCheck, SgCrudCheck, SecurityBlockingCheck,
 #    NetworkConnectivityCheck, TrafficFlowCheck, VpcIpConfigCheck,
-#    ByoipCheck, StablePrivateIpCheck, FloatingIpCheck, LocalizedDnsCheck,
+#    ByoipCheck, StablePrivateIpCheck, StableEgressIpCheck, FloatingIpCheck, LocalizedDnsCheck,
 #    VpcPeeringCheck, SgPolicyPropagationTimingCheck,
 #    BackendSwitchFabricCheck, NvlinkDomainCheck, StepSuccessCheck).
 #    The NET01-01 and NET02-02 checks validate
@@ -258,6 +258,23 @@ commands:
         args: ["--region", "{{region}}", "--cidr", "10.91.0.0/16"]
         timeout: 60
         output_schema: stable_ip
+
+      - name: stable_egress_ip_test
+        phase: test
+        command: "python ../scripts/network/stable_egress_ip_test.py"
+        args:
+          - "--region"
+          - "{{region}}"
+          - "--cidr"
+          - "10.100.0.0/16"
+          - "--probes"
+          - "3"
+          - "--interval-seconds"
+          - "2"
+          - "--endpoint"
+          - "https://api.ipify.org"
+        timeout: 60
+        output_schema: stable_egress_ip
 
       - name: floating_ip_test
         phase: test

--- a/isvctl/configs/providers/my-isv/scripts/network/stable_egress_ip_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/network/stable_egress_ip_test.py
@@ -59,9 +59,7 @@ def main() -> int:
     parser.add_argument("--region", required=True, help="Cloud region")
     parser.add_argument("--cidr", default="10.92.0.0/16", help="CIDR for test VPC")
     parser.add_argument("--probes", type=int, default=3, help="Number of egress IP probes")
-    parser.add_argument(
-        "--interval-seconds", type=float, default=2.0, help="Delay between probes"
-    )
+    parser.add_argument("--interval-seconds", type=float, default=2.0, help="Delay between probes")
     parser.add_argument(
         "--endpoint",
         default="https://api.ipify.org",
@@ -90,9 +88,7 @@ def main() -> int:
         }
         result["success"] = True
     else:
-        result["error"] = (
-            "Not implemented - replace with your platform's stable egress IP test logic"
-        )
+        result["error"] = "Not implemented - replace with your platform's stable egress IP test logic"
 
     print(json.dumps(result, indent=2))
     return 0 if result["success"] else 1

--- a/isvctl/configs/providers/my-isv/scripts/network/stable_egress_ip_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/network/stable_egress_ip_test.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stable egress IP test - TEMPLATE (replace with your platform implementation).
+
+This script is called during the "test" phase. It is SELF-CONTAINED:
+  1. Create a test instance with outbound internet access
+  2. Probe its egress IP N times against an external IP-discovery endpoint
+     (e.g., https://api.ipify.org)
+  3. Verify every probe returned the same address
+  4. Clean up all resources
+  5. Print a JSON object to stdout
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "network",
+    "test_name": "stable_egress_ip",
+    "tests": {
+      "create_instance":  {"passed": true},
+      "probe_egress_ip":  {"passed": true, "probes": N},
+      "egress_ip_stable": {"passed": true}
+    }
+  }
+
+Usage:
+    python stable_egress_ip_test.py --region <region> --cidr 10.92.0.0/16 \\
+        --probes 3 --interval-seconds 2 --endpoint https://api.ipify.org
+
+Reference implementation: ../../aws/network/stable_egress_ip_test.py
+"""
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+# ISVCTL_DEMO_MODE=1 enables demo-success output (used by `make demo-test`).
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+
+
+def main() -> int:
+    """Stable egress IP test (template) and emit structured JSON result."""
+    parser = argparse.ArgumentParser(description="Stable egress IP test (template)")
+    parser.add_argument("--region", required=True, help="Cloud region")
+    parser.add_argument("--cidr", default="10.92.0.0/16", help="CIDR for test VPC")
+    parser.add_argument("--probes", type=int, default=3, help="Number of egress IP probes")
+    parser.add_argument(
+        "--interval-seconds", type=float, default=2.0, help="Delay between probes"
+    )
+    parser.add_argument(
+        "--endpoint",
+        default="https://api.ipify.org",
+        help="IP-discovery endpoint that echoes the caller's egress IP",
+    )
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "network",
+        "test_name": "stable_egress_ip",
+        "tests": {
+            "create_instance": {"passed": False},
+            "probe_egress_ip": {"passed": False},
+            "egress_ip_stable": {"passed": False},
+        },
+    }
+
+    # TODO: Replace with your platform's stable egress IP implementation
+
+    if DEMO_MODE:
+        result["tests"] = {
+            "create_instance": {"passed": True},
+            "probe_egress_ip": {"passed": True, "probes": args.probes},
+            "egress_ip_stable": {"passed": True},
+        }
+        result["success"] = True
+    else:
+        result["error"] = (
+            "Not implemented - replace with your platform's stable egress IP test logic"
+        )
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/network.yaml
+++ b/isvctl/configs/suites/network.yaml
@@ -110,6 +110,8 @@ tests:
           step: byoip_test
         StablePrivateIpCheck:
           step: stable_ip_test
+        StableEgressIpCheck:
+          step: stable_egress_ip_test
         FloatingIpCheck:
           step: floating_ip_test
           max_switch_seconds: 10

--- a/isvctl/src/isvctl/config/output_schemas.py
+++ b/isvctl/src/isvctl/config/output_schemas.py
@@ -122,6 +122,8 @@ STEP_SCHEMA_MAPPING: dict[str, str | None] = {
     "byoip_validation": "byoip",
     "stable_ip_test": "stable_ip",
     "stable_ip_validation": "stable_ip",
+    "stable_egress_ip_test": "stable_egress_ip",
+    "stable_egress_ip_validation": "stable_egress_ip",
     "floating_ip_test": "floating_ip",
     "floating_ip_validation": "floating_ip",
     "dns_test": "localized_dns",
@@ -725,6 +727,23 @@ OUTPUT_SCHEMAS: dict[str, dict[str, Any]] = {
                     "ip_unchanged": {"type": "object"},
                 },
                 "description": "Stable private IP test results",
+            },
+        },
+        "additionalProperties": True,
+    },
+    "stable_egress_ip": {
+        "type": "object",
+        "required": ["success", "platform"],
+        "properties": {
+            **COMMON_PROPERTIES,
+            "tests": {
+                "type": "object",
+                "properties": {
+                    "create_instance": {"type": "object"},
+                    "probe_egress_ip": {"type": "object"},
+                    "egress_ip_stable": {"type": "object"},
+                },
+                "description": "Stable egress IP test results",
             },
         },
         "additionalProperties": True,

--- a/isvctl/tests/test_aws_network_scripts.py
+++ b/isvctl/tests/test_aws_network_scripts.py
@@ -33,6 +33,9 @@ from botocore.exceptions import ClientError
 ISVCTL_ROOT = Path(__file__).resolve().parents[1]
 AWS_NETWORK_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "network"
 MY_ISV_NETWORK_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "my-isv" / "scripts" / "network"
+STABLE_EGRESS_TEST_NAMES = {"create_instance", "probe_egress_ip", "egress_ip_stable"}
+STABLE_EGRESS_TOP_LEVEL_KEYS = {"success", "platform", "test_name", "tests"}
+STABLE_EGRESS_TEST_RESULT_KEYS = {"passed", "message", "probes"}
 
 
 def _load_network_script(script_name: str) -> ModuleType:
@@ -48,6 +51,18 @@ def _load_network_script(script_name: str) -> ModuleType:
 def _client_error(operation_name: str, code: str = "AccessDenied", message: str = "denied") -> ClientError:
     """Create a botocore ClientError for fake AWS client failures."""
     return ClientError({"Error": {"Code": code, "Message": message}}, operation_name)
+
+
+def _assert_stable_egress_contract(result: dict[str, Any]) -> None:
+    """Assert stable egress scripts emit the minimal provider JSON contract."""
+    assert set(result) == STABLE_EGRESS_TOP_LEVEL_KEYS
+    assert result["success"] is True
+    assert result["platform"] == "network"
+    assert result["test_name"] == "stable_egress_ip"
+    assert set(result["tests"]) == STABLE_EGRESS_TEST_NAMES
+    for test_result in result["tests"].values():
+        assert set(test_result) <= STABLE_EGRESS_TEST_RESULT_KEYS
+        assert isinstance(test_result["passed"], bool)
 
 
 class FakeServiceScopingEc2:
@@ -1596,3 +1611,111 @@ def test_my_isv_policy_propagation_demo_test_name_matches_suite_step() -> None:
     result: dict[str, Any] = json.loads(completed.stdout)
     assert result["test_name"] == "sg_policy_propagation"
     assert result["success"] is True
+
+
+class FakeStableEgressEc2:
+    """Fake EC2 client for stable egress IP main-path tests."""
+
+    def __init__(self) -> None:
+        """Track subnet creation without reaching AWS."""
+        self.created_subnet_cidrs: list[str] = []
+
+    def describe_availability_zones(self, Filters: list[dict[str, Any]]) -> dict[str, Any]:
+        """Return one available AZ."""
+        assert Filters == [{"Name": "state", "Values": ["available"]}]
+        return {"AvailabilityZones": [{"ZoneName": "us-west-2a"}]}
+
+    def create_subnet(self, VpcId: str, CidrBlock: str, AvailabilityZone: str) -> dict[str, Any]:
+        """Record the subnet CIDR used by main."""
+        assert VpcId == "vpc-egress"
+        assert AvailabilityZone == "us-west-2a"
+        self.created_subnet_cidrs.append(CidrBlock)
+        return {"Subnet": {"SubnetId": "subnet-egress"}}
+
+    def terminate_instances(self, InstanceIds: list[str]) -> dict[str, Any]:
+        """No-op terminate for cleanup."""
+        assert InstanceIds == ["i-egress"]
+        return {}
+
+    def delete_key_pair(self, KeyName: str) -> dict[str, Any]:
+        """No-op key cleanup."""
+        assert KeyName.startswith("isv-stable-egress-ip-")
+        return {}
+
+    def delete_security_group(self, GroupId: str) -> dict[str, Any]:
+        """No-op security group cleanup."""
+        assert GroupId == "sg-egress"
+        return {}
+
+    def delete_subnet(self, SubnetId: str) -> dict[str, Any]:
+        """No-op subnet cleanup."""
+        assert SubnetId == "subnet-egress"
+        return {}
+
+    def get_waiter(self, _name: str) -> Any:
+        """Return a waiter with a no-op wait method."""
+        return type("FakeWaiter", (), {"wait": lambda self, **kwargs: None})()
+
+
+def test_stable_egress_main_uses_cidr_parser_and_emits_minimal_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """AWS stable egress output should stay minimal and subnet CIDR derivation should be CIDR-aware."""
+    module = _load_network_script("stable_egress_ip_test.py")
+    fake_ec2 = FakeStableEgressEc2()
+
+    monkeypatch.setattr(module.boto3, "client", lambda service, region_name: fake_ec2)
+    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        module,
+        "create_test_vpc",
+        lambda ec2, cidr, name: {"passed": True, "vpc_id": "vpc-egress"},
+    )
+    monkeypatch.setattr(module, "create_internet_routing", lambda ec2, vpc_id, subnet_id, name, routing: None)
+    monkeypatch.setattr(module, "create_security_group", lambda ec2, vpc_id, name, description: "sg-egress")
+    monkeypatch.setattr(module, "create_key_pair", lambda ec2, key_name: "/tmp/isv-missing-egress-key.pem")
+    monkeypatch.setattr(
+        module,
+        "launch_instance",
+        lambda ec2, subnet_id, sg_id, key_name, name: {
+            "passed": True,
+            "instance_id": "i-egress",
+            "public_ip": "198.51.100.10",
+            "message": "Launched instance i-egress with public IP 198.51.100.10",
+        },
+    )
+    monkeypatch.setattr(
+        module,
+        "probe_egress_ip",
+        lambda public_ip, key_file, endpoint, probes, interval_seconds, ssh_user: {
+            "passed": True,
+            "ips": ["203.0.113.20"] * probes,
+            "endpoint": endpoint,
+            "probes": probes,
+            "message": f"Collected {probes} egress IP probes from {endpoint}",
+        },
+    )
+    monkeypatch.setattr(module, "delete_with_retry", lambda func, **kwargs: True)
+    monkeypatch.setattr(module, "delete_vpc", lambda ec2, vpc_id: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "stable_egress_ip_test.py",
+            "--region",
+            "us-west-2",
+            "--cidr",
+            "10.88.16.0/20",
+            "--probes",
+            "2",
+        ],
+    )
+
+    exit_code = module.main()
+
+    assert exit_code == 0
+    assert fake_ec2.created_subnet_cidrs == ["10.88.16.0/24"]
+    payload: dict[str, Any] = json.loads(capsys.readouterr().out)
+    _assert_stable_egress_contract(payload)
+    assert payload["tests"]["probe_egress_ip"]["probes"] == 2

--- a/isvctl/tests/test_aws_network_scripts.py
+++ b/isvctl/tests/test_aws_network_scripts.py
@@ -1719,3 +1719,33 @@ def test_stable_egress_main_uses_cidr_parser_and_emits_minimal_contract(
     payload: dict[str, Any] = json.loads(capsys.readouterr().out)
     _assert_stable_egress_contract(payload)
     assert payload["tests"]["probe_egress_ip"]["probes"] == 2
+
+
+def test_my_isv_stable_egress_demo_emits_minimal_contract() -> None:
+    """my-isv stable egress demo output should model the provider-neutral contract."""
+    script = MY_ISV_NETWORK_SCRIPTS / "stable_egress_ip_test.py"
+    env = os.environ | {"ISVCTL_DEMO_MODE": "1"}
+
+    try:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(script),
+                "--region",
+                "demo-region",
+                "--probes",
+                "2",
+            ],
+            capture_output=True,
+            env=env,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:
+        pytest.fail(f"{script} timed out after {exc.timeout} seconds\nstdout: {exc.stdout!r}\nstderr: {exc.stderr!r}")
+
+    assert completed.returncode == 0, completed.stderr
+    payload: dict[str, Any] = json.loads(completed.stdout)
+    _assert_stable_egress_contract(payload)
+    assert payload["tests"]["probe_egress_ip"]["probes"] == 2

--- a/isvtest/src/isvtest/validations/network.py
+++ b/isvtest/src/isvtest/validations/network.py
@@ -1359,6 +1359,58 @@ class StablePrivateIpCheck(BaseValidation):
             self.set_passed(f"Private IP {ip} stable across stop/start")
 
 
+class StableEgressIpCheck(BaseValidation):
+    """Validate egress IP stability across repeated probes (DMS05-01).
+
+    NVIDIA cloud services use IP allowlists, so workloads that call out to
+    them must present a stable egress IP. A provider script launches a
+    test instance, probes its egress IP N times against an external
+    IP-discovery endpoint (e.g., https://api.ipify.org), and reports
+    whether every probe returned the same address.
+
+    Config:
+        step_output: The step output to check
+
+    Step output:
+        tests: dict with create_instance, probe_egress_ip, egress_ip_stable
+    """
+
+    description: ClassVar[str] = "Check egress IP stability across probes"
+    labels: ClassVar[tuple[str, ...]] = ("network",)
+
+    def run(self) -> None:
+        """Validate stable egress IP subtest results and record the outcome."""
+        step_output = self.config.get("step_output", {})
+        tests = step_output.get("tests", {})
+
+        if not tests:
+            self.set_failed("No 'tests' in step output")
+            return
+
+        required = [
+            "create_instance",
+            "probe_egress_ip",
+            "egress_ip_stable",
+        ]
+        failed = []
+
+        for test_name in required:
+            test_result = tests.get(test_name, {})
+            if not test_result.get("passed"):
+                error = test_result.get("error", "test not found")
+                failed.append(f"{test_name}: {error}")
+
+        if failed:
+            self.set_failed(f"Stable egress IP tests failed: {'; '.join(failed)}")
+        else:
+            probe_result = tests.get("probe_egress_ip", {})
+            probes = probe_result.get("probes")
+            if probes is None:
+                self.set_failed("Malformed stable egress IP step output: missing probe_egress_ip.probes")
+            else:
+                self.set_passed(f"Egress IP stable across {probes} probes")
+
+
 class FloatingIpCheck(BaseValidation):
     """Validate floating IP can be atomically switched between instances.
 

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -47,6 +47,7 @@ from isvtest.validations.network import (
     NvlinkDomainCheck,
     SgPolicyPropagationTimingCheck,
     SgPortSecurityPolicyCheck,
+    StableEgressIpCheck,
     StablePrivateIpCheck,
     VpcPeeringCheck,
 )
@@ -1223,6 +1224,64 @@ class TestStablePrivateIpCheck:
 
     def test_empty_tests(self) -> None:
         v = StablePrivateIpCheck(config={"step_output": {}})
+        result = v.execute()
+        assert result["passed"] is False
+
+
+class TestStableEgressIpCheck:
+    """Tests for StableEgressIpCheck validation."""
+
+    def test_egress_ip_stable(self) -> None:
+        """Verify egress IP remains stable across probes."""
+        tests = {
+            "create_instance": {"passed": True},
+            "probe_egress_ip": {
+                "passed": True,
+                "probes": 3,
+            },
+            "egress_ip_stable": {"passed": True},
+        }
+        v = StableEgressIpCheck(config=_sdn_step_output(tests))
+        result = v.execute()
+        assert result["passed"] is True
+        assert result["output"] == "Egress IP stable across 3 probes"
+
+    def test_egress_ip_unstable(self) -> None:
+        """Verify detection of unstable egress IP across probes."""
+        tests = {
+            "create_instance": {"passed": True, "instance_id": "i-xxx"},
+            "probe_egress_ip": {
+                "passed": True,
+                "ips": ["3.5.1.2", "3.5.1.2", "3.5.9.99"],
+                "endpoint": "https://api.ipify.org",
+                "probes": 3,
+            },
+            "egress_ip_stable": {
+                "passed": False,
+                "distinct": 2,
+                "error": "Egress IP changed across probes: 3.5.1.2, 3.5.9.99",
+            },
+        }
+        v = StableEgressIpCheck(config=_sdn_step_output(tests))
+        result = v.execute()
+        assert result["passed"] is False
+        assert "egress_ip_stable" in result["error"]
+
+    def test_missing_probe_count_fails(self) -> None:
+        """Verify malformed successful output without probe count fails."""
+        tests = {
+            "create_instance": {"passed": True},
+            "probe_egress_ip": {"passed": True},
+            "egress_ip_stable": {"passed": True},
+        }
+        v = StableEgressIpCheck(config=_sdn_step_output(tests))
+        result = v.execute()
+        assert result["passed"] is False
+        assert "probe_egress_ip.probes" in result["error"]
+
+    def test_empty_tests(self) -> None:
+        """Verify behavior when step_output is empty."""
+        v = StableEgressIpCheck(config={"step_output": {}})
         result = v.execute()
         assert result["passed"] is False
 


### PR DESCRIPTION
## Summary

- Add `StableEgressIpCheck` (DMS05-01) so workloads calling NVIDIA services from a provider VPC must present the same egress IP across N probes - prerequisite for IP allowlisting.
- Add AWS reference script: provisions a temporary VPC + subnet + IGW + public-IP instance, then curls a discovery endpoint (default `https://api.ipify.org`) N times over SSH and asserts every probe reported the same address. Resources are tracked incrementally so a mid-setup failure still cleans up.
- Add `my-isv` template script gated by `ISVCTL_DEMO_MODE` so `make demo-test` exercises the validation end-to-end without cloud credentials, while a real run returns `Not implemented`.
- Wire the step into the network suite and the AWS/my-isv provider network configs; declare the `stable_egress_ip` output schema.

Closes #266

## Verification

- [x] `make test`
- [x] `make demo-test`
- [x] `make lint`
- [x] `uvx pre-commit run -a`
- [x] `ISVCTL_DEMO_MODE=1 ISVTEST_INCLUDE_UNRELEASED=1 uv run isvctl test run -f isvctl/configs/providers/my-isv/config/network.yaml`
- [x] `ISVTEST_INCLUDE_UNRELEASED=1 \
  uv run isvctl test run -f isvctl/configs/providers/aws/config/network.yaml \
    -- -k StableEgressIpCheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AWS stable egress IP check to verify consistent outbound IPs across configurable probes; includes a demo mode for offline demonstration.

* **Validation**
  * New StableEgressIpCheck added to network validations and the canonical suite to assert probe-based stability.

* **Schemas**
  * New stable_egress_ip output schema to standardize step results.

* **Tests**
  * Added unit and integration tests covering contract, probe behavior, demo mode, and validation outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/ISV-NCP-Validation-Suite/pull/436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->