### PR TITLE
feat(control-plane): add S3 object-lifecycle validation (DATASVC-XX-01)

### DIFF
--- a/isvctl/configs/providers/aws/config/control-plane.yaml
+++ b/isvctl/configs/providers/aws/config/control-plane.yaml
@@ -22,6 +22,8 @@
 # - API Health: Authentication and service connectivity
 # - Access Key Lifecycle: Create, authenticate, disable, verify rejection, delete
 # - Tenant Lifecycle: Create, list, get info, delete
+# - S3 Object Lifecycle: PutObject -> GetObject (byte-compare) -> DeleteObject
+#   (DATASVC-XX-01 / issue #262: authenticated S3-compatible API data path)
 #
 # Usage:
 #   uv run isvctl test run -f isvctl/configs/providers/aws/config/control-plane.yaml
@@ -29,7 +31,9 @@
 # Required IAM Permissions:
 #   sts:GetCallerIdentity, iam:ListUsers, ec2:DescribeRegions, s3:ListBuckets,
 #   iam:CreateUser, iam:DeleteUser, iam:CreateAccessKey, iam:DeleteAccessKey, iam:UpdateAccessKey,
-#   resource-groups:CreateGroup, resource-groups:DeleteGroup, resource-groups:ListGroups, resource-groups:GetGroup
+#   resource-groups:CreateGroup, resource-groups:DeleteGroup, resource-groups:ListGroups, resource-groups:GetGroup,
+#   s3:CreateBucket, s3:DeleteBucket, s3:ListBucket, s3:ListBucketVersions,
+#   s3:PutObject, s3:GetObject, s3:DeleteObject, s3:DeleteObjectVersion
 
 import:
   - ../../../suites/control-plane.yaml
@@ -133,6 +137,15 @@ commands:
           - "--region"
           - "{{region}}"
         timeout: 60
+
+      # =======================================================================
+      # TEST: S3 Object Lifecycle (DATASVC-XX-01)
+      # =======================================================================
+      - name: s3_object_lifecycle
+        phase: test
+        command: "python3 ../scripts/control-plane/s3_object_lifecycle.py"
+        args: ["--region", "{{region}}"]
+        timeout: 120
 
       # =======================================================================
       # TEARDOWN: Cleanup Resources

--- a/isvctl/configs/providers/aws/scripts/control-plane/s3_object_lifecycle.py
+++ b/isvctl/configs/providers/aws/scripts/control-plane/s3_object_lifecycle.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DATASVC-XX-01 data-path: PutObject -> GetObject -> DeleteObject on S3.
+
+Pairs with the existing control-plane ``check_api`` step (which calls
+``s3.list_buckets()`` to prove authenticated S3-compatible API access).
+This step creates a temp bucket, exercises the object lifecycle on a
+small object, byte-compares Get vs Put to detect data corruption, and
+deletes the bucket. The bucket is removed in the same step so this is
+self-contained and re-runnable without extra teardown wiring.
+
+Output JSON:
+{
+    "success": true,
+    "platform": "control_plane",
+    "test_name": "s3_object_lifecycle",
+    "bucket_name": "isv-validate-s3-xxxxxxxx",
+    "object_key": "isv-validate.txt",
+    "operations": {
+        "put":    {"passed": true},
+        "get":    {"passed": true, "content_matches": true},
+        "delete": {"passed": true}
+    }
+}
+"""
+
+import argparse
+import json
+import os
+import sys
+import uuid
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError, NoCredentialsError
+
+
+def _fail(op: dict[str, Any], code: str, message: str) -> None:
+    op["passed"] = False
+    op["error_code"] = code
+    op["error"] = message
+
+
+def _create_bucket(s3: Any, bucket: str, region: str) -> None:
+    if region == "us-east-1":
+        s3.create_bucket(Bucket=bucket)
+    else:
+        s3.create_bucket(
+            Bucket=bucket,
+            CreateBucketConfiguration={"LocationConstraint": region},
+        )
+
+
+def _delete_bucket_best_effort(s3: Any, bucket: str) -> str | None:
+    """Empty and delete a bucket. Returns an error message or None on success."""
+    try:
+        paginator = s3.get_paginator("list_object_versions")
+        batch: list[dict[str, Any]] = []
+        for page in paginator.paginate(Bucket=bucket):
+            for v in page.get("Versions", []) + page.get("DeleteMarkers", []):
+                batch.append({"Key": v["Key"], "VersionId": v["VersionId"]})
+                if len(batch) == 1000:
+                    s3.delete_objects(Bucket=bucket, Delete={"Objects": batch})
+                    batch = []
+        if batch:
+            s3.delete_objects(Bucket=bucket, Delete={"Objects": batch})
+        s3.delete_bucket(Bucket=bucket)
+        return None
+    except ClientError as e:
+        return str(e)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Exercise S3 object lifecycle (DATASVC-XX-01)")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument(
+        "--endpoint-url",
+        default=os.environ.get("S3_ENDPOINT_URL"),
+        help="Custom S3-compatible endpoint URL (optional)",
+    )
+    parser.add_argument("--bucket-prefix", default="isv-validate-s3")
+    args = parser.parse_args()
+
+    bucket_name = f"{args.bucket_prefix}-{uuid.uuid4().hex[:8]}"
+    object_key = f"isv-validate-{uuid.uuid4().hex[:8]}.txt"
+    expected_body = f"isv-ncp-validate s3 datasvc-xx-01 {uuid.uuid4().hex}".encode()
+
+    operations: dict[str, dict[str, Any]] = {
+        "put": {"passed": False},
+        "get": {"passed": False},
+        "delete": {"passed": False},
+    }
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "control_plane",
+        "test_name": "s3_object_lifecycle",
+        "bucket_name": bucket_name,
+        "object_key": object_key,
+        "operations": operations,
+    }
+
+    client_kwargs: dict[str, Any] = {"region_name": args.region}
+    if args.endpoint_url:
+        client_kwargs["endpoint_url"] = args.endpoint_url
+    try:
+        s3 = boto3.client("s3", **client_kwargs)
+    except NoCredentialsError as e:
+        result["error"] = f"No credentials: {e}"
+        print(json.dumps(result, indent=2))
+        return 1
+
+    bucket_created = False
+    try:
+        try:
+            _create_bucket(s3, bucket_name, args.region)
+            bucket_created = True
+        except ClientError as e:
+            result["error"] = f"CreateBucket failed: {e}"
+            print(json.dumps(result, indent=2))
+            return 1
+
+        try:
+            s3.put_object(Bucket=bucket_name, Key=object_key, Body=expected_body)
+            operations["put"]["passed"] = True
+        except ClientError as e:
+            _fail(operations["put"], e.response["Error"]["Code"], str(e))
+
+        if operations["put"]["passed"]:
+            try:
+                response = s3.get_object(Bucket=bucket_name, Key=object_key)
+                body = response["Body"].read()
+                content_matches = body == expected_body
+                operations["get"]["content_matches"] = content_matches
+                if content_matches:
+                    operations["get"]["passed"] = True
+                else:
+                    _fail(
+                        operations["get"],
+                        "ContentMismatch",
+                        "GetObject body does not match PutObject body",
+                    )
+            except ClientError as e:
+                _fail(operations["get"], e.response["Error"]["Code"], str(e))
+
+        try:
+            s3.delete_object(Bucket=bucket_name, Key=object_key)
+            operations["delete"]["passed"] = True
+        except ClientError as e:
+            _fail(operations["delete"], e.response["Error"]["Code"], str(e))
+
+        result["success"] = all(op["passed"] for op in operations.values())
+
+    finally:
+        if bucket_created:
+            cleanup_error = _delete_bucket_best_effort(s3, bucket_name)
+            if cleanup_error:
+                result.setdefault("cleanup_errors", []).append(cleanup_error)
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/aws/scripts/control-plane/s3_object_lifecycle.py
+++ b/isvctl/configs/providers/aws/scripts/control-plane/s3_object_lifecycle.py
@@ -29,7 +29,7 @@ Output JSON:
     "platform": "control_plane",
     "test_name": "s3_object_lifecycle",
     "bucket_name": "isv-validate-s3-xxxxxxxx",
-    "object_key": "isv-validate.txt",
+    "object_key": "isv-validate-xxxxxxxx.txt",
     "operations": {
         "put":    {"passed": true},
         "get":    {"passed": true, "content_matches": true},
@@ -116,19 +116,14 @@ def main() -> int:
     client_kwargs: dict[str, Any] = {"region_name": args.region}
     if args.endpoint_url:
         client_kwargs["endpoint_url"] = args.endpoint_url
-    try:
-        s3 = boto3.client("s3", **client_kwargs)
-    except NoCredentialsError as e:
-        result["error"] = f"No credentials: {e}"
-        print(json.dumps(result, indent=2))
-        return 1
+    s3 = boto3.client("s3", **client_kwargs)
 
     bucket_created = False
     try:
         try:
             _create_bucket(s3, bucket_name, args.region)
             bucket_created = True
-        except ClientError as e:
+        except (ClientError, NoCredentialsError) as e:
             result["error"] = f"CreateBucket failed: {e}"
             print(json.dumps(result, indent=2))
             return 1
@@ -138,6 +133,8 @@ def main() -> int:
             operations["put"]["passed"] = True
         except ClientError as e:
             _fail(operations["put"], e.response["Error"]["Code"], str(e))
+        except NoCredentialsError as e:
+            _fail(operations["put"], "NoCredentials", str(e))
 
         if operations["put"]["passed"]:
             try:
@@ -155,12 +152,16 @@ def main() -> int:
                     )
             except ClientError as e:
                 _fail(operations["get"], e.response["Error"]["Code"], str(e))
+            except NoCredentialsError as e:
+                _fail(operations["get"], "NoCredentials", str(e))
 
-        try:
-            s3.delete_object(Bucket=bucket_name, Key=object_key)
-            operations["delete"]["passed"] = True
-        except ClientError as e:
-            _fail(operations["delete"], e.response["Error"]["Code"], str(e))
+            try:
+                s3.delete_object(Bucket=bucket_name, Key=object_key)
+                operations["delete"]["passed"] = True
+            except ClientError as e:
+                _fail(operations["delete"], e.response["Error"]["Code"], str(e))
+            except NoCredentialsError as e:
+                _fail(operations["delete"], "NoCredentials", str(e))
 
         result["success"] = all(op["passed"] for op in operations.values())
 

--- a/isvctl/configs/providers/aws/scripts/control-plane/s3_object_lifecycle.py
+++ b/isvctl/configs/providers/aws/scripts/control-plane/s3_object_lifecycle.py
@@ -50,12 +50,14 @@ from botocore.exceptions import ClientError, NoCredentialsError
 
 
 def _fail(op: dict[str, Any], code: str, message: str) -> None:
+    """Mark an operation as failed and attach normalized error details."""
     op["passed"] = False
     op["error_code"] = code
     op["error"] = message
 
 
 def _create_bucket(s3: Any, bucket: str, region: str) -> None:
+    """Create an S3 bucket, handling the us-east-1 LocationConstraint special case."""
     if region == "us-east-1":
         s3.create_bucket(Bucket=bucket)
     else:
@@ -85,6 +87,7 @@ def _delete_bucket_best_effort(s3: Any, bucket: str) -> str | None:
 
 
 def main() -> int:
+    """Run the S3 object lifecycle probe and print a structured JSON result."""
     parser = argparse.ArgumentParser(description="Exercise S3 object lifecycle (DATASVC-XX-01)")
     parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
     parser.add_argument(

--- a/isvctl/configs/providers/aws/scripts/control-plane/s3_object_lifecycle.py
+++ b/isvctl/configs/providers/aws/scripts/control-plane/s3_object_lifecycle.py
@@ -170,6 +170,9 @@ def main() -> int:
             cleanup_error = _delete_bucket_best_effort(s3, bucket_name)
             if cleanup_error:
                 result.setdefault("cleanup_errors", []).append(cleanup_error)
+                cleanup_msg = f"Cleanup failed: {cleanup_error}"
+                result["error"] = f"{result['error']}; {cleanup_msg}" if result.get("error") else cleanup_msg
+                result["success"] = False
 
     print(json.dumps(result, indent=2))
     return 0 if result["success"] else 1

--- a/isvctl/configs/providers/my-isv/config/control-plane.yaml
+++ b/isvctl/configs/providers/my-isv/config/control-plane.yaml
@@ -26,14 +26,16 @@
 #     2. create_access_key - Create test user + access key
 #     3. create_tenant     - Create test tenant
 #   TEST
-#     4. test_access_key     - Authenticate with the key
-#     5. disable_access_key  - Deactivate the key
-#     6. verify_key_rejected - Confirm disabled key is rejected
-#     7. list_tenants        - Find created tenant in list
-#     8. get_tenant          - Retrieve tenant details
+#     4. test_access_key      - Authenticate with the key
+#     5. disable_access_key   - Deactivate the key
+#     6. verify_key_rejected  - Confirm disabled key is rejected
+#     7. list_tenants         - Find created tenant in list
+#     8. get_tenant           - Retrieve tenant details
+#     9. s3_object_lifecycle  - PutObject -> GetObject (byte compare) -> DeleteObject
+#                               (DATASVC-XX-01 / issue #262: authenticated S3 data path)
 #   TEARDOWN
-#     9. delete_access_key - Clean up user + key
-#    10. delete_tenant     - Clean up tenant
+#    10. delete_access_key - Clean up user + key
+#    11. delete_tenant     - Clean up tenant
 #
 # Usage:
 #   uv run isvctl test run -f isvctl/configs/providers/my-isv/config/control-plane.yaml
@@ -122,6 +124,12 @@ commands:
           - "--region"
           - "{{region}}"
         timeout: 60
+
+      - name: s3_object_lifecycle
+        phase: test
+        command: "python ../scripts/control-plane/s3_object_lifecycle.py"
+        args: ["--region", "{{region}}"]
+        timeout: 120
 
       - name: delete_access_key
         phase: teardown

--- a/isvctl/configs/providers/my-isv/scripts/control-plane/s3_object_lifecycle.py
+++ b/isvctl/configs/providers/my-isv/scripts/control-plane/s3_object_lifecycle.py
@@ -105,9 +105,7 @@ def main() -> int:
         result["success"] = True
     else:
         operations["put"]["error"] = "Not implemented"
-        result["error"] = (
-            "Not implemented - replace with your platform's PutObject/GetObject/DeleteObject logic"
-        )
+        result["error"] = "Not implemented - replace with your platform's PutObject/GetObject/DeleteObject logic"
 
     print(json.dumps(result, indent=2))
     return 0 if result["success"] else 1

--- a/isvctl/configs/providers/my-isv/scripts/control-plane/s3_object_lifecycle.py
+++ b/isvctl/configs/providers/my-isv/scripts/control-plane/s3_object_lifecycle.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DATASVC-XX-01 data-path: PutObject -> GetObject -> DeleteObject on the
+platform's S3-compatible object store.
+
+Provider-agnostic template - replace the TODO section with your platform's
+PutObject / GetObject / DeleteObject calls. The GetObject result MUST be
+byte-compared with the body that was put to detect data corruption.
+
+The script creates a temp bucket, runs the lifecycle, byte-compares Get vs
+Put, and deletes the bucket - self-contained so re-runs do not leak
+resources.
+
+Required JSON output:
+{
+    "success":     bool   - true iff all three operations passed AND bytes matched,
+    "platform":    str    - "control_plane",
+    "test_name":   str    - "s3_object_lifecycle",
+    "bucket_name": str    - bucket the object was written to,
+    "object_key":  str    - key of the test object,
+    "operations": {
+        "put":    {"passed": bool, "error": str?},
+        "get":    {"passed": bool, "content_matches": bool, "error": str?},
+        "delete": {"passed": bool, "error": str?}
+    }
+}
+
+Usage:
+    python s3_object_lifecycle.py --region <region>
+
+AWS reference implementation:
+    ../aws/control-plane/s3_object_lifecycle.py
+"""
+
+import argparse
+import json
+import os
+import sys
+import uuid
+from typing import Any
+
+# ISVCTL_DEMO_MODE=1 enables demo-success output (used by `make demo-test`).
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+
+
+def main() -> int:
+    """Exercise the object lifecycle and emit structured JSON result."""
+    parser = argparse.ArgumentParser(description="Verify S3 object lifecycle (Put/Get/Delete)")
+    parser.add_argument("--region", required=True, help="Cloud region / availability zone")
+    parser.add_argument("--bucket-prefix", default="isv-validate-s3")
+    args = parser.parse_args()
+
+    bucket_name = f"{args.bucket_prefix}-{uuid.uuid4().hex[:8]}"
+    object_key = f"isv-validate-{uuid.uuid4().hex[:8]}.txt"
+
+    operations: dict[str, dict[str, Any]] = {
+        "put": {"passed": False},
+        "get": {"passed": False},
+        "delete": {"passed": False},
+    }
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "control_plane",
+        "test_name": "s3_object_lifecycle",
+        "bucket_name": bucket_name,
+        "object_key": object_key,
+        "operations": operations,
+    }
+
+    # ╔══════════════════════════════════════════════════════════════════╗
+    # ║  TODO: Replace this block with your platform's implementation    ║
+    # ║                                                                  ║
+    # ║  1. body = b"some small payload"                                 ║
+    # ║  2. CreateBucket(bucket_name) in args.region                     ║
+    # ║  3. PutObject(bucket_name, object_key, body)                     ║
+    # ║       -> operations["put"]["passed"] = True (or False + error)   ║
+    # ║  4. response = GetObject(bucket_name, object_key)                ║
+    # ║       -> operations["get"]["content_matches"] = (response==body) ║
+    # ║       -> operations["get"]["passed"] = content_matches           ║
+    # ║  5. DeleteObject(bucket_name, object_key)                        ║
+    # ║       -> operations["delete"]["passed"] = True                   ║
+    # ║  6. Best-effort: DeleteBucket(bucket_name) in a finally block    ║
+    # ║  7. result["success"] = all(op["passed"] for op in operations…)  ║
+    # ╚══════════════════════════════════════════════════════════════════╝
+
+    if DEMO_MODE:
+        operations["put"]["passed"] = True
+        operations["get"]["passed"] = True
+        operations["get"]["content_matches"] = True
+        operations["delete"]["passed"] = True
+        result["success"] = True
+    else:
+        operations["put"]["error"] = "Not implemented"
+        result["error"] = (
+            "Not implemented - replace with your platform's PutObject/GetObject/DeleteObject logic"
+        )
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -128,6 +128,7 @@ Validations use `sinfo`/`srun` directly: partitions, GPU allocation, job schedul
 | `verify_key_rejected` | test | `providers/my-isv/scripts/control-plane/verify_key_rejected.py` | `rejected`, `error_code` |
 | `list_tenants` | test | `providers/my-isv/scripts/control-plane/list_tenants.py` | `found_target`, `target_tenant`, `count` |
 | `get_tenant` | test | `providers/my-isv/scripts/control-plane/get_tenant.py` | `tenant_name`, `description` |
+| `s3_object_lifecycle` | test | `providers/my-isv/scripts/control-plane/s3_object_lifecycle.py` | `bucket_name`, `object_key`, `operations.{put,get,delete}` (get includes `content_matches`) |
 | `delete_access_key` | teardown | `providers/my-isv/scripts/control-plane/delete_access_key.py` | `resources_deleted` |
 | `delete_tenant` | teardown | `providers/my-isv/scripts/control-plane/delete_tenant.py` | `resources_deleted` |
 

--- a/isvctl/configs/suites/control-plane.yaml
+++ b/isvctl/configs/suites/control-plane.yaml
@@ -86,10 +86,6 @@ tests:
         TenantInfoCheck:
           step: get_tenant
 
-    # DATASVC-XX-01: object-storage data-path lifecycle on an S3-compatible API.
-    # Scripts must emit operations: {put, get, delete} each with passed:bool, and
-    # the get operation must include content_matches:bool (byte compare of the
-    # written body) - set passed:false if bytes differ.
     s3_object_lifecycle:
       step: s3_object_lifecycle
       checks:

--- a/isvctl/configs/suites/control-plane.yaml
+++ b/isvctl/configs/suites/control-plane.yaml
@@ -22,6 +22,13 @@
 # only inspects JSON output fields. As long as your scripts output the
 # right fields, the validations pass regardless of which cloud you use.
 #
+# Coverage notes:
+# - API Health (check_api) is provider-agnostic: at minimum it must prove
+#   authenticated reachability of the platform's object-storage / S3-compatible
+#   API. This is sufficient to satisfy the "authenticated endpoint" half of
+#   DATASVC-XX-01 (issue #262); the data-path half is covered by the
+#   s3_object_lifecycle validation below.
+#
 # Quick start:
 #   1. Copy providers/my-isv/config/control-plane.yaml to providers/<your-platform>/config/control-plane.yaml
 #   2. Replace stub paths with your platform scripts
@@ -78,6 +85,19 @@ tests:
           step: list_tenants
         TenantInfoCheck:
           step: get_tenant
+
+    # DATASVC-XX-01: object-storage data-path lifecycle on an S3-compatible API.
+    # Scripts must emit operations: {put, get, delete} each with passed:bool, and
+    # the get operation must include content_matches:bool (byte compare of the
+    # written body) - set passed:false if bytes differ.
+    s3_object_lifecycle:
+      step: s3_object_lifecycle
+      checks:
+        StepSuccessCheck: {}
+        FieldExistsCheck:
+          fields: ["bucket_name", "object_key", "operations"]
+        CrudOperationsCheck:
+          operations: ["put", "get", "delete"]
 
     teardown_checks:
       checks:

--- a/isvctl/tests/test_aws_control_plane_scripts.py
+++ b/isvctl/tests/test_aws_control_plane_scripts.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for AWS control-plane reference scripts."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+AWS_CONTROL_PLANE_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "control-plane"
+
+
+def _load_control_plane_script(script_name: str) -> ModuleType:
+    """Load an AWS control-plane script as a module for direct helper testing."""
+    script_path = AWS_CONTROL_PLANE_SCRIPTS / script_name
+    spec = importlib.util.spec_from_file_location(f"test_{script_path.stem}", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeS3LifecycleClient:
+    """Fake S3 client covering successful object lifecycle calls."""
+
+    def __init__(self) -> None:
+        """Initialize fake object storage."""
+        self.objects: dict[tuple[str, str], bytes] = {}
+
+    def create_bucket(self, **kwargs: Any) -> None:
+        """Accept bucket creation calls."""
+
+    def put_object(self, Bucket: str, Key: str, Body: bytes) -> None:
+        """Store the uploaded object body."""
+        self.objects[(Bucket, Key)] = Body
+
+    def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+        """Return the uploaded object body."""
+        return {"Body": FakeStreamingBody(self.objects[(Bucket, Key)])}
+
+    def delete_object(self, Bucket: str, Key: str) -> None:
+        """Delete the uploaded object."""
+        del self.objects[(Bucket, Key)]
+
+
+class FakeStreamingBody:
+    """Small fake for a boto3 streaming body."""
+
+    def __init__(self, body: bytes) -> None:
+        """Store the response body."""
+        self.body = body
+
+    def read(self) -> bytes:
+        """Return the response body."""
+        return self.body
+
+
+def test_s3_object_lifecycle_cleanup_error_fails_step(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A leaked temp bucket makes the S3 lifecycle step fail."""
+    module = _load_control_plane_script("s3_object_lifecycle.py")
+    fake_s3 = FakeS3LifecycleClient()
+    monkeypatch.setattr(module.boto3, "client", lambda *args, **kwargs: fake_s3)
+    monkeypatch.setattr(module, "_delete_bucket_best_effort", lambda *args, **kwargs: "DeleteBucket failed")
+    monkeypatch.setattr(sys, "argv", ["s3_object_lifecycle.py", "--region", "us-west-2"])
+
+    exit_code = module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert payload["cleanup_errors"] == ["DeleteBucket failed"]

--- a/isvtest/src/isvtest/validations/generic.py
+++ b/isvtest/src/isvtest/validations/generic.py
@@ -56,6 +56,19 @@ class FieldExistsCheck(BaseValidation):
             self.set_passed(f"All required fields present: {', '.join(fields)}")
 
 
+def _get_field_value(step_output: dict[str, Any], field: str) -> tuple[bool, Any]:
+    """Return a top-level or dotted-path field from step output."""
+    if field in step_output:
+        return True, step_output[field]
+
+    current: Any = step_output
+    for part in field.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return False, None
+        current = current[part]
+    return True, current
+
+
 class FieldValueCheck(BaseValidation):
     """Check that a field has an expected value.
 
@@ -79,11 +92,10 @@ class FieldValueCheck(BaseValidation):
             self.set_failed("No 'field' specified")
             return
 
-        if field not in step_output:
+        found, actual = _get_field_value(step_output, field)
+        if not found:
             self.set_failed(f"Field '{field}' not found in output")
             return
-
-        actual = step_output[field]
 
         # Check exact match
         expected = self.config.get("expected")

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -31,6 +31,7 @@ from isvtest.tests.test_validations import (
     test_validation as run_validation_entry_point,
 )
 from isvtest.validations.bm_host_status import BmHostStatusLog
+from isvtest.validations.generic import FieldValueCheck
 from isvtest.validations.instance import (
     InstanceListCheck,
     InstancePowerCycleCheck,
@@ -2399,3 +2400,35 @@ class TestBmHostStatusLog:
         result = v.execute()
         assert result["passed"] is False
         assert "required_sources" in result["error"]
+
+
+def test_field_value_check_supports_nested_dot_paths() -> None:
+    """FieldValueCheck can assert nested step-output contract fields."""
+    validation = FieldValueCheck(
+        config={
+            "step_output": {"operations": {"get": {"passed": True, "content_matches": True}}},
+            "field": "operations.get.content_matches",
+            "expected": True,
+        }
+    )
+
+    result = validation.execute()
+
+    assert result["passed"] is True
+    assert "operations.get.content_matches=True" in result["output"]
+
+
+def test_field_value_check_requires_nested_dot_path_to_exist() -> None:
+    """Missing nested fields fail instead of silently passing."""
+    validation = FieldValueCheck(
+        config={
+            "step_output": {"operations": {"get": {"passed": True}}},
+            "field": "operations.get.content_matches",
+            "expected": True,
+        }
+    )
+
+    result = validation.execute()
+
+    assert result["passed"] is False
+    assert "Field 'operations.get.content_matches' not found" in result["error"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #262.

## What
Adds the data-path half of **DATASVC-XX-01: Verify S3-compatible API access with authenticated endpoints** to the existing `control-plane` validation suite: an authenticated `PutObject -> GetObject -> DeleteObject` round-trip on a temp bucket with a byte-compare to detect data corruption. The existing `check_api` step already covers the authenticated-`ListBuckets` half via its S3 service probe.

## Changes
- **`suites/control-plane.yaml`** – adds an `s3_object_lifecycle` validation block. Reuses existing `StepSuccessCheck` + `FieldExistsCheck` + `CrudOperationsCheck`. **No new validation classes**, no edit to `released_tests.json`.
- **`providers/aws/config/control-plane.yaml`** + **`providers/aws/scripts/control-plane/s3_object_lifecycle.py`** – AWS implementation using boto3: create temp bucket → Put/Get/Delete a small object → byte-compare Get vs Put → best-effort delete the bucket (versioned-safe). IAM permission list updated.
- **`providers/my-isv/config/control-plane.yaml`** + **`providers/my-isv/scripts/control-plane/s3_object_lifecycle.py`** – matching scaffold with the standard `TODO` block and `ISVCTL_DEMO_MODE` gate so the living example continues to pass `make demo-test`.
- **`suites/README.md`** – the new step is appended to the control-plane row.

## JSON contract (provider-neutral)
```
{
  "success": true,
  "platform": "control_plane",
  "test_name": "s3_object_lifecycle",
  "bucket_name": "isv-validate-s3-...",
  "object_key": "isv-validate-....txt",
  "operations": {
    "put":    {"passed": true},
    "get":    {"passed": true, "content_matches": true},
    "delete": {"passed": true}
  }
}
```
If `content_matches` is false, `operations.get.passed` is set to false and `success` flips to false — `CrudOperationsCheck` then fails the validation.

## Validation

Exercised end-to-end against a real AWS account (us-west-2) via the full control-plane suite. The new `s3_object_lifecycle` step passes:

```text
[s3_object_lifecycle] StepSuccessCheck: PASSED - Step completed successfully
[s3_object_lifecycle] FieldExistsCheck: PASSED - All required fields present: bucket_name, object_key, operations
[s3_object_lifecycle] CrudOperationsCheck: PASSED - All CRUD operations passed: put, get, delete
```

Full suite result: **14 validations passed across setup/test/teardown, no leaked bucket**. Command used:

```bash
ISVTEST_INCLUDE_UNRELEASED=1 AWS_PROFILE=ncp-isv-lab \
  uv run isvctl test run -f isvctl/configs/providers/aws/config/control-plane.yaml --lab-id 37 -- -v -s
```

Supporting checks:

- ✅ `make test` — 829 unit tests + 40 script tests pass
- ✅ `make lint` / `uvx pre-commit run -a` / `make demo-test` — clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-216ab809-ac90-407a-8e68-9e5dd5ee0b67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-216ab809-ac90-407a-8e68-9e5dd5ee0b67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added S3 object lifecycle validation (Put → Get byte-compare → Delete) to control‑plane tests and suites.
  * Validation now surfaces nested field path lookups when checking step outputs.

* **Documentation**
  * Updated control‑plane suite listing to include the new S3 lifecycle test and expected output fields.

* **Tests**
  * Added tests covering control‑plane script cleanup/error behavior and nested field‑path validation handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/ISV-NCP-Validation-Suite/pull/438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->