### PR TITLE
feat: add isvctl doctor pre-flight diagnostics command

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,6 +24,12 @@ Verify installation:
 uv run isvctl --help
 ```
 
+Run a pre-flight check:
+
+```bash
+uv run isvctl doctor
+```
+
 ## Quick Start
 
 ### Try it without cloud credentials (~10s)
@@ -55,6 +61,12 @@ Then preview the generated VM flow without cloud access:
 
 ```bash
 ISVCTL_DEMO_MODE=1 uv run isvctl test run -f isvctl/configs/providers/acme/config/vm.yaml
+```
+
+Before a real provider run, check required tools, credentials, and config:
+
+```bash
+uv run isvctl doctor --provider aws -f isvctl/configs/providers/aws/config/control-plane.yaml
 ```
 
 ### Running Validation Tests

--- a/docs/packages/isvctl.md
+++ b/docs/packages/isvctl.md
@@ -42,6 +42,9 @@ isvctl test run -f isvctl/configs/suites/slurm.yaml
 # Create a provider scaffold
 isvctl provider scaffold acme
 
+# Check local readiness before a run
+isvctl doctor -f isvctl/configs/suites/k8s.yaml
+
 # Pass extra pytest args
 isvctl test run -f isvctl/configs/suites/k8s.yaml -- -v -s -k "NodeCount"
 ```
@@ -68,6 +71,25 @@ isvctl/
 ```
 
 ## Usage
+
+### Pre-flight Diagnostics
+
+Use `isvctl doctor` before longer runs or in CI to check local tools,
+environment variables, and config files.
+
+```bash
+# Check tools, environment, and default config discovery
+isvctl doctor
+
+# Validate a config file before running it
+isvctl doctor -f isvctl/configs/suites/k8s.yaml
+
+# Require provider-specific checks such as AWS tools and credentials
+isvctl doctor --provider aws -f isvctl/configs/providers/aws/config/control-plane.yaml
+
+# Machine-readable output; use --strict to treat warnings as failures
+isvctl doctor --json --strict
+```
 
 ### Run Validation
 

--- a/isvctl/README.md
+++ b/isvctl/README.md
@@ -7,7 +7,11 @@ Unified controller for ISV Lab cluster lifecycle orchestration.
 ```bash
 # From workspace root
 uv sync
+uv run isvctl doctor
 uv run isvctl test run -f isvctl/configs/suites/k8s.yaml
+
+# Check a specific config before running it
+uv run isvctl doctor -f isvctl/configs/suites/k8s.yaml
 
 # View documentation
 uv run isvctl docs

--- a/isvctl/src/isvctl/cli/doctor.py
+++ b/isvctl/src/isvctl/cli/doctor.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Doctor subcommand for isvctl.
+
+Pre-flight diagnostics: verify external tools, environment variables, and
+config integrity before a full ``isvctl test run``.
+"""
+
+import logging
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from isvreporter.version import get_version
+
+from isvctl.cli import setup_logging
+from isvctl.doctor.checks import check_configs, check_env, check_tools
+from isvctl.doctor.report import render_json, render_rich
+from isvctl.doctor.result import CategoryReport, Status, worst
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer(
+    name="doctor",
+    help="Pre-flight diagnostics for tools, environment, and configs",
+    invoke_without_command=True,
+    no_args_is_help=False,
+)
+
+# Categories the user can pass to --check. Keep in sync with the dispatch
+# table inside `doctor()`.
+_CATEGORY_NAMES: tuple[str, ...] = ("tools", "env", "config")
+
+
+def _parse_csv(value: str | None) -> list[str]:
+    """Split a comma-separated CLI value into a clean list."""
+    if not value:
+        return []
+    return [token.strip() for token in value.split(",") if token.strip()]
+
+
+@app.callback(invoke_without_command=True)
+def doctor(
+    ctx: typer.Context,
+    config_files: Annotated[
+        list[Path] | None,
+        typer.Option(
+            "--config",
+            "-f",
+            help="Validate this YAML config (repeatable; merged like `isvctl test run`).",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            readable=True,
+        ),
+    ] = None,
+    provider: Annotated[
+        str | None,
+        typer.Option(
+            "--provider",
+            help="Comma-separated provider names (e.g. 'aws') to require their tools "
+            "and run provider-specific readiness checks (e.g. the AWS credential chain).",
+        ),
+    ] = None,
+    check: Annotated[
+        str | None,
+        typer.Option(
+            "--check",
+            help=f"Comma-separated subset of categories to run ({', '.join(_CATEGORY_NAMES)}).",
+        ),
+    ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit the report as JSON to stdout."),
+    ] = False,
+    verbose: Annotated[
+        bool,
+        typer.Option("--verbose", "-v", help="Show detail lines (paths, versions) per check."),
+    ] = False,
+    strict: Annotated[
+        bool,
+        typer.Option(
+            "--strict",
+            help="Treat warnings as failures for exit-code purposes.",
+        ),
+    ] = False,
+) -> None:
+    """Diagnose the local environment for `isvctl test run`.
+
+    Examples:
+        isvctl doctor
+        isvctl doctor -f path/to/your-config.yaml
+        isvctl doctor --provider aws -v
+        isvctl doctor --check env --json
+    """
+    # When invoked with a real subcommand, defer to it. (There are none today
+    # but the callback shape leaves room for future grouping like `doctor
+    # show <category>`.)
+    if ctx.invoked_subcommand is not None:
+        return
+
+    setup_logging(verbose)
+
+    providers = _parse_csv(provider)
+    requested = _parse_csv(check) or list(_CATEGORY_NAMES)
+    unknown = [c for c in requested if c not in _CATEGORY_NAMES]
+    if unknown:
+        typer.echo(
+            f"Error: unknown --check value(s): {', '.join(unknown)}. Valid: {', '.join(_CATEGORY_NAMES)}",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    reports: list[CategoryReport] = []
+    if "tools" in requested:
+        reports.append(check_tools(providers))
+    if "env" in requested:
+        reports.append(check_env(providers))
+    if "config" in requested:
+        reports.append(check_configs(config_files or None, providers))
+
+    version = get_version("isvctl")
+
+    if json_output:
+        typer.echo(render_json(reports, isvctl_version=version, verbose=verbose))
+    else:
+        render_rich(reports, isvctl_version=version, verbose=verbose)
+
+    overall = worst([r.worst_status for r in reports])
+    if overall == Status.FAIL or (strict and overall == Status.WARN):
+        raise typer.Exit(code=1)

--- a/isvctl/src/isvctl/doctor/__init__.py
+++ b/isvctl/src/isvctl/doctor/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pre-flight diagnostics for isvctl.
+
+The `doctor` subcommand runs grouped checks (tools, environment, configs) and
+reports a Rich-styled or JSON summary so users can fix setup issues before
+kicking off a real `isvctl test run`.
+"""
+
+from isvctl.doctor.result import CategoryReport, CheckResult, Status
+
+__all__ = ["CategoryReport", "CheckResult", "Status"]

--- a/isvctl/src/isvctl/doctor/checks/__init__.py
+++ b/isvctl/src/isvctl/doctor/checks/__init__.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-category check implementations."""
+
+from isvctl.doctor.checks.config import check_configs
+from isvctl.doctor.checks.env import check_env
+from isvctl.doctor.checks.tools import check_tools
+
+__all__ = ["check_configs", "check_env", "check_tools"]

--- a/isvctl/src/isvctl/doctor/checks/config.py
+++ b/isvctl/src/isvctl/doctor/checks/config.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Config and provider-asset sanity checks."""
+
+from pathlib import Path
+
+from isvctl.config.merger import merge_yaml_files
+from isvctl.config.schema import RunConfig
+from isvctl.doctor.result import CategoryReport, CheckResult, Status
+
+
+def _find_repo_root() -> Path | None:
+    """Walk up from this file until we find an ``isvctl/configs`` directory.
+
+    Returns the workspace root (parent of ``isvctl/``), or None if we can't
+    locate it (e.g., the package was installed outside its source tree).
+    """
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        if (ancestor / "isvctl" / "configs").is_dir():
+            return ancestor
+    return None
+
+
+def _check_repo_layout(root: Path) -> list[CheckResult]:
+    """Verify the shipped suites directory is intact.
+
+    Provider directories are not enumerated here — `doctor` is ISV-agnostic by
+    default; the shipped `aws` and `my-isv` trees are reference/scaffold and
+    should not be flagged as something the user is expected to have. Per-provider
+    script checks happen only when the user opts in via ``--provider <name>``.
+    """
+    results: list[CheckResult] = []
+
+    suites_dir = root / "isvctl" / "configs" / "suites"
+    suite_yamls = sorted(suites_dir.glob("*.yaml")) if suites_dir.is_dir() else []
+    if suite_yamls:
+        results.append(
+            CheckResult(
+                name="configs/suites",
+                status=Status.OK,
+                message=f"{len(suite_yamls)} suite(s) present",
+                detail="\n".join(str(p.relative_to(root)) for p in suite_yamls),
+            )
+        )
+    else:
+        results.append(
+            CheckResult(
+                name="configs/suites",
+                status=Status.FAIL,
+                message="no suite YAMLs found",
+                remediation=f"re-clone the repository; expected files under {suites_dir}",
+            )
+        )
+
+    return results
+
+
+def _check_provider_arg(root: Path, providers: list[str]) -> list[CheckResult]:
+    """Validate every --provider value against the on-disk provider directories."""
+    results: list[CheckResult] = []
+    base = root / "isvctl" / "configs" / "providers"
+    for prov in providers:
+        prov_dir = base / prov
+        scripts_dir = prov_dir / "scripts"
+        if scripts_dir.is_dir():
+            results.append(
+                CheckResult(
+                    name=f"--provider {prov}",
+                    status=Status.OK,
+                    message="scripts directory present",
+                    detail=f"path: {scripts_dir}",
+                )
+            )
+        else:
+            results.append(
+                CheckResult(
+                    name=f"--provider {prov}",
+                    status=Status.FAIL,
+                    message="provider scripts directory not found",
+                    remediation=f"expected path: {scripts_dir}",
+                )
+            )
+    return results
+
+
+def _validate_config_file(paths: list[Path]) -> CheckResult:
+    """Run the merge + RunConfig pipeline against a list of -f paths."""
+    name = " + ".join(p.name for p in paths)
+    try:
+        merged = merge_yaml_files([str(p) for p in paths], [])
+    except Exception as exc:
+        return CheckResult(
+            name=name,
+            status=Status.FAIL,
+            message=f"merge failed: {exc.__class__.__name__}",
+            detail=str(exc),
+            remediation="check YAML syntax and any `import:` paths",
+        )
+
+    try:
+        RunConfig.model_validate(merged)
+    except Exception as exc:
+        return CheckResult(
+            name=name,
+            status=Status.FAIL,
+            message=f"schema validation failed: {exc.__class__.__name__}",
+            detail=str(exc),
+            remediation="see `isvctl test validate -f ...` for full Pydantic errors",
+        )
+
+    return CheckResult(
+        name=name,
+        status=Status.OK,
+        message="merged and validated",
+    )
+
+
+def check_configs(
+    config_files: list[Path] | None = None,
+    providers: list[str] | None = None,
+) -> CategoryReport:
+    """Run the config category.
+
+    Args:
+        config_files: When provided, merge + validate these -f files together
+            (same semantics as ``isvctl test run -f ...``).
+        providers: --provider values to verify against on-disk provider dirs.
+
+    Returns:
+        CategoryReport with at least a repo-layout result, plus per-config
+        validation results when ``config_files`` is supplied.
+    """
+    results: list[CheckResult] = []
+    root = _find_repo_root()
+
+    if root is None:
+        results.append(
+            CheckResult(
+                name="repo layout",
+                status=Status.WARN,
+                message="could not locate workspace root from package location",
+                remediation="run `doctor` from inside a source checkout",
+            )
+        )
+    else:
+        results.extend(_check_repo_layout(root))
+        if providers:
+            results.extend(_check_provider_arg(root, providers))
+
+    if config_files:
+        results.append(_validate_config_file(config_files))
+
+    return CategoryReport(name="config", results=results)

--- a/isvctl/src/isvctl/doctor/checks/env.py
+++ b/isvctl/src/isvctl/doctor/checks/env.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Environment-variable presence checks.
+
+Values are never read into CheckResult.message/detail — only set/unset state
+is reported, so this category is safe to print and to emit as JSON.
+"""
+
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+from isvctl.doctor.result import CategoryReport, CheckResult, Status
+
+
+class Requirement(StrEnum):
+    """How strictly an env var is needed."""
+
+    REQUIRED = "required"  # missing → FAIL
+    RECOMMENDED = "recommended"  # missing → WARN
+    OPTIONAL = "optional"  # missing → SKIP (informational only)
+
+
+@dataclass(frozen=True)
+class _Var:
+    """One environment variable to check."""
+
+    name: str
+    group: str
+    requirement: Requirement
+    hint: str
+
+
+# Variable table — single source of truth for which env vars `doctor` knows
+# about and how it classifies them. Keep grouped for stable rendering order.
+_VARS: tuple[_Var, ...] = (
+    # ISV Lab Service
+    _Var(
+        "ISV_SERVICE_ENDPOINT",
+        "ISV Lab Service",
+        Requirement.RECOMMENDED,
+        "needed to upload results to ISV Lab Service",
+    ),
+    _Var(
+        "ISV_SSA_ISSUER",
+        "ISV Lab Service",
+        Requirement.RECOMMENDED,
+        "needed for SSA auth against ISV Lab Service",
+    ),
+    _Var(
+        "ISV_CLIENT_ID",
+        "ISV Lab Service",
+        Requirement.RECOMMENDED,
+        "needed to authenticate result uploads",
+    ),
+    _Var(
+        "ISV_CLIENT_SECRET",
+        "ISV Lab Service",
+        Requirement.RECOMMENDED,
+        "needed to authenticate result uploads",
+    ),
+    # NGC
+    _Var(
+        "NGC_API_KEY",
+        "NGC",
+        Requirement.RECOMMENDED,
+        "needed for NIM workloads and the NGC container registry",
+    ),
+    _Var(
+        "NGC_NIM_API_KEY",
+        "NGC",
+        Requirement.OPTIONAL,
+        "alternative to NGC_API_KEY for NIM workloads",
+    ),
+    # AWS — informational only. Static keys are just one of several credential
+    # sources boto3 accepts; `--provider aws` runs `_check_aws_provider` which
+    # validates the whole chain instead of demanding these specific vars.
+    _Var(
+        "AWS_ACCESS_KEY_ID",
+        "AWS",
+        Requirement.OPTIONAL,
+        "one way to supply AWS credentials (see also AWS_PROFILE / SSO)",
+    ),
+    _Var(
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS",
+        Requirement.OPTIONAL,
+        "one way to supply AWS credentials (see also AWS_PROFILE / SSO)",
+    ),
+    _Var(
+        "AWS_REGION",
+        "AWS",
+        Requirement.OPTIONAL,
+        "AWS region; may also come from AWS_DEFAULT_REGION or ~/.aws/config",
+    ),
+    # Flags — informational only.
+    _Var(
+        "KUBECTL",
+        "Flags",
+        Requirement.OPTIONAL,
+        "override the kubectl command (POSIX shlex split)",
+    ),
+    _Var(
+        "ISVCTL_DEMO_MODE",
+        "Flags",
+        Requirement.OPTIONAL,
+        "set to '1' to use my-isv demo stubs",
+    ),
+    _Var(
+        "ISVTEST_INCLUDE_UNRELEASED",
+        "Flags",
+        Requirement.OPTIONAL,
+        "include unreleased validations",
+    ),
+    _Var(
+        "AWS_SKIP_TEARDOWN",
+        "Flags",
+        Requirement.OPTIONAL,
+        "skip AWS teardown phase",
+    ),
+)
+
+
+def _status_for(requirement: Requirement, present: bool) -> Status:
+    """Map (requirement, presence) to a Status."""
+    if present:
+        return Status.OK
+    match requirement:
+        case Requirement.REQUIRED:
+            return Status.FAIL
+        case Requirement.RECOMMENDED:
+            return Status.WARN
+        case Requirement.OPTIONAL:
+            return Status.SKIP
+
+
+def _aws_credentials_present() -> bool:
+    """Mirror boto3's credential chain closely enough to avoid false failures.
+
+    boto3 accepts static keys, a named profile, web-identity/assume-role, or a
+    shared credentials/config file (which also backs SSO sessions). We only
+    check that *a* source is configured — never that it is valid.
+    """
+    if os.environ.get("AWS_ACCESS_KEY_ID") and os.environ.get("AWS_SECRET_ACCESS_KEY"):
+        return True
+    if os.environ.get("AWS_PROFILE"):
+        return True
+    if os.environ.get("AWS_ROLE_ARN") and os.environ.get("AWS_WEB_IDENTITY_TOKEN_FILE"):
+        return True
+    aws_dir = Path.home() / ".aws"
+    return (aws_dir / "credentials").is_file() or (aws_dir / "config").is_file()
+
+
+def _aws_region_present() -> bool:
+    """AWS scripts need a region; it can come from env or a shared config file."""
+    if os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION"):
+        return True
+    return (Path.home() / ".aws" / "config").is_file()
+
+
+def _check_aws_provider() -> list[CheckResult]:
+    """AWS readiness, modeled on boto3's credential resolution.
+
+    Replaces a naive "static keys must be set" rule that would falsely FAIL for
+    users authenticated via AWS_PROFILE, SSO, or an instance/role credential.
+    """
+    creds_ok = _aws_credentials_present()
+    region_ok = _aws_region_present()
+    return [
+        CheckResult(
+            name="AWS credentials",
+            status=Status.OK if creds_ok else Status.FAIL,
+            message="resolved" if creds_ok else "no credential source found",
+            remediation=None
+            if creds_ok
+            else "export AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, set AWS_PROFILE, "
+            "or run `aws configure` / `aws sso login`",
+            group="AWS",
+        ),
+        CheckResult(
+            name="AWS region",
+            status=Status.OK if region_ok else Status.FAIL,
+            message="resolved" if region_ok else "no region configured",
+            remediation=None
+            if region_ok
+            else "export AWS_REGION (or AWS_DEFAULT_REGION), or set `region` in ~/.aws/config",
+            group="AWS",
+        ),
+    ]
+
+
+# Provider-conditional readiness checks. A selected provider gets a real
+# capability check (credential chain, etc.) appended to the env category.
+_PROVIDER_CHECKS: dict[str, Callable[[], list[CheckResult]]] = {
+    "aws": _check_aws_provider,
+}
+
+
+def check_env(providers: list[str] | None = None) -> CategoryReport:
+    """Run the env category.
+
+    Args:
+        providers: Provider names whose readiness checks (e.g. the AWS
+            credential chain) get appended.
+
+    Returns:
+        CategoryReport. Values are never recorded — only set/unset state.
+    """
+    results: list[CheckResult] = []
+    for var in _VARS:
+        # "set" means exported, even if empty — distinguishing set-but-empty
+        # from truly unset (a bare `bool()` would mis-report `FOO=` as unset).
+        present = os.environ.get(var.name) is not None
+        status = _status_for(var.requirement, present)
+
+        if present:
+            message = "set"
+        elif status == Status.FAIL:
+            message = "unset (required)"
+        elif status == Status.WARN:
+            message = "unset (recommended)"
+        else:
+            message = "unset (optional)"
+
+        results.append(
+            CheckResult(
+                name=var.name,
+                status=status,
+                message=message,
+                remediation=None if present else var.hint,
+                group=var.group,
+            )
+        )
+
+    for prov in providers or []:
+        provider_check = _PROVIDER_CHECKS.get(prov)
+        if provider_check is not None:
+            results.extend(provider_check())
+
+    return CategoryReport(name="env", results=results)

--- a/isvctl/src/isvctl/doctor/checks/tools.py
+++ b/isvctl/src/isvctl/doctor/checks/tools.py
@@ -1,0 +1,242 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""External-tool presence and version checks."""
+
+import importlib.util
+import json
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+import yaml
+from isvtest.core.k8s import get_kubectl_command
+
+from isvctl.doctor.result import CategoryReport, CheckResult, Status
+
+# Providers that, when selected, upgrade their tool from "recommended" to "required".
+# Keys must be real provider directories under `isvctl/configs/providers/` so the
+# tools and config categories agree on what a valid `--provider` is.
+_PROVIDER_TOOLS: dict[str, frozenset[str]] = {
+    "aws": frozenset({"terraform", "aws"}),
+}
+
+
+@dataclass(frozen=True)
+class _Tool:
+    """Describes how to look up and version-probe a single binary."""
+
+    name: str
+    version_args: tuple[str, ...] | None  # None → skip version probe
+    required: bool  # True → missing is FAIL, False → missing is WARN
+
+
+# Always-required toolchain. `pytest` is intentionally absent: isvtest runs it
+# in-process via `pytest.main()`, so it must be importable, not on PATH (see
+# `_check_pytest`).
+_BASE_TOOLS: tuple[_Tool, ...] = (
+    _Tool("python3", ("--version",), required=True),
+    _Tool("uv", ("--version",), required=True),
+)
+
+# Recommended / provider-conditional toolchain — missing is WARN unless a
+# selected provider escalates it. `ssh`/`scp` are only used by `deploy run`
+# (remote transfer), so a local-only `test run` does not need them.
+_OPTIONAL_TOOLS: tuple[_Tool, ...] = (
+    _Tool("ssh", ("-V",), required=False),
+    _Tool("scp", None, required=False),
+    _Tool("terraform", ("-version",), required=False),
+    _Tool("aws", ("--version",), required=False),
+    _Tool("kubectl", ("version", "--client=true", "--output=yaml"), required=False),
+)
+
+
+def _probe_output(executable: str, args: tuple[str, ...]) -> str | None:
+    """Run `<executable> <args>` with a short timeout and return combined output.
+
+    Returns None on any failure — version probes are best-effort and must never
+    raise out of this module.
+    """
+    try:
+        proc = subprocess.run(
+            [executable, *args],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    # Some tools (ssh, terraform) print to stderr.
+    blob = (proc.stdout or "") + (proc.stderr or "")
+    blob = blob.strip()
+    return blob or None
+
+
+def _probe_version(executable: str, args: tuple[str, ...]) -> str | None:
+    """Run `<executable> <args>` with a short timeout and return the first line."""
+    blob = _probe_output(executable, args)
+    if not blob:
+        return None
+    return blob.splitlines()[0]
+
+
+def _kubectl_client_version(output: str) -> str | None:
+    """Extract clientVersion.gitVersion from kubectl JSON/YAML output."""
+    for loader in (json.loads, yaml.safe_load):
+        try:
+            data = loader(output)
+        except (json.JSONDecodeError, yaml.YAMLError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        client_version = data.get("clientVersion")
+        if not isinstance(client_version, dict):
+            continue
+        git_version = client_version.get("gitVersion")
+        if isinstance(git_version, str) and git_version.strip():
+            return git_version.strip()
+    return None
+
+
+def _probe_kubectl_version(executable: str, args: tuple[str, ...]) -> str | None:
+    """Run kubectl's version probe and return the actual client gitVersion."""
+    blob = _probe_output(executable, args)
+    if not blob:
+        return None
+    return _kubectl_client_version(blob) or blob.splitlines()[0]
+
+
+def _kubectl_command() -> list[str]:
+    """Resolve the kubectl invocation the suite would actually use.
+
+    Reuses isvtest's resolver so doctor honors $KUBECTL *and* K8S_PROVIDER
+    (microk8s/k3s/minikube) exactly like a real run — e.g. ["microk8s",
+    "kubectl"]. Falls back to the configured tokens (or bare ["kubectl"]) when
+    resolution raises, so the caller's `shutil.which` still reports it missing.
+
+    The resolver logs its decision at INFO; we silence it here so the report
+    (which may be machine-read JSON on stdout) is never polluted.
+    """
+    resolver_log = logging.getLogger("isvtest.core.k8s")
+    previous_level = resolver_log.level
+    resolver_log.setLevel(logging.WARNING)
+    try:
+        return get_kubectl_command()
+    except (FileNotFoundError, ValueError):
+        override = (os.environ.get("KUBECTL") or "").strip()
+        if override:
+            try:
+                tokens = shlex.split(override, posix=True)
+            except ValueError:
+                tokens = []
+            if tokens:
+                return tokens
+        return ["kubectl"]
+    finally:
+        resolver_log.setLevel(previous_level)
+
+
+def _check_pytest() -> CheckResult:
+    """Verify pytest is importable.
+
+    isvtest runs pytest in-process via ``pytest.main()`` (see isvtest.main), so
+    it must be an importable module — not necessarily a binary on PATH.
+    """
+    if importlib.util.find_spec("pytest") is None:
+        return CheckResult(
+            name="pytest",
+            status=Status.FAIL,
+            message="not importable",
+            remediation="install pytest (a workspace dependency); run `uv sync`",
+        )
+    try:
+        version: str | None = _pkg_version("pytest")
+    except PackageNotFoundError:
+        version = None
+    return CheckResult(
+        name="pytest",
+        status=Status.OK,
+        message=version or "importable",
+        detail=f"version: {version}" if version else None,
+    )
+
+
+def _check_one(tool: _Tool, *, escalate_to_required: bool) -> CheckResult:
+    """Look up one binary and produce a CheckResult.
+
+    `escalate_to_required` overrides `tool.required` for provider-conditional
+    tools when the user selected a provider that needs them.
+    """
+    if tool.name == "kubectl":
+        command = _kubectl_command()
+        executable = command[0]
+        prefix: tuple[str, ...] = tuple(command[1:])
+    else:
+        executable = tool.name
+        prefix = ()
+    resolved = shutil.which(executable)
+
+    if resolved is None:
+        status = Status.FAIL if (tool.required or escalate_to_required) else Status.WARN
+        msg = f"not found in PATH (looked for '{executable}')"
+        hint = (
+            f"install {executable}"
+            if tool.required or escalate_to_required
+            else f"install {executable} if you need it for this workflow"
+        )
+        return CheckResult(name=tool.name, status=status, message=msg, remediation=hint)
+
+    version: str | None = None
+    if tool.version_args is not None:
+        probe_args = (*prefix, *tool.version_args)
+        if tool.name == "kubectl":
+            version = _probe_kubectl_version(executable, probe_args)
+        else:
+            version = _probe_version(executable, probe_args)
+
+    detail = f"path: {resolved}" + (f"\nversion: {version}" if version else "")
+    summary = version or "found"
+    return CheckResult(name=tool.name, status=Status.OK, message=summary, detail=detail)
+
+
+def check_tools(providers: list[str] | None = None) -> CategoryReport:
+    """Run the tools category.
+
+    Args:
+        providers: Provider names (e.g. ["aws"]) that escalate optional tools
+            to required. None / empty → all optional tools stay recommended.
+
+    Returns:
+        CategoryReport with one CheckResult per probed tool.
+    """
+    selected = set(providers or [])
+    escalations: set[str] = set()
+    for prov in selected:
+        escalations |= _PROVIDER_TOOLS.get(prov, frozenset())
+
+    results: list[CheckResult] = []
+    for tool in _BASE_TOOLS:
+        results.append(_check_one(tool, escalate_to_required=False))
+    results.append(_check_pytest())
+    for tool in _OPTIONAL_TOOLS:
+        results.append(_check_one(tool, escalate_to_required=tool.name in escalations))
+
+    return CategoryReport(name="tools", results=results)

--- a/isvctl/src/isvctl/doctor/report.py
+++ b/isvctl/src/isvctl/doctor/report.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Renderers for doctor reports.
+
+Two output modes:
+
+- ``render_rich``: grouped, colored, human-readable summary for terminals.
+- ``render_json``: stable JSON contract for CI consumers.
+"""
+
+import json
+from typing import Any
+
+from rich.console import Console
+
+from isvctl.doctor.result import CategoryReport, CheckResult, Status, worst
+
+_GLYPHS: dict[Status, str] = {
+    Status.OK: "[✓]",
+    Status.WARN: "[⚠]",
+    Status.FAIL: "[✗]",
+    Status.SKIP: "[-]",
+}
+
+_STYLES: dict[Status, str] = {
+    Status.OK: "green",
+    Status.WARN: "yellow",
+    Status.FAIL: "red",
+    Status.SKIP: "dim",
+}
+
+
+def _glyph(status: Status) -> str:
+    """Render a status glyph with Rich markup."""
+    return f"[{_STYLES[status]}]{_GLYPHS[status]}[/{_STYLES[status]}]"
+
+
+def _aggregate_counts(reports: list[CategoryReport]) -> dict[Status, int]:
+    """Sum per-status counts across all reports (single source of truth)."""
+    counts: dict[Status, int] = {s: 0 for s in Status}
+    for report in reports:
+        for status, n in report.counts().items():
+            counts[status] += n
+    return counts
+
+
+def render_rich(
+    reports: list[CategoryReport],
+    *,
+    isvctl_version: str,
+    verbose: bool = False,
+    console: Console | None = None,
+) -> None:
+    """Print a grouped, colored summary to the console."""
+    out = console or Console()
+    overall = worst([r.worst_status for r in reports])
+
+    out.print(
+        f"[bold]isvctl doctor[/bold] {isvctl_version}  —  "
+        f"{len(reports)} categor{'y' if len(reports) == 1 else 'ies'} checked"
+    )
+    out.print()
+
+    for report in reports:
+        header = f"{_glyph(report.worst_status)} [bold]{report.name}[/bold]"
+        out.print(header)
+
+        # Group results by their `group` field, preserving insertion order so
+        # the env category prints "ISV Lab Service" before "NGC" etc.
+        groups: dict[str | None, list[CheckResult]] = {}
+        for r in report.results:
+            groups.setdefault(r.group, []).append(r)
+
+        for group_label, items in groups.items():
+            if group_label:
+                out.print(f"    [dim]{group_label}[/dim]")
+                indent = "      "
+            else:
+                indent = "    "
+            for r in items:
+                line = f"{indent}{_glyph(r.status)} {r.name}"
+                if r.message:
+                    line += f"  {r.message}"
+                out.print(line)
+                if r.remediation and r.status in (Status.FAIL, Status.WARN):
+                    out.print(f"{indent}    [dim]hint:[/dim] {r.remediation}")
+                if verbose and r.detail:
+                    for detail_line in r.detail.splitlines():
+                        out.print(f"{indent}    [dim]{detail_line}[/dim]")
+        out.print()
+
+    counts = _aggregate_counts(reports)
+
+    summary_bits = (
+        f"[green]{counts[Status.OK]} ok[/green]",
+        f"[yellow]{counts[Status.WARN]} warn[/yellow]",
+        f"[red]{counts[Status.FAIL]} fail[/red]",
+        f"[dim]{counts[Status.SKIP]} skip[/dim]",
+    )
+    out.print("Summary: " + ", ".join(summary_bits))
+
+    if overall == Status.FAIL:
+        out.print("[red]Doctor found issues that will block isvctl runs.[/red]")
+    elif overall == Status.WARN:
+        out.print("[yellow]Doctor found warnings; review hints above.[/yellow]")
+    else:
+        out.print("[green]All checks passed.[/green]")
+
+
+def render_json(
+    reports: list[CategoryReport],
+    *,
+    isvctl_version: str,
+    verbose: bool = False,
+) -> str:
+    """Return a stable JSON payload for the report.
+
+    ``detail`` (tool paths, versions) is only emitted when ``verbose`` is set,
+    mirroring ``render_rich`` so a plain ``--json`` run does not leak local
+    filesystem paths; the key is always present (``null`` when withheld).
+
+    Shape (stable contract — do not break without versioning):
+
+        {
+          "isvctl_version": "<version>",
+          "overall_status": "OK|WARN|FAIL|SKIP",
+          "categories": [{
+            "name": "<category>",
+            "status": "<status>",
+            "results": [{
+              "name": "...", "status": "...", "message": "...",
+              "group": "..." | null, "remediation": "..." | null,
+              "detail": "..." | null
+            }],
+          }, ...],
+          "summary": {"ok": N, "warn": N, "fail": N, "skip": N}
+        }
+    """
+    counts = _aggregate_counts(reports)
+    categories: list[dict[str, Any]] = []
+    for report in reports:
+        cat_results: list[dict[str, Any]] = []
+        for r in report.results:
+            cat_results.append(
+                {
+                    "name": r.name,
+                    "status": r.status.value,
+                    "message": r.message,
+                    "group": r.group,
+                    "remediation": r.remediation,
+                    "detail": r.detail if verbose else None,
+                }
+            )
+        categories.append(
+            {
+                "name": report.name,
+                "status": report.worst_status.value,
+                "results": cat_results,
+            }
+        )
+
+    payload = {
+        "isvctl_version": isvctl_version,
+        "overall_status": worst([r.worst_status for r in reports]).value,
+        "categories": categories,
+        "summary": {
+            "ok": counts[Status.OK],
+            "warn": counts[Status.WARN],
+            "fail": counts[Status.FAIL],
+            "skip": counts[Status.SKIP],
+        },
+    }
+    return json.dumps(payload, indent=2)

--- a/isvctl/src/isvctl/doctor/result.py
+++ b/isvctl/src/isvctl/doctor/result.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Result types for doctor checks."""
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class Status(StrEnum):
+    """Status of a single check or a category as a whole."""
+
+    OK = "OK"
+    WARN = "WARN"
+    FAIL = "FAIL"
+    SKIP = "SKIP"
+
+
+# Worst-status ranking: FAIL beats WARN beats OK beats SKIP.
+_RANK: dict[Status, int] = {
+    Status.SKIP: 0,
+    Status.OK: 1,
+    Status.WARN: 2,
+    Status.FAIL: 3,
+}
+
+
+def worst(statuses: list[Status]) -> Status:
+    """Return the worst (most severe) status from a list.
+
+    Empty list collapses to SKIP so an empty category renders neutrally.
+    """
+    if not statuses:
+        return Status.SKIP
+    return max(statuses, key=lambda s: _RANK[s])
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """One row in a category report.
+
+    Attributes:
+        name: short identifier of the thing being checked (e.g. "terraform",
+            "ISV_CLIENT_ID").
+        status: OK / WARN / FAIL / SKIP.
+        message: one-line summary suitable for terminal display.
+        detail: verbose-mode-only extra info (path, version, traceback excerpt).
+        remediation: short user-facing hint on how to fix a FAIL/WARN.
+        group: optional sub-group label for rendering (e.g. "ISV Lab Service").
+    """
+
+    name: str
+    status: Status
+    message: str = ""
+    detail: str | None = None
+    remediation: str | None = None
+    group: str | None = None
+
+
+@dataclass
+class CategoryReport:
+    """A category of related checks (tools, env, configs)."""
+
+    name: str
+    results: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def worst_status(self) -> Status:
+        """Worst status across all results."""
+        return worst([r.status for r in self.results])
+
+    def counts(self) -> dict[Status, int]:
+        """Return per-status counts."""
+        out: dict[Status, int] = {s: 0 for s in Status}
+        for r in self.results:
+            out[r.status] += 1
+        return out

--- a/isvctl/src/isvctl/main.py
+++ b/isvctl/src/isvctl/main.py
@@ -21,7 +21,7 @@ import typer
 from isvreporter.main import app as report_app
 from isvreporter.version import get_version
 
-from isvctl.cli import catalog, clean, deploy, docs, provider, test
+from isvctl.cli import catalog, clean, deploy, docs, doctor, provider, test
 
 app = typer.Typer(
     name="isvctl",
@@ -52,6 +52,7 @@ app.add_typer(catalog.app, name="catalog")
 app.add_typer(clean.app, name="clean")
 app.add_typer(deploy.app, name="deploy")
 app.add_typer(docs.app, name="docs")
+app.add_typer(doctor.app, name="doctor")
 app.add_typer(provider.app, name="provider")
 app.add_typer(test.app, name="test")
 app.add_typer(report_app, name="report")

--- a/isvctl/tests/test_doctor_cli.py
+++ b/isvctl/tests/test_doctor_cli.py
@@ -1,0 +1,332 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the doctor CLI subcommand."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from isvctl.cli.doctor import app
+from isvctl.doctor.checks import env as env_checks
+from isvctl.doctor.checks import tools as tools_checks
+from isvctl.doctor.result import Status, worst
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def all_tools_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub shutil.which so every probed binary "exists" and skip version probes."""
+
+    def fake_which(name: str) -> str:
+        return f"/fake/bin/{name}"
+
+    def fake_probe(executable: str, args: tuple[str, ...]) -> str:
+        return f"{executable} 1.2.3"
+
+    monkeypatch.setattr(tools_checks.shutil, "which", fake_which)
+    monkeypatch.setattr(tools_checks, "_probe_version", fake_probe)
+
+
+@pytest.fixture
+def all_env_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set every env var the doctor knows about so the env category is all-OK."""
+    for var in env_checks._VARS:
+        monkeypatch.setenv(var.name, "x")
+
+
+@pytest.fixture
+def all_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure no known env var is set (independent of the host environment)."""
+    for var in env_checks._VARS:
+        monkeypatch.delenv(var.name, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_help() -> None:
+    """The doctor command should expose its help text."""
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "Pre-flight diagnostics" in result.output
+
+
+def test_doctor_unknown_check_value() -> None:
+    """Unknown --check values should fail with Typer's usage exit code."""
+    result = runner.invoke(app, ["--check", "bogus"])
+    assert result.exit_code == 2
+    assert "unknown --check value" in result.output
+
+
+def test_doctor_all_pass_exits_zero(all_tools_present: None, all_env_set: None) -> None:
+    """A clean doctor run should exit 0 and print the success summary."""
+    result = runner.invoke(app, [])
+    assert result.exit_code == 0, result.output
+    assert "All checks passed." in result.output
+
+
+# ---------------------------------------------------------------------------
+# Failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_missing_required_tool_fails(monkeypatch: pytest.MonkeyPatch, all_env_set: None) -> None:
+    """A missing required base tool (uv) must produce exit 1."""
+
+    def fake_which(name: str) -> str | None:
+        return None if name == "uv" else f"/fake/bin/{name}"
+
+    monkeypatch.setattr(tools_checks.shutil, "which", fake_which)
+    monkeypatch.setattr(tools_checks, "_probe_version", lambda exe, args: f"{exe} x")
+
+    result = runner.invoke(app, ["--check", "tools"])
+    assert result.exit_code == 1
+    assert "uv" in result.output
+    assert "not found in PATH" in result.output
+
+
+def test_doctor_provider_escalates_optional_tool(monkeypatch: pytest.MonkeyPatch, all_env_set: None) -> None:
+    """--provider aws should turn missing terraform from WARN to FAIL."""
+
+    def fake_which(name: str) -> str | None:
+        return None if name == "terraform" else f"/fake/bin/{name}"
+
+    monkeypatch.setattr(tools_checks.shutil, "which", fake_which)
+    monkeypatch.setattr(tools_checks, "_probe_version", lambda exe, args: f"{exe} x")
+
+    # Without --provider, only WARN → exit 0.
+    result = runner.invoke(app, ["--check", "tools"])
+    assert result.exit_code == 0
+    # With --provider aws, terraform becomes required → exit 1.
+    result = runner.invoke(app, ["--check", "tools", "--provider", "aws"])
+    assert result.exit_code == 1
+
+
+def test_doctor_aws_provider_no_credentials_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, all_tools_present: None, all_env_unset: None
+) -> None:
+    """--provider aws fails when no credential source (env, profile, or files) exists."""
+    for var in (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_PROFILE",
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "AWS_ROLE_ARN",
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    # Point home at an empty dir so ~/.aws/{credentials,config} are absent.
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = runner.invoke(app, ["--check", "env", "--provider", "aws"])
+    assert result.exit_code == 1
+    assert "AWS credentials" in result.output
+
+
+def test_doctor_aws_provider_accepts_profile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, all_tools_present: None, all_env_unset: None
+) -> None:
+    """AWS_PROFILE (no static keys) must satisfy the credential check — no false FAIL."""
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("AWS_PROFILE", "dev")
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+    result = runner.invoke(app, ["--check", "env", "--provider", "aws"])
+    assert result.exit_code == 0, result.output
+    assert "AWS credentials" in result.output
+
+
+def test_doctor_strict_flips_warnings_to_failure(all_tools_present: None, all_env_unset: None) -> None:
+    """Without --strict, recommended-but-missing env vars only WARN."""
+    result = runner.invoke(app, ["--check", "env"])
+    assert result.exit_code == 0
+    result = runner.invoke(app, ["--check", "env", "--strict"])
+    assert result.exit_code == 1
+
+
+def test_doctor_required_env_var_reports_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing required env vars should say required, not optional."""
+    name = "ISVCTL_REQUIRED_FOR_TEST"
+    monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(
+        env_checks,
+        "_VARS",
+        (
+            env_checks._Var(
+                name=name,
+                group="Test",
+                requirement=env_checks.Requirement.REQUIRED,
+                hint="set it",
+            ),
+        ),
+    )
+
+    report = env_checks.check_env()
+
+    assert report.results[0].status == Status.FAIL
+    assert report.results[0].message == "unset (required)"
+
+
+# ---------------------------------------------------------------------------
+# Category filtering
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_check_filter_runs_only_requested(all_tools_present: None, all_env_set: None) -> None:
+    """--check should render only the selected category."""
+    result = runner.invoke(app, ["--check", "env"])
+    assert result.exit_code == 0
+    assert "1 category checked" in result.output
+    # The tools and config categories should not have been rendered.
+    assert "[✓] tools" not in result.output
+    assert "[✓] config" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# JSON output contract
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_json_shape(all_tools_present: None, all_env_set: None) -> None:
+    """JSON output should expose the stable top-level doctor contract."""
+    result = runner.invoke(app, ["--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["overall_status"] == "OK"
+    assert {c["name"] for c in payload["categories"]} == {"tools", "env", "config"}
+    summary = payload["summary"]
+    assert set(summary) == {"ok", "warn", "fail", "skip"}
+    assert sum(summary.values()) > 0
+
+
+def test_doctor_json_does_not_leak_env_values(monkeypatch: pytest.MonkeyPatch, all_tools_present: None) -> None:
+    """Env values are sensitive — JSON output must only report set/unset state."""
+    secret = "super-secret-token-1234567890"
+    monkeypatch.setenv("ISV_CLIENT_SECRET", secret)
+    monkeypatch.setenv("NGC_API_KEY", secret)
+
+    result = runner.invoke(app, ["--check", "env", "--json"])
+    assert result.exit_code == 0
+    assert secret not in result.output
+
+
+def test_doctor_json_detail_gated_by_verbose(all_tools_present: None, all_env_set: None) -> None:
+    """Tool paths (in `detail`) must only appear in JSON when --verbose is set."""
+    plain = runner.invoke(app, ["--check", "tools", "--json"])
+    assert plain.exit_code == 0, plain.output
+    for result in json.loads(plain.output)["categories"][0]["results"]:
+        assert result["detail"] is None
+
+    verbose = runner.invoke(app, ["--check", "tools", "--json", "--verbose"])
+    assert verbose.exit_code == 0, verbose.output
+    details = [r["detail"] for r in json.loads(verbose.output)["categories"][0]["results"]]
+    assert any(d and "/fake/bin/" in d for d in details)
+
+
+# ---------------------------------------------------------------------------
+# Config validation path
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_validates_real_provider_config(all_tools_present: None, all_env_set: None) -> None:
+    """The shipped aws reference config must parse cleanly under the merger + schema."""
+    repo_root = Path(__file__).resolve().parents[2]
+    cfg = repo_root / "isvctl" / "configs" / "providers" / "aws" / "config" / "control-plane.yaml"
+    assert cfg.exists(), f"fixture config missing: {cfg}"
+
+    result = runner.invoke(app, ["--check", "config", "-f", str(cfg)])
+    assert result.exit_code == 0, result.output
+    assert "merged and validated" in result.output
+
+
+def test_doctor_reports_invalid_yaml(tmp_path: Path, all_tools_present: None, all_env_set: None) -> None:
+    """A broken YAML payload should produce a FAIL row and exit 1."""
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("commands: [\n  not-closed\n")
+
+    result = runner.invoke(app, ["--check", "config", "-f", str(bad)])
+    assert result.exit_code == 1
+    assert "merge failed" in result.output or "schema validation failed" in result.output
+
+
+def test_doctor_unknown_provider_directory_fails(all_tools_present: None, all_env_set: None) -> None:
+    """--provider <name> with no on-disk scripts/ directory must surface as FAIL."""
+    result = runner.invoke(app, ["--check", "config", "--provider", "no-such-provider"])
+    assert result.exit_code == 1
+    assert "no-such-provider" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_status_worst_priority() -> None:
+    """The aggregate status priority should prefer blocking failures."""
+    assert worst([Status.OK, Status.WARN, Status.SKIP]) == Status.WARN
+    assert worst([Status.OK, Status.FAIL, Status.WARN]) == Status.FAIL
+    assert worst([Status.SKIP, Status.OK]) == Status.OK
+    assert worst([]) == Status.SKIP
+
+
+def test_check_tools_returns_category_report() -> None:
+    """Smoke: with shutil.which fully patched, every tool resolves OK."""
+    with (
+        patch.object(tools_checks.shutil, "which", lambda name: f"/fake/{name}"),
+        patch.object(tools_checks, "_probe_version", lambda exe, args: "1.0"),
+    ):
+        report = tools_checks.check_tools()
+    assert report.name == "tools"
+    assert report.worst_status == Status.OK
+    assert all(r.status == Status.OK for r in report.results)
+
+
+def test_check_tools_reports_kubectl_client_git_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    """kubectl structured output should render the actual client version."""
+
+    def fake_run(*args, **kwargs):
+        return tools_checks.subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout='clientVersion:\n  gitVersion: "v1.36.0"\nkustomizeVersion: v5.8.1\n',
+            stderr="",
+        )
+
+    monkeypatch.setattr(tools_checks.shutil, "which", lambda name: f"/fake/bin/{name}")
+    monkeypatch.setattr(tools_checks, "_kubectl_command", lambda: ["kubectl"])
+    monkeypatch.setattr(tools_checks.subprocess, "run", fake_run)
+
+    report = tools_checks.check_tools()
+    kubectl = next(result for result in report.results if result.name == "kubectl")
+
+    assert kubectl.status == Status.OK
+    assert kubectl.message == "v1.36.0"
+    assert kubectl.detail is not None
+    assert "version: v1.36.0" in kubectl.detail


### PR DESCRIPTION
## Summary

- Add `isvctl doctor` for pre-flight diagnostics across local tools, environment variables, and merged run configs before a real `isvctl test run`.
- Add provider-aware doctor checks plus text/JSON reporting, severity aggregation, `--strict`, `--check`, and verbose path/version detail without exposing environment values.
- Document the command in the getting-started and isvctl docs, with CLI coverage for output shape, provider behavior, config validation, and exit codes.

## Verification

- [x] `make test`
- [x] `make lint`
- [x] `make demo-test`
- [x] `uvx pre-commit run -a`
- [x] `git diff --check origin/main...HEAD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added isvctl doctor subcommand for pre‑flight diagnostics: checks required tools, environment, and configs; supports provider‑specific checks, multiple -f configs, JSON output, verbose detail, and --strict to treat warnings as failures.

* **Documentation**
  * Updated Quick Start and getting‑started docs to include running the pre‑flight doctor step before validation.

* **Tests**
  * Added comprehensive test suite covering CLI flags, JSON shape, provider behaviors, strict mode, and config validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/ISV-NCP-Validation-Suite/pull/440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->