### PR TITLE
refactor(cli): send diagnostics to stderr, reserve stdout for output

### DIFF
--- a/isvctl/src/isvctl/cli/catalog.py
+++ b/isvctl/src/isvctl/cli/catalog.py
@@ -29,7 +29,7 @@ from rich.console import Console
 from rich.table import Table
 
 from isvctl.cli import setup_logging
-from isvctl.cli.common import get_output_dir
+from isvctl.cli.common import get_output_dir, print_error, print_progress
 
 logger = logging.getLogger(__name__)
 
@@ -123,36 +123,30 @@ def push(
     """
     setup_logging(verbose)
 
-    typer.echo("Building test catalog...")
+    print_progress("Building test catalog...")
     catalog_entries = build_catalog()
     catalog_version = get_catalog_version()
-    typer.echo(f"  {len(catalog_entries)} tests (version: {catalog_version})")
+    print_progress(f"  {len(catalog_entries)} tests (version: {catalog_version})")
 
     output_dir = get_output_dir()
     catalog_path = output_dir / "test_catalog.json"
     catalog_path.write_text(json.dumps({"isvTestVersion": catalog_version, "entries": catalog_entries}, indent=2))
-    typer.echo(f"  Saved to: {catalog_path}")
+    print_progress(f"  Saved to: {catalog_path}")
 
     if no_upload:
-        typer.echo("Skipping upload (--no-upload)")
+        print_progress("Skipping upload (--no-upload)")
         return
 
     from isvctl.reporting import check_upload_credentials, get_environment_config
 
     can_upload, client_id, client_secret = check_upload_credentials()
     if not can_upload or not client_id or not client_secret:
-        typer.echo(
-            typer.style("Error:", fg=typer.colors.RED) + " ISV_CLIENT_ID and/or ISV_CLIENT_SECRET not set",
-            err=True,
-        )
+        print_error("ISV_CLIENT_ID and/or ISV_CLIENT_SECRET not set")
         raise typer.Exit(1)
 
     endpoint, ssa_issuer = get_environment_config()
     if not endpoint or not ssa_issuer:
-        typer.echo(
-            typer.style("Error:", fg=typer.colors.RED) + " ISV_SERVICE_ENDPOINT and/or ISV_SSA_ISSUER not set",
-            err=True,
-        )
+        print_error("ISV_SERVICE_ENDPOINT and/or ISV_SSA_ISSUER not set")
         raise typer.Exit(1)
 
     from isvreporter.auth import get_jwt_token
@@ -165,7 +159,7 @@ def push(
         isv_test_version=catalog_version,
         entries=catalog_entries,
     ):
-        typer.echo(typer.style("[OK]", fg=typer.colors.GREEN) + " Catalog push complete")
+        print_progress(typer.style("[OK]", fg=typer.colors.GREEN) + " Catalog push complete")
     else:
-        typer.echo(typer.style("[FAIL]", fg=typer.colors.RED) + " Catalog upload failed")
+        print_error("Catalog upload failed")
         raise typer.Exit(1)

--- a/isvctl/src/isvctl/cli/clean.py
+++ b/isvctl/src/isvctl/cli/clean.py
@@ -27,6 +27,7 @@ import typer
 from isvctl.cleaner.operations import OPERATIONS
 from isvctl.cleaner.runner import OperationRunner
 from isvctl.cli import setup_logging
+from isvctl.cli.common import print_error, print_progress
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +113,7 @@ def run(
     try:
         operations_to_run = _validate_operations(operations)
     except typer.BadParameter as e:
-        typer.echo(f"Error: {e}", err=True)
+        print_error(str(e))
         raise typer.Exit(code=1)
 
     # Create runner instance
@@ -123,7 +124,7 @@ def run(
     )
 
     # Execute operations
-    typer.echo("Starting NVIDIA ISV Lab clean-up operations...")
+    print_progress("Starting NVIDIA ISV Lab clean-up operations...")
     results = runner.run_operations(operations_to_run)
 
     # Report results

--- a/isvctl/src/isvctl/cli/common.py
+++ b/isvctl/src/isvctl/cli/common.py
@@ -17,7 +17,34 @@
 
 from pathlib import Path
 
+import typer
+from rich.console import Console
+
 OUTPUT_DIR_NAME = "_output"
+
+# Rich console for DIAGNOSTIC output (warnings/errors rendered with rich markup).
+# Primary data tables/markdown keep using a plain Console() at the call site.
+err_console = Console(stderr=True)
+
+
+def print_error(message: str) -> None:
+    """Write a standardized error message to stderr."""
+    typer.echo(typer.style("Error:", fg=typer.colors.RED) + f" {message}", err=True)
+
+
+def print_warning(message: str) -> None:
+    """Write a standardized warning message to stderr."""
+    typer.echo(typer.style("Warning:", fg=typer.colors.YELLOW) + f" {message}", err=True)
+
+
+def print_progress(message: str) -> None:
+    """Write a progress/status line to stderr (no prefix)."""
+    typer.echo(message, err=True)
+
+
+def print_step(message: str) -> None:
+    """Write a progress step with the '==>' marker to stderr."""
+    typer.echo(typer.style("==>", fg=typer.colors.GREEN) + f" {message}", err=True)
 
 
 def get_output_dir(root: Path | None = None) -> Path:

--- a/isvctl/src/isvctl/cli/deploy.py
+++ b/isvctl/src/isvctl/cli/deploy.py
@@ -31,7 +31,7 @@ from isvreporter.config import get_endpoint, get_ssa_issuer
 from isvreporter.platform import get_platform_from_config
 
 from isvctl.cli import setup_logging
-from isvctl.cli.common import get_output_dir
+from isvctl.cli.common import get_output_dir, print_error, print_progress, print_step, print_warning
 from isvctl.orchestrator.loop import Phase
 from isvctl.remote import SCPTransfer, SSHClient, TarArchive
 from isvctl.remote.archive import DEFAULT_EXCLUDES as DEFAULT_ARCHIVE_EXCLUDES
@@ -115,21 +115,21 @@ def _print_configuration(
     upload_results: bool,
 ) -> None:
     """Print deployment configuration summary."""
-    typer.echo("=========================================")
-    typer.echo("Deployment Configuration")
-    typer.echo("=========================================")
-    typer.echo(f"Remote IP:        {remote_ip}")
-    typer.echo(f"SSH Port:         {port}")
+    print_progress("=========================================")
+    print_progress("Deployment Configuration")
+    print_progress("=========================================")
+    print_progress(f"Remote IP:        {remote_ip}")
+    print_progress(f"SSH Port:         {port}")
     if jumphost:
-        typer.echo(f"Jumphost:         {jumphost}")
-    typer.echo(f"Remote User:      {user}")
-    typer.echo(f"Remote Directory: {remote_dir}")
-    typer.echo(f"Config Files:     {' '.join(configs)}")
-    typer.echo(f"Phase:            {phase.value}")
-    typer.echo(f"Environment:      {environment}")
-    typer.echo(f"Upload Results:   {upload_results}")
-    typer.echo("=========================================")
-    typer.echo("")
+        print_progress(f"Jumphost:         {jumphost}")
+    print_progress(f"Remote User:      {user}")
+    print_progress(f"Remote Directory: {remote_dir}")
+    print_progress(f"Config Files:     {' '.join(configs)}")
+    print_progress(f"Phase:            {phase.value}")
+    print_progress(f"Environment:      {environment}")
+    print_progress(f"Upload Results:   {upload_results}")
+    print_progress("=========================================")
+    print_progress("")
 
 
 @app.command("run", context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
@@ -265,7 +265,7 @@ def run(
     try:
         configs = _resolve_config_paths(config_files, working_dir)
     except typer.BadParameter as e:
-        typer.echo(typer.style("Error:", fg=typer.colors.RED) + f" {e}", err=True)
+        print_error(str(e))
         raise typer.Exit(code=1)
 
     # Environment configuration
@@ -275,20 +275,13 @@ def run(
     upload_results = not no_upload
     if upload_results:
         if not lab_id:
-            typer.echo(
-                typer.style("Warning:", fg=typer.colors.YELLOW) + " --lab-id not specified, skipping result upload"
-            )
+            print_warning("--lab-id not specified, skipping result upload")
             upload_results = False
         else:
             can_upload, _, _ = check_upload_credentials()
             if not can_upload:
-                typer.echo(
-                    typer.style("Warning:", fg=typer.colors.YELLOW) + " ISV_CLIENT_ID and/or ISV_CLIENT_SECRET not set"
-                )
-                typer.echo(
-                    typer.style("Warning:", fg=typer.colors.YELLOW)
-                    + " Test results will not be uploaded to ISV Lab Service"
-                )
+                print_warning("ISV_CLIENT_ID and/or ISV_CLIENT_SECRET not set")
+                print_warning("Test results will not be uploaded to ISV Lab Service")
                 upload_results = False
             else:
                 endpoint = get_endpoint()
@@ -299,10 +292,7 @@ def run(
                         missing.append("ISV_SERVICE_ENDPOINT")
                     if not ssa_issuer:
                         missing.append("ISV_SSA_ISSUER")
-                    typer.echo(
-                        typer.style("Warning:", fg=typer.colors.YELLOW)
-                        + f" {', '.join(missing)} not set, skipping result upload"
-                    )
+                    print_warning(f"{', '.join(missing)} not set, skipping result upload")
                     upload_results = False
                 else:
                     os.environ["ISV_SERVICE_ENDPOINT"] = endpoint
@@ -331,7 +321,7 @@ def run(
 
     try:
         # Step 1: Create archive
-        typer.echo(typer.style("==>", fg=typer.colors.GREEN) + f" Creating archive: {archive_name}")
+        print_step(f"Creating archive: {archive_name}")
         archiver = TarArchive(working_dir=working_dir)
 
         archive_paths = list(DEFAULT_ARCHIVE_PATHS)
@@ -343,89 +333,59 @@ def run(
         )
 
         archive_size = archive_path.stat().st_size / (1024 * 1024)
-        typer.echo(
-            typer.style("==>", fg=typer.colors.GREEN) + f" Archive created successfully (size: {archive_size:.1f}MB)"
-        )
+        print_step(f"Archive created successfully (size: {archive_size:.1f}MB)")
 
         # Step 2: Test SSH connection
         if jumphost:
-            typer.echo(
-                typer.style("==>", fg=typer.colors.GREEN)
-                + f" Testing SSH connection to {remote_ip} via jumphost {jumphost}..."
-            )
+            print_step(f"Testing SSH connection to {remote_ip} via jumphost {jumphost}...")
         else:
-            typer.echo(typer.style("==>", fg=typer.colors.GREEN) + f" Testing SSH connection to {remote_ip}...")
+            print_step(f"Testing SSH connection to {remote_ip}...")
 
         conn_result = ssh.test_connection()
         if not conn_result.success:
             if ssh.is_connection_error(conn_result):
-                typer.echo(
-                    typer.style("Error:", fg=typer.colors.RED) + " SSH connection failed",
-                    err=True,
-                )
+                print_error("SSH connection failed")
                 if jumphost:
-                    typer.echo(
-                        f"  Could not connect to {remote_ip} via jumphost {jumphost}",
-                        err=True,
-                    )
-                    typer.echo(
-                        "  Hint: If using certificate-based auth, you may need to refresh your credentials",
-                        err=True,
-                    )
-                    typer.echo(
-                        "        (e.g., re-run your organization's SSH credential/bootstrap command)",
-                        err=True,
-                    )
+                    print_progress(f"  Could not connect to {remote_ip} via jumphost {jumphost}")
+                    print_progress("  Hint: If using certificate-based auth, you may need to refresh your credentials")
+                    print_progress("        (e.g., re-run your organization's SSH credential/bootstrap command)")
                 else:
-                    typer.echo(f"  Could not connect to {remote_ip}", err=True)
+                    print_progress(f"  Could not connect to {remote_ip}")
                 if conn_result.stderr:
-                    typer.echo(f"  Details: {conn_result.stderr.strip()}", err=True)
+                    print_progress(f"  Details: {conn_result.stderr.strip()}")
             else:
-                typer.echo(
-                    typer.style("Error:", fg=typer.colors.RED)
-                    + f" SSH connection test failed (exit code {conn_result.exit_code})",
-                    err=True,
-                )
+                print_error(f"SSH connection test failed (exit code {conn_result.exit_code})")
             raise typer.Exit(code=1)
 
-        typer.echo(typer.style("==>", fg=typer.colors.GREEN) + " SSH connection successful")
+        print_step("SSH connection successful")
 
         # Step 3: Check remote directory and uv installation
-        typer.echo(
-            typer.style("==>", fg=typer.colors.GREEN) + " Ensuring remote directory exists and uv is installed..."
-        )
+        print_step("Ensuring remote directory exists and uv is installed...")
 
         dir_result = ssh.ensure_directory(effective_remote_dir)
         if not dir_result.success:
-            typer.echo(
-                typer.style("Error:", fg=typer.colors.RED) + " Failed to create remote directory",
-                err=True,
-            )
+            print_error("Failed to create remote directory")
             if dir_result.stderr:
-                typer.echo(f"  Details: {dir_result.stderr.strip()}", err=True)
+                print_progress(f"  Details: {dir_result.stderr.strip()}")
             raise typer.Exit(code=1)
 
         if not ssh.check_command_exists("uv"):
-            typer.echo(
-                typer.style("Error:", fg=typer.colors.RED)
-                + " 'uv' is not installed on the remote machine (or not in PATH).",
-                err=True,
-            )
-            typer.echo("Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh")
-            typer.echo("Then ensure ~/.local/bin is in your PATH")
+            print_error("'uv' is not installed on the remote machine (or not in PATH).")
+            print_progress("Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh")
+            print_progress("Then ensure ~/.local/bin is in your PATH")
             raise typer.Exit(code=1)
 
         # Step 3: Upload archive
-        typer.echo(typer.style("==>", fg=typer.colors.GREEN) + " Copying archive to remote machine...")
+        print_step("Copying archive to remote machine...")
         scp.upload(archive_path, f"{effective_remote_dir}/{archive_name}")
-        typer.echo(typer.style("==>", fg=typer.colors.GREEN) + " Archive copied successfully")
+        print_step("Archive copied successfully")
 
         # Step 4: Create test run (if uploading results)
         test_run_id: str | None = None
         start_time = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
         if upload_results and lab_id:
-            typer.echo(typer.style("==>", fg=typer.colors.GREEN) + " Creating test run in isvreporter...")
+            print_step("Creating test run in isvreporter...")
             # Derive platform from first config file
             platform = get_platform_from_config(config_files[0]) if config_files else "kubernetes"
             test_run_id = create_test_run(
@@ -438,16 +398,11 @@ def run(
                 isv_software_version=isv_software_version,
             )
             if not test_run_id:
-                typer.echo(
-                    typer.style("Warning:", fg=typer.colors.YELLOW)
-                    + " Failed to create test run, continuing without upload"
-                )
+                print_warning("Failed to create test run, continuing without upload")
                 upload_results = False
 
         # Step 5: Run tests on remote
-        typer.echo(
-            typer.style("==>", fg=typer.colors.GREEN) + " Extracting archive and running tests on remote machine..."
-        )
+        print_step("Extracting archive and running tests on remote machine...")
 
         # Build config args for isvctl
         config_args = " ".join(f"-f {c}" for c in configs)
@@ -498,33 +453,30 @@ exit ${{TEST_RESULT:-1}}
         result = ssh.execute(remote_script, stream=True)
         test_exit_code = result.exit_code
 
-        typer.echo("")
+        print_progress("")
 
         # Step 6: Download results (always download to working_dir)
-        typer.echo(typer.style("==>", fg=typer.colors.GREEN) + " Copying test results from remote machine...")
+        print_step("Copying test results from remote machine...")
 
         output_dir = get_output_dir(working_dir)
 
         local_log = output_dir / "pytest-output.log"
         if scp.download_optional(f"{effective_remote_dir}/pytest-output.log", local_log):
-            typer.echo(typer.style("==>", fg=typer.colors.GREEN) + f" Test log copied to {local_log}")
+            print_step(f"Test log copied to {local_log}")
         else:
-            typer.echo(typer.style("Warning:", fg=typer.colors.YELLOW) + " Failed to copy test log from remote")
+            print_warning("Failed to copy test log from remote")
 
         # Download JUnit XML
         local_junit: Path | None = output_dir / "junit-validation.xml"
         if scp.download_optional(f"{effective_remote_dir}/junit-validation.xml", local_junit):
-            typer.echo(typer.style("==>", fg=typer.colors.GREEN) + f" JUnit XML copied to {local_junit}")
+            print_step(f"JUnit XML copied to {local_junit}")
         else:
-            typer.echo(
-                typer.style("Warning:", fg=typer.colors.YELLOW)
-                + " Failed to copy JUnit XML from remote (may not exist)"
-            )
+            print_warning("Failed to copy JUnit XML from remote (may not exist)")
             local_junit = None
 
         # Step 7: Upload results to isvreporter (only if upload_results is enabled)
         if upload_results and test_run_id and lab_id:
-            typer.echo(typer.style("==>", fg=typer.colors.GREEN) + " Uploading test results to isvreporter...")
+            print_step("Uploading test results to isvreporter...")
 
             if update_test_run(
                 lab_id=lab_id,
@@ -535,9 +487,9 @@ exit ${{TEST_RESULT:-1}}
                 junit_xml=local_junit if local_junit and local_junit.exists() else None,
                 isv_software_version=isv_software_version,
             ):
-                typer.echo(typer.style("==>", fg=typer.colors.GREEN) + " Test results uploaded successfully")
+                print_step("Test results uploaded successfully")
             else:
-                typer.echo(typer.style("Warning:", fg=typer.colors.YELLOW) + " Failed to upload test results")
+                print_warning("Failed to upload test results")
 
         # Clean up downloaded artifacts (only if --cleanup flag is used)
         if cleanup:
@@ -548,18 +500,18 @@ exit ${{TEST_RESULT:-1}}
 
         # Final status
         if test_exit_code != 0:
-            typer.echo("")
-            typer.echo(typer.style("Error:", fg=typer.colors.RED) + " Remote execution tests failed")
+            print_progress("")
+            print_error("Remote execution tests failed")
             raise typer.Exit(code=1)
 
-        typer.echo("")
-        typer.echo(typer.style("==>", fg=typer.colors.GREEN) + " Deployment and testing completed successfully!")
+        print_progress("")
+        print_step("Deployment and testing completed successfully!")
 
     except ArchiveError as e:
-        typer.echo(typer.style("Error:", fg=typer.colors.RED) + f" Failed to create archive: {e}", err=True)
+        print_error(f"Failed to create archive: {e}")
         raise typer.Exit(code=1)
     except SCPTransferError as e:
-        typer.echo(typer.style("Error:", fg=typer.colors.RED) + f" File transfer failed: {e}", err=True)
+        print_error(f"File transfer failed: {e}")
         raise typer.Exit(code=1)
     finally:
         # Clean up archive

--- a/isvctl/src/isvctl/cli/docs.py
+++ b/isvctl/src/isvctl/cli/docs.py
@@ -30,6 +30,8 @@ from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.table import Table
 
+from isvctl.cli.common import err_console, print_error, print_progress
+
 app = typer.Typer(help="Access ISV NCP Validation Suite documentation")
 
 console = Console()
@@ -108,18 +110,18 @@ def docs(
     local_docs = _find_local_docs()
 
     if not local_docs:
-        typer.echo("Documentation not found.")
-        typer.echo("Run from the install directory or clone the repository.")
+        print_error("Documentation not found.")
+        print_progress("Run from the install directory or clone the repository.")
         raise typer.Exit(1)
 
     if topic:
         if topic not in TOPICS:
-            typer.echo(f"Unknown topic: {topic}")
-            typer.echo(f"Available: {', '.join(TOPICS)}")
+            print_error(f"Unknown topic: {topic}")
+            print_progress(f"Available: {', '.join(TOPICS)}")
             raise typer.Exit(1)
         doc_file = local_docs / TOPICS[topic]
         if not doc_file.exists():
-            typer.echo(f"Topic file not found: {doc_file}")
+            print_error(f"Topic file not found: {doc_file}")
             raise typer.Exit(1)
     else:
         doc_file = local_docs / "README.md"
@@ -173,7 +175,7 @@ def tests(
     all_classes = list(discover_all_tests())
 
     if not all_classes:
-        console.print("[yellow]No validation tests discovered.[/yellow]")
+        err_console.print("[yellow]No validation tests discovered.[/yellow]")
         raise typer.Exit(1)
 
     _warn_duplicates(all_classes)
@@ -197,7 +199,7 @@ def _warn_duplicates(classes: list[type]) -> None:
         seen[cls.__name__] = seen.get(cls.__name__, 0) + 1
     dupes = [name for name, count in seen.items() if count > 1]
     if dupes:
-        console.print(f"[yellow]Warning: Duplicate test class names found: {', '.join(dupes)}[/yellow]")
+        err_console.print(f"[yellow]Warning: Duplicate test class names found: {', '.join(dupes)}[/yellow]")
 
 
 def _print_test_info(classes: list[type], name: str) -> None:
@@ -206,10 +208,10 @@ def _print_test_info(classes: list[type], name: str) -> None:
     cls = by_name.get(name)
 
     if cls is None:
-        console.print(f"[red]Test not found:[/red] {name}")
+        err_console.print(f"[red]Test not found:[/red] {name}")
         close = [c.__name__ for c in classes if name in c.__name__]
         if close:
-            console.print(f"[dim]Did you mean: {', '.join(close)}?[/dim]")
+            err_console.print(f"[dim]Did you mean: {', '.join(close)}?[/dim]")
         raise typer.Exit(1)
 
     source_file = Path(inspect.getfile(cls))
@@ -259,7 +261,7 @@ def _print_grouped(classes: list[type], label_filter: list[str] | None) -> None:
         by_label = {k: v for k, v in by_label.items() if k in label_filter}
 
     if not by_label:
-        console.print("[yellow]No tests found for the given labels.[/yellow]")
+        err_console.print("[yellow]No tests found for the given labels.[/yellow]")
         raise typer.Exit(1)
 
     total = len({cls.__name__ for group in by_label.values() for cls in group})
@@ -353,7 +355,7 @@ def _print_config_instances(classes: list[type], config_path: Path, label_filter
     categories = _extract_config_instances(config_path)
 
     if not categories:
-        console.print("[yellow]No validations found in config file.[/yellow]")
+        err_console.print("[yellow]No validations found in config file.[/yellow]")
         raise typer.Exit(1)
 
     if label_filter:
@@ -370,7 +372,7 @@ def _print_config_instances(classes: list[type], config_path: Path, label_filter
         categories = filtered
 
     if not categories:
-        console.print("[yellow]No test instances match the given labels.[/yellow]")
+        err_console.print("[yellow]No test instances match the given labels.[/yellow]")
         raise typer.Exit(1)
 
     total = sum(len(names) for names in categories.values())
@@ -417,7 +419,7 @@ def _print_flat(classes: list[type], label_filter: list[str] | None) -> None:
         classes = [cls for cls in classes if any(label in get_validation_labels(cls) for label in label_filter)]
 
     if not classes:
-        console.print("[yellow]No tests found for the given labels.[/yellow]")
+        err_console.print("[yellow]No tests found for the given labels.[/yellow]")
         raise typer.Exit(1)
 
     table = Table(

--- a/isvctl/src/isvctl/cli/provider.py
+++ b/isvctl/src/isvctl/cli/provider.py
@@ -24,6 +24,8 @@ from typing import Annotated
 
 import typer
 
+from isvctl.cli.common import print_error, print_progress
+
 app = typer.Typer(
     name="provider",
     help="Manage provider scaffolds",
@@ -264,7 +266,7 @@ def scaffold(
                 if overwrite:
                     _assert_safe_to_overwrite(target_dir, template_dir)
                 else:
-                    typer.echo(f"Note: target exists; --overwrite would be required: {_display_path(target_dir)}")
+                    print_progress(f"Note: target exists; --overwrite would be required: {_display_path(target_dir)}")
             _print_next_steps(target_dir, "Would create")
             return
 
@@ -273,7 +275,7 @@ def scaffold(
 
         _copy_scaffold(template_dir, target_dir, provider_name)
     except (FileExistsError, FileNotFoundError, ValueError) as exc:
-        typer.echo(f"Error: {exc}", err=True)
+        print_error(str(exc))
         raise typer.Exit(code=1) from exc
 
     _print_next_steps(target_dir, "Created")

--- a/isvctl/src/isvctl/cli/test.py
+++ b/isvctl/src/isvctl/cli/test.py
@@ -30,7 +30,13 @@ import yaml
 from isvtest.catalog import build_catalog, get_catalog_version
 
 from isvctl.cli import setup_logging
-from isvctl.cli.common import OUTPUT_DIR_NAME, get_output_dir
+from isvctl.cli.common import (
+    OUTPUT_DIR_NAME,
+    get_output_dir,
+    print_error,
+    print_progress,
+    print_warning,
+)
 from isvctl.config.merger import merge_yaml_files
 from isvctl.config.schema import RunConfig
 from isvctl.orchestrator.loop import Orchestrator, Phase
@@ -195,7 +201,7 @@ def run(
 
     # Validate at least one config file is provided
     if not config_files:
-        typer.echo("Error: At least one --config/-f config file is required.", err=True)
+        print_error("At least one --config/-f config file is required.")
         raise typer.Exit(code=1)
 
     # Collect extra pytest args from context (after --)
@@ -207,7 +213,7 @@ def run(
     try:
         merged_config = merge_yaml_files([str(p) for p in config_files], set_values or [])
     except Exception as e:
-        typer.echo(f"Failed to load configuration: {e}", err=True)
+        print_error(f"Failed to load configuration: {e}")
         raise typer.Exit(code=1)
 
     # Count imports by parsing each file's top-level keys
@@ -225,22 +231,24 @@ def run(
     if import_count:
         parts.append(f"{import_count} import{'s' if import_count > 1 else ''}")
     if parts:
-        typer.echo(f"Loaded configuration ({', '.join(parts)}).")
+        print_progress(f"Loaded configuration ({', '.join(parts)}).")
 
     # Validate against schema
-    typer.echo("Validating configuration...")
+    print_progress("Validating configuration...")
     try:
         config = RunConfig.model_validate(merged_config)
     except Exception as e:
-        typer.echo(f"Configuration validation failed: {e}", err=True)
+        print_error(f"Configuration validation failed: {e}")
         raise typer.Exit(code=1)
 
     if dry_run:
-        typer.echo("\n--- Dry Run: Configuration ---")
+        # Keep stdout as pure JSON so it can be consumed with `json.loads`;
+        # decorative headers and extra args go to stderr.
+        print_progress("\n--- Dry Run: Configuration ---")
         redacted_config = redact_dict(config.model_dump(mode="json"))
         typer.echo(json.dumps(redacted_config, indent=2))
         if extra_pytest_args:
-            typer.echo(f"\n--- Extra pytest args ---\n{extra_pytest_args}")
+            print_progress(f"\n--- Extra pytest args ---\n{extra_pytest_args}")
         return
 
     # Determine which phases to run
@@ -249,7 +257,7 @@ def run(
     else:
         phases = [phase]
 
-    typer.echo(f"\nRunning phases: {[p.value for p in phases]}")
+    print_progress(f"\nRunning phases: {[p.value for p in phases]}")
 
     # Default working directory to first config file's parent (for relative paths in config)
     effective_working_dir = working_dir or config_files[0].parent
@@ -263,18 +271,11 @@ def run(
     if upload_results:
         can_upload, _, _ = check_upload_credentials()
         if not can_upload:
-            typer.echo(
-                typer.style("Warning:", fg=typer.colors.YELLOW) + " ISV_CLIENT_ID and/or ISV_CLIENT_SECRET not set"
-            )
-            typer.echo(
-                typer.style("Warning:", fg=typer.colors.YELLOW)
-                + " Test results will not be uploaded to ISV Lab Service"
-            )
+            print_warning("ISV_CLIENT_ID and/or ISV_CLIENT_SECRET not set")
+            print_warning("Test results will not be uploaded to ISV Lab Service")
             upload_results = False
         elif not lab_id:
-            typer.echo(
-                typer.style("Warning:", fg=typer.colors.YELLOW) + " --lab-id not specified, skipping result upload"
-            )
+            print_warning("--lab-id not specified, skipping result upload")
             upload_results = False
         else:
             endpoint, ssa_issuer = get_environment_config()
@@ -284,15 +285,12 @@ def run(
                     missing.append("ISV_SERVICE_ENDPOINT")
                 if not ssa_issuer:
                     missing.append("ISV_SSA_ISSUER")
-                typer.echo(
-                    typer.style("Warning:", fg=typer.colors.YELLOW)
-                    + f" {', '.join(missing)} not set, skipping result upload"
-                )
+                print_warning(f"{', '.join(missing)} not set, skipping result upload")
                 upload_results = False
 
     # Create test run before running tests
     if upload_results and lab_id:
-        typer.echo("Creating test run in ISV Lab Service...")
+        print_progress("Creating test run in ISV Lab Service...")
         platform = config.tests.platform if config.tests and config.tests.platform else "kubernetes"
         test_run_id = create_test_run(
             lab_id=lab_id,
@@ -302,10 +300,7 @@ def run(
             isv_software_version=isv_software_version,
         )
         if not test_run_id:
-            typer.echo(
-                typer.style("Warning:", fg=typer.colors.YELLOW)
-                + " Failed to create test run, continuing without upload"
-            )
+            print_warning("Failed to create test run, continuing without upload")
             upload_results = False
 
     # Run orchestration with log file capture (tee to _output/pytest-output.log)
@@ -335,12 +330,12 @@ def run(
                 try:
                     catalog_entries = build_catalog()
                     catalog_version = get_catalog_version()
-                    typer.echo(f"Built test catalog: {len(catalog_entries)} tests (version: {catalog_version})")
+                    print_progress(f"Built test catalog: {len(catalog_entries)} tests (version: {catalog_version})")
                     catalog_path = output_dir / "test_catalog.json"
                     catalog_path.write_text(
                         json.dumps({"isvTestVersion": catalog_version, "entries": catalog_entries}, indent=2)
                     )
-                    typer.echo(f"  Saved test catalog to: {catalog_path}")
+                    print_progress(f"  Saved test catalog to: {catalog_path}")
                 except Exception as e:
                     logger.warning("Failed to build test catalog: %s", e)
         finally:
@@ -348,7 +343,7 @@ def run(
 
     # Update test run after tests complete
     if upload_results and test_run_id and lab_id:
-        typer.echo("Uploading test results to ISV Lab Service...")
+        print_progress("Uploading test results to ISV Lab Service...")
         # Look for junit XML in _output, working directory, or current directory
         junit_path = output_dir / "junit-validation.xml"
         if not junit_path.exists():
@@ -367,9 +362,9 @@ def run(
             catalog_entries=catalog_entries,
             catalog_version=catalog_version,
         ):
-            typer.echo(typer.style("[OK]", fg=typer.colors.GREEN) + " Test results uploaded successfully")
+            print_progress(typer.style("[OK]", fg=typer.colors.GREEN) + " Test results uploaded successfully")
         else:
-            typer.echo(typer.style("Warning:", fg=typer.colors.YELLOW) + " Failed to upload test results")
+            print_warning("Failed to upload test results")
 
     # Display results
     typer.echo("\n" + "=" * 60)
@@ -483,14 +478,14 @@ def validate(
     """
     # Validate at least one config file is provided
     if not config_files:
-        typer.echo("Error: At least one --config/-f config file is required.", err=True)
+        print_error("At least one --config/-f config file is required.")
         raise typer.Exit(code=1)
 
-    typer.echo(f"Validating {len(config_files)} configuration file(s)...")
+    print_progress(f"Validating {len(config_files)} configuration file(s)...")
     try:
         merged_config = merge_yaml_files([str(p) for p in config_files], set_values or [])
     except Exception as e:
-        typer.echo(f"Failed to merge configuration files: {e}", err=True)
+        print_error(f"Failed to merge configuration files: {e}")
         raise typer.Exit(code=1)
 
     try:
@@ -503,6 +498,5 @@ def validate(
         if run_config.context:
             typer.echo(f"Context variables: {list(run_config.context.keys())}")
     except Exception as e:
-        err_status = typer.style("[ERROR]", fg=typer.colors.RED)
-        typer.echo(f"{err_status} Validation failed: {e}", err=True)
+        print_error(f"Validation failed: {e}")
         raise typer.Exit(code=1)

--- a/isvctl/tests/test_cli_streams.py
+++ b/isvctl/tests/test_cli_streams.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stream-discipline regression tests for the isvctl CLI.
+
+Diagnostics (progress, warnings, errors) must go to stderr; stdout is reserved
+for primary machine-consumable output. These tests pin that contract using the
+CliRunner's separate ``result.stdout`` / ``result.stderr`` streams (Typer keeps
+the mixed view in ``result.output``, which the older CLI tests rely on).
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+import isvctl.cli.catalog as catalog_cli
+import isvctl.cli.clean as clean_cli
+import isvctl.cli.test as test_cli
+
+runner = CliRunner()
+
+_FAKE_ENTRIES = [
+    {
+        "name": "AlphaCheck",
+        "description": "Alpha description",
+        "labels": ["kubernetes"],
+        "module": "isvtest.validations.alpha",
+        "platforms": ["KUBERNETES"],
+    },
+]
+
+
+def _write_config(tmp_path: Path) -> Path:
+    """Write a minimal, self-contained isvctl test config (no imports)."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+commands:
+  kubernetes:
+    phases: [test]
+    steps:
+      - name: test_step
+        command: echo
+        args: ['{"success": true}']
+        phase: test
+tests:
+  platform: kubernetes
+  validations: {}
+""",
+        encoding="utf-8",
+    )
+    return config
+
+
+def test_dry_run_stdout_is_pure_json(tmp_path: Path) -> None:
+    """`test run --dry-run` emits only JSON on stdout; progress goes to stderr."""
+    config = _write_config(tmp_path)
+
+    result = runner.invoke(test_cli.app, ["run", "-f", str(config), "--no-upload", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    # stdout must be parseable JSON with nothing else mixed in.
+    payload = json.loads(result.stdout)
+    assert payload["tests"]["platform"] == "kubernetes"
+    # Progress lives on stderr, never on the machine-readable stdout stream.
+    assert "Validating configuration" in result.stderr
+    assert "Validating configuration" not in result.stdout
+    assert "--- Dry Run: Configuration ---" not in result.stdout
+
+
+def test_catalog_list_json_stdout_is_pure_json() -> None:
+    """`catalog list --json` keeps stdout free of diagnostics."""
+    with (
+        patch("isvctl.cli.catalog.build_catalog", return_value=_FAKE_ENTRIES),
+        patch("isvctl.cli.catalog.get_catalog_version", return_value="1.2.3"),
+    ):
+        result = runner.invoke(catalog_cli.app, ["list", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["isvTestVersion"] == "1.2.3"
+    assert payload["entries"] == _FAKE_ENTRIES
+
+
+def test_clean_run_unknown_operation_error_on_stderr() -> None:
+    """A bad `clean run` operation reports the error on stderr, leaving stdout clean."""
+    result = runner.invoke(clean_cli.app, ["run", "bogus-op"])
+
+    assert result.exit_code == 1
+    assert "Error:" in result.stderr
+    assert "Unknown operation" in result.stderr
+    # Nothing should be written to stdout for a pure error path.
+    assert result.stdout.strip() == ""

--- a/isvtest/src/isvtest/core/logger.py
+++ b/isvtest/src/isvtest/core/logger.py
@@ -26,7 +26,9 @@ def setup_logger(name: str = "isvtest", level: int = logging.INFO) -> logging.Lo
 
     # Only add handler if logger doesn't have any handlers yet
     if not logger.handlers:
-        handler = logging.StreamHandler(sys.stdout)
+        # Diagnostics go to stderr so stdout stays reserved for primary,
+        # machine-consumable output (e.g. `isvctl catalog list --json`).
+        handler = logging.StreamHandler(sys.stderr)
         handler.setLevel(level)
 
         formatter = logging.Formatter(

--- a/isvtest/tests/test_logger.py
+++ b/isvtest/tests/test_logger.py
@@ -16,6 +16,7 @@
 """Tests for logger module."""
 
 import logging
+import sys
 
 from isvtest.core.logger import setup_logger
 
@@ -67,6 +68,13 @@ class TestSetupLogger:
         # Find the handler added by setup_logger
         stream_handlers = [h for h in logger.handlers if isinstance(h, logging.StreamHandler)]
         assert len(stream_handlers) >= 1
+
+    def test_handler_writes_to_stderr(self) -> None:
+        """Diagnostics must go to stderr, leaving stdout for machine-readable output."""
+        logger = setup_logger("test_logger_stderr")
+        stream_handlers = [h for h in logger.handlers if isinstance(h, logging.StreamHandler)]
+        assert stream_handlers
+        assert stream_handlers[0].stream is sys.stderr
 
     def test_no_duplicate_handlers(self) -> None:
         """Test that calling setup_logger twice doesn't add duplicate handlers."""


### PR DESCRIPTION
## Summary

- Route `isvctl` progress, warnings, and errors through shared stderr helpers so stdout stays reserved for primary command output.
- Preserve stdout contracts for JSON/table/docs/result output, including pure dry-run JSON and catalog JSON without log noise.
- Move the shared `isvtest` logger handler to stderr and add stream-contract coverage for CLI commands and logger setup.

## What This Fixes

This keeps machine-readable stdout clean while moving operator-facing noise to stderr.

Examples:
- `isvctl test run --dry-run --json` now emits parseable JSON on stdout without progress or warning lines mixed in.
- `isvctl catalog list --json` no longer has `isvtest` INFO logs prepended to stdout, so CI can pipe it directly to tools like `jq`.

## Verification

- [x] `make test`
- [x] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified CLI output helpers applied across commands for consistent error, warning, step, and progress messaging; progress/errors now go to stderr while machine-readable output stays on stdout
  * Logger updated to emit diagnostic logs to stderr

* **Tests**
  * Added regression tests to enforce stderr for progress/errors and pure JSON/results on stdout

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/ISV-NCP-Validation-Suite/pull/441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
