### PR TITLE
feat(k8s): create separate CPU and GPU node pools (K8S06)

### DIFF
--- a/isvctl/configs/providers/aws/config/eks.yaml
+++ b/isvctl/configs/providers/aws/config/eks.yaml
@@ -53,9 +53,13 @@ commands:
           TF_VAR_gpu_node_instance_types: '["g5.2xlarge"]'
           TF_VAR_gpu_node_desired_size: "1"
 
-      # Test the Terraform node-pool create path. Runs after the
-      # cluster is up; reads cluster state via terraform_remote_state in the
-      # node-pool module. See ../scripts/eks/terraform-node-pool/README.md.
+      # Exercise the node-pool create path twice to prove separate CPU and GPU
+      # pools can coexist in the same cluster with independent node counts
+      # (K8S06). Each pool keeps its own Terraform state via
+      # NODE_POOL_STATE_FILE so the two node groups don't clobber one another.
+      # Runs after the cluster is up; reads cluster state via
+      # terraform_remote_state in the node-pool module. See
+      # ../scripts/eks/terraform-node-pool/README.md.
       - name: create_test_node_pool
         phase: setup
         command: "../scripts/eks/create_node_pool.sh"
@@ -63,6 +67,7 @@ commands:
         timeout: 900 # 15 min - EKS node group join can take 5-8 min
         env:
           TF_AUTO_APPROVE: "true"
+          NODE_POOL_STATE_FILE: "terraform.tfstate"
           TF_VAR_test_pool_name: "isv-test-pool"
           TF_VAR_test_pool_instance_types: '["m6i.large"]'
           TF_VAR_test_pool_desired_size: "1"
@@ -70,7 +75,26 @@ commands:
           TF_VAR_test_pool_taints_json: '[{"key":"isv.ncp.validation/dedicated","value":"test","effect":"NoSchedule"}]'
           TF_VAR_test_pool_node_type: "cpu"
 
-      # Scale the same pool to a new target count. Re-applies the
+      # The GPU pool: a separate node group with a GPU instance type, its own
+      # state file, and its own node count, created alongside the CPU pool
+      # above. This is the second half of "separate CPU and GPU pools in the
+      # same cluster" - the GPU AMI mirrors the cluster's GPU node group.
+      - name: create_test_gpu_node_pool
+        phase: setup
+        command: "../scripts/eks/create_node_pool.sh"
+        output_schema: node_pool
+        timeout: 900 # 15 min - EKS node group join can take 5-8 min
+        env:
+          TF_AUTO_APPROVE: "true"
+          NODE_POOL_STATE_FILE: "terraform-gpu.tfstate"
+          TF_VAR_test_pool_name: "isv-test-gpu-pool"
+          TF_VAR_test_pool_instance_types: '["g5.2xlarge"]'
+          TF_VAR_test_pool_ami_type: "AL2_x86_64_GPU"
+          TF_VAR_test_pool_desired_size: "1"
+          TF_VAR_test_pool_labels_json: '{"isv.ncp.validation/workload":"gpu-compute"}'
+          TF_VAR_test_pool_node_type: "gpu"
+
+      # Scale the CPU pool to a new target count. Re-applies the
       # terraform-node-pool module with a bumped desired_size; create_node_pool.sh
       # is reused because `terraform apply` is idempotent. The emitted
       # node_pool payload carries the new replica count. This runs in the test
@@ -84,6 +108,7 @@ commands:
         env:
           NODE_POOL_ACTION: "Updating"
           TF_AUTO_APPROVE: "true"
+          NODE_POOL_STATE_FILE: "terraform.tfstate"
           TF_VAR_test_pool_name: "isv-test-pool"
           TF_VAR_test_pool_instance_types: '["m6i.large"]'
           TF_VAR_test_pool_desired_size: "2"
@@ -91,14 +116,24 @@ commands:
           TF_VAR_test_pool_taints_json: '[{"key":"isv.ncp.validation/dedicated","value":"test","effect":"NoSchedule"}]'
           TF_VAR_test_pool_node_type: "cpu"
 
-      # Teardown order: destroy the test node pool before tearing down the
-      # cluster so its ENIs/instances are freed before the VPC comes down.
+      # Teardown order: destroy both test node pools before tearing down the
+      # cluster so their ENIs/instances are freed before the VPC comes down.
+      # Each destroy targets its pool's state file (matching create).
       - name: destroy_test_node_pool
         phase: teardown
         command: "../scripts/eks/destroy_node_pool.sh"
         timeout: 900
         env:
           TF_AUTO_APPROVE: "true"
+          NODE_POOL_STATE_FILE: "terraform.tfstate"
+
+      - name: destroy_test_gpu_node_pool
+        phase: teardown
+        command: "../scripts/eks/destroy_node_pool.sh"
+        timeout: 900
+        env:
+          TF_AUTO_APPROVE: "true"
+          NODE_POOL_STATE_FILE: "terraform-gpu.tfstate"
 
       - name: teardown
         phase: teardown
@@ -114,11 +149,22 @@ tests:
     kubernetes:
       checks:
         K8sNodeCountCheck:
-          # Keep the generic node count scoped to the baseline cluster. The
-          # test phase intentionally scales a temporary CPU node pool before
-          # this check runs; K8sNodePoolCheck validates that pool separately.
+          # Keep the generic node count scoped to the baseline cluster. Setup
+          # adds temporary CPU and GPU test pools (and the test phase scales
+          # the CPU one) before this check runs; K8sNodePoolCheck validates
+          # those pools separately. Every test-pool node carries the stable
+          # `isv.ncp.validation/pool=test` marker, so one selector excludes
+          # both pools at once.
           count: "{{ steps.setup.kubernetes.node_count | default(4, true) }}"
-          exclude_label_selector: "{{ steps.update_test_node_pool.label_selector | default('', true) }}"
+          exclude_label_selector: "isv.ncp.validation/pool=test"
+        K8sGpuPodAccessCheck:
+          # This check probes every current GPU node. The setup phase creates
+          # a temporary g5.2xlarge GPU test pool after baseline inventory is
+          # captured, so include its 1-GPU pod target per replica.
+          total_gpu_count: "{{ (steps.setup.kubernetes.gpu_node_count | default(4, true) | int) + (steps.create_test_gpu_node_pool.expected_replicas | default(0, true) | int) }}"
+        K8sGpuCapacityCheck:
+          # The g5.2xlarge test pool contributes one advertised GPU per node.
+          expected_total: "{{ (steps.setup.kubernetes.total_gpus | default(16, true) | int) + (steps.create_test_gpu_node_pool.expected_replicas | default(0, true) | int) }}"
 
   exclude:
     tests:

--- a/isvctl/configs/providers/aws/scripts/eks/create_node_pool.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/create_node_pool.sh
@@ -24,9 +24,18 @@
 # K8sNodePoolCheck via {{steps.create_test_node_pool.*}} /
 # {{steps.update_test_node_pool.*}} in the suite config.
 #
+# The module manages a single node group per state file, so multiple
+# coexisting pools (e.g. a CPU pool and a GPU pool in the same cluster) are
+# kept independent by pointing each at its own local state via
+# NODE_POOL_STATE_FILE. The default preserves the original single-pool path.
+#
 # Environment variables (all optional):
 #   NODE_POOL_ACTION                  - Banner verb: "Creating" | "Updating"
 #                                       (default "Creating")
+#   NODE_POOL_STATE_FILE              - Local Terraform state filename within
+#                                       terraform-node-pool/ (default
+#                                       "terraform.tfstate"). Use a distinct
+#                                       file per coexisting pool.
 #   TF_AUTO_APPROVE                   - "true" to skip approval (default: false)
 #   TF_VAR_region                     - AWS region (default from cluster state)
 #   TF_VAR_test_pool_name             - Node pool name (default "isv-test-pool")
@@ -47,6 +56,17 @@ set -eo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TF_DIR="${SCRIPT_DIR}/terraform-node-pool"
 CLUSTER_TF_DIR="${SCRIPT_DIR}/terraform"
+STATE_FILE="${NODE_POOL_STATE_FILE:-terraform.tfstate}"
+
+if [[ -z "${STATE_FILE}" ]] \
+    || [[ "${STATE_FILE}" == .* ]] \
+    || [[ "${STATE_FILE}" == *"/"* ]] \
+    || [[ "${STATE_FILE}" == *".."* ]] \
+    || [[ "${STATE_FILE}" == \~* ]] \
+    || [[ ! "${STATE_FILE}" =~ ^[A-Za-z0-9._-]+\.tfstate$ ]]; then
+    echo "Error: NODE_POOL_STATE_FILE must be a local .tfstate filename using only letters, numbers, dots, underscores, and hyphens." >&2
+    exit 1
+fi
 
 if ! command -v terraform &> /dev/null; then
     echo "Error: terraform not found - install from https://terraform.io" >&2
@@ -102,6 +122,7 @@ echo "  desired size: ${DESIRED_SIZE}" >&2
 echo "  ami type: ${AMI_TYPE}" >&2
 echo "  capacity: ${CAPACITY_TYPE}" >&2
 echo "  node type tag: ${NODE_TYPE}" >&2
+echo "  state file: ${STATE_FILE}" >&2
 echo "" >&2
 
 cd "${TF_DIR}"
@@ -119,22 +140,24 @@ export TF_VAR_capacity_type="${CAPACITY_TYPE}"
 export TF_VAR_labels="${LABELS_JSON}"
 export TF_VAR_taints="${TAINTS_JSON}"
 
+# Each pool keeps its own local state file so multiple node groups can coexist
+# in the same cluster without clobbering one another's state.
 TF_AUTO_APPROVE="${TF_AUTO_APPROVE:-false}"
 if [ "${TF_AUTO_APPROVE}" = "true" ]; then
-    terraform apply -auto-approve >&2
+    terraform apply -auto-approve -state="${STATE_FILE}" >&2
 else
-    terraform apply >&2
+    terraform apply -state="${STATE_FILE}" >&2
 fi
 
 # Read what Terraform actually created. expected_taints comes back with
 # Kubernetes effect spelling - the validation compares directly against
 # kubectl, so no further translation is needed.
-TF_OUT_NODE_POOL_NAME=$(terraform output -raw node_pool_name)
-TF_OUT_LABEL_SELECTOR=$(terraform output -raw label_selector)
-TF_OUT_DESIRED_SIZE=$(terraform output -raw desired_size)
-TF_OUT_EXPECTED_LABELS=$(terraform output -json expected_labels)
-TF_OUT_EXPECTED_TAINTS=$(terraform output -json expected_taints)
-TF_OUT_EXPECTED_INSTANCE_TYPES=$(terraform output -json expected_instance_types)
+TF_OUT_NODE_POOL_NAME=$(terraform output -state="${STATE_FILE}" -raw node_pool_name)
+TF_OUT_LABEL_SELECTOR=$(terraform output -state="${STATE_FILE}" -raw label_selector)
+TF_OUT_DESIRED_SIZE=$(terraform output -state="${STATE_FILE}" -raw desired_size)
+TF_OUT_EXPECTED_LABELS=$(terraform output -state="${STATE_FILE}" -json expected_labels)
+TF_OUT_EXPECTED_TAINTS=$(terraform output -state="${STATE_FILE}" -json expected_taints)
+TF_OUT_EXPECTED_INSTANCE_TYPES=$(terraform output -state="${STATE_FILE}" -json expected_instance_types)
 
 cd - > /dev/null
 

--- a/isvctl/configs/providers/aws/scripts/eks/destroy_node_pool.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/destroy_node_pool.sh
@@ -18,15 +18,30 @@
 #
 # Runs `terraform destroy` on the isolated terraform-node-pool state. This
 # runs before the cluster teardown so the node group's ENIs and instances
-# are freed before the VPC comes down.
+# are freed before the VPC comes down. NODE_POOL_STATE_FILE must match the
+# value used at create time so the correct pool is torn down (the create and
+# destroy steps for a given pool share one state file).
 #
 # Environment variables:
-#   TF_AUTO_APPROVE   - "true" to skip confirmation (default: false)
+#   TF_AUTO_APPROVE      - "true" to skip confirmation (default: false)
+#   NODE_POOL_STATE_FILE - Local Terraform state filename within
+#                          terraform-node-pool/ (default "terraform.tfstate").
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TF_DIR="${SCRIPT_DIR}/terraform-node-pool"
+STATE_FILE="${NODE_POOL_STATE_FILE:-terraform.tfstate}"
+
+if [[ -z "${STATE_FILE}" ]] \
+    || [[ "${STATE_FILE}" == .* ]] \
+    || [[ "${STATE_FILE}" == *"/"* ]] \
+    || [[ "${STATE_FILE}" == *".."* ]] \
+    || [[ "${STATE_FILE}" == \~* ]] \
+    || [[ ! "${STATE_FILE}" =~ ^[A-Za-z0-9._-]+\.tfstate$ ]]; then
+    echo "Error: NODE_POOL_STATE_FILE must be a local .tfstate filename using only letters, numbers, dots, underscores, and hyphens." >&2
+    exit 1
+fi
 
 if ! command -v terraform &> /dev/null; then
     echo "Error: terraform not found" >&2
@@ -36,8 +51,8 @@ fi
 # If the module was never applied (e.g. create step failed before
 # `terraform apply`), there is no state to destroy. Report success so the
 # overall teardown phase can proceed to the main cluster destroy.
-if [ ! -f "${TF_DIR}/terraform.tfstate" ]; then
-    echo "No node-pool state found at ${TF_DIR}/terraform.tfstate; nothing to destroy." >&2
+if [ ! -f "${TF_DIR}/${STATE_FILE}" ]; then
+    echo "No node-pool state found at ${TF_DIR}/${STATE_FILE}; nothing to destroy." >&2
     cat << 'EOF'
 {
   "success": true,
@@ -54,6 +69,7 @@ cd "${TF_DIR}"
 echo "" >&2
 echo "========================================" >&2
 echo "  Destroying test node pool" >&2
+echo "  state file: ${STATE_FILE}" >&2
 echo "========================================" >&2
 
 if [ ! -d ".terraform" ]; then
@@ -62,9 +78,9 @@ fi
 
 TF_AUTO_APPROVE="${TF_AUTO_APPROVE:-false}"
 if [ "${TF_AUTO_APPROVE}" = "true" ]; then
-    terraform destroy -auto-approve >&2
+    terraform destroy -auto-approve -state="${STATE_FILE}" >&2
 else
-    terraform destroy >&2
+    terraform destroy -state="${STATE_FILE}" >&2
 fi
 
 cat << 'EOF'

--- a/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/README.md
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform-node-pool/README.md
@@ -9,9 +9,20 @@ not `terraform apply` it by hand.
 
 ## State
 
-Local backend: `terraform.tfstate` in this directory. The main cluster state
-in `../terraform/terraform.tfstate` is read via `terraform_remote_state` but
-never written.
+Local backend: by default `terraform.tfstate` in this directory. The main
+cluster state in `../terraform/terraform.tfstate` is read via
+`terraform_remote_state` but never written.
+
+The module manages exactly one node group per state file. To run **several
+pools side by side** in the same cluster (e.g. a CPU pool and a GPU pool with
+independent node counts, per K8S06), give each pool its own state file via the
+`NODE_POOL_STATE_FILE` env var on `create_node_pool.sh`/`destroy_node_pool.sh`
+(e.g. `terraform.tfstate` for the CPU pool, `terraform-gpu.tfstate` for the
+GPU pool). The scripts pass it through with `terraform apply -state=<file>` /
+`terraform destroy -state=<file>`, so the pools never clobber one another's
+state. See the `create_test_node_pool` / `create_test_gpu_node_pool` steps in
+`../../../config/eks.yaml` for the wiring. A pool's destroy step must use the
+same `NODE_POOL_STATE_FILE` as its create step.
 
 ## Inputs
 

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -66,11 +66,14 @@ tests:
     # string rendering doesn't mangle the structure, and K8sNodePoolCheck
     # json-parses them. The `step` field binds each check to the phase of
     # the operation it validates, so create can be asserted before update
-    # scales the same pool. The check is listed twice - once per operation -
-    # so list form is required (dict form would collide on the class name).
+    # scales the same pool. The check is listed once per operation/pool, so
+    # list form is required (dict form would collide on the class name).
+    # The separate CPU and GPU create checks prove distinct pools, each with
+    # its own instance type and node count, coexist in the same cluster.
     k8s_node_pools:
       - K8sNodePoolCheck:
-          # Create: pool reaches desired replica count.
+          # Create (CPU pool): pool reaches desired replica count with its
+          # specified CPU instance type.
           step: create_test_node_pool
           label_selector: "{{ steps.create_test_node_pool.label_selector }}"
           expected_replicas: "{{ steps.create_test_node_pool.expected_replicas | default(1, true) }}"
@@ -78,6 +81,18 @@ tests:
           expected_taints: "{{ steps.create_test_node_pool.expected_taints_json | default('[]', true) }}"
           expected_instance_types: "{{ steps.create_test_node_pool.expected_instance_types_json | default('[]', true) }}"
           node_type: "{{ steps.create_test_node_pool.node_type | default('cpu') }}"
+          wait_timeout: 900
+          poll_interval: 10
+      - K8sNodePoolCheck:
+          # Create (GPU pool): a separate pool reaches its own node count with
+          # its specified GPU instance type, coexisting with the CPU pool.
+          step: create_test_gpu_node_pool
+          label_selector: "{{ steps.create_test_gpu_node_pool.label_selector }}"
+          expected_replicas: "{{ steps.create_test_gpu_node_pool.expected_replicas | default(1, true) }}"
+          expected_labels: "{{ steps.create_test_gpu_node_pool.expected_labels_json | default('{}', true) }}"
+          expected_taints: "{{ steps.create_test_gpu_node_pool.expected_taints_json | default('[]', true) }}"
+          expected_instance_types: "{{ steps.create_test_gpu_node_pool.expected_instance_types_json | default('[]', true) }}"
+          node_type: "{{ steps.create_test_gpu_node_pool.node_type | default('gpu') }}"
           wait_timeout: 900
           poll_interval: 10
       - K8sNodePoolCheck:

--- a/isvctl/tests/test_aws_eks_node_pool_scripts.py
+++ b/isvctl/tests/test_aws_eks_node_pool_scripts.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for AWS EKS node-pool helper scripts."""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+AWS_EKS_DIR = Path(__file__).resolve().parents[1] / "configs" / "providers" / "aws" / "scripts" / "eks"
+
+
+@pytest.mark.parametrize("script_name", ["create_node_pool.sh", "destroy_node_pool.sh"])
+@pytest.mark.parametrize("state_file", ["../terraform.tfstate", "/tmp/node-pool.tfstate"])
+def test_node_pool_scripts_reject_state_file_paths(script_name: str, state_file: str) -> None:
+    """Node-pool state overrides must stay local to terraform-node-pool/."""
+    env = {**os.environ, "NODE_POOL_STATE_FILE": state_file}
+
+    completed = subprocess.run(
+        ["bash", str(AWS_EKS_DIR / script_name)],
+        capture_output=True,
+        check=False,
+        env=env,
+        text=True,
+    )
+
+    assert completed.returncode == 1
+    assert "NODE_POOL_STATE_FILE must be a local .tfstate filename" in completed.stderr

--- a/isvctl/tests/test_merger.py
+++ b/isvctl/tests/test_merger.py
@@ -501,20 +501,46 @@ class TestImportEndToEnd:
         assert "kubernetes" in validations
         assert "k8s_workloads" in validations
         node_count_check = validations["kubernetes"]["checks"]["K8sNodeCountCheck"]
+        gpu_pod_access_check = validations["kubernetes"]["checks"]["K8sGpuPodAccessCheck"]
+        gpu_capacity_check = validations["kubernetes"]["checks"]["K8sGpuCapacityCheck"]
         node_count = node_count_check["count"]
         exclude_selector = node_count_check["exclude_label_selector"]
-        assert "steps.update_test_node_pool.label_selector" in exclude_selector
+        total_gpu_count = gpu_pod_access_check["total_gpu_count"]
+        expected_total = gpu_capacity_check["expected_total"]
+        # Separate CPU and GPU test pools both carry the stable pool marker, so
+        # the baseline node count excludes them with one static selector.
+        assert exclude_selector == "isv.ncp.validation/pool=test"
+
+        # Separate CPU and GPU node pools are created with independent state
+        # files and instance types (K8S06), each validated by its own check.
+        steps_by_name = {s["name"]: s for s in result["commands"]["kubernetes"]["steps"]}
+        cpu_create = steps_by_name["create_test_node_pool"]["env"]
+        gpu_create = steps_by_name["create_test_gpu_node_pool"]["env"]
+        assert cpu_create["NODE_POOL_STATE_FILE"] != gpu_create["NODE_POOL_STATE_FILE"]
+        assert cpu_create["TF_VAR_test_pool_node_type"] == "cpu"
+        assert gpu_create["TF_VAR_test_pool_node_type"] == "gpu"
+        # The GPU destroy step must target the GPU pool's state file.
+        assert (
+            steps_by_name["destroy_test_gpu_node_pool"]["env"]["NODE_POOL_STATE_FILE"]
+            == gpu_create["NODE_POOL_STATE_FILE"]
+        )
+        node_pool_checks = validations["k8s_node_pools"]
+        checked_steps = {next(iter(entry.values()))["step"] for entry in node_pool_checks}
+        assert {"create_test_node_pool", "create_test_gpu_node_pool", "update_test_node_pool"} <= checked_steps
+
         config = RunConfig.model_validate(result)
         context = Context(config)
         for step in config.get_steps("kubernetes"):
             context.set_step_phase(step.name, step.phase or "setup")
-        context.set_step_output("setup", {"kubernetes": {"node_count": 3}})
         context.set_step_output(
-            "update_test_node_pool",
-            {"label_selector": "eks.amazonaws.com/nodegroup=isv-test-pool"},
+            "setup",
+            {"kubernetes": {"node_count": 3, "gpu_node_count": 1, "gpu_per_node": 1, "total_gpus": 1}},
         )
+        context.set_step_output("create_test_gpu_node_pool", {"expected_replicas": 1})
         assert context.render_string(node_count) == "3"
-        assert context.render_string(exclude_selector) == "eks.amazonaws.com/nodegroup=isv-test-pool"
+        assert context.render_string(exclude_selector) == "isv.ncp.validation/pool=test"
+        assert context.render_string(total_gpu_count) == "2"
+        assert context.render_string(expected_total) == "2"
         assert result["tests"]["platform"] == "kubernetes"
 
     def test_aws_eks_does_not_hardcode_world_open_endpoint_allowlist(self) -> None:


### PR DESCRIPTION
## Summary

- Exercise K8S06 by provisioning separate CPU and GPU EKS node pools in the AWS config, each with its own Terraform state file, instance type, node type, and teardown step.
- Extend the canonical K8s node-pool suite with a GPU-pool `K8sNodePoolCheck` and adjust baseline node/GPU expectations so temporary test pools do not distort cluster-wide checks.
- Teach the EKS node-pool create/destroy scripts to honor `NODE_POOL_STATE_FILE`, document the multi-pool state-file convention, and add merger coverage for the AWS EKS wiring.

Closes https://github.com/NVIDIA/ISV-NCP-Validation-Suite/issues/221

## Verification

- [x] `make test`
- [x] `make lint`
- [x] `make demo-test`
- [x] `uvx pre-commit run -a`
- [x] `git diff --check origin/main...HEAD`
- [x] AWS EKS cluster run `uv run isvctl test run \
    --no-upload \
    --verbose \
    --junitxml _output/k8s06-eks-targeted.xml \
    -f isvctl/configs/providers/aws/config/eks.yaml \
    -- -v -s -k "K8sNodePoolCheck or K8sNodeCountCheck or K8sGpuPodAccessCheck or K8sGpuCapacityCheck"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for GPU node pools in EKS, allowing CPU and GPU pools to coexist in the same cluster.
  * Added GPU-specific validations for pod access and GPU capacity.

* **Bug Fixes**
  * Isolated node-pool state so each pool uses its own local state file, preventing state clobbering.

* **Documentation**
  * Clarified multi-pool state workflow and usage guidance.

* **Tests**
  * Added tests validating state-file name rules and multi-pool behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/ISV-NCP-Validation-Suite/pull/442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->