### PR TITLE
fix(vm): adapt VcpuPinningCheck NUMA check to GB200 and add local mode

### DIFF
--- a/isvctl/configs/providers/aws/scripts/vm/docs/aws-vm.md
+++ b/isvctl/configs/providers/aws/scripts/vm/docs/aws-vm.md
@@ -154,7 +154,7 @@ Validates vCPU provisioning, online status, and NUMA topology.
 | `vcpu_count` | vCPU count matches `expected_vcpus` (if set) |
 | `vcpu_online` | All vCPUs are online |
 | `cpu_affinity` | CPU affinity mask of PID 1 spans all vCPUs |
-| `numa_topology` | All NUMA nodes have CPUs assigned |
+| `numa_topology` | Every vCPU is mapped to a NUMA node (CPU-less memory-only / GPU memory nodes are allowed) |
 | `gpu{N}_numa` | GPU PCI device NUMA node (GPU-CPU locality) |
 
 | Parameter | Type | Default | Description |

--- a/isvtest/src/isvtest/core/ssh.py
+++ b/isvtest/src/isvtest/core/ssh.py
@@ -30,6 +30,7 @@ Requires paramiko: pip install paramiko
 from __future__ import annotations
 
 import logging
+import subprocess
 import threading
 import time
 from typing import TYPE_CHECKING, Any
@@ -73,12 +74,80 @@ def get_ssh_client(
     return ssh_client
 
 
+class LocalExecutor:
+    """Session sentinel that runs commands on the local host.
+
+    Used by host validations that already execute on the target machine
+    (e.g. via ``isvctl deploy run``), so they run shell commands directly
+    instead of opening a second SSH connection back into the host (which
+    would otherwise need its own private key).
+
+    It duck-types the subset of ``paramiko.SSHClient`` that host validations
+    rely on: it is accepted by :func:`run_ssh_command` and supports ``close()``.
+    """
+
+    def close(self) -> None:
+        """No-op for interface parity with ``paramiko.SSHClient``."""
+        return None
+
+
+def is_local_execution(config: dict[str, Any]) -> bool:
+    """Whether to run commands locally (``local: true``) instead of over SSH.
+
+    Use when the validation already runs on the target host.
+    """
+    return bool(config.get("local"))
+
+
+def open_host_session(
+    ssh_cfg: dict[str, Any],
+    config: dict[str, Any],
+    timeout: int = 30,
+) -> paramiko.SSHClient | LocalExecutor:
+    """Open a command session to the host under test.
+
+    Returns a connected paramiko SSH client, or a :class:`LocalExecutor` when
+    local execution is enabled (config ``local: true``). Both are accepted by
+    :func:`run_ssh_command`.
+    """
+    if is_local_execution(config):
+        return LocalExecutor()
+    return get_ssh_client(
+        ssh_cfg["ssh_host"],
+        ssh_cfg["ssh_user"],
+        ssh_cfg["ssh_key_path"],
+        timeout=timeout,
+    )
+
+
+def _run_local_command(command: str, timeout: int) -> tuple[int, str, str]:
+    """Run a shell command on the local host, mirroring run_ssh_command's contract.
+
+    Raises:
+        TimeoutError: If the command does not complete within timeout.
+    """
+    try:
+        proc = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise TimeoutError("timed out") from exc
+    return proc.returncode, proc.stdout, proc.stderr
+
+
 def run_ssh_command(
-    ssh: paramiko.SSHClient,
+    ssh: paramiko.SSHClient | LocalExecutor,
     command: str,
     timeout: int = 120,
 ) -> tuple[int, str, str]:
-    """Run command via SSH and return exit_code, stdout, stderr.
+    """Run command via SSH (or locally) and return exit_code, stdout, stderr.
+
+    When ``ssh`` is a :class:`LocalExecutor`, the command runs on the local
+    host via a subprocess. Otherwise it runs over the paramiko SSH channel.
 
     Uses a threading event to enforce a wall-clock timeout, since
     paramiko's channel timeout only applies to socket operations and
@@ -87,7 +156,7 @@ def run_ssh_command(
     the channel window size.
 
     Args:
-        ssh: Connected SSH client
+        ssh: Connected SSH client or LocalExecutor
         command: Command to execute
         timeout: Wall-clock timeout in seconds (default: 120)
 
@@ -97,6 +166,9 @@ def run_ssh_command(
     Raises:
         TimeoutError: If the command does not complete within timeout
     """
+    if isinstance(ssh, LocalExecutor):
+        return _run_local_command(command, timeout)
+
     _, stdout, _stderr = ssh.exec_command(command)
     channel = stdout.channel
 

--- a/isvtest/src/isvtest/validations/host.py
+++ b/isvtest/src/isvtest/validations/host.py
@@ -45,6 +45,8 @@ from isvtest.core.ssh import (
     get_failed_subtests,
     get_ssh_client,
     get_ssh_config,
+    is_local_execution,
+    open_host_session,
     parse_cpu_range_count,
     run_ssh_command,
 )
@@ -354,12 +356,17 @@ class VcpuPinningCheck(BaseValidation):
     - All vCPUs are online
     - NUMA topology is consistent (vCPUs grouped by NUMA node)
     - CPU affinity mask covers all expected vCPUs
-    - CPU-to-NUMA mapping is balanced (no empty NUMA nodes)
+    - CPU-to-NUMA mapping accounts for every vCPU (CPU-less memory-only nodes
+      are valid: e.g. Grace-Hopper / Grace-Blackwell expose GPU memory as
+      additional NUMA nodes without CPUs)
     - GPU-to-NUMA locality: GPUs share NUMA node with assigned CPUs
 
     Config:
         host, key_file, user: SSH connection details
         expected_vcpus: Expected vCPU count (optional)
+        local: Run commands on the local host instead of via SSH (optional).
+            Use when the validation already executes on the target host, e.g.
+            via ``isvctl deploy run`` - avoids a redundant SSH hop and key.
     """
 
     description: ClassVar[str] = "Validates vCPU pinning and NUMA affinity"
@@ -367,24 +374,25 @@ class VcpuPinningCheck(BaseValidation):
     labels: ClassVar[tuple[str, ...]] = ("ssh", "vm")
 
     def run(self) -> None:
-        try:
-            import paramiko  # noqa: F401
-        except ImportError:
-            self.set_failed("paramiko not installed")
-            return
-
         ssh_cfg = get_ssh_config(self.config, self.config.get("inventory", {}))
         host = ssh_cfg["ssh_host"]
-        user = ssh_cfg["ssh_user"]
         key_path = ssh_cfg["ssh_key_path"]
         expected_vcpus = self.config.get("expected_vcpus")
+        local = is_local_execution(self.config)
+        target = host or "localhost"
 
-        if not host or not key_path:
-            self.set_failed("Missing host or key_file")
-            return
+        if not local:
+            try:
+                import paramiko  # noqa: F401
+            except ImportError:
+                self.set_failed("paramiko not installed")
+                return
+            if not host or not key_path:
+                self.set_failed("Missing host or key_file")
+                return
 
         try:
-            ssh = get_ssh_client(host, user, key_path)
+            ssh = open_host_session(ssh_cfg, self.config)
 
             # --- Check 1: vCPU count ---
             exit_code, stdout, _ = run_ssh_command(ssh, "nproc")
@@ -425,29 +433,52 @@ class VcpuPinningCheck(BaseValidation):
                 self.report_subtest("cpu_affinity", True, affinity_info[:80])
 
             # --- Check 4: NUMA topology ---
+            # CPU-less NUMA nodes are valid and expected: memory-only nodes and,
+            # on Grace-Hopper / Grace-Blackwell systems, GPU memory
+            # is exposed as additional CPU-less NUMA nodes. So we do not require
+            # every node to have CPUs; we only require that at least one node has
+            # CPUs and that the topology accounts for all vCPUs.
             exit_code, stdout, _ = run_ssh_command(ssh, "lscpu | grep -E '^NUMA node[0-9]+ CPU' || echo 'no_numa'")
             if exit_code == 0 and "no_numa" not in stdout:
                 numa_lines = [line.strip() for line in stdout.strip().split("\n") if line.strip()]
                 numa_nodes = len(numa_lines)
-                # Check all NUMA nodes have CPUs assigned (balanced)
-                all_have_cpus = all(":" in line and line.split(":")[-1].strip() != "" for line in numa_lines)
-                self.report_subtest(
-                    "numa_topology",
-                    all_have_cpus,
-                    f"{numa_nodes} NUMA node(s), all populated: {all_have_cpus}",
-                )
 
-                # Report per-node detail
+                node_cpus: list[tuple[str, str, int]] = []
                 for line in numa_lines:
                     parts = line.split(":")
                     if len(parts) == 2:
                         node_name = parts[0].strip().replace("NUMA ", "").replace(" CPU(s)", "")
                         cpus = parts[1].strip()
                         cpu_cnt = parse_cpu_range_count(cpus) if cpus else 0
+                        node_cpus.append((node_name, cpus, cpu_cnt))
+
+                cpu_node_count = sum(1 for _, _, cnt in node_cpus if cnt > 0)
+                memory_only_count = sum(1 for _, _, cnt in node_cpus if cnt == 0)
+                total_vcpus_mapped = sum(cnt for _, _, cnt in node_cpus)
+                # Consistent when at least one node has CPUs and every vCPU is mapped.
+                topology_ok = cpu_node_count > 0 and total_vcpus_mapped == vcpu_count
+                self.report_subtest(
+                    "numa_topology",
+                    topology_ok,
+                    f"{numa_nodes} NUMA node(s): {cpu_node_count} with CPUs, "
+                    f"{memory_only_count} memory-only; {total_vcpus_mapped}/{vcpu_count} vCPUs mapped",
+                )
+
+                # Report per-node detail. CPU-less nodes are valid memory-only /
+                # GPU memory nodes, so they are reported as passing informational
+                # entries rather than failures.
+                for node_name, cpus, cpu_cnt in node_cpus:
+                    if cpu_cnt > 0:
                         self.report_subtest(
                             f"numa_{node_name}",
-                            cpu_cnt > 0,
+                            True,
                             f"{node_name}: CPUs {cpus} ({cpu_cnt} cores)",
+                        )
+                    else:
+                        self.report_subtest(
+                            f"numa_{node_name}",
+                            True,
+                            f"{node_name}: no CPUs (memory-only / GPU memory node)",
                         )
             else:
                 self.report_subtest("numa_topology", True, "Single NUMA node (no NUMA)")
@@ -488,7 +519,7 @@ class VcpuPinningCheck(BaseValidation):
             elif expected_vcpus and vcpu_count != expected_vcpus:
                 self.set_failed(f"vCPU count mismatch: got {vcpu_count}, expected {expected_vcpus}")
             else:
-                self.set_passed(f"vCPU pinning check on {host} OK ({vcpu_count} vCPUs)")
+                self.set_passed(f"vCPU pinning check on {target} OK ({vcpu_count} vCPUs)")
 
         except Exception as e:
             self.set_failed(f"vCPU pinning check failed: {e}")

--- a/isvtest/tests/test_ssh.py
+++ b/isvtest/tests/test_ssh.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for SSH/local command helpers in isvtest.core.ssh."""
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from isvtest.core.ssh import (
+    LocalExecutor,
+    is_local_execution,
+    open_host_session,
+    run_ssh_command,
+)
+
+
+class TestIsLocalExecution:
+    """Tests for the local-execution config flag."""
+
+    def test_enabled_when_local_true(self) -> None:
+        assert is_local_execution({"local": True}) is True
+
+    def test_disabled_by_default(self) -> None:
+        assert is_local_execution({}) is False
+
+    def test_disabled_when_falsey(self) -> None:
+        assert is_local_execution({"local": False}) is False
+
+
+class TestOpenHostSession:
+    """open_host_session returns a LocalExecutor only in local mode."""
+
+    def test_returns_local_executor_in_local_mode(self) -> None:
+        session = open_host_session({}, {"local": True})
+        assert isinstance(session, LocalExecutor)
+
+    def test_uses_ssh_client_when_not_local(self) -> None:
+        ssh_cfg = {"ssh_host": "10.0.0.1", "ssh_user": "ubuntu", "ssh_key_path": "/tmp/k.pem"}
+        with patch("isvtest.core.ssh.get_ssh_client") as mock_client:
+            open_host_session(ssh_cfg, {})
+        mock_client.assert_called_once_with("10.0.0.1", "ubuntu", "/tmp/k.pem", timeout=30)
+
+
+class TestRunSshCommandLocal:
+    """run_ssh_command executes locally when given a LocalExecutor."""
+
+    def test_local_stdout_and_exit_code(self) -> None:
+        exit_code, stdout, _ = run_ssh_command(LocalExecutor(), "printf hello")
+        assert exit_code == 0
+        assert stdout == "hello"
+
+    def test_local_nonzero_exit_code(self) -> None:
+        exit_code, _, _ = run_ssh_command(LocalExecutor(), "exit 3")
+        assert exit_code == 3
+
+    def test_local_timeout_raises(self) -> None:
+        with patch("isvtest.core.ssh.subprocess.run", side_effect=subprocess.TimeoutExpired("cmd", 1)):
+            with pytest.raises(TimeoutError):
+                run_ssh_command(LocalExecutor(), "sleep 100", timeout=1)
+
+
+def test_local_executor_close_is_noop() -> None:
+    assert LocalExecutor().close() is None

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -2491,3 +2491,98 @@ def test_field_value_check_requires_nested_dot_path_to_exist() -> None:
 
     assert result["passed"] is False
     assert "Field 'operations.get.content_matches' not found" in result["error"]
+
+
+def _gb200_numa_lscpu() -> str:
+    """lscpu NUMA lines for a GB200 node: 2 CPU nodes + 32 CPU-less nodes."""
+    lines = ["NUMA node0 CPU(s):0-71", "NUMA node1 CPU(s):72-143"]
+    lines += [f"NUMA node{n} CPU(s):" for n in range(2, 34)]
+    return "\n".join(lines)
+
+
+def _vcpu_responder(numa_lscpu: str, vcpus: int, *, online: str | None = None):
+    """Build a run_ssh_command side_effect keyed on command substrings."""
+    online_range = online if online is not None else f"0-{vcpus - 1}"
+
+    def _run(_ssh: Any, command: str, *_args: Any, **_kwargs: Any) -> tuple[int, str, str]:
+        if command == "nproc":
+            return (0, f"{vcpus}\n", "")
+        if "cpu/online" in command:
+            return (0, f"{online_range}\n", "")
+        if "taskset" in command:
+            return (0, "pid 1's current affinity mask: " + "f" * 16, "")
+        if "NUMA node" in command:
+            return (0, numa_lscpu, "")
+        if "nvidia-smi" in command:
+            return (0, "0, 00000008:01:00.0\n", "")
+        if "numa_node" in command:
+            return (0, "2\n", "")
+        return (0, "", "")
+
+    return _run
+
+
+class TestVcpuPinningCheckLocalMode:
+    """VcpuPinningCheck in local mode (runs commands on the host, no SSH key)."""
+
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_gb200_topology_passes(self, mock_ssh_cfg: MagicMock, mock_run: MagicMock) -> None:
+        """CPU-less GPU-memory NUMA nodes (GB200) must not fail numa_topology."""
+        from isvtest.validations.host import VcpuPinningCheck
+
+        mock_ssh_cfg.return_value = {"ssh_host": "", "ssh_user": "ubuntu", "ssh_key_path": ""}
+        mock_run.side_effect = _vcpu_responder(_gb200_numa_lscpu(), 144)
+
+        result = VcpuPinningCheck(config={"local": True}).execute()
+
+        assert result["passed"] is True
+        assert "144 vCPUs" in result["output"]
+        subtests = {s["name"]: s for s in result["subtests"]}
+        assert subtests["numa_topology"]["passed"] is True
+        assert "2 with CPUs, 32 memory-only" in subtests["numa_topology"]["message"]
+        # Every CPU-less node is reported as a passing (informational) subtest.
+        assert subtests["numa_node2"]["passed"] is True
+        assert subtests["numa_node33"]["passed"] is True
+
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_local_mode_does_not_require_key(self, mock_ssh_cfg: MagicMock, mock_run: MagicMock) -> None:
+        """Local mode skips the host/key_file requirement."""
+        from isvtest.validations.host import VcpuPinningCheck
+
+        mock_ssh_cfg.return_value = {"ssh_host": "", "ssh_user": "ubuntu", "ssh_key_path": ""}
+        mock_run.side_effect = _vcpu_responder("NUMA node0 CPU(s):0-3", 4)
+
+        result = VcpuPinningCheck(config={"local": True}).execute()
+
+        assert result["passed"] is True
+        assert "Missing host or key_file" not in (result["error"] or "")
+
+    @patch("isvtest.validations.host.run_ssh_command")
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_unmapped_vcpus_fail_topology(self, mock_ssh_cfg: MagicMock, mock_run: MagicMock) -> None:
+        """numa_topology fails when the NUMA CPU listing doesn't account for all vCPUs."""
+        from isvtest.validations.host import VcpuPinningCheck
+
+        mock_ssh_cfg.return_value = {"ssh_host": "", "ssh_user": "ubuntu", "ssh_key_path": ""}
+        # 8 vCPUs reported by nproc, but NUMA lists only 4 -> inconsistent.
+        mock_run.side_effect = _vcpu_responder("NUMA node0 CPU(s):0-3", 8)
+
+        result = VcpuPinningCheck(config={"local": True}).execute()
+
+        assert result["passed"] is False
+        subtests = {s["name"]: s for s in result["subtests"]}
+        assert subtests["numa_topology"]["passed"] is False
+
+    @patch("isvtest.validations.host.get_ssh_config")
+    def test_non_local_missing_key_fails(self, mock_ssh_cfg: MagicMock) -> None:
+        """Without local mode, a missing key_file is still a failure."""
+        from isvtest.validations.host import VcpuPinningCheck
+
+        mock_ssh_cfg.return_value = {"ssh_host": "10.0.0.1", "ssh_user": "ubuntu", "ssh_key_path": ""}
+
+        result = VcpuPinningCheck(config={}).execute()
+
+        assert result["passed"] is False
+        assert "Missing host or key_file" in result["error"]


### PR DESCRIPTION
## Summary

- **Fix `numa_topology` for GB200 / Grace-Blackwell:** the subtest previously required *every* NUMA node to have CPUs, which fails on Grace-Hopper/Grace-Blackwell systems where GPU memory is exposed as additional **CPU-less** NUMA nodes. It now tolerates CPU-less memory-only nodes and instead verifies that **every vCPU is mapped** to a NUMA node (and at least one node has CPUs). CPU-less nodes are reported as passing informational subtests.
- **Add `local: true` execution mode** for host validations: runs the probes directly on the target host (e.g. when already on the node via `isvctl deploy run`) instead of opening a second SSH connection back into the host, which would otherwise require a private key on the target.
- Update the `aws-vm.md` subtest description.
- Add unit tests for the local-execution helpers (`test_ssh.py`) and the GB200 CPU-less NUMA topology (`test_validation.py`).

## Validation

Verified on a real **GB200** GPU node: **144 vCPUs across 34 NUMA nodes** (2 with CPUs, 32 CPU-less). Old check failed `numa_topology` + ~32 per-node subtests; new check passes all of them:

```
[host_os] VcpuPinningCheck: PASSED - vCPU pinning check on localhost OK (144 vCPUs)
numa_topology PASS - 34 NUMA node(s): 2 with CPUs, 32 memory-only; 144/144 vCPUs mapped
```

## Notes

- `lscpu` (not `numactl`) remains the data source — it provides the CPU-to-NUMA mapping the check needs; `numactl` would only add memory/distance info this check doesn't use, and isn't always installed.
- `released_tests.json` is intentionally untouched: this changes behavior within an already-released check and adds an opt-in config flag.

## Test plan

- [x] `make lint` clean
- [x] `pre-commit run` clean (SPDX, ruff, format, links)
- [x] `isvtest` suite: 873 passed (incl. 13 new tests)
- [x] Live run on real GB200 GPU node passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for local validation execution without requiring SSH connections to target hosts
  * NUMA topology validation now supports CPU-less nodes (memory-only and GPU memory configurations)

* **Documentation**
  * Updated NUMA topology validation documentation to reflect CPU-less node compatibility

* **Tests**
  * Added comprehensive test coverage for local execution and validation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->