### PR TITLE
feat(nico): add NICo governance metrics validation (CAP01-01)

### DIFF
--- a/isvctl/configs/providers/nico/config/bare_metal.yaml
+++ b/isvctl/configs/providers/nico/config/bare_metal.yaml
@@ -16,16 +16,20 @@
 # NICo Bare Metal (BMaaS) Validation Configuration
 #
 # Imports the provider-agnostic bare_metal contract and wires the NICo
-# hardware-lifecycle steps. NICo currently implements the hardware ingestion
-# and DPU health steps; the remaining bare_metal validations are skipped
-# automatically because their steps are not defined here (a future PR will
-# wire the full lifecycle so NICo can pass the entire BM suite).
+# hardware-lifecycle steps. NICo currently implements the hardware ingestion,
+# DPU health, and governance-metrics steps; the remaining bare_metal
+# validations are skipped automatically because their steps are not defined
+# here (a future PR will wire the full lifecycle so NICo can pass the entire
+# BM suite).
 #
 # Architecture:
 #   - verify_ingestion.py compares expected-machine manifest vs discovered
 #     machines (joined by machineId); HardwareIngestionCheck validates it.
 #   - check_dpu_health.py queries machine health data; DpuHealthCheck
 #     validates DPU presence, heartbeat, and alerts.
+#   - query_metrics.py aggregates per-status node and GPU counts into the
+#     Delivered / Healthy / Reserved / Active governance buckets;
+#     GovernanceMetricsCheck verifies the API contract (CAP01-01).
 #
 # Prerequisites:
 #   - NICO_API_BASE set to the NICo API base URL
@@ -68,6 +72,22 @@ commands:
       - name: check_dpu_health
         phase: test
         command: "python ../scripts/dpu/check_dpu_health.py"
+        args:
+          - "--org"
+          - "{{org}}"
+          - "--site-id"
+          - "{{site_id}}"
+          - "--api-base"
+          - "{{nico_api_base}}"
+        timeout: 120
+
+      # ─── Query Governance Metrics ──────────────────────────────────
+      # Aggregates every machine at the site into the Delivered / Healthy
+      # / Reserved / Active governance buckets (CAP01-01). Counts are
+      # produced for both nodes and GPUs.
+      - name: query_governance_metrics
+        phase: test
+        command: "python ../scripts/governance/query_metrics.py"
         args:
           - "--org"
           - "{{org}}"

--- a/isvctl/configs/providers/nico/scripts/governance/query_metrics.py
+++ b/isvctl/configs/providers/nico/scripts/governance/query_metrics.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Aggregate site-wide governance metrics for the bare-metal fleet (CAP01-01).
+
+Queries the NICo REST API for every machine at a site and aggregates them
+into the four governance buckets a Cloud Governance API must surface:
+Delivered, Healthy, Reserved, and Active. Counts are produced for both nodes
+and GPUs so the validation can verify the API contract end-to-end.
+
+NICo MachineStatus enum (per the upstream OpenAPI spec) used here:
+  Initializing | Ready | Reset | Maintenance | InUse | Error | Decommissioned | Unknown
+
+Bucket mapping for NICo:
+  Delivered: status NOT in {Decommissioned, Unknown} -- machines NICo
+             currently manages with a known state.
+  Healthy:   subset of Delivered with no entries under ``health.alerts``.
+  Reserved:  status in {InUse, Maintenance} -- machines committed to a tenant
+             (in-use or held).
+  Active:    status in {InUse} -- machines currently running a tenant workload.
+
+NICo API endpoints used:
+  GET /v2/org/{org}/carbide/machine?siteId={site_id}
+
+Auth:
+  - NICO_BEARER_TOKEN, or
+  - OIDC client_credentials via NICO_SSA_ISSUER,
+    NICO_CLIENT_ID, NICO_CLIENT_SECRET, and optional NICO_OIDC_SCOPE.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "nico",
+    "site_id": "...",
+    "machine_count": 20,
+    "metrics": {
+      "delivered": {"nodes": 20, "gpus": 160},
+      "healthy":   {"nodes": 19, "gpus": 152},
+      "reserved":  {"nodes": 15, "gpus": 120},
+      "active":    {"nodes": 10, "gpus":  80}
+    }
+  }
+
+Usage:
+    NICO_BEARER_TOKEN=<token> python query_metrics.py --org <org> --site-id <uuid> --api-base <url>
+
+    Wired via the bare_metal suite:
+      uv run isvctl test run -f isvctl/configs/providers/nico/config/bare_metal.yaml
+
+Reference:
+    OpenAPI spec: ncp-isv-carbide-proxy-service/src/main/resources/docs/openapi/forge_api.yaml
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.nico_client import NicoAuthError, classify_health, forge_get_all, resolve_auth, sum_capabilities
+
+# Machine status sets used to classify each machine into governance buckets.
+# Sourced from MachineStatus in the upstream NICo OpenAPI spec.
+DELIVERED_EXCLUDE_STATUSES: frozenset[str] = frozenset({"Decommissioned", "Unknown"})
+RESERVED_STATUSES: frozenset[str] = frozenset({"InUse", "Maintenance"})
+ACTIVE_STATUSES: frozenset[str] = frozenset({"InUse"})
+
+# Empty metric template so every bucket appears in the output (even when zero)
+# and the validation does not have to special-case missing keys.
+_EMPTY_BUCKET: dict[str, int] = {"nodes": 0, "gpus": 0}
+
+
+def _empty_metrics() -> dict[str, dict[str, int]]:
+    """Return a fresh zeroed metrics dict with all four required buckets."""
+    return {
+        "delivered": dict(_EMPTY_BUCKET),
+        "healthy": dict(_EMPTY_BUCKET),
+        "reserved": dict(_EMPTY_BUCKET),
+        "active": dict(_EMPTY_BUCKET),
+    }
+
+
+def _add(bucket: dict[str, int], nodes: int, gpus: int) -> None:
+    """Accumulate node and GPU counts into ``bucket`` in place."""
+    bucket["nodes"] += nodes
+    bucket["gpus"] += gpus
+
+
+def aggregate_metrics(machines: list[dict[str, Any]]) -> dict[str, dict[str, int]]:
+    """Classify NICo machines into the four governance buckets and sum counts."""
+    metrics = _empty_metrics()
+
+    for machine in machines:
+        status = machine.get("status") or "Unknown"
+        capabilities = machine.get("machineCapabilities") or []
+        gpu_count = sum_capabilities(capabilities, "GPU")
+        health = machine.get("health") or {}
+
+        if status in DELIVERED_EXCLUDE_STATUSES:
+            # Decommissioned/Unknown machines are ignored entirely so they
+            # cannot leak into Reserved or Active via a sloppy status string.
+            continue
+
+        _add(metrics["delivered"], nodes=1, gpus=gpu_count)
+
+        if classify_health(health) == "healthy":
+            _add(metrics["healthy"], nodes=1, gpus=gpu_count)
+
+        if status in RESERVED_STATUSES:
+            _add(metrics["reserved"], nodes=1, gpus=gpu_count)
+
+        if status in ACTIVE_STATUSES:
+            _add(metrics["active"], nodes=1, gpus=gpu_count)
+
+    return metrics
+
+
+def main() -> int:
+    """Aggregate site-level governance metrics and print the JSON contract."""
+    parser = argparse.ArgumentParser(description="Aggregate NICo site governance metrics")
+    parser.add_argument("--org", required=True, help="NGC org name")
+    parser.add_argument("--site-id", required=True, help="NICo site UUID")
+    parser.add_argument("--api-base", required=True, help="NICo API base URL")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "nico",
+        "site_id": args.site_id,
+        "machine_count": 0,
+        "metrics": _empty_metrics(),
+    }
+
+    try:
+        auth = resolve_auth()
+
+        machines = forge_get_all(
+            args.org,
+            "machine",
+            auth.token,
+            base_url=args.api_base,
+            params={"siteId": args.site_id},
+            result_key="machines",
+        )
+
+        result["metrics"] = aggregate_metrics(machines)
+        result["machine_count"] = len(machines)
+        result["success"] = True
+
+    except NicoAuthError as e:
+        result["error_type"] = "auth"
+        result["error"] = str(e)
+    except Exception as e:
+        result["error"] = f"{type(e).__name__}: {e}"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/nico/scripts/governance/query_metrics.py
+++ b/isvctl/configs/providers/nico/scripts/governance/query_metrics.py
@@ -80,25 +80,15 @@ DELIVERED_EXCLUDE_STATUSES: frozenset[str] = frozenset({"Decommissioned", "Unkno
 RESERVED_STATUSES: frozenset[str] = frozenset({"InUse", "Maintenance"})
 ACTIVE_STATUSES: frozenset[str] = frozenset({"InUse"})
 
-# Empty metric template so every bucket appears in the output (even when zero)
-# and the validation does not have to special-case missing keys.
-_EMPTY_BUCKET: dict[str, int] = {"nodes": 0, "gpus": 0}
+# The four governance buckets, in conventional order. Listed once so every
+# bucket appears in the output (even when zero) and the validation does not
+# have to special-case missing keys.
+METRIC_BUCKETS: tuple[str, ...] = ("delivered", "healthy", "reserved", "active")
 
 
 def _empty_metrics() -> dict[str, dict[str, int]]:
     """Return a fresh zeroed metrics dict with all four required buckets."""
-    return {
-        "delivered": dict(_EMPTY_BUCKET),
-        "healthy": dict(_EMPTY_BUCKET),
-        "reserved": dict(_EMPTY_BUCKET),
-        "active": dict(_EMPTY_BUCKET),
-    }
-
-
-def _add(bucket: dict[str, int], nodes: int, gpus: int) -> None:
-    """Accumulate node and GPU counts into ``bucket`` in place."""
-    bucket["nodes"] += nodes
-    bucket["gpus"] += gpus
+    return {bucket: {"nodes": 0, "gpus": 0} for bucket in METRIC_BUCKETS}
 
 
 def aggregate_metrics(machines: list[dict[str, Any]]) -> dict[str, dict[str, int]]:
@@ -107,25 +97,26 @@ def aggregate_metrics(machines: list[dict[str, Any]]) -> dict[str, dict[str, int
 
     for machine in machines:
         status = machine.get("status") or "Unknown"
-        capabilities = machine.get("machineCapabilities") or []
-        gpu_count = sum_capabilities(capabilities, "GPU")
-        health = machine.get("health") or {}
-
         if status in DELIVERED_EXCLUDE_STATUSES:
             # Decommissioned/Unknown machines are ignored entirely so they
             # cannot leak into Reserved or Active via a sloppy status string.
             continue
 
-        _add(metrics["delivered"], nodes=1, gpus=gpu_count)
+        gpus = sum_capabilities(machine.get("machineCapabilities") or [], "GPU")
+        health = machine.get("health") or {}
 
-        if classify_health(health) == "healthy":
-            _add(metrics["healthy"], nodes=1, gpus=gpu_count)
-
-        if status in RESERVED_STATUSES:
-            _add(metrics["reserved"], nodes=1, gpus=gpu_count)
-
-        if status in ACTIVE_STATUSES:
-            _add(metrics["active"], nodes=1, gpus=gpu_count)
+        # A delivered machine contributes one node and its GPUs to every bucket
+        # whose membership condition it satisfies.
+        membership = {
+            "delivered": True,
+            "healthy": classify_health(health) == "healthy",
+            "reserved": status in RESERVED_STATUSES,
+            "active": status in ACTIVE_STATUSES,
+        }
+        for bucket, matched in membership.items():
+            if matched:
+                metrics[bucket]["nodes"] += 1
+                metrics[bucket]["gpus"] += gpus
 
     return metrics
 

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -109,6 +109,7 @@ For the domain / script-count / AWS-reference overview see the
 | `verify_teardown` | teardown | `providers/my-isv/scripts/bare_metal/verify_terminated.py` | `checks.instance_terminated`, `checks.sg_deleted` |
 | `verify_ingestion` | test | `providers/nico/scripts/hardware_ingestion/verify_ingestion.py` | `expected_count`, `ingested_count`, `matched_count`, `missing`, `extra`, `machines[].status`, `machines[].health` |
 | `check_dpu_health` | test | `providers/nico/scripts/dpu/check_dpu_health.py` | `machines_checked`, `machines[].dpu_count`, `machines[].dpu_agent_heartbeat`, `machines[].health_summary`, `machines[].health_alerts` |
+| `query_governance_metrics` | test | `providers/nico/scripts/governance/query_metrics.py` | `machine_count`, `metrics.delivered.{nodes,gpus}`, `metrics.healthy.{nodes,gpus}`, `metrics.reserved.{nodes,gpus}`, `metrics.active.{nodes,gpus}` |
 
 ### Kubernetes (`k8s.yaml`)
 

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -335,5 +335,15 @@ tests:
         DpuHealthCheck:
           require_heartbeat: true
 
+    # Governance metrics (CAP01-01): the provider's governance API must
+    # surface Delivered, Healthy, Reserved, and Active counts for nodes and
+    # GPUs. Only runs for providers that implement the
+    # query_governance_metrics step.
+    governance_metrics:
+      step: query_governance_metrics
+      checks:
+        GovernanceMetricsCheck:
+          min_delivered_nodes: 1
+
   exclude:
     labels: []

--- a/isvctl/tests/test_nico_provider.py
+++ b/isvctl/tests/test_nico_provider.py
@@ -105,6 +105,17 @@ def _load_ingestion_script() -> ModuleType:
     return module
 
 
+def _load_governance_metrics_script() -> ModuleType:
+    """Load the query_metrics (governance) script as a module for direct unit testing."""
+    script_path = NICO_SCRIPTS / "governance" / "query_metrics.py"
+    spec = importlib.util.spec_from_file_location("test_governance_query_metrics", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    with _isolated_common_imports():
+        spec.loader.exec_module(module)
+    return module
+
+
 def test_nico_auth_prefers_explicit_bearer_token(monkeypatch: pytest.MonkeyPatch) -> None:
     """A locally supplied NICo bearer token should be the simplest auth path."""
     module = _load_nico_client()
@@ -206,7 +217,10 @@ def test_forge_get_all_extracts_result_key_from_wrapped_response(monkeypatch: py
     assert items == [{"id": "m-1"}]
 
 
-@pytest.mark.parametrize("step_name", ["verify_ingestion", "check_dpu_health"])
+@pytest.mark.parametrize(
+    "step_name",
+    ["verify_ingestion", "check_dpu_health", "query_governance_metrics"],
+)
 def test_nico_bare_metal_config_exposes_api_base_setting(step_name: str) -> None:
     """The shipped NICo bare_metal config should pass a configurable API base to scripts."""
     merged = merge_yaml_files([NICO_CONFIG / "bare_metal.yaml"])
@@ -224,6 +238,7 @@ def test_nico_bare_metal_config_exposes_api_base_setting(step_name: str) -> None
     [
         ("verify_ingestion.py", _load_ingestion_script),
         ("check_dpu_health.py", _load_dpu_health_script),
+        ("query_metrics.py", _load_governance_metrics_script),
     ],
 )
 def test_nico_scripts_require_api_base(
@@ -386,3 +401,183 @@ def test_dpu_health_script_treats_nullable_alert_fields_as_empty(
     assert payload["machines"][0]["health_successes"] == ["DpuDiskUtilizationCheck"]
     assert payload["machines"][0]["health_alerts"] == []
     assert payload["machines"][0]["dpu_agent_heartbeat"] is True
+
+
+# ---------------------------------------------------------------------------
+# query_metrics (governance) script
+# ---------------------------------------------------------------------------
+
+
+def _governance_machine(
+    *,
+    status: str,
+    gpus: int = 8,
+    alerts: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal NICo machine payload used to drive the governance script."""
+    return {
+        "id": f"m-{status.lower()}-{gpus}",
+        "status": status,
+        "machineCapabilities": [{"type": "GPU", "name": "H100", "count": gpus}],
+        "health": {"alerts": alerts or []},
+    }
+
+
+def _run_governance_script(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    machines: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Drive the governance script with mocked auth/API and return its JSON output."""
+    module = _load_governance_metrics_script()
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(module, "forge_get_all", lambda *args, **kwargs: machines)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "query_metrics.py",
+            "--org",
+            "test-org",
+            "--site-id",
+            "site-1",
+            "--api-base",
+            "http://127.0.0.1:8080/v2/org",
+        ],
+    )
+
+    exit_code = module.main()
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0, payload
+    return payload
+
+
+def test_governance_script_classifies_each_status_bucket(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Each MachineStatus value should land in the correct governance bucket."""
+    machines = [
+        _governance_machine(status="Ready", gpus=8),
+        _governance_machine(status="Ready", gpus=8, alerts=[{"id": "FanSpeed"}]),
+        _governance_machine(status="Maintenance", gpus=8),
+        _governance_machine(status="InUse", gpus=8),
+        _governance_machine(status="InUse", gpus=4),
+        _governance_machine(status="Error", gpus=8),
+        # The next two must be ignored entirely so they cannot leak into
+        # Reserved/Active via permissive status matching.
+        _governance_machine(status="Decommissioned", gpus=8),
+        _governance_machine(status="Unknown", gpus=8),
+    ]
+
+    payload = _run_governance_script(monkeypatch, capsys, machines)
+
+    assert payload["success"] is True
+    assert payload["platform"] == "nico"
+    assert payload["site_id"] == "site-1"
+    assert payload["machine_count"] == len(machines)
+
+    metrics = payload["metrics"]
+    # Delivered excludes the Decommissioned + Unknown machines.
+    assert metrics["delivered"] == {"nodes": 6, "gpus": 44}
+    # Healthy excludes the machine with the FanSpeed alert.
+    assert metrics["healthy"] == {"nodes": 5, "gpus": 36}
+    # Reserved = InUse + Maintenance.
+    assert metrics["reserved"] == {"nodes": 3, "gpus": 20}
+    # Active = InUse only.
+    assert metrics["active"] == {"nodes": 2, "gpus": 12}
+
+
+def test_governance_script_empty_site_returns_zero_buckets(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A site with no machines should still emit all four buckets zeroed out."""
+    payload = _run_governance_script(monkeypatch, capsys, machines=[])
+
+    assert payload["machine_count"] == 0
+    assert payload["metrics"] == {
+        "delivered": {"nodes": 0, "gpus": 0},
+        "healthy": {"nodes": 0, "gpus": 0},
+        "reserved": {"nodes": 0, "gpus": 0},
+        "active": {"nodes": 0, "gpus": 0},
+    }
+
+
+def test_governance_script_tolerates_missing_optional_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Nullable capability and health fields must not crash aggregation."""
+    machines = [
+        # No capabilities and no health at all -- counted as delivered + healthy
+        # (no alerts means healthy) but contributes zero GPUs.
+        {"id": "no-caps", "status": "Ready"},
+        # Null inner fields, common in real responses.
+        {"id": "null-fields", "status": "Ready", "machineCapabilities": None, "health": None},
+    ]
+
+    payload = _run_governance_script(monkeypatch, capsys, machines)
+
+    assert payload["metrics"]["delivered"] == {"nodes": 2, "gpus": 0}
+    assert payload["metrics"]["healthy"] == {"nodes": 2, "gpus": 0}
+    assert payload["metrics"]["reserved"] == {"nodes": 0, "gpus": 0}
+    assert payload["metrics"]["active"] == {"nodes": 0, "gpus": 0}
+
+
+def test_governance_script_output_satisfies_validation_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """End-to-end: NICo governance JSON should pass GovernanceMetricsCheck."""
+    from isvtest.validations.governance import GovernanceMetricsCheck
+
+    payload = _run_governance_script(
+        monkeypatch,
+        capsys,
+        machines=[
+            _governance_machine(status="Ready", gpus=8),
+            _governance_machine(status="InUse", gpus=8),
+        ],
+    )
+
+    check = GovernanceMetricsCheck(config={"step_output": payload})
+    check.run()
+    assert check._passed is True, check._error
+
+
+def test_governance_script_surfaces_api_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Exceptions from the NICo client should be reported, not raised."""
+    module = _load_governance_metrics_script()
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+
+    def _boom(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("simulated outage")
+
+    monkeypatch.setattr(module, "forge_get_all", _boom)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "query_metrics.py",
+            "--org",
+            "test-org",
+            "--site-id",
+            "site-1",
+            "--api-base",
+            "http://127.0.0.1:8080/v2/org",
+        ],
+    )
+
+    exit_code = module.main()
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert "simulated outage" in payload["error"]

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -38,6 +38,9 @@ from isvtest.validations.generic import (
     SchemaValidation,
     StepSuccessCheck,
 )
+from isvtest.validations.governance import (
+    GovernanceMetricsCheck,
+)
 from isvtest.validations.host import (
     CloudInitCheck,
     ContainerRuntimeCheck,
@@ -152,6 +155,7 @@ __all__ = [
     "FieldExistsCheck",
     "FieldValueCheck",
     "FloatingIpCheck",
+    "GovernanceMetricsCheck",
     "GpuOperatorInstalledCheck",
     "InsecureProtocolsCheck",
     "InstanceCreatedCheck",

--- a/isvtest/src/isvtest/validations/governance.py
+++ b/isvtest/src/isvtest/validations/governance.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Governance and capacity-fleet metrics validations.
+
+Validations that assert a provider's governance API exposes the Delivered,
+Healthy, Reserved, and Active capacity metrics for nodes and GPUs (test ID
+CAP01-01).
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from isvtest.core.validation import BaseValidation
+
+# Metric buckets the governance API must expose, in the conventional ordering
+# (Delivered ⊇ Reserved ⊇ Active; Healthy is independent of allocation state).
+REQUIRED_METRICS: tuple[str, ...] = ("delivered", "healthy", "reserved", "active")
+
+# Resource dimensions surfaced per metric.
+REQUIRED_RESOURCES: tuple[str, ...] = ("nodes", "gpus")
+
+
+class GovernanceMetricsCheck(BaseValidation):
+    """Validate the governance API returns the required capacity metrics.
+
+    Asserts that the step output exposes per-resource counts (nodes, GPUs) for
+    the four governance metric buckets (Delivered, Healthy, Reserved, Active)
+    and that the relationships between them are internally consistent.
+
+    Config:
+        step_output: Step output containing the governance metrics.
+        min_delivered_nodes: Optional minimum Delivered node count (default: 0).
+        min_delivered_gpus: Optional minimum Delivered GPU count (default: 0).
+
+    Step output:
+        success: bool
+        platform: str
+        metrics: dict[str, dict[str, int]]:
+            delivered: {"nodes": int, "gpus": int}
+            healthy:   {"nodes": int, "gpus": int}
+            reserved:  {"nodes": int, "gpus": int}
+            active:    {"nodes": int, "gpus": int}
+
+    Definitions (provider-agnostic):
+        Delivered: hardware the provider has onboarded and made available to
+            tenants (any reservable/active state).
+        Healthy:   subset of Delivered passing the provider's health probes.
+        Reserved:  subset of Delivered allocated to a tenant (in-use or held).
+        Active:    subset of Reserved currently running tenant workloads.
+    """
+
+    description: ClassVar[str] = "Check governance API exposes Delivered/Healthy/Reserved/Active node and GPU metrics"
+    timeout: ClassVar[int] = 60
+    labels: ClassVar[tuple[str, ...]] = ("bare_metal", "governance")
+
+    def run(self) -> None:
+        """Validate metric presence, value sanity, and inter-metric relationships."""
+        step_output = self.config.get("step_output", {})
+
+        if not step_output.get("success"):
+            self.set_failed(f"Governance metrics step failed: {step_output.get('error', 'Unknown error')}")
+            return
+
+        metrics = step_output.get("metrics")
+        if not isinstance(metrics, dict):
+            self.set_failed("Governance step output is missing the 'metrics' object")
+            return
+
+        missing_metrics = [m for m in REQUIRED_METRICS if m not in metrics]
+        if missing_metrics:
+            self.set_failed(f"Governance metrics missing required buckets: {', '.join(missing_metrics)}")
+            return
+
+        # Validate the shape and values of every bucket up front; bail out
+        # before relationship checks if anything is malformed (so we report
+        # the schema problem rather than a misleading consistency error).
+        bucket_values: dict[str, dict[str, int]] = {}
+        for metric_name in REQUIRED_METRICS:
+            bucket = metrics[metric_name]
+            if not isinstance(bucket, dict):
+                self.set_failed(f"Governance metric '{metric_name}' is not an object")
+                return
+
+            resources: dict[str, int] = {}
+            for resource in REQUIRED_RESOURCES:
+                if resource not in bucket:
+                    self.set_failed(f"Governance metric '{metric_name}' is missing required resource '{resource}'")
+                    return
+                value = bucket[resource]
+                # bool is a subclass of int in Python; reject it explicitly so a
+                # truthy/falsy flag is not silently accepted as a count.
+                if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                    self.set_failed(
+                        f"Governance metric '{metric_name}.{resource}' must be a non-negative integer, got {value!r}"
+                    )
+                    return
+                resources[resource] = value
+            bucket_values[metric_name] = resources
+            self.report_subtest(
+                f"metric_{metric_name}",
+                passed=True,
+                message=f"{metric_name}: nodes={resources['nodes']}, gpus={resources['gpus']}",
+            )
+
+        min_nodes = self._coerce_non_negative_int("min_delivered_nodes", default=0)
+        min_gpus = self._coerce_non_negative_int("min_delivered_gpus", default=0)
+        if min_nodes is None or min_gpus is None:
+            return
+
+        delivered_nodes = bucket_values["delivered"]["nodes"]
+        delivered_gpus = bucket_values["delivered"]["gpus"]
+
+        threshold_failures: list[str] = []
+        if delivered_nodes < min_nodes:
+            threshold_failures.append(f"Delivered nodes {delivered_nodes} < min {min_nodes}")
+        if delivered_gpus < min_gpus:
+            threshold_failures.append(f"Delivered gpus {delivered_gpus} < min {min_gpus}")
+
+        # Inter-metric ordering: Delivered ⊇ Reserved ⊇ Active and Delivered ⊇ Healthy.
+        relationship_failures = self._check_relationships(bucket_values)
+
+        failures = threshold_failures + relationship_failures
+        if failures:
+            self.set_failed(f"Governance metrics invariants violated: {'; '.join(failures)}")
+            return
+
+        self.set_passed(
+            f"Governance metrics OK (delivered: nodes={delivered_nodes}, gpus={delivered_gpus})"
+        )
+
+    def _coerce_non_negative_int(self, key: str, *, default: int) -> int | None:
+        """Read ``key`` from config and coerce to int >= 0; fail otherwise."""
+        raw = self.config.get(key, default)
+        if isinstance(raw, bool) or not isinstance(raw, int) or raw < 0:
+            self.set_failed(f"`{key}` must be a non-negative integer, got {raw!r}")
+            return None
+        return raw
+
+    def _check_relationships(self, buckets: dict[str, dict[str, int]]) -> list[str]:
+        """Return a list of human-readable invariant violations (empty if OK)."""
+        # subset pairs: (subset_metric, superset_metric)
+        invariants: tuple[tuple[str, str], ...] = (
+            ("healthy", "delivered"),
+            ("reserved", "delivered"),
+            ("active", "reserved"),
+        )
+        failures: list[str] = []
+        for subset, superset in invariants:
+            for resource in REQUIRED_RESOURCES:
+                sub = buckets[subset][resource]
+                sup = buckets[superset][resource]
+                if sub > sup:
+                    failures.append(
+                        f"{subset} {resource} ({sub}) exceeds {superset} {resource} ({sup})"
+                    )
+        return failures

--- a/isvtest/src/isvtest/validations/governance.py
+++ b/isvtest/src/isvtest/validations/governance.py
@@ -138,9 +138,7 @@ class GovernanceMetricsCheck(BaseValidation):
             self.set_failed(f"Governance metrics invariants violated: {'; '.join(failures)}")
             return
 
-        self.set_passed(
-            f"Governance metrics OK (delivered: nodes={delivered_nodes}, gpus={delivered_gpus})"
-        )
+        self.set_passed(f"Governance metrics OK (delivered: nodes={delivered_nodes}, gpus={delivered_gpus})")
 
     def _coerce_non_negative_int(self, key: str, *, default: int) -> int | None:
         """Read ``key`` from config and coerce to int >= 0; fail otherwise."""
@@ -164,7 +162,5 @@ class GovernanceMetricsCheck(BaseValidation):
                 sub = buckets[subset][resource]
                 sup = buckets[superset][resource]
                 if sub > sup:
-                    failures.append(
-                        f"{subset} {resource} ({sub}) exceeds {superset} {resource} ({sup})"
-                    )
+                    failures.append(f"{subset} {resource} ({sub}) exceeds {superset} {resource} ({sup})")
         return failures

--- a/isvtest/src/isvtest/validations/governance.py
+++ b/isvtest/src/isvtest/validations/governance.py
@@ -16,8 +16,7 @@
 """Governance and capacity-fleet metrics validations.
 
 Validations that assert a provider's governance API exposes the Delivered,
-Healthy, Reserved, and Active capacity metrics for nodes and GPUs (test ID
-CAP01-01).
+Healthy, Reserved, and Active capacity metrics for nodes and GPUs (test ID CAP01-01).
 """
 
 from __future__ import annotations

--- a/isvtest/tests/test_governance.py
+++ b/isvtest/tests/test_governance.py
@@ -73,9 +73,7 @@ class TestGovernanceMetricsCheck:
 
     def test_step_failure_propagates(self) -> None:
         """When the underlying step reports failure the check should fail."""
-        check = GovernanceMetricsCheck(
-            config={"step_output": _metrics_output(success=False, error="API down")}
-        )
+        check = GovernanceMetricsCheck(config={"step_output": _metrics_output(success=False, error="API down")})
         check.run()
         assert check._passed is False
         assert "API down" in check._error
@@ -172,9 +170,7 @@ class TestGovernanceMetricsCheck:
     def test_min_delivered_thresholds_enforced(self) -> None:
         """Configurable minimum thresholds enforce a delivered fleet floor."""
         output = _metrics_output(delivered={"nodes": 0, "gpus": 0})
-        check = GovernanceMetricsCheck(
-            config={"step_output": output, "min_delivered_nodes": 1}
-        )
+        check = GovernanceMetricsCheck(config={"step_output": output, "min_delivered_nodes": 1})
         check.run()
         assert check._passed is False
         assert "Delivered nodes 0" in check._error
@@ -182,9 +178,7 @@ class TestGovernanceMetricsCheck:
     def test_min_delivered_thresholds_default_zero(self) -> None:
         """Without overrides, a zero-machine site is still well-formed."""
         zero = {"nodes": 0, "gpus": 0}
-        output = _metrics_output(
-            delivered=zero, healthy=zero, reserved=zero, active=zero
-        )
+        output = _metrics_output(delivered=zero, healthy=zero, reserved=zero, active=zero)
         check = GovernanceMetricsCheck(config={"step_output": output})
         check.run()
         assert check._passed is True

--- a/isvtest/tests/test_governance.py
+++ b/isvtest/tests/test_governance.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for governance metrics validations."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from isvtest.validations.governance import GovernanceMetricsCheck
+
+
+def _metrics_output(
+    *,
+    success: bool = True,
+    delivered: dict[str, int] | None = None,
+    healthy: dict[str, int] | None = None,
+    reserved: dict[str, int] | None = None,
+    active: dict[str, int] | None = None,
+    error: str = "",
+) -> dict[str, Any]:
+    """Build a governance metrics step output with valid defaults.
+
+    Defaults satisfy the inter-metric invariants (Healthy/Reserved ⊆ Delivered,
+    Active ⊆ Reserved) so individual fields can be overridden per test.
+    """
+    return {
+        "success": success,
+        "platform": "nico",
+        "site_id": "test-site-001",
+        "machine_count": 20,
+        "metrics": {
+            "delivered": delivered or {"nodes": 20, "gpus": 160},
+            "healthy": healthy or {"nodes": 19, "gpus": 152},
+            "reserved": reserved or {"nodes": 15, "gpus": 120},
+            "active": active or {"nodes": 10, "gpus": 80},
+        },
+        "error": error,
+    }
+
+
+class TestGovernanceMetricsCheck:
+    """Tests for GovernanceMetricsCheck."""
+
+    def test_well_formed_metrics_pass(self) -> None:
+        """All four buckets present with consistent counts -- should pass."""
+        check = GovernanceMetricsCheck(config={"step_output": _metrics_output()})
+        check.run()
+        assert check._passed is True
+        # One passing subtest per bucket, so callers see the counts.
+        bucket_subtests = [r for r in check._subtest_results if r["name"].startswith("metric_")]
+        assert {r["name"] for r in bucket_subtests} == {
+            "metric_delivered",
+            "metric_healthy",
+            "metric_reserved",
+            "metric_active",
+        }
+        assert all(r["passed"] for r in bucket_subtests)
+        assert "delivered" in check._output
+
+    def test_step_failure_propagates(self) -> None:
+        """When the underlying step reports failure the check should fail."""
+        check = GovernanceMetricsCheck(
+            config={"step_output": _metrics_output(success=False, error="API down")}
+        )
+        check.run()
+        assert check._passed is False
+        assert "API down" in check._error
+
+    def test_missing_metrics_object_fails(self) -> None:
+        """A step output without a 'metrics' object should fail with a clear message."""
+        output = _metrics_output()
+        del output["metrics"]
+        check = GovernanceMetricsCheck(config={"step_output": output})
+        check.run()
+        assert check._passed is False
+        assert "missing the 'metrics' object" in check._error
+
+    def test_missing_required_bucket_fails(self) -> None:
+        """All four canonical buckets are required."""
+        output = _metrics_output()
+        del output["metrics"]["active"]
+        check = GovernanceMetricsCheck(config={"step_output": output})
+        check.run()
+        assert check._passed is False
+        assert "missing required buckets" in check._error
+        assert "active" in check._error
+
+    def test_missing_resource_field_fails(self) -> None:
+        """Each bucket must expose both ``nodes`` and ``gpus``."""
+        output = _metrics_output()
+        del output["metrics"]["delivered"]["gpus"]
+        check = GovernanceMetricsCheck(config={"step_output": output})
+        check.run()
+        assert check._passed is False
+        assert "delivered" in check._error and "gpus" in check._error
+
+    def test_negative_count_fails(self) -> None:
+        """Counts must be non-negative integers."""
+        output = _metrics_output(delivered={"nodes": -1, "gpus": 0})
+        check = GovernanceMetricsCheck(config={"step_output": output})
+        check.run()
+        assert check._passed is False
+        assert "delivered.nodes" in check._error
+
+    def test_bool_rejected_as_count(self) -> None:
+        """A boolean masquerading as an int should be rejected."""
+        output = _metrics_output()
+        output["metrics"]["healthy"]["nodes"] = True  # type: ignore[assignment]
+        check = GovernanceMetricsCheck(config={"step_output": output})
+        check.run()
+        assert check._passed is False
+        assert "healthy.nodes" in check._error
+
+    def test_string_value_fails(self) -> None:
+        """Non-integer count types should be rejected."""
+        output = _metrics_output()
+        output["metrics"]["reserved"]["gpus"] = "120"  # type: ignore[assignment]
+        check = GovernanceMetricsCheck(config={"step_output": output})
+        check.run()
+        assert check._passed is False
+        assert "reserved.gpus" in check._error
+
+    def test_healthy_exceeds_delivered_fails(self) -> None:
+        """Healthy must be a subset of Delivered."""
+        output = _metrics_output(
+            delivered={"nodes": 5, "gpus": 40},
+            healthy={"nodes": 6, "gpus": 40},
+        )
+        check = GovernanceMetricsCheck(config={"step_output": output})
+        check.run()
+        assert check._passed is False
+        assert "healthy nodes" in check._error
+        assert "delivered nodes" in check._error
+
+    def test_reserved_exceeds_delivered_fails(self) -> None:
+        """Reserved must be a subset of Delivered."""
+        output = _metrics_output(
+            delivered={"nodes": 5, "gpus": 40},
+            reserved={"nodes": 5, "gpus": 48},
+        )
+        check = GovernanceMetricsCheck(config={"step_output": output})
+        check.run()
+        assert check._passed is False
+        assert "reserved gpus" in check._error
+
+    def test_active_exceeds_reserved_fails(self) -> None:
+        """Active must be a subset of Reserved."""
+        output = _metrics_output(
+            reserved={"nodes": 3, "gpus": 24},
+            active={"nodes": 4, "gpus": 24},
+        )
+        check = GovernanceMetricsCheck(config={"step_output": output})
+        check.run()
+        assert check._passed is False
+        assert "active nodes" in check._error
+        assert "reserved nodes" in check._error
+
+    def test_min_delivered_thresholds_enforced(self) -> None:
+        """Configurable minimum thresholds enforce a delivered fleet floor."""
+        output = _metrics_output(delivered={"nodes": 0, "gpus": 0})
+        check = GovernanceMetricsCheck(
+            config={"step_output": output, "min_delivered_nodes": 1}
+        )
+        check.run()
+        assert check._passed is False
+        assert "Delivered nodes 0" in check._error
+
+    def test_min_delivered_thresholds_default_zero(self) -> None:
+        """Without overrides, a zero-machine site is still well-formed."""
+        zero = {"nodes": 0, "gpus": 0}
+        output = _metrics_output(
+            delivered=zero, healthy=zero, reserved=zero, active=zero
+        )
+        check = GovernanceMetricsCheck(config={"step_output": output})
+        check.run()
+        assert check._passed is True
+
+    def test_invalid_min_threshold_type_fails(self) -> None:
+        """A non-int min threshold should produce an actionable error."""
+        check = GovernanceMetricsCheck(
+            config={
+                "step_output": _metrics_output(),
+                "min_delivered_nodes": "many",
+            }
+        )
+        check.run()
+        assert check._passed is False
+        assert "min_delivered_nodes" in check._error
+
+    def test_bucket_not_an_object_fails(self) -> None:
+        """A metric bucket that is not a dict should be rejected up front."""
+        output = _metrics_output()
+        output["metrics"]["healthy"] = [1, 2, 3]  # type: ignore[assignment]
+        check = GovernanceMetricsCheck(config={"step_output": output})
+        check.run()
+        assert check._passed is False
+        assert "healthy" in check._error
+
+    def test_empty_step_output_fails(self) -> None:
+        """Empty step_output should fail (no success flag)."""
+        check = GovernanceMetricsCheck(config={"step_output": {}})
+        check.run()
+        assert check._passed is False
+        assert "step failed" in check._error
+
+    def test_default_step_output_unchanged(self) -> None:
+        """The helper should hand back independent dicts so tests don't bleed into each other."""
+        # If the default mutates across calls a later test could silently see
+        # the previous test's overrides; pin the contract here.
+        first = _metrics_output()
+        second = _metrics_output()
+        assert first is not second
+        assert first["metrics"] == second["metrics"]
+        # Mutating one must not change the other.
+        snapshot = copy.deepcopy(second["metrics"])
+        first["metrics"]["delivered"]["nodes"] = 42
+        assert second["metrics"] == snapshot


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the M6 **CAP01-01** governance metrics validation as a follow-up to the NICo work in #450. A Cloud Governance API must expose Delivered, Healthy, Reserved, and Active counts for nodes and GPUs; this PR validates that contract end-to-end on the NICo provider.

- **`GovernanceMetricsCheck`** (`isvtest/.../validations/governance.py`): provider-agnostic check that the four buckets exist with non-negative integer `(nodes, gpus)` counts and that `Healthy/Reserved ⊆ Delivered` and `Active ⊆ Reserved`. Optional `min_delivered_{nodes,gpus}` thresholds.
- **NICo `query_metrics.py`** (`providers/nico/scripts/governance/`): pages the site's machines via the shared NICo client and maps each `MachineStatus` into a bucket (`Decommissioned`/`Unknown` excluded). GPU counts sum `MachineCapability.count`.
- **Wiring**: `bare_metal.yaml` gets a `governance_metrics` validation on a new `query_governance_metrics` step (opt-in, so providers that don't wire it skip automatically); the NICo config wires the script with the existing `org`/`site_id`/`api_base` settings.
- **Docs**: `configs/suites/README.md` lists the new step and JSON fields.

NICo `MachineStatus` → bucket: **Delivered** = not `{Decommissioned, Unknown}`; **Healthy** = Delivered with no `health.alerts`; **Reserved** = `{InUse, Maintenance}`; **Active** = `{InUse}`.

Ships **unreleased** (`released_tests.json` untouched); run with `ISVTEST_INCLUDE_UNRELEASED=1`.

## Testing

- `make test` — 925 pass (17 new validation cases + 6 new NICo script cases, incl. an end-to-end test piping the script's JSON through the validation).
- `make lint` / `uvx pre-commit run -a` — clean.
- `make demo-test` — `my-isv` configs pass; new check skips with `step_not_configured` where the step isn't wired.
- **Live NICo run** (`ISVTEST_INCLUDE_UNRELEASED=1 isvctl test run -f providers/nico/config/bare_metal.yaml`): `GovernanceMetricsCheck PASSED — delivered: nodes=20, gpus=160` across the 20-machine site.

Closes #251

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9dab5404-f77f-45cf-bff7-7a932a2a035e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9dab5404-f77f-45cf-bff7-7a932a2a035e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added governance metrics validation for bare-metal systems to query and aggregate machine states (delivered, healthy, reserved, active) and enforce minimum delivery thresholds.

* **Documentation**
  * Updated validation suite documentation to describe the new governance metrics validation step and its expected output fields.

* **Tests**
  * Added comprehensive test coverage for governance metrics aggregation, validation logic, error handling, and API failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->