### PR TITLE
feat(nico): add inventory/readiness validations

### DIFF
--- a/isvctl/configs/providers/nico/config/bare_metal.yaml
+++ b/isvctl/configs/providers/nico/config/bare_metal.yaml
@@ -16,12 +16,11 @@
 # NICo Bare Metal (BMaaS) Validation Configuration
 #
 # Imports the provider-agnostic bare_metal contract and wires the NICo
-# hardware-lifecycle steps. NICo currently implements the hardware ingestion,
-# DPU health, governance-metrics, unified host-health, and InfiniBand
-# fabric-security steps; the remaining bare_metal
-# validations are skipped automatically because their steps are not defined
-# here (a future PR will wire the full lifecycle so NICo can pass the entire
-# BM suite).
+# hardware-lifecycle and inventory steps. NICo currently implements hardware
+# ingestion, DPU health, governance metrics, unified host-health, InfiniBand
+# fabric security, tenant-transition sanitization, attestation, and existing
+# instance inventory checks. Full lifecycle and SSH-host validations remain
+# excluded until those steps are wired for NICo.
 #
 # Architecture:
 #   - verify_ingestion.py compares expected-machine manifest vs discovered
@@ -52,6 +51,8 @@
 #     nico-admin-cli into the provider-neutral attestation contract (SEC22-01 /
 #     CNP09-02). It requires operator/admin CLI credentials in addition to the
 #     tenant REST credentials used for machine enumeration.
+#   - list_instances.py / describe_instance.py query existing instances;
+#     InstanceListCheck and InstanceStateCheck validate the JSON contract.
 #
 # Prerequisites:
 #   - NICO_API_BASE set to the NICo API base URL
@@ -59,6 +60,7 @@
 #     NICO_SSA_ISSUER, NICO_CLIENT_ID, and NICO_CLIENT_SECRET
 #   - Expected machines pre-registered; machines ingested and DPUs initialized
 #   - NICO_ORGANIZATION and NICO_SITE_ID environment variables set
+#   - Optional NICO_INSTANCE_ID narrows inventory checks to a known instance
 #
 # Usage:
 #   NICO_BEARER_TOKEN=<token> NICO_ORGANIZATION=<org-name> NICO_SITE_ID=<uuid> \
@@ -223,17 +225,71 @@ commands:
           - "{{nico_api_base}}"
         timeout: 120
 
+      # ─── List Existing Instances ───────────────────────────────────
+      # Lists instances visible to NICo at the configured site.
+      - name: list_instances
+        phase: test
+        command: "python ../scripts/bare_metal/list_instances.py"
+        args:
+          - "--org"
+          - "{{org}}"
+          - "--site-id"
+          - "{{site_id}}"
+          - "--api-base"
+          - "{{nico_api_base}}"
+          - "--instance-id={{instance_id}}"
+        timeout: 120
+
+      # ─── Describe Existing Instance ────────────────────────────────
+      # Describes NICO_INSTANCE_ID, or the first instance found at the site.
+      - name: describe_instance
+        phase: test
+        command: "python ../scripts/bare_metal/describe_instance.py"
+        args:
+          - "--org"
+          - "{{org}}"
+          - "--site-id"
+          - "{{site_id}}"
+          - "--api-base"
+          - "{{nico_api_base}}"
+          - "--instance-id={{instance_id}}"
+        timeout: 120
+
 tests:
   cluster_name: "nico-bare-metal-validation"
-  description: "Verify NICo bare-metal hardware ingestion and DPU health"
+  description: "Verify NICo bare-metal hardware ingestion, DPU health, governance, host health, and instance inventory"
 
   settings:
     org: "{{env.NICO_ORGANIZATION}}"
     site_id: "{{env.NICO_SITE_ID}}"
     nico_api_base: "{{env.NICO_API_BASE}}"
+    instance_id: "{{env.NICO_INSTANCE_ID}}"
     # The imported bare_metal suite defines these for the full instance
     # lifecycle, which NICo does not run yet. Blank them so the suite's
     # {{instance_type}} self-reference does not emit missing-variable warnings.
     region: ""
     instance_type: ""
     teardown_flag: ""
+
+  # Adding describe_instance enables all suite checks anchored to that step.
+  # Keep SSH, host GPU, interconnect, and workload checks out until their
+  # scripts are wired. Exclude by validation name so NICo's wired fabric and
+  # sanitization security checks are not suppressed by broad labels.
+  exclude:
+    labels: []
+    tests:
+      - ConnectivityCheck
+      - OsCheck
+      - GpuCheck
+      - VcpuPinningCheck
+      - PciBusCheck
+      - HostSoftwareCheck
+      - GpuStressCheck
+      - NcclCheck
+      - TrainingCheck
+      - NvlinkCheck
+      - InfiniBandCheck
+      - EthernetCheck
+      - DriverCheck
+      - CpuInfoCheck
+      - ContainerRuntimeCheck

--- a/isvctl/configs/providers/nico/config/control-plane.yaml
+++ b/isvctl/configs/providers/nico/config/control-plane.yaml
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NICo Control Plane Validation Configuration
+#
+# Wires NICo API health checks adapted from the earlier Carbide provider work.
+# This file does not import the full provider-agnostic control-plane suite
+# because NICo does not yet wire the access-key, tenant, or object-lifecycle
+# steps required by that suite.
+#
+# Required:
+#   NICO_API_BASE, NICO_ORGANIZATION, NICO_SITE_ID, and NICo auth.
+#
+# Usage:
+#   uv run isvctl test run -f isvctl/configs/providers/nico/config/control-plane.yaml
+
+version: "1.0"
+
+commands:
+  control_plane:
+    phases: ["test"]
+    steps:
+      - name: check_api
+        phase: test
+        command: "python ../scripts/control-plane/check_api.py"
+        args:
+          - "--org"
+          - "{{org}}"
+          - "--site-id"
+          - "{{site_id}}"
+          - "--api-base"
+          - "{{nico_api_base}}"
+        timeout: 120
+
+tests:
+  platform: control_plane
+  cluster_name: "nico-control-plane-validation"
+  description: "Verify NICo API health"
+
+  settings:
+    org: "{{env.NICO_ORGANIZATION}}"
+    site_id: "{{env.NICO_SITE_ID}}"
+    nico_api_base: "{{env.NICO_API_BASE}}"
+
+  validations:
+    api_health:
+      step: check_api
+      checks:
+        FieldExistsCheck:
+          test_id: "N/A"
+          labels: ["control_plane"]
+          fields: ["account_id", "tests"]
+        FieldValueCheck:
+          test_id: "CP-XX-03"
+          labels: ["control_plane"]
+          field: "success"
+          expected: true
+
+  exclude:
+    labels: []

--- a/isvctl/configs/providers/nico/config/iam.yaml
+++ b/isvctl/configs/providers/nico/config/iam.yaml
@@ -60,7 +60,7 @@ tests:
         FieldExistsCheck:
           test_id: "N/A"
           labels: ["iam"]
-          fields: ["account_id", "authenticated", "identity_id", "tests"]
+          fields: ["account_id", "authenticated", "tests"]
         StepSuccessCheck:
           test_id: "N/A"
           labels: ["iam"]

--- a/isvctl/configs/providers/nico/config/iam.yaml
+++ b/isvctl/configs/providers/nico/config/iam.yaml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NICo IAM Validation Configuration
+#
+# Wires NICo credential readiness checks adapted from the earlier Carbide
+# provider work. This file does not import the full provider-agnostic IAM suite
+# because NICo does not yet wire user create/delete lifecycle steps.
+#
+# Required:
+#   NICO_API_BASE, NICO_ORGANIZATION, NICO_SITE_ID, and NICo auth.
+#
+# Usage:
+#   uv run isvctl test run -f isvctl/configs/providers/nico/config/iam.yaml
+
+version: "1.0"
+
+commands:
+  iam:
+    phases: ["test"]
+    steps:
+      - name: check_credentials
+        phase: test
+        command: "python ../scripts/iam/check_credentials.py"
+        args:
+          - "--org"
+          - "{{org}}"
+          - "--site-id"
+          - "{{site_id}}"
+          - "--api-base"
+          - "{{nico_api_base}}"
+        timeout: 120
+
+tests:
+  platform: iam
+  cluster_name: "nico-iam-validation"
+  description: "Verify NICo credential readiness"
+
+  settings:
+    org: "{{env.NICO_ORGANIZATION}}"
+    site_id: "{{env.NICO_SITE_ID}}"
+    nico_api_base: "{{env.NICO_API_BASE}}"
+
+  validations:
+    credential_readiness:
+      step: check_credentials
+      checks:
+        FieldExistsCheck:
+          test_id: "N/A"
+          labels: ["iam"]
+          fields: ["account_id", "authenticated", "identity_id", "tests"]
+        StepSuccessCheck:
+          test_id: "N/A"
+          labels: ["iam"]
+
+  exclude:
+    labels: []

--- a/isvctl/configs/providers/nico/config/network.yaml
+++ b/isvctl/configs/providers/nico/config/network.yaml
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NICo Network Validation Configuration
+#
+# Wires existing VPC, subnet, and network-assignment probes adapted from the
+# earlier Carbide provider work. This file does not import the full
+# provider-agnostic network suite because NICo does not yet wire VPC/SG/SDN
+# lifecycle and traffic-test steps required by that suite.
+#
+# Required:
+#   NICO_API_BASE, NICO_ORGANIZATION, NICO_SITE_ID, and NICo auth.
+#
+# Optional:
+#   NICO_VPC_ID and NICO_SUBNET_ID narrow checks to known pre-existing
+#   resources. If omitted, detail checks use the first matching resource found
+#   at the site.
+#
+# Usage:
+#   uv run isvctl test run -f isvctl/configs/providers/nico/config/network.yaml
+
+version: "1.0"
+
+commands:
+  network:
+    phases: ["test"]
+    steps:
+      - name: list_vpcs
+        phase: test
+        command: "python ../scripts/network/list_vpcs.py"
+        args:
+          - "--org"
+          - "{{org}}"
+          - "--site-id"
+          - "{{site_id}}"
+          - "--api-base"
+          - "{{nico_api_base}}"
+          - "--vpc-id={{vpc_id}}"
+        timeout: 120
+
+      - name: get_vpc
+        phase: test
+        command: "python ../scripts/network/get_vpc.py"
+        args:
+          - "--org"
+          - "{{org}}"
+          - "--site-id"
+          - "{{site_id}}"
+          - "--api-base"
+          - "{{nico_api_base}}"
+          - "--vpc-id={{vpc_id}}"
+        timeout: 120
+
+      - name: network_connectivity
+        phase: test
+        command: "python ../scripts/network/test_connectivity.py"
+        args:
+          - "--org"
+          - "{{org}}"
+          - "--site-id"
+          - "{{site_id}}"
+          - "--api-base"
+          - "{{nico_api_base}}"
+          - "--vpc-id={{vpc_id}}"
+          - "--subnet-id={{subnet_id}}"
+        timeout: 120
+
+      - name: traffic_validation
+        phase: test
+        command: "python ../scripts/network/traffic_validation.py"
+        args:
+          - "--org"
+          - "{{org}}"
+          - "--site-id"
+          - "{{site_id}}"
+          - "--api-base"
+          - "{{nico_api_base}}"
+          - "--vpc-id={{vpc_id}}"
+          - "--subnet-id={{subnet_id}}"
+        timeout: 120
+
+tests:
+  platform: network
+  cluster_name: "nico-network-validation"
+  description: "Verify NICo VPC and subnet inventory"
+
+  settings:
+    org: "{{env.NICO_ORGANIZATION}}"
+    site_id: "{{env.NICO_SITE_ID}}"
+    nico_api_base: "{{env.NICO_API_BASE}}"
+    vpc_id: "{{env.NICO_VPC_ID}}"
+    subnet_id: "{{env.NICO_SUBNET_ID}}"
+
+  validations:
+    vpc_inventory:
+      step: list_vpcs
+      checks:
+        TenantListedCheck:
+          test_id: "N/A"
+          labels: ["network"]
+
+    vpc_info:
+      step: get_vpc
+      checks:
+        TenantInfoCheck:
+          test_id: "SDN01-02"
+          labels: ["min_req", "network"]
+
+    network_connectivity:
+      step: network_connectivity
+      checks:
+        StepSuccessCheck:
+          test_id: "N/A"
+          labels: ["network"]
+        FieldValueCheck:
+          test_id: "N/A"
+          labels: ["network"]
+          field: "tests.network_assigned.passed"
+          expected: true
+
+    traffic_validation:
+      step: traffic_validation
+      checks:
+        StepSuccessCheck:
+          test_id: "N/A"
+          labels: ["network"]
+        FieldValueCheck:
+          test_id: "N/A"
+          labels: ["network"]
+          field: "tests.network_setup.passed"
+          expected: true
+
+  exclude:
+    labels: []

--- a/isvctl/configs/providers/nico/scripts/bare_metal/describe_instance.py
+++ b/isvctl/configs/providers/nico/scripts/bare_metal/describe_instance.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Describe a NICo instance without mutating it."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.inventory import first_non_empty_id, normalize_instance
+from common.nico_client import NicoAuthError, forge_get, forge_get_all, resolve_auth
+
+
+def _first_instance_id(org: str, site_id: str, token: str, *, base_url: str) -> str:
+    """Return the first instance id for a site, or an empty string."""
+    raw_instances = forge_get_all(
+        org,
+        "instance",
+        token,
+        base_url=base_url,
+        params={"siteId": site_id},
+        result_key="instances",
+    )
+    instances = [normalize_instance(instance) for instance in raw_instances]
+    return first_non_empty_id(instances, "instance_id")
+
+
+def main() -> int:
+    """Fetch one NICo instance and emit the InstanceStateCheck contract."""
+    parser = argparse.ArgumentParser(description="Describe NICo instance")
+    parser.add_argument("--org", required=True, help="NGC org name")
+    parser.add_argument("--site-id", required=True, help="NICo site UUID")
+    parser.add_argument("--api-base", required=True, help="NICo API base URL")
+    parser.add_argument("--instance-id", default="", help="Instance UUID; defaults to the first site instance")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "nico",
+        "site_id": args.site_id,
+    }
+
+    try:
+        auth = resolve_auth()
+        instance_id = args.instance_id or _first_instance_id(args.org, args.site_id, auth.token, base_url=args.api_base)
+        if not instance_id:
+            result["success"] = True
+            result["skipped"] = True
+            result["skip_reason"] = "No instances found at site; instance detail validation has no resource to inspect"
+            print(json.dumps(result, indent=2))
+            return 0
+
+        raw_instance = forge_get(args.org, f"instance/{instance_id}", auth.token, base_url=args.api_base)
+        result.update(normalize_instance(raw_instance))
+        result["success"] = True
+
+    except NicoAuthError as e:
+        result["error_type"] = "auth"
+        result["error"] = str(e)
+    except Exception as e:
+        result["error"] = f"{type(e).__name__}: {e}"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/nico/scripts/bare_metal/list_instances.py
+++ b/isvctl/configs/providers/nico/scripts/bare_metal/list_instances.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""List NICo instances without mutating them."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.inventory import normalize_instance
+from common.nico_client import NicoAuthError, forge_get_all, resolve_auth
+
+
+def main() -> int:
+    """Fetch NICo instances for a site and emit the InstanceListCheck contract."""
+    parser = argparse.ArgumentParser(description="List NICo instances")
+    parser.add_argument("--org", required=True, help="NGC org name")
+    parser.add_argument("--site-id", required=True, help="NICo site UUID")
+    parser.add_argument("--api-base", required=True, help="NICo API base URL")
+    parser.add_argument("--instance-id", default="", help="Optional target instance UUID")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "nico",
+        "site_id": args.site_id,
+        "instances": [],
+        "count": 0,
+    }
+    if args.instance_id:
+        result["target_instance"] = args.instance_id
+        result["found_target"] = False
+
+    try:
+        auth = resolve_auth()
+        raw_instances = forge_get_all(
+            args.org,
+            "instance",
+            auth.token,
+            base_url=args.api_base,
+            params={"siteId": args.site_id},
+            result_key="instances",
+        )
+        instances = [normalize_instance(instance) for instance in raw_instances]
+
+        result["instances"] = instances
+        result["count"] = len(instances)
+        if args.instance_id:
+            result["found_target"] = any(instance["instance_id"] == args.instance_id for instance in instances)
+        elif not instances:
+            result["skipped"] = True
+            result["skip_reason"] = (
+                "No instances found at site; instance inventory validation has no resource to inspect"
+            )
+        result["success"] = True
+
+    except NicoAuthError as e:
+        result["error_type"] = "auth"
+        result["error"] = str(e)
+    except Exception as e:
+        result["error"] = f"{type(e).__name__}: {e}"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/nico/scripts/common/inventory.py
+++ b/isvctl/configs/providers/nico/scripts/common/inventory.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Normalization helpers for NICo inventory validation scripts."""
+
+from typing import Any
+
+
+def first_string(data: dict[str, Any], *keys: str) -> str:
+    """Return the first non-empty string-ish field from a NICo API object."""
+    for key in keys:
+        value = data.get(key)
+        if value is None:
+            continue
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped:
+                return stripped
+            continue
+        if isinstance(value, int | float | bool):
+            return str(value)
+    return ""
+
+
+def normalize_state(data: dict[str, Any]) -> str:
+    """Normalize NICo state/status fields to validation contract values."""
+    raw = first_string(data, "state", "status", "instanceState")
+    state = raw.lower()
+    if state in {"active", "inuse", "in-use", "ready", "running"}:
+        return "running"
+    if state in {"deleted", "deleting", "terminated"}:
+        return "terminated"
+    if state in {"stopped", "stopping"}:
+        return "stopped"
+    return state or "unknown"
+
+
+def normalize_instance(data: dict[str, Any]) -> dict[str, str]:
+    """Normalize a NICo instance object for instance validations."""
+    return {
+        "instance_id": first_string(data, "instance_id", "instanceId", "id"),
+        "state": normalize_state(data),
+        "vpc_id": first_string(data, "vpc_id", "vpcId", "network_id", "networkId"),
+        "public_ip": first_string(data, "public_ip", "publicIp", "ip_address", "ipAddress"),
+        "private_ip": first_string(data, "private_ip", "privateIp", "internal_ip", "internalIp"),
+    }
+
+
+def normalize_vpc(data: dict[str, Any]) -> dict[str, str]:
+    """Normalize a NICo VPC object to tenant-compatible fields."""
+    vpc_id = first_string(data, "vpc_id", "vpcId", "id")
+    name = first_string(data, "name", "vpc_name", "vpcName") or vpc_id
+    return {
+        "tenant_id": vpc_id,
+        "tenant_name": name,
+        "description": first_string(data, "description"),
+    }
+
+
+def normalize_subnet(data: dict[str, Any]) -> dict[str, str]:
+    """Normalize a NICo subnet object for network inventory checks."""
+    return {
+        "subnet_id": first_string(data, "subnet_id", "subnetId", "id"),
+        "vpc_id": first_string(data, "vpc_id", "vpcId", "network_id", "networkId"),
+        "cidr": first_string(data, "cidr", "cidrBlock", "cidr_block"),
+    }
+
+
+def first_non_empty_id(items: list[dict[str, str]], key: str) -> str:
+    """Return the first non-empty identifier in a normalized object list."""
+    for item in items:
+        value = item.get(key, "").strip()
+        if value:
+            return value
+    return ""

--- a/isvctl/configs/providers/nico/scripts/control-plane/check_api.py
+++ b/isvctl/configs/providers/nico/scripts/control-plane/check_api.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NICo API health probe."""
+
+import argparse
+import json
+import sys
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.nico_client import NicoAuthError, forge_get, forge_get_all, resolve_auth
+
+
+def _timed(call: Callable[[], Any]) -> tuple[Any, float]:
+    """Run a callable and return its result with elapsed milliseconds."""
+    start = time.monotonic()
+    payload = call()
+    return payload, round((time.monotonic() - start) * 1000, 2)
+
+
+def main() -> int:
+    """Authenticate to NICo and verify site endpoints are reachable."""
+    parser = argparse.ArgumentParser(description="Check NICo API health")
+    parser.add_argument("--org", required=True, help="NGC org name")
+    parser.add_argument("--site-id", required=True, help="NICo site UUID")
+    parser.add_argument("--api-base", required=True, help="NICo API base URL")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "nico",
+        "account_id": args.org,
+        "tests": {},
+    }
+
+    try:
+        auth = resolve_auth()
+        site, site_latency = _timed(
+            lambda: forge_get(
+                args.org,
+                f"site/{args.site_id}",
+                auth.token,
+                base_url=args.api_base,
+            )
+        )
+        sites, sites_latency = _timed(
+            lambda: forge_get_all(
+                args.org,
+                "site",
+                auth.token,
+                base_url=args.api_base,
+                params={"pageSize": "100"},
+                result_key="sites",
+            )
+        )
+
+        result["tests"]["site"] = {
+            "passed": bool(site.get("id") or site.get("siteId")),
+            "latency_ms": site_latency,
+        }
+        result["tests"]["sites"] = {
+            "passed": isinstance(sites, list),
+            "latency_ms": sites_latency,
+            "count": len(sites),
+        }
+        result["success"] = all(test["passed"] for test in result["tests"].values())
+
+    except NicoAuthError as e:
+        result["error_type"] = "auth"
+        result["error"] = str(e)
+    except Exception as e:
+        result["error"] = f"{type(e).__name__}: {e}"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/nico/scripts/iam/check_credentials.py
+++ b/isvctl/configs/providers/nico/scripts/iam/check_credentials.py
@@ -40,11 +40,15 @@ def main() -> int:
         "platform": "nico",
         "account_id": args.org,
         "authenticated": False,
+        "auth_source": "unresolved",
+        "identity_id": f"unresolved:{args.org}",
         "tests": {},
     }
 
     try:
         auth = resolve_auth()
+        result["auth_source"] = auth.source
+        result["identity_id"] = f"{auth.source}:{args.org}"
         site = forge_get(args.org, f"site/{args.site_id}", auth.token, base_url=args.api_base)
         sites = forge_get_all(
             args.org,
@@ -56,8 +60,6 @@ def main() -> int:
         )
 
         result["authenticated"] = True
-        result["auth_source"] = auth.source
-        result["identity_id"] = f"{auth.source}:{args.org}"
         result["tests"]["identity"] = {
             "passed": bool(site.get("id") or site.get("siteId")),
             "message": f"Authenticated to NICo as org {args.org}",

--- a/isvctl/configs/providers/nico/scripts/iam/check_credentials.py
+++ b/isvctl/configs/providers/nico/scripts/iam/check_credentials.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NICo credential readiness probe."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.nico_client import NicoAuthError, forge_get, forge_get_all, resolve_auth
+
+
+def main() -> int:
+    """Validate that configured NICo credentials can read site data."""
+    parser = argparse.ArgumentParser(description="Check NICo credentials")
+    parser.add_argument("--org", required=True, help="NGC org name")
+    parser.add_argument("--site-id", required=True, help="NICo site UUID")
+    parser.add_argument("--api-base", required=True, help="NICo API base URL")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "nico",
+        "account_id": args.org,
+        "authenticated": False,
+        "tests": {},
+    }
+
+    try:
+        auth = resolve_auth()
+        site = forge_get(args.org, f"site/{args.site_id}", auth.token, base_url=args.api_base)
+        sites = forge_get_all(
+            args.org,
+            "site",
+            auth.token,
+            base_url=args.api_base,
+            params={"pageSize": "100"},
+            result_key="sites",
+        )
+
+        result["authenticated"] = True
+        result["auth_source"] = auth.source
+        result["identity_id"] = f"{auth.source}:{args.org}"
+        result["tests"]["identity"] = {
+            "passed": bool(site.get("id") or site.get("siteId")),
+            "message": f"Authenticated to NICo as org {args.org}",
+        }
+        result["tests"]["access"] = {
+            "passed": isinstance(sites, list),
+            "message": "Read access verified with site list",
+            "site_count": len(sites),
+        }
+        result["success"] = result["tests"]["identity"]["passed"] and result["tests"]["access"]["passed"]
+
+    except NicoAuthError as e:
+        result["error_type"] = "auth"
+        result["error"] = str(e)
+    except Exception as e:
+        result["error"] = f"{type(e).__name__}: {e}"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/nico/scripts/network/get_vpc.py
+++ b/isvctl/configs/providers/nico/scripts/network/get_vpc.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Describe a NICo VPC without mutating it."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.inventory import first_non_empty_id, normalize_vpc
+from common.nico_client import NicoAuthError, forge_get, forge_get_all, resolve_auth
+
+
+def _first_vpc_id(org: str, site_id: str, token: str, *, base_url: str) -> str:
+    """Return the first VPC id for a site, or an empty string."""
+    raw_vpcs = forge_get_all(
+        org,
+        "vpc",
+        token,
+        base_url=base_url,
+        params={"siteId": site_id},
+        result_key="vpcs",
+    )
+    vpcs = [normalize_vpc(vpc) for vpc in raw_vpcs]
+    return first_non_empty_id(vpcs, "tenant_id")
+
+
+def main() -> int:
+    """Fetch one NICo VPC and emit tenant-compatible detail fields."""
+    parser = argparse.ArgumentParser(description="Get NICo VPC")
+    parser.add_argument("--org", required=True, help="NGC org name")
+    parser.add_argument("--site-id", required=True, help="NICo site UUID")
+    parser.add_argument("--api-base", required=True, help="NICo API base URL")
+    parser.add_argument("--vpc-id", default="", help="VPC UUID; defaults to the first site VPC")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "nico",
+        "site_id": args.site_id,
+    }
+
+    try:
+        auth = resolve_auth()
+        vpc_id = args.vpc_id or _first_vpc_id(args.org, args.site_id, auth.token, base_url=args.api_base)
+        if not vpc_id:
+            result["success"] = True
+            result["skipped"] = True
+            result["skip_reason"] = "No VPCs found at site; VPC detail validation has no resource to inspect"
+            print(json.dumps(result, indent=2))
+            return 0
+
+        raw_vpc = forge_get(args.org, f"vpc/{vpc_id}", auth.token, base_url=args.api_base)
+        result.update(normalize_vpc(raw_vpc))
+        result["success"] = True
+
+    except NicoAuthError as e:
+        result["error_type"] = "auth"
+        result["error"] = str(e)
+    except Exception as e:
+        result["error"] = f"{type(e).__name__}: {e}"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/nico/scripts/network/list_vpcs.py
+++ b/isvctl/configs/providers/nico/scripts/network/list_vpcs.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""List NICo VPCs without mutating them."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.inventory import normalize_vpc
+from common.nico_client import NicoAuthError, forge_get_all, resolve_auth
+
+
+def main() -> int:
+    """Fetch NICo VPCs and emit tenant-compatible list fields."""
+    parser = argparse.ArgumentParser(description="List NICo VPCs")
+    parser.add_argument("--org", required=True, help="NGC org name")
+    parser.add_argument("--site-id", required=True, help="NICo site UUID")
+    parser.add_argument("--api-base", required=True, help="NICo API base URL")
+    parser.add_argument("--vpc-id", default="", help="Optional target VPC UUID")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "nico",
+        "site_id": args.site_id,
+        "tenants": [],
+        "vpcs": [],
+        "count": 0,
+    }
+    if args.vpc_id:
+        result["target_tenant"] = args.vpc_id
+        result["found_target"] = False
+
+    try:
+        auth = resolve_auth()
+        raw_vpcs = forge_get_all(
+            args.org,
+            "vpc",
+            auth.token,
+            base_url=args.api_base,
+            params={"siteId": args.site_id},
+            result_key="vpcs",
+        )
+        vpcs = [normalize_vpc(vpc) for vpc in raw_vpcs]
+        tenants = [{"tenant_id": vpc["tenant_id"], "tenant_name": vpc["tenant_name"]} for vpc in vpcs]
+
+        result["vpcs"] = vpcs
+        result["tenants"] = tenants
+        result["count"] = len(vpcs)
+        if args.vpc_id:
+            result["found_target"] = any(
+                vpc["tenant_id"] == args.vpc_id or vpc["tenant_name"] == args.vpc_id for vpc in vpcs
+            )
+        result["success"] = True
+
+    except NicoAuthError as e:
+        result["error_type"] = "auth"
+        result["error"] = str(e)
+    except Exception as e:
+        result["error"] = f"{type(e).__name__}: {e}"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/nico/scripts/network/test_connectivity.py
+++ b/isvctl/configs/providers/nico/scripts/network/test_connectivity.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NICo network assignment probe."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.inventory import normalize_subnet
+from common.nico_client import NicoAuthError, forge_get_all, resolve_auth
+
+
+def main() -> int:
+    """Verify that an existing NICo VPC has at least one subnet."""
+    parser = argparse.ArgumentParser(description="Check NICo network assignment")
+    parser.add_argument("--org", required=True, help="NGC org name")
+    parser.add_argument("--site-id", required=True, help="NICo site UUID")
+    parser.add_argument("--api-base", required=True, help="NICo API base URL")
+    parser.add_argument("--vpc-id", default="", help="Optional VPC UUID")
+    parser.add_argument("--subnet-id", default="", help="Optional subnet UUID")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "nico",
+        "site_id": args.site_id,
+        "vpc_id": args.vpc_id,
+        "subnets": [],
+        "subnet_count": 0,
+        "tests": {},
+    }
+
+    try:
+        auth = resolve_auth()
+        params = {"siteId": args.site_id}
+        if args.vpc_id:
+            params["vpcId"] = args.vpc_id
+        raw_subnets = forge_get_all(
+            args.org,
+            "subnet",
+            auth.token,
+            base_url=args.api_base,
+            params=params,
+            result_key="subnets",
+        )
+        subnets = [normalize_subnet(subnet) for subnet in raw_subnets]
+        subnet_ids = {subnet["subnet_id"] for subnet in subnets if subnet["subnet_id"]}
+        has_subnet = bool(subnet_ids)
+        target_found = args.subnet_id in subnet_ids if args.subnet_id else has_subnet
+
+        result["subnets"] = subnets
+        result["subnet_count"] = len(subnets)
+        if not has_subnet and not args.subnet_id:
+            result["success"] = True
+            result["skipped"] = True
+            result["skip_reason"] = "No subnets found at site; network assignment validation has no resource to inspect"
+            print(json.dumps(result, indent=2))
+            return 0
+
+        result["tests"]["network_assigned"] = {"passed": has_subnet and target_found}
+        result["success"] = result["tests"]["network_assigned"]["passed"]
+
+    except NicoAuthError as e:
+        result["error_type"] = "auth"
+        result["error"] = str(e)
+    except Exception as e:
+        result["tests"]["network_assigned"] = {"passed": False, "error": str(e)}
+        result["error"] = f"{type(e).__name__}: {e}"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/nico/scripts/network/traffic_validation.py
+++ b/isvctl/configs/providers/nico/scripts/network/traffic_validation.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NICo network topology probe."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.inventory import first_non_empty_id, normalize_subnet, normalize_vpc
+from common.nico_client import NicoAuthError, forge_get, forge_get_all, resolve_auth
+
+
+def _first_vpc_id(org: str, site_id: str, token: str, *, base_url: str) -> str:
+    """Return the first VPC id for a site, or an empty string."""
+    raw_vpcs = forge_get_all(
+        org,
+        "vpc",
+        token,
+        base_url=base_url,
+        params={"siteId": site_id},
+        result_key="vpcs",
+    )
+    vpcs = [normalize_vpc(vpc) for vpc in raw_vpcs]
+    return first_non_empty_id(vpcs, "tenant_id")
+
+
+def main() -> int:
+    """Verify that an existing NICo VPC exists and has associated subnets."""
+    parser = argparse.ArgumentParser(description="Validate NICo network topology")
+    parser.add_argument("--org", required=True, help="NGC org name")
+    parser.add_argument("--site-id", required=True, help="NICo site UUID")
+    parser.add_argument("--api-base", required=True, help="NICo API base URL")
+    parser.add_argument("--vpc-id", default="", help="VPC UUID; defaults to the first site VPC")
+    parser.add_argument("--subnet-id", default="", help="Optional subnet UUID")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "nico",
+        "site_id": args.site_id,
+        "vpc_id": args.vpc_id,
+        "subnets": [],
+        "subnet_count": 0,
+        "tests": {},
+    }
+
+    try:
+        auth = resolve_auth()
+        vpc_id = args.vpc_id or _first_vpc_id(args.org, args.site_id, auth.token, base_url=args.api_base)
+        if not vpc_id:
+            result["success"] = True
+            result["skipped"] = True
+            result["skip_reason"] = "No VPCs found at site; network topology validation has no resource to inspect"
+            print(json.dumps(result, indent=2))
+            return 0
+
+        raw_vpc = forge_get(args.org, f"vpc/{vpc_id}", auth.token, base_url=args.api_base)
+        params = {"siteId": args.site_id, "vpcId": vpc_id}
+        raw_subnets = forge_get_all(
+            args.org,
+            "subnet",
+            auth.token,
+            base_url=args.api_base,
+            params=params,
+            result_key="subnets",
+        )
+        subnets = [normalize_subnet(subnet) for subnet in raw_subnets]
+        subnet_ids = {subnet["subnet_id"] for subnet in subnets if subnet["subnet_id"]}
+        target_found = args.subnet_id in subnet_ids if args.subnet_id else bool(subnet_ids)
+
+        result.update({"vpc_id": vpc_id, **normalize_vpc(raw_vpc)})
+        result["subnets"] = subnets
+        result["subnet_count"] = len(subnets)
+        if not subnet_ids and not args.subnet_id:
+            result["success"] = True
+            result["skipped"] = True
+            result["skip_reason"] = "No subnets found for VPC; network topology validation has no resource to inspect"
+            print(json.dumps(result, indent=2))
+            return 0
+
+        result["tests"]["network_setup"] = {"passed": bool(raw_vpc) and target_found}
+        result["success"] = result["tests"]["network_setup"]["passed"]
+
+    except NicoAuthError as e:
+        result["error_type"] = "auth"
+        result["error"] = str(e)
+    except Exception as e:
+        result["tests"]["network_setup"] = {"passed": False, "error": str(e)}
+        result["error"] = f"{type(e).__name__}: {e}"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/tests/providers/nico/test_nico_provider.py
+++ b/isvctl/tests/providers/nico/test_nico_provider.py
@@ -446,6 +446,65 @@ def test_nico_check_api_reads_site_and_site_list(
     ]
 
 
+def test_nico_iam_config_platform_matches_command_group() -> None:
+    """The orchestrator uses tests.platform to look up the IAM commands group."""
+    merged, _steps = _merged_nico_config_steps("iam.yaml", "iam")
+
+    assert merged["tests"]["platform"] == "iam"
+
+
+def test_nico_iam_config_wires_credential_readiness() -> None:
+    """The NICo IAM config should wire the credential readiness probe."""
+    merged, steps = _merged_nico_config_steps("iam.yaml", "iam")
+
+    assert set(steps) == {"check_credentials"}
+    _assert_steps_use_nico_api_base(steps)
+
+    validations = merged["tests"]["validations"]
+    assert merged["tests"]["settings"]["nico_api_base"] == "{{env.NICO_API_BASE}}"
+    assert validations["credential_readiness"]["step"] == "check_credentials"
+
+
+def test_nico_check_credentials_reports_api_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The credentials probe should validate bearer/OIDC auth with inventory API calls."""
+    module = _load_nico_script("iam/check_credentials.py", "test_nico_check_credentials")
+
+    monkeypatch.setattr(
+        module,
+        "resolve_auth",
+        lambda: SimpleNamespace(token="test-token", source="oidc_client_credentials"),
+    )
+    monkeypatch.setattr(module, "forge_get", lambda *args, **kwargs: {"id": "site-1", "name": "NICo lab"})
+    monkeypatch.setattr(module, "forge_get_all", lambda *args, **kwargs: [{"id": "site-1"}])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_credentials.py",
+            "--org",
+            "test-org",
+            "--site-id",
+            "site-1",
+            "--api-base",
+            "https://nico.example/v2/org",
+        ],
+    )
+
+    exit_code = module.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0, payload
+    assert payload["success"] is True
+    assert payload["account_id"] == "test-org"
+    assert payload["authenticated"] is True
+    assert payload["identity_id"] == "oidc_client_credentials:test-org"
+    assert payload["tests"]["identity"]["passed"] is True
+    assert payload["tests"]["access"]["passed"] is True
+
+
 @pytest.mark.parametrize(
     ("script_name", "load_script"),
     [

--- a/isvctl/tests/providers/nico/test_nico_provider.py
+++ b/isvctl/tests/providers/nico/test_nico_provider.py
@@ -691,6 +691,238 @@ def test_nico_instance_inventory_scripts_skip_when_site_has_no_instances(
     assert "No instances found" in describe_payload["skip_reason"]
 
 
+def test_nico_network_config_platform_matches_command_group() -> None:
+    """The orchestrator uses tests.platform to look up the network commands group."""
+    merged, _steps = _merged_nico_config_steps("network.yaml", "network")
+
+    assert merged["tests"]["platform"] == "network"
+
+
+def test_nico_network_config_wires_network_inventory_probes() -> None:
+    """The NICo network config should wire inventory and topology probes."""
+    merged, steps = _merged_nico_config_steps("network.yaml", "network")
+
+    assert set(steps) == {"list_vpcs", "get_vpc", "network_connectivity", "traffic_validation"}
+    _assert_steps_use_nico_api_base(steps)
+
+    validations = merged["tests"]["validations"]
+    assert merged["tests"]["settings"]["nico_api_base"] == "{{env.NICO_API_BASE}}"
+    assert validations["vpc_inventory"]["step"] == "list_vpcs"
+    assert validations["vpc_info"]["step"] == "get_vpc"
+    assert validations["network_connectivity"]["step"] == "network_connectivity"
+    assert validations["traffic_validation"]["step"] == "traffic_validation"
+
+
+def test_nico_network_config_keeps_empty_vpc_and_subnet_ids_attached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset optional network IDs should not render dangling argparse flags."""
+    monkeypatch.delenv("NICO_VPC_ID", raising=False)
+    monkeypatch.delenv("NICO_SUBNET_ID", raising=False)
+    merged, steps = _merged_nico_config_steps("network.yaml", "network")
+    context = Context(RunConfig.model_validate(merged))
+    executor = StepExecutor()
+
+    for step_name in ("list_vpcs", "get_vpc", "network_connectivity", "traffic_validation"):
+        rendered = executor._render_args(steps[step_name]["args"], context)
+
+        assert "--vpc-id" not in rendered
+        assert "--vpc-id=" in rendered
+
+    for step_name in ("network_connectivity", "traffic_validation"):
+        rendered = executor._render_args(steps[step_name]["args"], context)
+
+        assert "--subnet-id" not in rendered
+        assert "--subnet-id=" in rendered
+
+
+def test_nico_vpc_inventory_scripts_normalize_vpc_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The VPC probes should normalize NICo fields for tenant validations."""
+    list_module = _load_nico_script("network/list_vpcs.py", "test_nico_list_vpcs")
+    get_module = _load_nico_script("network/get_vpc.py", "test_nico_get_vpc")
+
+    monkeypatch.setattr(list_module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(get_module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(
+        list_module,
+        "forge_get_all",
+        lambda *args, **kwargs: [{"id": "vpc-1", "name": "tenant-a", "description": "lab network"}],
+    )
+    monkeypatch.setattr(
+        get_module,
+        "forge_get",
+        lambda *args, **kwargs: {"vpcId": "vpc-1", "vpcName": "tenant-a", "description": "lab network"},
+    )
+
+    base_argv = [
+        "--org",
+        "test-org",
+        "--site-id",
+        "site-1",
+        "--api-base",
+        "https://nico.example/v2/org",
+        "--vpc-id",
+        "vpc-1",
+    ]
+
+    monkeypatch.setattr(sys, "argv", ["list_vpcs.py", *base_argv])
+    assert list_module.main() == 0
+    list_payload = json.loads(capsys.readouterr().out)
+
+    monkeypatch.setattr(sys, "argv", ["get_vpc.py", *base_argv])
+    assert get_module.main() == 0
+    get_payload = json.loads(capsys.readouterr().out)
+
+    assert list_payload["success"] is True
+    assert list_payload["count"] == 1
+    assert list_payload["found_target"] is True
+    assert list_payload["tenants"] == [{"tenant_id": "vpc-1", "tenant_name": "tenant-a"}]
+    assert get_payload["success"] is True
+    assert get_payload["tenant_id"] == "vpc-1"
+    assert get_payload["tenant_name"] == "tenant-a"
+    assert get_payload["description"] == "lab network"
+
+
+def test_nico_get_vpc_skips_when_site_has_no_vpcs(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An empty site should skip detail validation instead of failing get_vpc."""
+    module = _load_nico_script("network/get_vpc.py", "test_nico_get_vpc_empty")
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(module, "forge_get_all", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        module,
+        "forge_get",
+        lambda *args, **kwargs: pytest.fail("get_vpc should not fetch detail when no VPC exists"),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "get_vpc.py",
+            "--org",
+            "test-org",
+            "--site-id",
+            "site-1",
+            "--api-base",
+            "https://nico.example/v2/org",
+            "--vpc-id=",
+        ],
+    )
+
+    assert module.main() == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is True
+    assert payload["skipped"] is True
+    assert "No VPCs found" in payload["skip_reason"]
+
+
+def test_nico_network_inventory_scripts_check_existing_vpc_and_subnets(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Network probes should pass when the requested VPC and subnet exist."""
+    connectivity_module = _load_nico_script("network/test_connectivity.py", "test_nico_network_connectivity")
+    traffic_module = _load_nico_script("network/traffic_validation.py", "test_nico_traffic_validation")
+
+    monkeypatch.setattr(connectivity_module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(traffic_module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(
+        connectivity_module,
+        "forge_get_all",
+        lambda *args, **kwargs: [{"id": "subnet-1", "vpcId": "vpc-1", "cidrBlock": "10.0.0.0/24"}],
+    )
+    monkeypatch.setattr(
+        traffic_module,
+        "forge_get",
+        lambda *args, **kwargs: {"id": "vpc-1", "name": "tenant-a"},
+    )
+    monkeypatch.setattr(
+        traffic_module,
+        "forge_get_all",
+        lambda *args, **kwargs: [{"id": "subnet-1", "vpcId": "vpc-1", "cidrBlock": "10.0.0.0/24"}],
+    )
+
+    base_argv = [
+        "--org",
+        "test-org",
+        "--site-id",
+        "site-1",
+        "--api-base",
+        "https://nico.example/v2/org",
+        "--vpc-id",
+        "vpc-1",
+        "--subnet-id",
+        "subnet-1",
+    ]
+
+    monkeypatch.setattr(sys, "argv", ["test_connectivity.py", *base_argv])
+    assert connectivity_module.main() == 0
+    connectivity_payload = json.loads(capsys.readouterr().out)
+
+    monkeypatch.setattr(sys, "argv", ["traffic_validation.py", *base_argv])
+    assert traffic_module.main() == 0
+    traffic_payload = json.loads(capsys.readouterr().out)
+
+    assert connectivity_payload["success"] is True
+    assert connectivity_payload["subnet_count"] == 1
+    assert connectivity_payload["tests"]["network_assigned"]["passed"] is True
+    assert traffic_payload["success"] is True
+    assert traffic_payload["tenant_id"] == "vpc-1"
+    assert traffic_payload["subnet_count"] == 1
+    assert traffic_payload["tests"]["network_setup"]["passed"] is True
+
+
+def test_nico_network_inventory_scripts_skip_when_site_has_no_network_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A site without VPCs or subnets should skip dependent network validations."""
+    connectivity_module = _load_nico_script("network/test_connectivity.py", "test_nico_network_connectivity_empty")
+    traffic_module = _load_nico_script("network/traffic_validation.py", "test_nico_traffic_validation_empty")
+
+    monkeypatch.setattr(connectivity_module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(traffic_module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(connectivity_module, "forge_get_all", lambda *args, **kwargs: [])
+    monkeypatch.setattr(traffic_module, "forge_get_all", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        traffic_module,
+        "forge_get",
+        lambda *args, **kwargs: pytest.fail("traffic_validation should not fetch detail when no VPC exists"),
+    )
+
+    base_argv = [
+        "--org",
+        "test-org",
+        "--site-id",
+        "site-1",
+        "--api-base",
+        "https://nico.example/v2/org",
+        "--vpc-id=",
+        "--subnet-id=",
+    ]
+
+    monkeypatch.setattr(sys, "argv", ["test_connectivity.py", *base_argv])
+    assert connectivity_module.main() == 0
+    connectivity_payload = json.loads(capsys.readouterr().out)
+
+    monkeypatch.setattr(sys, "argv", ["traffic_validation.py", *base_argv])
+    assert traffic_module.main() == 0
+    traffic_payload = json.loads(capsys.readouterr().out)
+
+    assert connectivity_payload["success"] is True
+    assert connectivity_payload["skipped"] is True
+    assert "No subnets found" in connectivity_payload["skip_reason"]
+    assert traffic_payload["success"] is True
+    assert traffic_payload["skipped"] is True
+    assert "No VPCs found" in traffic_payload["skip_reason"]
+
+
 @pytest.mark.parametrize(
     ("script_name", "load_script"),
     [

--- a/isvctl/tests/providers/nico/test_nico_provider.py
+++ b/isvctl/tests/providers/nico/test_nico_provider.py
@@ -466,6 +466,11 @@ def test_nico_iam_config_wires_credential_readiness() -> None:
     validations = merged["tests"]["validations"]
     assert merged["tests"]["settings"]["nico_api_base"] == "{{env.NICO_API_BASE}}"
     assert validations["credential_readiness"]["step"] == "check_credentials"
+    assert validations["credential_readiness"]["checks"]["FieldExistsCheck"]["fields"] == [
+        "account_id",
+        "authenticated",
+        "tests",
+    ]
 
 
 def test_nico_check_credentials_reports_api_readiness(
@@ -506,6 +511,44 @@ def test_nico_check_credentials_reports_api_readiness(
     assert payload["identity_id"] == "oidc_client_credentials:test-org"
     assert payload["tests"]["identity"]["passed"] is True
     assert payload["tests"]["access"]["passed"] is True
+
+
+def test_nico_check_credentials_reports_identity_shape_on_auth_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The credentials probe should keep a stable identity shape when auth fails."""
+    module = _load_nico_script("iam/check_credentials.py", "test_nico_check_credentials_auth_failure")
+
+    def raise_auth_error() -> None:
+        raise module.NicoAuthError("missing credentials")
+
+    monkeypatch.setattr(module, "resolve_auth", raise_auth_error)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_credentials.py",
+            "--org",
+            "test-org",
+            "--site-id",
+            "site-1",
+            "--api-base",
+            "https://nico.example/v2/org",
+        ],
+    )
+
+    exit_code = module.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1, payload
+    assert payload["success"] is False
+    assert payload["account_id"] == "test-org"
+    assert payload["authenticated"] is False
+    assert payload["auth_source"] == "unresolved"
+    assert payload["identity_id"] == "unresolved:test-org"
+    assert payload["error_type"] == "auth"
+    assert payload["error"] == "missing credentials"
 
 
 def test_nico_bare_metal_config_platform_matches_command_group() -> None:

--- a/isvctl/tests/providers/nico/test_nico_provider.py
+++ b/isvctl/tests/providers/nico/test_nico_provider.py
@@ -115,6 +115,17 @@ def _load_ingestion_script() -> ModuleType:
     return module
 
 
+def _load_nico_script(relative_path: str, module_name: str) -> ModuleType:
+    """Load a NICo provider script as a module for direct unit testing."""
+    script_path = NICO_SCRIPTS / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    with _isolated_common_imports():
+        spec.loader.exec_module(module)
+    return module
+
+
 def _load_governance_metrics_script() -> ModuleType:
     """Load the query_metrics (governance) script as a module for direct unit testing."""
     script_path = NICO_SCRIPTS / "governance" / "query_metrics.py"
@@ -327,6 +338,112 @@ def test_nico_bare_metal_config_exposes_api_base_setting(step_name: str) -> None
     assert merged["tests"]["settings"]["nico_api_base"] == "{{env.NICO_API_BASE}}"
     assert "--api-base" in step["args"]
     assert "{{nico_api_base}}" in step["args"]
+
+
+def _merged_nico_config_steps(
+    config_name: str,
+    command_group: str,
+) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    merged = merge_yaml_files([NICO_CONFIG / config_name])
+    steps = {step["name"]: step for step in merged["commands"][command_group]["steps"]}
+    return merged, steps
+
+
+def _assert_steps_use_nico_api_base(steps: dict[str, dict[str, Any]]) -> None:
+    assert all(step["phase"] == "test" for step in steps.values())
+    for step in steps.values():
+        assert "--api-base" in step["args"]
+        assert "{{nico_api_base}}" in step["args"]
+
+
+def test_nico_control_plane_config_platform_matches_command_group() -> None:
+    """The orchestrator uses tests.platform to look up the control-plane commands group."""
+    merged, _steps = _merged_nico_config_steps("control-plane.yaml", "control_plane")
+
+    assert merged["tests"]["platform"] == "control_plane"
+
+
+def test_nico_control_plane_config_wires_api_health() -> None:
+    """The NICo control-plane config should wire the API health probe."""
+    merged, steps = _merged_nico_config_steps("control-plane.yaml", "control_plane")
+
+    assert set(steps) == {"check_api"}
+    _assert_steps_use_nico_api_base(steps)
+
+    validations = merged["tests"]["validations"]
+    assert merged["tests"]["settings"]["nico_api_base"] == "{{env.NICO_API_BASE}}"
+    assert validations["api_health"]["step"] == "check_api"
+
+
+def test_nico_check_api_reads_site_and_site_list(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The API health probe should authenticate and read site metadata only."""
+    module = _load_nico_script("control-plane/check_api.py", "test_nico_check_api")
+    calls: list[tuple[str, str, dict[str, str] | None]] = []
+
+    def fake_forge_get_all(
+        org: str,
+        path: str,
+        token: str,
+        *,
+        base_url: str,
+        params: dict[str, str] | None = None,
+        **_kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        calls.append((org, path, params))
+        assert token == "test-token"
+        assert base_url == "https://nico.example/v2/org"
+        if path == "site":
+            return [{"id": "site-1", "name": "NICo lab"}]
+        raise AssertionError(path)
+
+    def fake_forge_get(
+        org: str,
+        path: str,
+        token: str,
+        *,
+        base_url: str,
+        params: dict[str, str] | None = None,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        calls.append((org, path, params))
+        assert token == "test-token"
+        assert base_url == "https://nico.example/v2/org"
+        if path == "site/site-1":
+            return {"id": "site-1", "name": "NICo lab"}
+        raise AssertionError(path)
+
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="test-token", source="bearer"))
+    monkeypatch.setattr(module, "forge_get", fake_forge_get)
+    monkeypatch.setattr(module, "forge_get_all", fake_forge_get_all)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_api.py",
+            "--org",
+            "test-org",
+            "--site-id",
+            "site-1",
+            "--api-base",
+            "https://nico.example/v2/org",
+        ],
+    )
+
+    exit_code = module.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0, payload
+    assert payload["success"] is True
+    assert payload["account_id"] == "test-org"
+    assert payload["tests"]["site"]["passed"] is True
+    assert payload["tests"]["sites"]["passed"] is True
+    assert calls == [
+        ("test-org", "site/site-1", None),
+        ("test-org", "site", {"pageSize": "100"}),
+    ]
 
 
 @pytest.mark.parametrize(

--- a/isvctl/tests/providers/nico/test_nico_provider.py
+++ b/isvctl/tests/providers/nico/test_nico_provider.py
@@ -41,6 +41,9 @@ from isvtest.validations.sanitization import (
 )
 
 from isvctl.config.merger import merge_yaml_files
+from isvctl.config.schema import RunConfig
+from isvctl.orchestrator.context import Context
+from isvctl.orchestrator.step_executor import StepExecutor
 
 ISVCTL_ROOT = Path(__file__).resolve().parents[3]
 NICO_COMMON = ISVCTL_ROOT / "configs" / "providers" / "nico" / "scripts" / "common"
@@ -503,6 +506,189 @@ def test_nico_check_credentials_reports_api_readiness(
     assert payload["identity_id"] == "oidc_client_credentials:test-org"
     assert payload["tests"]["identity"]["passed"] is True
     assert payload["tests"]["access"]["passed"] is True
+
+
+def test_nico_bare_metal_config_platform_matches_command_group() -> None:
+    """The orchestrator uses tests.platform to look up the bare-metal commands group."""
+    merged, _steps = _merged_nico_config_steps("bare_metal.yaml", "bare_metal")
+
+    assert merged["tests"]["platform"] == "bare_metal"
+
+
+def test_nico_bare_metal_config_wires_instance_inventory_probes() -> None:
+    """The NICo bare metal config should wire instance inventory probes."""
+    merged, steps = _merged_nico_config_steps("bare_metal.yaml", "bare_metal")
+
+    inventory_steps = {
+        "list_instances": steps["list_instances"],
+        "describe_instance": steps["describe_instance"],
+    }
+    _assert_steps_use_nico_api_base(inventory_steps)
+
+    validations = merged["tests"]["validations"]
+    assert merged["tests"]["settings"]["nico_api_base"] == "{{env.NICO_API_BASE}}"
+    assert validations["list_instances"]["step"] == "list_instances"
+    assert validations["instance_info"]["step"] == "describe_instance"
+
+
+def test_nico_bare_metal_config_keeps_empty_instance_id_attached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset NICO_INSTANCE_ID should not render a dangling argparse flag."""
+    monkeypatch.delenv("NICO_INSTANCE_ID", raising=False)
+    merged, steps = _merged_nico_config_steps("bare_metal.yaml", "bare_metal")
+    context = Context(RunConfig.model_validate(merged))
+    executor = StepExecutor()
+
+    for step_name in ("list_instances", "describe_instance"):
+        rendered = executor._render_args(steps[step_name]["args"], context)
+
+        assert "--instance-id" not in rendered
+        assert "--instance-id=" in rendered
+
+
+def test_nico_list_instances_normalizes_instance_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The instance list probe should normalize NICo fields for InstanceListCheck."""
+    module = _load_nico_script("bare_metal/list_instances.py", "test_nico_list_instances")
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(
+        module,
+        "forge_get_all",
+        lambda *args, **kwargs: [
+            {
+                "id": "instance-1",
+                "status": "Active",
+                "vpcId": "vpc-1",
+                "publicIp": "203.0.113.10",
+                "privateIp": "10.0.0.10",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "list_instances.py",
+            "--org",
+            "test-org",
+            "--site-id",
+            "site-1",
+            "--api-base",
+            "https://nico.example/v2/org",
+            "--instance-id",
+            "instance-1",
+        ],
+    )
+
+    exit_code = module.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0, payload
+    assert payload["success"] is True
+    assert payload["count"] == 1
+    assert payload["found_target"] is True
+    assert payload["instances"] == [
+        {
+            "instance_id": "instance-1",
+            "state": "running",
+            "vpc_id": "vpc-1",
+            "public_ip": "203.0.113.10",
+            "private_ip": "10.0.0.10",
+        }
+    ]
+
+
+def test_nico_describe_instance_normalizes_instance_detail(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The instance detail probe should normalize NICo fields for InstanceStateCheck."""
+    module = _load_nico_script("bare_metal/describe_instance.py", "test_nico_describe_instance")
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(
+        module,
+        "forge_get",
+        lambda *args, **kwargs: {
+            "id": "instance-1",
+            "status": "InUse",
+            "vpcId": "vpc-1",
+            "ipAddress": "203.0.113.10",
+            "internalIp": "10.0.0.10",
+        },
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "describe_instance.py",
+            "--org",
+            "test-org",
+            "--site-id",
+            "site-1",
+            "--api-base",
+            "https://nico.example/v2/org",
+            "--instance-id",
+            "instance-1",
+        ],
+    )
+
+    exit_code = module.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0, payload
+    assert payload["success"] is True
+    assert payload["instance_id"] == "instance-1"
+    assert payload["state"] == "running"
+    assert payload["vpc_id"] == "vpc-1"
+    assert payload["public_ip"] == "203.0.113.10"
+    assert payload["private_ip"] == "10.0.0.10"
+
+
+def test_nico_instance_inventory_scripts_skip_when_site_has_no_instances(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A site with no instance inventory should skip dependent instance validations."""
+    list_module = _load_nico_script("bare_metal/list_instances.py", "test_nico_list_instances_empty")
+    describe_module = _load_nico_script("bare_metal/describe_instance.py", "test_nico_describe_instance_empty")
+
+    monkeypatch.setattr(list_module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(describe_module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(list_module, "forge_get_all", lambda *args, **kwargs: [])
+    monkeypatch.setattr(describe_module, "forge_get_all", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        describe_module,
+        "forge_get",
+        lambda *args, **kwargs: pytest.fail("describe_instance should not fetch detail when no instance exists"),
+    )
+
+    base_argv = [
+        "--org",
+        "test-org",
+        "--site-id",
+        "site-1",
+        "--api-base",
+        "https://nico.example/v2/org",
+        "--instance-id=",
+    ]
+
+    monkeypatch.setattr(sys, "argv", ["list_instances.py", *base_argv])
+    assert list_module.main() == 0
+    list_payload = json.loads(capsys.readouterr().out)
+
+    monkeypatch.setattr(sys, "argv", ["describe_instance.py", *base_argv])
+    assert describe_module.main() == 0
+    describe_payload = json.loads(capsys.readouterr().out)
+
+    assert list_payload["success"] is True
+    assert list_payload["skipped"] is True
+    assert "No instances found" in list_payload["skip_reason"]
+    assert describe_payload["success"] is True
+    assert describe_payload["skipped"] is True
+    assert "No instances found" in describe_payload["skip_reason"]
 
 
 @pytest.mark.parametrize(

--- a/isvtest/src/isvtest/core/validation.py
+++ b/isvtest/src/isvtest/core/validation.py
@@ -237,6 +237,12 @@ class BaseValidation(ABC):
         start_time = time.time()
         error_reason: str | None = None
         try:
+            step_output = self.config.get("step_output")
+            if isinstance(step_output, dict) and step_output.get("skipped") is True:
+                # Lazy import keeps the core validation module usable outside pytest runs.
+                import pytest
+
+                pytest.skip(step_output.get("skip_reason") or f"{self.name} skipped")
             self.run()
         except Exception as e:
             self.set_failed(f"Validation raised exception: {e}")

--- a/isvtest/tests/test_main.py
+++ b/isvtest/tests/test_main.py
@@ -102,6 +102,29 @@ def test_run_validations_via_pytest_updates_ready_entries() -> None:
     assert results[1].message == "NIM was not deployed"
 
 
+def test_run_validations_via_pytest_skips_structured_step_skips() -> None:
+    """A step-level structured skip should skip all dependent validations."""
+    step_output = {"success": True, "skipped": True, "skip_reason": "No VPCs found at site"}
+    entries = [
+        _ready("TenantInfoCheck", "vpc_info", {"step_output": step_output}),
+        _ready(
+            "FieldValueCheck",
+            "traffic_validation",
+            {
+                "step_output": step_output,
+                "field": "tests.network_setup.passed",
+                "expected": True,
+            },
+        ),
+    ]
+
+    exit_code, results = run_validations_via_pytest(entries=entries)
+
+    assert exit_code == 0
+    assert [result.state for result in results] == [State.SKIPPED, State.SKIPPED]
+    assert {result.message for result in results} == {"No VPCs found at site"}
+
+
 def test_run_validations_via_pytest_does_not_rerender_resolved_config_strings() -> None:
     """Resolved temp configs may contain literal Jinja-looking strings from step output."""
     jsonpath_probe = "kubectl get pods -o jsonpath='{{\"\\t\"}}'"


### PR DESCRIPTION
## Summary

Adds read-only NICo inventory and readiness validation coverage as a follow-up to the NICo hardware-ingestion and DPU-health work from PR #450. This wires existing NICo resources into the current validation contracts without creating or deleting infrastructure.

## Changes

- **Structured step skips** (`isvtest` validation execution) now convert step output with `skipped: true` into pytest skips, so read-only probes that have no existing resource to inspect can skip dependent checks cleanly.
- **NICo control-plane config** (`providers/nico/config/control-plane.yaml`) wires `check_api.py` to verify site endpoint reachability and site-list access.
- **NICo IAM config** (`providers/nico/config/iam.yaml`) wires `check_credentials.py` to verify bearer/OIDC auth and read access against site inventory.
- **NICo network config** (`providers/nico/config/network.yaml`) wires VPC and subnet inventory probes for existing resources, using tenant-compatible output fields for the existing network checks.
- **NICo bare-metal config** (`providers/nico/config/bare_metal.yaml`) adds `list_instances` and `describe_instance` steps so existing instance inventory checks can run against NICo, with optional `NICO_INSTANCE_ID` narrowing.
- **Shared normalization helpers** (`providers/nico/scripts/common/inventory.py`) normalize NICo instance, VPC, subnet, and state fields into provider-neutral JSON contracts.
- **Provider tests** expand `test_nico_provider.py` to cover config wiring, argument rendering, auth readiness, script output normalization, structured skips, and network inventory behavior.

## Behavior notes / decisions

- The new NICo probes are intentionally **read-only**. They validate API visibility and existing inventory rather than provisioning or mutating resources.
- The control-plane, IAM, and network configs do not import the full provider-agnostic suites yet because NICo does not wire the lifecycle steps those suites require.
- Optional `NICO_VPC_ID`, `NICO_SUBNET_ID`, and `NICO_INSTANCE_ID` narrow checks to known resources. When the network or instance detail probes can proceed without an explicit resource id, they use the first matching site resource.
- Inventory probes that cannot find an existing VPC, subnet, or instance return structured skip output instead of failing unrelated validations.
- Instance states are normalized into the existing contract values, for example `Active` / `InUse` / `running` become `running`.
- The bare-metal config keeps SSH, GPU, workload, and broader network checks excluded until those NICo steps are wired.

## Test plan

- [x] `uv run pytest isvctl/tests/providers/nico/test_nico_provider.py isvtest/tests/test_main.py -q` -- 106 passed.
- [x] `make lint`
- [x] `make test`
- [x] `uvx pre-commit run -a`
- [x] Live NICo run against configured control-plane, IAM, network, and bare-metal inventory configs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NICo validation workflows for control plane, IAM, bare metal, and network checks.
  * Added support for optional instance and VPC/subnet targeting to narrow inventory-based checks.
  * Introduced clearer skip handling when no matching resources are found.

* **Bug Fixes**
  * Improved validation behavior so skipped step results now correctly skip dependent checks instead of failing.
  * Refined validation coverage to keep only the intended NICo checks active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->