### PR TITLE
feat(nico): add unified host health and primitive-level aggregation validations (CAP05-01, CAP05-02)

### DIFF
--- a/isvctl/configs/providers/nico/config/bare_metal.yaml
+++ b/isvctl/configs/providers/nico/config/bare_metal.yaml
@@ -17,7 +17,8 @@
 #
 # Imports the provider-agnostic bare_metal contract and wires the NICo
 # hardware-lifecycle steps. NICo currently implements the hardware ingestion,
-# DPU health, and governance-metrics steps; the remaining bare_metal
+# DPU health, governance-metrics, and unified host-health steps; the remaining
+# bare_metal
 # validations are skipped automatically because their steps are not defined
 # here (a future PR will wire the full lifecycle so NICo can pass the entire
 # BM suite).
@@ -30,6 +31,10 @@
 #   - query_metrics.py aggregates per-status node and GPU counts into the
 #     Delivered / Healthy / Reserved / Active governance buckets;
 #     GovernanceMetricsCheck verifies the API contract (CAP01-01).
+#   - query_host_health.py maps machine health probes into GPU/thermal/memory
+#     categories; HostHealthCheck validates per-host coverage (CAP05-01).
+#   - query_health_aggregation.py rolls host health up to the nodegroup
+#     primitive; HealthAggregationCheck validates it (CAP05-02).
 #
 # Prerequisites:
 #   - NICO_API_BASE set to the NICo API base URL
@@ -88,6 +93,36 @@ commands:
       - name: query_governance_metrics
         phase: test
         command: "python ../scripts/governance/query_metrics.py"
+        args:
+          - "--org"
+          - "{{org}}"
+          - "--site-id"
+          - "{{site_id}}"
+          - "--api-base"
+          - "{{nico_api_base}}"
+        timeout: 120
+
+      # ─── Query Per-Host Health (CAP05-01) ──────────────────────────
+      # Maps each machine's health probes into GPU state, thermal status,
+      # and memory health, plus the freshness of the observation.
+      - name: query_host_health
+        phase: test
+        command: "python ../scripts/health/query_host_health.py"
+        args:
+          - "--org"
+          - "{{org}}"
+          - "--site-id"
+          - "{{site_id}}"
+          - "--api-base"
+          - "{{nico_api_base}}"
+        timeout: 120
+
+      # ─── Aggregate Health by Nodegroup (CAP05-02) ──────────────────
+      # Rolls per-host health up to the InstanceType (nodegroup) primitive
+      # with per-group healthy/unhealthy counts and an aggregate status.
+      - name: query_health_aggregation
+        phase: test
+        command: "python ../scripts/health/query_health_aggregation.py"
         args:
           - "--org"
           - "{{org}}"

--- a/isvctl/configs/providers/nico/config/bare_metal.yaml
+++ b/isvctl/configs/providers/nico/config/bare_metal.yaml
@@ -31,8 +31,9 @@
 #   - query_metrics.py aggregates per-status node and GPU counts into the
 #     Delivered / Healthy / Reserved / Active governance buckets;
 #     GovernanceMetricsCheck verifies the API contract (CAP01-01).
-#   - query_host_health.py maps machine health probes into GPU/thermal/memory
-#     categories; HostHealthCheck validates per-host coverage (CAP05-01).
+#   - query_host_health.py reports each machine's health probes, alerts, and
+#     classifications; HostHealthCheck validates the per-host report is
+#     alert-free (CAP05-01). Leak detection (BmcLeakDetection/Leak) is included.
 #   - query_health_aggregation.py rolls host health up to the nodegroup
 #     primitive; HealthAggregationCheck validates it (CAP05-02).
 #

--- a/isvctl/configs/providers/nico/scripts/health/query_health_aggregation.py
+++ b/isvctl/configs/providers/nico/scripts/health/query_health_aggregation.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Aggregate host health to the nodegroup primitive for a NICo site (CAP05-02).
+
+NICo's nodegroup primitive is the InstanceType: machines carry an
+``instanceTypeId`` that groups them into a logical pool. This script rolls
+per-host health up to that primitive, producing a per-group healthy/unhealthy
+breakdown and an aggregate status the validation can check for internal
+consistency. Machines with no instance type are grouped under ``unassigned``;
+``Decommissioned`` machines are excluded from the live fleet.
+
+NICo API endpoints used:
+  GET /v2/org/{org}/carbide/machine?siteId={site_id}
+
+Auth:
+  - NICO_BEARER_TOKEN, or
+  - OIDC client_credentials via NICO_SSA_ISSUER,
+    NICO_CLIENT_ID, NICO_CLIENT_SECRET, and optional NICO_OIDC_SCOPE.
+
+A machine counts as unhealthy when its status is Error/Unknown or its health
+report carries any alerts; otherwise it is healthy.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "nico",
+    "site_id": "...",
+    "aggregation_level": "nodegroup",
+    "groups": [
+      {
+        "group_id": "...",
+        "group_type": "instance_type",
+        "name": "...",
+        "total": 20,
+        "healthy": 19,
+        "unhealthy": 1,
+        "status": "Degraded",
+        "unhealthy_hosts": ["..."]
+      }
+    ]
+  }
+
+Usage:
+    NICO_BEARER_TOKEN=<token> python query_health_aggregation.py --org <org> --site-id <uuid> --api-base <url>
+
+    Wired via the bare_metal suite:
+      uv run isvctl test run -f isvctl/configs/providers/nico/config/bare_metal.yaml
+
+Reference:
+    OpenAPI spec: rest-api/openapi/spec.yaml (Machine.instanceTypeId, MachineStatusBreakdown)
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Allow importing from sibling common/ directory
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.nico_client import NicoAuthError, classify_health, forge_get_all, resolve_auth
+
+# The nodegroup primitive NICo aggregates health over.
+AGGREGATION_LEVEL = "nodegroup"
+GROUP_TYPE = "instance_type"
+UNASSIGNED_GROUP = "unassigned"
+
+# Machine statuses that are unhealthy regardless of the probe report.
+UNHEALTHY_STATUSES: frozenset[str] = frozenset({"Error", "Unknown"})
+# Machines in this status are no longer part of the live fleet.
+EXCLUDED_STATUSES: frozenset[str] = frozenset({"Decommissioned"})
+
+
+def _is_unhealthy(machine: dict[str, Any]) -> bool:
+    """Return whether a machine is unhealthy by status or health alerts."""
+    status = machine.get("status") or "Unknown"
+    if status in UNHEALTHY_STATUSES:
+        return True
+    return classify_health(machine.get("health") or {}) == "unhealthy"
+
+
+def aggregate_by_nodegroup(machines: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group machines by instance type and summarize per-group health."""
+    groups: dict[str, dict[str, Any]] = {}
+
+    for machine in machines:
+        status = machine.get("status") or "Unknown"
+        if status in EXCLUDED_STATUSES:
+            continue
+
+        group_id = machine.get("instanceTypeId") or UNASSIGNED_GROUP
+        group = groups.setdefault(
+            group_id,
+            {
+                "group_id": group_id,
+                "group_type": GROUP_TYPE,
+                "name": group_id,
+                "total": 0,
+                "healthy": 0,
+                "unhealthy": 0,
+                "status": "Healthy",
+                "unhealthy_hosts": [],
+            },
+        )
+
+        group["total"] += 1
+        if _is_unhealthy(machine):
+            group["unhealthy"] += 1
+            group["unhealthy_hosts"].append(machine.get("id", ""))
+        else:
+            group["healthy"] += 1
+
+    for group in groups.values():
+        group["status"] = "Healthy" if group["unhealthy"] == 0 else "Degraded"
+
+    # Stable ordering keeps the output deterministic across runs.
+    return [groups[key] for key in sorted(groups)]
+
+
+def main() -> int:
+    """Aggregate NICo host health by nodegroup and print the JSON contract."""
+    parser = argparse.ArgumentParser(description="Aggregate NICo host health by nodegroup")
+    parser.add_argument("--org", required=True, help="NGC org name")
+    parser.add_argument("--site-id", required=True, help="NICo site UUID")
+    parser.add_argument("--api-base", required=True, help="NICo API base URL")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "nico",
+        "site_id": args.site_id,
+        "aggregation_level": AGGREGATION_LEVEL,
+        "groups": [],
+    }
+
+    try:
+        auth = resolve_auth()
+
+        machines = forge_get_all(
+            args.org,
+            "machine",
+            auth.token,
+            base_url=args.api_base,
+            params={"siteId": args.site_id},
+            result_key="machines",
+        )
+
+        result["groups"] = aggregate_by_nodegroup(machines)
+        result["success"] = True
+
+    except NicoAuthError as e:
+        result["error_type"] = "auth"
+        result["error"] = str(e)
+    except Exception as e:
+        result["error"] = f"{type(e).__name__}: {e}"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/nico/scripts/health/query_host_health.py
+++ b/isvctl/configs/providers/nico/scripts/health/query_host_health.py
@@ -85,8 +85,13 @@ CATEGORY_KEYWORDS: dict[str, tuple[str, ...]] = {
 
 
 def _probe_text(probe: dict[str, Any]) -> str:
-    """Return the lowercased ``id`` + ``target`` text used for category matching."""
-    parts = [probe.get("id"), probe.get("target")]
+    """Return the lowercased ``id`` + ``target`` + ``message`` text for matching.
+
+    NICo reports BMC sensors under a single ``BmcSensor`` probe id and carries
+    the sensor identity in ``target`` and the entity type in ``message`` (e.g.
+    ``power_supply``, ``temperature``), so all three fields are searched.
+    """
+    parts = [probe.get("id"), probe.get("target"), probe.get("message")]
     return " ".join(p for p in parts if isinstance(p, str)).lower()
 
 
@@ -169,11 +174,18 @@ def main() -> int:
         for machine in machines:
             health = machine.get("health") or {}
             chassis_serial = ((machine.get("metadata") or {}).get("dmiData") or {}).get("chassisSerial", "")
+            # The health API returned a report for this host if it carries any
+            # probe data or an observation timestamp (NICo only lists alerts on
+            # failure, so a healthy host can have an empty successes list).
+            health_present = bool(
+                (health.get("successes") or []) or (health.get("alerts") or []) or health.get("observedAt")
+            )
             result["hosts"].append(
                 {
                     "host_id": machine.get("id", ""),
                     "chassis_serial": chassis_serial,
                     "status": machine.get("status", "Unknown"),
+                    "health_present": health_present,
                     "observed_age_seconds": observed_age_seconds(health),
                     "categories": categorize_health(health),
                 }

--- a/isvctl/configs/providers/nico/scripts/health/query_host_health.py
+++ b/isvctl/configs/providers/nico/scripts/health/query_host_health.py
@@ -95,9 +95,8 @@ def _probe_text(probe: dict[str, Any]) -> str:
     return " ".join(p for p in parts if isinstance(p, str)).lower()
 
 
-def _matches_category(probe: dict[str, Any], keywords: tuple[str, ...]) -> bool:
-    """Check whether a probe belongs to a category by keyword substring match."""
-    text = _probe_text(probe)
+def _matches_keywords(text: str, keywords: tuple[str, ...]) -> bool:
+    """Check whether precomputed probe text contains any category keyword."""
     return any(keyword in text for keyword in keywords)
 
 
@@ -106,13 +105,18 @@ def categorize_health(health: dict[str, Any]) -> dict[str, dict[str, Any]]:
     successes = health.get("successes") or []
     alerts = health.get("alerts") or []
 
+    # Compute each probe's match text once, then reuse it across every category
+    # rather than rebuilding the lowercased string per (probe, category) pair.
+    success_texts = [(s, _probe_text(s)) for s in successes]
+    alert_texts = [(a, _probe_text(a)) for a in alerts]
+
     categories: dict[str, dict[str, Any]] = {}
     for category, keywords in CATEGORY_KEYWORDS.items():
-        probe_ids = [s.get("id", "") for s in successes if _matches_category(s, keywords) and s.get("id")]
+        probe_ids = [s.get("id", "") for s, text in success_texts if _matches_keywords(text, keywords) and s.get("id")]
         cat_alerts = [
             {"id": a.get("id", ""), "target": a.get("target", ""), "message": a.get("message", "")}
-            for a in alerts
-            if _matches_category(a, keywords)
+            for a, text in alert_texts
+            if _matches_keywords(text, keywords)
         ]
         categories[category] = {
             "present": bool(probe_ids or cat_alerts),

--- a/isvctl/configs/providers/nico/scripts/health/query_host_health.py
+++ b/isvctl/configs/providers/nico/scripts/health/query_host_health.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Query per-host health for all machines at a NICo site (CAP05-01).
+
+NICo exposes host health as a probe report (``health.successes`` and
+``health.alerts``), where each probe has a stable ``id`` and an optional
+``target`` component. This script maps those probes into the GPU-state,
+thermal, and memory-health categories NVIDIA requires a per-host health API to
+surface, and reports the freshness of the observation so the validation can
+confirm the data is real-time.
+
+NICo API endpoints used:
+  GET /v2/org/{org}/carbide/machine?siteId={site_id}&includeMetadata=true
+
+Auth:
+  - NICO_BEARER_TOKEN, or
+  - OIDC client_credentials via NICO_SSA_ISSUER,
+    NICO_CLIENT_ID, NICO_CLIENT_SECRET, and optional NICO_OIDC_SCOPE.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "nico",
+    "site_id": "...",
+    "hosts_checked": 1,
+    "hosts": [
+      {
+        "host_id": "...",
+        "chassis_serial": "...",
+        "status": "Ready",
+        "observed_age_seconds": 12,
+        "categories": {
+          "gpu":     {"present": true, "healthy": true,  "probes": ["GpuRemappedRows"], "alerts": []},
+          "thermal": {"present": true, "healthy": true,  "probes": ["Temperature"],     "alerts": []},
+          "memory":  {"present": true, "healthy": false, "probes": [], "alerts": [{"id": "MemoryEcc", "message": "..."}]}
+        }
+      }
+    ]
+  }
+
+Usage:
+    NICO_BEARER_TOKEN=<token> python query_host_health.py --org <org> --site-id <uuid> --api-base <url>
+
+    Wired via the bare_metal suite:
+      uv run isvctl test run -f isvctl/configs/providers/nico/config/bare_metal.yaml
+
+Reference:
+    OpenAPI spec: rest-api/openapi/spec.yaml (HealthReport / HealthProbe* schemas)
+"""
+
+import argparse
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# Allow importing from sibling common/ directory
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.nico_client import NicoAuthError, forge_get_all, resolve_auth
+
+# Substring keywords that map a NICo health probe (by id or target) into one of
+# the categories a per-host health API must surface for CAP05-01. Lowercased
+# comparison; a probe matches a category if any keyword appears in its id or target.
+CATEGORY_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "gpu": ("gpu", "nvlink", "nvswitch", "nvml", "xid", "vbios", "vgpu"),
+    "thermal": ("temp", "thermal", "fan", "coolant", "cooling"),
+    "memory": ("memory", "ecc", "dimm", "rowremap", "row_remap", "hbm", "sram"),
+}
+
+
+def _probe_text(probe: dict[str, Any]) -> str:
+    """Return the lowercased ``id`` + ``target`` text used for category matching."""
+    parts = [probe.get("id"), probe.get("target")]
+    return " ".join(p for p in parts if isinstance(p, str)).lower()
+
+
+def _matches_category(probe: dict[str, Any], keywords: tuple[str, ...]) -> bool:
+    """Check whether a probe belongs to a category by keyword substring match."""
+    text = _probe_text(probe)
+    return any(keyword in text for keyword in keywords)
+
+
+def categorize_health(health: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Map a NICo health report into per-category presence/health summaries."""
+    successes = health.get("successes") or []
+    alerts = health.get("alerts") or []
+
+    categories: dict[str, dict[str, Any]] = {}
+    for category, keywords in CATEGORY_KEYWORDS.items():
+        probe_ids = [s.get("id", "") for s in successes if _matches_category(s, keywords) and s.get("id")]
+        cat_alerts = [
+            {"id": a.get("id", ""), "target": a.get("target", ""), "message": a.get("message", "")}
+            for a in alerts
+            if _matches_category(a, keywords)
+        ]
+        categories[category] = {
+            "present": bool(probe_ids or cat_alerts),
+            "healthy": len(cat_alerts) == 0,
+            "probes": probe_ids,
+            "alerts": cat_alerts,
+        }
+    return categories
+
+
+def observed_age_seconds(health: dict[str, Any], *, now: datetime | None = None) -> int | None:
+    """Return the age in seconds of the health observation, or None if unknown.
+
+    NICo timestamps are RFC 3339 / ISO 8601 (e.g. ``2019-08-24T14:15:22Z``).
+    A missing or unparseable timestamp yields None so the validation can decide
+    how strict to be about freshness.
+    """
+    observed_at = health.get("observedAt")
+    if not isinstance(observed_at, str) or not observed_at:
+        return None
+    try:
+        parsed = datetime.fromisoformat(observed_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    reference = now or datetime.now(UTC)
+    return max(0, int((reference - parsed).total_seconds()))
+
+
+def main() -> int:
+    """Query NICo machine health and print per-host category health JSON."""
+    parser = argparse.ArgumentParser(description="Query per-host health on NICo machines")
+    parser.add_argument("--org", required=True, help="NGC org name")
+    parser.add_argument("--site-id", required=True, help="NICo site UUID")
+    parser.add_argument("--api-base", required=True, help="NICo API base URL")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "nico",
+        "site_id": args.site_id,
+        "hosts_checked": 0,
+        "hosts": [],
+    }
+
+    try:
+        auth = resolve_auth()
+
+        machines = forge_get_all(
+            args.org,
+            "machine",
+            auth.token,
+            base_url=args.api_base,
+            params={"siteId": args.site_id, "includeMetadata": "true"},
+            result_key="machines",
+        )
+
+        for machine in machines:
+            health = machine.get("health") or {}
+            chassis_serial = ((machine.get("metadata") or {}).get("dmiData") or {}).get("chassisSerial", "")
+            result["hosts"].append(
+                {
+                    "host_id": machine.get("id", ""),
+                    "chassis_serial": chassis_serial,
+                    "status": machine.get("status", "Unknown"),
+                    "observed_age_seconds": observed_age_seconds(health),
+                    "categories": categorize_health(health),
+                }
+            )
+
+        result["hosts_checked"] = len(result["hosts"])
+        result["success"] = True
+
+    except NicoAuthError as e:
+        result["error_type"] = "auth"
+        result["error"] = str(e)
+    except Exception as e:
+        result["error"] = f"{type(e).__name__}: {e}"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/nico/scripts/health/query_host_health.py
+++ b/isvctl/configs/providers/nico/scripts/health/query_host_health.py
@@ -16,12 +16,20 @@
 
 """Query per-host health for all machines at a NICo site (CAP05-01).
 
-NICo exposes host health as a probe report (``health.successes`` and
-``health.alerts``), where each probe has a stable ``id`` and an optional
-``target`` component. This script maps those probes into the GPU-state,
-thermal, and memory-health categories NVIDIA requires a per-host health API to
-surface, and reports the freshness of the observation so the validation can
-confirm the data is real-time.
+NICo exposes host health as an alert-driven report (``health.successes`` and
+``health.alerts``): a healthy subsystem is simply the absence of an alert, so a
+passing per-category probe is not guaranteed. Each probe has a stable ``id``
+(e.g. ``BmcSensor``, ``BmcLeakDetection``, ``HeartbeatTimeout``), an optional
+``target`` component, and ``classifications`` (e.g. ``SensorCritical``,
+``Leak``). This script reports, per host, the probe IDs the API returned, every
+alert with its classifications, and the observation freshness, so the
+validation can assert the per-host health API works and the host is healthy.
+
+It additionally emits an *informational* component breakdown (GPU / thermal /
+memory / cooling) derived from probe targets -- NICo folds a GPU/DIMM
+temperature into a ``BmcSensor`` whose ``target`` names the component, and
+liquid-cooling leaks into ``BmcLeakDetection`` -- but the validation does not
+gate on this breakdown.
 
 NICo API endpoints used:
   GET /v2/org/{org}/carbide/machine?siteId={site_id}&includeMetadata=true
@@ -42,11 +50,19 @@ Required JSON output fields:
         "host_id": "...",
         "chassis_serial": "...",
         "status": "Ready",
+        "health_present": true,
+        "healthy": true,
         "observed_age_seconds": 12,
-        "categories": {
-          "gpu":     {"present": true, "healthy": true,  "probes": ["GpuRemappedRows"], "alerts": []},
-          "thermal": {"present": true, "healthy": true,  "probes": ["Temperature"],     "alerts": []},
-          "memory":  {"present": true, "healthy": false, "probes": [], "alerts": [{"id": "MemoryEcc", "message": "..."}]}
+        "probe_ids": ["BmcSensor", "BgpDaemonEnabled"],
+        "alerts": [
+          {"id": "BmcLeakDetection", "target": "RackLeakDetector_1",
+           "message": "...", "classifications": ["Leak"]}
+        ],
+        "components": {
+          "gpu":     {"present": true, "alerting": false, "probes": ["BmcSensor"]},
+          "thermal": {"present": true, "alerting": false, "probes": ["BmcSensor"]},
+          "memory":  {"present": false, "alerting": false, "probes": []},
+          "cooling": {"present": true, "alerting": false, "probes": ["BmcLeakDetection"]}
         }
       }
     ]
@@ -59,7 +75,9 @@ Usage:
       uv run isvctl test run -f isvctl/configs/providers/nico/config/bare_metal.yaml
 
 Reference:
-    OpenAPI spec: rest-api/openapi/spec.yaml (HealthReport / HealthProbe* schemas)
+    Probe IDs:        infra-controller docs/architecture/health/health_probe_ids.md
+    Classifications:  infra-controller docs/architecture/health/health_alert_classifications.md
+    OpenAPI spec:     rest-api/openapi/spec.yaml (HealthReport / HealthProbe* schemas)
 """
 
 import argparse
@@ -74,13 +92,17 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from common.nico_client import NicoAuthError, forge_get_all, resolve_auth
 
-# Substring keywords that map a NICo health probe (by id or target) into one of
-# the categories a per-host health API must surface for CAP05-01. Lowercased
-# comparison; a probe matches a category if any keyword appears in its id or target.
-CATEGORY_KEYWORDS: dict[str, tuple[str, ...]] = {
+# Substring keywords that map a NICo health probe (by id/target/message) into an
+# informational hardware component bucket. NICo does not model GPU/thermal/memory
+# as first-class probes -- a GPU or DIMM temperature surfaces as a ``BmcSensor``
+# whose target names the component, and a coolant leak as ``BmcLeakDetection`` --
+# so this breakdown is best-effort and for visibility only. The validation gates
+# on probe IDs, alerts, and classifications, not on these buckets.
+COMPONENT_KEYWORDS: dict[str, tuple[str, ...]] = {
     "gpu": ("gpu", "nvlink", "nvswitch", "nvml", "xid", "vbios", "vgpu"),
-    "thermal": ("temp", "thermal", "fan", "coolant", "cooling"),
+    "thermal": ("temp", "thermal", "fan"),
     "memory": ("memory", "ecc", "dimm", "rowremap", "row_remap", "hbm", "sram"),
+    "cooling": ("leak", "coolant", "cooling", "cdu", "liquid", "water"),
 }
 
 
@@ -96,35 +118,51 @@ def _probe_text(probe: dict[str, Any]) -> str:
 
 
 def _matches_keywords(text: str, keywords: tuple[str, ...]) -> bool:
-    """Check whether precomputed probe text contains any category keyword."""
+    """Check whether precomputed probe text contains any component keyword."""
     return any(keyword in text for keyword in keywords)
 
 
-def categorize_health(health: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    """Map a NICo health report into per-category presence/health summaries."""
+def _classifications(probe: dict[str, Any]) -> list[str]:
+    """Return a probe's classification strings, tolerating null/missing values."""
+    return [c for c in (probe.get("classifications") or []) if isinstance(c, str)]
+
+
+def summarize_alert(alert: dict[str, Any]) -> dict[str, Any]:
+    """Reduce a NICo health alert to the provider-neutral fields validations use."""
+    return {
+        "id": alert.get("id", ""),
+        "target": alert.get("target", ""),
+        "message": alert.get("message", ""),
+        "classifications": _classifications(alert),
+    }
+
+
+def component_breakdown(health: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Map a NICo health report into an informational per-component summary."""
     successes = health.get("successes") or []
     alerts = health.get("alerts") or []
 
-    # Compute each probe's match text once, then reuse it across every category
-    # rather than rebuilding the lowercased string per (probe, category) pair.
+    # Compute each probe's match text once, then reuse it across every component
+    # rather than rebuilding the lowercased string per (probe, component) pair.
     success_texts = [(s, _probe_text(s)) for s in successes]
     alert_texts = [(a, _probe_text(a)) for a in alerts]
 
-    categories: dict[str, dict[str, Any]] = {}
-    for category, keywords in CATEGORY_KEYWORDS.items():
-        probe_ids = [s.get("id", "") for s, text in success_texts if _matches_keywords(text, keywords) and s.get("id")]
-        cat_alerts = [
-            {"id": a.get("id", ""), "target": a.get("target", ""), "message": a.get("message", "")}
-            for a, text in alert_texts
-            if _matches_keywords(text, keywords)
-        ]
-        categories[category] = {
-            "present": bool(probe_ids or cat_alerts),
-            "healthy": len(cat_alerts) == 0,
+    components: dict[str, dict[str, Any]] = {}
+    for component, keywords in COMPONENT_KEYWORDS.items():
+        probe_ids = sorted(
+            {
+                s.get("id", "")
+                for s, text in (*success_texts, *alert_texts)
+                if _matches_keywords(text, keywords) and s.get("id")
+            }
+        )
+        alerting = any(_matches_keywords(text, keywords) for _, text in alert_texts)
+        components[component] = {
+            "present": bool(probe_ids),
+            "alerting": alerting,
             "probes": probe_ids,
-            "alerts": cat_alerts,
         }
-    return categories
+    return components
 
 
 def observed_age_seconds(health: dict[str, Any], *, now: datetime | None = None) -> int | None:
@@ -147,8 +185,34 @@ def observed_age_seconds(health: dict[str, Any], *, now: datetime | None = None)
     return max(0, int((reference - parsed).total_seconds()))
 
 
+def host_health(machine: dict[str, Any]) -> dict[str, Any]:
+    """Build the per-host health record from a NICo machine payload."""
+    health = machine.get("health") or {}
+    successes = health.get("successes") or []
+    alerts = health.get("alerts") or []
+    chassis_serial = ((machine.get("metadata") or {}).get("dmiData") or {}).get("chassisSerial", "")
+
+    probe_ids = sorted({p.get("id", "") for p in (*successes, *alerts) if p.get("id")})
+    # The health API returned a report for this host if it carries any probe data
+    # or an observation timestamp (NICo only lists alerts on failure, so a healthy
+    # host can have an empty successes list).
+    health_present = bool(successes or alerts or health.get("observedAt"))
+
+    return {
+        "host_id": machine.get("id", ""),
+        "chassis_serial": chassis_serial,
+        "status": machine.get("status", "Unknown"),
+        "health_present": health_present,
+        "healthy": len(alerts) == 0,
+        "observed_age_seconds": observed_age_seconds(health),
+        "probe_ids": probe_ids,
+        "alerts": [summarize_alert(a) for a in alerts],
+        "components": component_breakdown(health),
+    }
+
+
 def main() -> int:
-    """Query NICo machine health and print per-host category health JSON."""
+    """Query NICo machine health and print per-host health JSON to stdout."""
     parser = argparse.ArgumentParser(description="Query per-host health on NICo machines")
     parser.add_argument("--org", required=True, help="NGC org name")
     parser.add_argument("--site-id", required=True, help="NICo site UUID")
@@ -175,26 +239,7 @@ def main() -> int:
             result_key="machines",
         )
 
-        for machine in machines:
-            health = machine.get("health") or {}
-            chassis_serial = ((machine.get("metadata") or {}).get("dmiData") or {}).get("chassisSerial", "")
-            # The health API returned a report for this host if it carries any
-            # probe data or an observation timestamp (NICo only lists alerts on
-            # failure, so a healthy host can have an empty successes list).
-            health_present = bool(
-                (health.get("successes") or []) or (health.get("alerts") or []) or health.get("observedAt")
-            )
-            result["hosts"].append(
-                {
-                    "host_id": machine.get("id", ""),
-                    "chassis_serial": chassis_serial,
-                    "status": machine.get("status", "Unknown"),
-                    "health_present": health_present,
-                    "observed_age_seconds": observed_age_seconds(health),
-                    "categories": categorize_health(health),
-                }
-            )
-
+        result["hosts"] = [host_health(machine) for machine in machines]
         result["hosts_checked"] = len(result["hosts"])
         result["success"] = True
 

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -110,7 +110,7 @@ For the domain / script-count / AWS-reference overview see the
 | `verify_ingestion` | test | `providers/nico/scripts/hardware_ingestion/verify_ingestion.py` | `expected_count`, `ingested_count`, `matched_count`, `missing`, `extra`, `machines[].status`, `machines[].health` |
 | `check_dpu_health` | test | `providers/nico/scripts/dpu/check_dpu_health.py` | `machines_checked`, `machines[].dpu_count`, `machines[].dpu_agent_heartbeat`, `machines[].health_summary`, `machines[].health_alerts` |
 | `query_governance_metrics` | test | `providers/nico/scripts/governance/query_metrics.py` | `machine_count`, `metrics.delivered.{nodes,gpus}`, `metrics.healthy.{nodes,gpus}`, `metrics.reserved.{nodes,gpus}`, `metrics.active.{nodes,gpus}` |
-| `query_host_health` | test | `providers/nico/scripts/health/query_host_health.py` | `hosts_checked`, `hosts[].health_present`, `hosts[].observed_age_seconds`, `hosts[].categories.{gpu,thermal,memory}.{present,healthy,probes,alerts}` |
+| `query_host_health` | test | `providers/nico/scripts/health/query_host_health.py` | `hosts_checked`, `hosts[].health_present`, `hosts[].healthy`, `hosts[].observed_age_seconds`, `hosts[].probe_ids`, `hosts[].alerts[].{id,target,message,classifications}`, `hosts[].components.{gpu,thermal,memory,cooling}` |
 | `query_health_aggregation` | test | `providers/nico/scripts/health/query_health_aggregation.py` | `aggregation_level`, `groups[].{total,healthy,unhealthy,status,unhealthy_hosts}` |
 
 ### Kubernetes (`k8s.yaml`)

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -110,7 +110,7 @@ For the domain / script-count / AWS-reference overview see the
 | `verify_ingestion` | test | `providers/nico/scripts/hardware_ingestion/verify_ingestion.py` | `expected_count`, `ingested_count`, `matched_count`, `missing`, `extra`, `machines[].status`, `machines[].health` |
 | `check_dpu_health` | test | `providers/nico/scripts/dpu/check_dpu_health.py` | `machines_checked`, `machines[].dpu_count`, `machines[].dpu_agent_heartbeat`, `machines[].health_summary`, `machines[].health_alerts` |
 | `query_governance_metrics` | test | `providers/nico/scripts/governance/query_metrics.py` | `machine_count`, `metrics.delivered.{nodes,gpus}`, `metrics.healthy.{nodes,gpus}`, `metrics.reserved.{nodes,gpus}`, `metrics.active.{nodes,gpus}` |
-| `query_host_health` | test | `providers/nico/scripts/health/query_host_health.py` | `hosts_checked`, `hosts[].observed_age_seconds`, `hosts[].categories.{gpu,thermal,memory}.{present,healthy,probes,alerts}` |
+| `query_host_health` | test | `providers/nico/scripts/health/query_host_health.py` | `hosts_checked`, `hosts[].health_present`, `hosts[].observed_age_seconds`, `hosts[].categories.{gpu,thermal,memory}.{present,healthy,probes,alerts}` |
 | `query_health_aggregation` | test | `providers/nico/scripts/health/query_health_aggregation.py` | `aggregation_level`, `groups[].{total,healthy,unhealthy,status,unhealthy_hosts}` |
 
 ### Kubernetes (`k8s.yaml`)

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -110,6 +110,8 @@ For the domain / script-count / AWS-reference overview see the
 | `verify_ingestion` | test | `providers/nico/scripts/hardware_ingestion/verify_ingestion.py` | `expected_count`, `ingested_count`, `matched_count`, `missing`, `extra`, `machines[].status`, `machines[].health` |
 | `check_dpu_health` | test | `providers/nico/scripts/dpu/check_dpu_health.py` | `machines_checked`, `machines[].dpu_count`, `machines[].dpu_agent_heartbeat`, `machines[].health_summary`, `machines[].health_alerts` |
 | `query_governance_metrics` | test | `providers/nico/scripts/governance/query_metrics.py` | `machine_count`, `metrics.delivered.{nodes,gpus}`, `metrics.healthy.{nodes,gpus}`, `metrics.reserved.{nodes,gpus}`, `metrics.active.{nodes,gpus}` |
+| `query_host_health` | test | `providers/nico/scripts/health/query_host_health.py` | `hosts_checked`, `hosts[].observed_age_seconds`, `hosts[].categories.{gpu,thermal,memory}.{present,healthy,probes,alerts}` |
+| `query_health_aggregation` | test | `providers/nico/scripts/health/query_health_aggregation.py` | `aggregation_level`, `groups[].{total,healthy,unhealthy,status,unhealthy_hosts}` |
 
 ### Kubernetes (`k8s.yaml`)
 

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -345,5 +345,23 @@ tests:
         GovernanceMetricsCheck:
           min_delivered_nodes: 1
 
+    # Per-host health API: GPU state, thermal status, memory health (CAP05-01).
+    # Only runs for providers that implement the query_host_health step.
+    host_health:
+      step: query_host_health
+      checks:
+        HostHealthCheck:
+          required_categories: ["gpu", "thermal", "memory"]
+          require_present: true
+
+    # Primitive-level health aggregation at the nodegroup/reservation level
+    # (CAP05-02). Only runs for providers that implement the
+    # query_health_aggregation step.
+    health_aggregation:
+      step: query_health_aggregation
+      checks:
+        HealthAggregationCheck:
+          min_groups: 1
+
   exclude:
     labels: []

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -347,12 +347,15 @@ tests:
 
     # Per-host health API: GPU state, thermal status, memory health (CAP05-01).
     # Only runs for providers that implement the query_host_health step.
+    # require_present is left at its default (false) because alert-driven health
+    # APIs (e.g. NICo) only surface a category when it is failing; set it true
+    # for providers whose API enumerates every category as a passing probe.
     host_health:
       step: query_host_health
       checks:
         HostHealthCheck:
           required_categories: ["gpu", "thermal", "memory"]
-          require_present: true
+          require_report: true
 
     # Primitive-level health aggregation at the nodegroup/reservation level
     # (CAP05-02). Only runs for providers that implement the

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -345,16 +345,16 @@ tests:
         GovernanceMetricsCheck:
           min_delivered_nodes: 1
 
-    # Per-host health API: GPU state, thermal status, memory health (CAP05-01).
-    # Only runs for providers that implement the query_host_health step.
-    # require_present is left at its default (false) because alert-driven health
-    # APIs (e.g. NICo) only surface a category when it is failing; set it true
-    # for providers whose API enumerates every category as a passing probe.
+    # Per-host health API (CAP05-01). Asserts the API returns a report per host
+    # and the host is alert-free. Only runs for providers that implement the
+    # query_host_health step. fail_on_classifications is omitted so ANY alert
+    # (BMC sensor critical/failure, BmcLeakDetection/Leak, DPU heartbeat, ...)
+    # fails the host; set it to scope failures to specific severities, or set
+    # require_probes to enforce that specific signals are present.
     host_health:
       step: query_host_health
       checks:
         HostHealthCheck:
-          required_categories: ["gpu", "thermal", "memory"]
           require_report: true
 
     # Primitive-level health aggregation at the nodegroup/reservation level

--- a/isvctl/tests/test_nico_provider.py
+++ b/isvctl/tests/test_nico_provider.py
@@ -30,6 +30,8 @@ from typing import Any
 from urllib.parse import parse_qs
 
 import pytest
+from isvtest.validations.governance import GovernanceMetricsCheck
+from isvtest.validations.health import HealthAggregationCheck, HostHealthCheck
 
 from isvctl.config.merger import merge_yaml_files
 
@@ -593,8 +595,6 @@ def test_governance_script_output_satisfies_validation_contract(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """End-to-end: NICo governance JSON should pass GovernanceMetricsCheck."""
-    from isvtest.validations.governance import GovernanceMetricsCheck
-
     payload = _run_governance_script(
         monkeypatch,
         capsys,
@@ -745,9 +745,6 @@ def test_host_health_real_world_bmc_sensors_pass_by_default(
     alerts. HostHealthCheck should pass: a report is returned and there are no
     alerts -- no dedicated memory probe is required.
     """
-    # Local import: isvtest validation framework only needed for this end-to-end test
-    from isvtest.validations.health import HostHealthCheck
-
     module = _load_host_health_script()
     machines = [
         {
@@ -782,9 +779,6 @@ def test_host_health_leak_alert_fails_validation_end_to_end(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """End-to-end: a leak-detection alert flows through to a HostHealthCheck failure."""
-    # Local import: isvtest validation framework only needed for this end-to-end test
-    from isvtest.validations.health import HostHealthCheck
-
     module = _load_host_health_script()
     machines = [
         {
@@ -851,9 +845,6 @@ def test_health_aggregation_script_output_satisfies_validation_contract(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """End-to-end: NICo aggregation JSON should pass HealthAggregationCheck."""
-    # Local import: isvtest validation framework only needed for this end-to-end test
-    from isvtest.validations.health import HealthAggregationCheck
-
     module = _load_health_aggregation_script()
     machines = [
         {"id": "m-1", "status": "Ready", "instanceTypeId": "it-a", "health": {"alerts": []}},

--- a/isvctl/tests/test_nico_provider.py
+++ b/isvctl/tests/test_nico_provider.py
@@ -609,11 +609,11 @@ def test_governance_script_output_satisfies_validation_contract(
     assert check._passed is True, check._error
 
 
-def test_host_health_script_categorizes_probes(
+def test_host_health_script_reports_probes_and_components(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Health probes should be mapped into GPU/thermal/memory categories."""
+    """The script reports probe IDs and an informational component breakdown."""
     module = _load_host_health_script()
     machines = [
         {
@@ -623,9 +623,8 @@ def test_host_health_script_categorizes_probes(
             "health": {
                 "observedAt": None,
                 "successes": [
-                    {"id": "GpuRemappedRows", "target": "GPU0"},
-                    {"id": "Temperature", "target": "CPU1 Temp"},
-                    {"id": "MemoryEcc", "target": "DIMM_A1"},
+                    {"id": "BmcSensor", "target": "GPU0_Temp", "message": "temperature 'GPU0_Temp': OK"},
+                    {"id": "BmcSensor", "target": "DIMM_A1", "message": "temperature 'DIMM_A1': OK"},
                     {"id": "BgpDaemonEnabled", "target": None},
                 ],
                 "alerts": [],
@@ -641,17 +640,21 @@ def test_host_health_script_categorizes_probes(
     assert host["host_id"] == "m-1"
     assert host["chassis_serial"] == "SER-1"
     assert host["health_present"] is True
-    cats = host["categories"]
-    assert cats["gpu"] == {"present": True, "healthy": True, "probes": ["GpuRemappedRows"], "alerts": []}
-    assert cats["thermal"]["present"] is True and cats["thermal"]["probes"] == ["Temperature"]
-    assert cats["memory"]["present"] is True and cats["memory"]["probes"] == ["MemoryEcc"]
+    assert host["healthy"] is True
+    assert host["probe_ids"] == ["BgpDaemonEnabled", "BmcSensor"]
+    assert host["alerts"] == []
+    # Informational component breakdown: the GPU/DIMM temp sensors map to those buckets.
+    comps = host["components"]
+    assert comps["gpu"]["present"] is True and comps["gpu"]["probes"] == ["BmcSensor"]
+    assert comps["thermal"]["present"] is True
+    assert comps["memory"]["present"] is True
 
 
-def test_host_health_script_flags_category_alert(
+def test_host_health_script_surfaces_alert_classifications(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """An alert on a GPU target should mark the gpu category unhealthy."""
+    """Alerts (incl. leak detection) are surfaced with their classifications."""
     module = _load_host_health_script()
     machines = [
         {
@@ -659,19 +662,26 @@ def test_host_health_script_flags_category_alert(
             "status": "Error",
             "health": {
                 "successes": None,
-                "alerts": [{"id": "GpuXidError", "target": "GPU3", "message": "Xid 79"}],
+                "alerts": [
+                    {
+                        "id": "BmcLeakDetection",
+                        "target": "RackLeakDetector_1",
+                        "message": "Leak detector reports leak",
+                        "classifications": ["Leak", "LeakDetector"],
+                    }
+                ],
             },
         }
     ]
 
     payload = _run_script(module, monkeypatch, capsys, script_name="query_host_health.py", machines=machines)
 
-    cats = payload["hosts"][0]["categories"]
-    assert cats["gpu"]["present"] is True
-    assert cats["gpu"]["healthy"] is False
-    assert cats["gpu"]["alerts"][0]["message"] == "Xid 79"
-    # No thermal or memory probes were returned for this host.
-    assert cats["thermal"] == {"present": False, "healthy": True, "probes": [], "alerts": []}
+    host = payload["hosts"][0]
+    assert host["healthy"] is False
+    assert host["alerts"][0]["id"] == "BmcLeakDetection"
+    assert host["alerts"][0]["classifications"] == ["Leak", "LeakDetector"]
+    assert host["components"]["cooling"]["present"] is True
+    assert host["components"]["cooling"]["alerting"] is True
 
 
 def test_host_health_script_computes_observation_age(
@@ -690,36 +700,6 @@ def test_host_health_script_computes_observation_age(
     age = payload["hosts"][0]["observed_age_seconds"]
     assert isinstance(age, int)
     assert 40 <= age <= 120
-
-
-def test_host_health_script_output_satisfies_validation_contract(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """End-to-end: NICo host-health JSON should pass HostHealthCheck."""
-    from isvtest.validations.health import HostHealthCheck
-
-    module = _load_host_health_script()
-    machines = [
-        {
-            "id": "m-1",
-            "status": "Ready",
-            "health": {
-                "successes": [
-                    {"id": "GpuRemappedRows", "target": "GPU0"},
-                    {"id": "Temperature", "target": "GPU0 Temp"},
-                    {"id": "GpuMemoryEcc", "target": "GPU0"},
-                ],
-                "alerts": [],
-            },
-        }
-    ]
-
-    payload = _run_script(module, monkeypatch, capsys, script_name="query_host_health.py", machines=machines)
-
-    check = HostHealthCheck(config={"step_output": payload})
-    check.run()
-    assert check._passed is True, check._error
 
 
 def test_governance_script_surfaces_api_errors(
@@ -761,11 +741,11 @@ def test_host_health_real_world_bmc_sensors_pass_by_default(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """A healthy NICo host (BmcSensor probes, no memory probe) passes by default.
+    """A healthy NICo host (BmcSensor probes, no alerts) passes by default.
 
-    Mirrors a live NICo site where machine health surfaces BMC sensors (mapped
-    to thermal/gpu by target) but no dedicated memory probe. With the default
-    config (require_present false), the absent memory category must not fail.
+    Mirrors a live NICo site where machine health surfaces BMC sensors and no
+    alerts. HostHealthCheck should pass: a report is returned and there are no
+    alerts -- no dedicated memory probe is required.
     """
     from isvtest.validations.health import HostHealthCheck
 
@@ -790,12 +770,46 @@ def test_host_health_real_world_bmc_sensors_pass_by_default(
 
     host = payload["hosts"][0]
     assert host["health_present"] is True
-    assert host["categories"]["thermal"]["present"] is True
-    assert host["categories"]["memory"]["present"] is False
+    assert host["healthy"] is True
+    assert host["components"]["memory"]["present"] is False
 
     check = HostHealthCheck(config={"step_output": payload})
     check.run()
     assert check._passed is True, check._error
+
+
+def test_host_health_leak_alert_fails_validation_end_to_end(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """End-to-end: a leak-detection alert flows through to a HostHealthCheck failure."""
+    from isvtest.validations.health import HostHealthCheck
+
+    module = _load_host_health_script()
+    machines = [
+        {
+            "id": "m-1",
+            "status": "Error",
+            "health": {
+                "successes": [{"id": "BmcSensor", "target": "GPU0_Temp", "message": "temperature 'GPU0_Temp': OK"}],
+                "alerts": [
+                    {
+                        "id": "BmcLeakDetection",
+                        "target": "TrayLeakDetector_3",
+                        "message": "2 leaking trays",
+                        "classifications": ["Leak"],
+                    }
+                ],
+            },
+        }
+    ]
+
+    payload = _run_script(module, monkeypatch, capsys, script_name="query_host_health.py", machines=machines)
+
+    check = HostHealthCheck(config={"step_output": payload})
+    check.run()
+    assert check._passed is False
+    assert "BmcLeakDetection" in check._error or "1 alert(s)" in check._error
 
 
 # ---------------------------------------------------------------------------

--- a/isvctl/tests/test_nico_provider.py
+++ b/isvctl/tests/test_nico_provider.py
@@ -23,7 +23,7 @@ import importlib.util
 import json
 import sys
 from collections.abc import Callable, Iterator
-from datetime import UTC
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
@@ -690,8 +690,6 @@ def test_host_health_script_computes_observation_age(
 ) -> None:
     """A valid observedAt timestamp yields a non-negative age in seconds."""
     module = _load_host_health_script()
-    from datetime import datetime, timedelta
-
     observed = (datetime.now(UTC) - timedelta(seconds=42)).strftime("%Y-%m-%dT%H:%M:%SZ")
     machines = [{"id": "m-3", "status": "Ready", "health": {"observedAt": observed, "successes": [], "alerts": []}}]
 
@@ -747,6 +745,7 @@ def test_host_health_real_world_bmc_sensors_pass_by_default(
     alerts. HostHealthCheck should pass: a report is returned and there are no
     alerts -- no dedicated memory probe is required.
     """
+    # Local import: isvtest validation framework only needed for this end-to-end test
     from isvtest.validations.health import HostHealthCheck
 
     module = _load_host_health_script()
@@ -783,6 +782,7 @@ def test_host_health_leak_alert_fails_validation_end_to_end(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """End-to-end: a leak-detection alert flows through to a HostHealthCheck failure."""
+    # Local import: isvtest validation framework only needed for this end-to-end test
     from isvtest.validations.health import HostHealthCheck
 
     module = _load_host_health_script()
@@ -851,6 +851,7 @@ def test_health_aggregation_script_output_satisfies_validation_contract(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """End-to-end: NICo aggregation JSON should pass HealthAggregationCheck."""
+    # Local import: isvtest validation framework only needed for this end-to-end test
     from isvtest.validations.health import HealthAggregationCheck
 
     module = _load_health_aggregation_script()

--- a/isvctl/tests/test_nico_provider.py
+++ b/isvctl/tests/test_nico_provider.py
@@ -23,6 +23,7 @@ import importlib.util
 import json
 import sys
 from collections.abc import Callable, Iterator
+from datetime import UTC
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
@@ -109,6 +110,28 @@ def _load_governance_metrics_script() -> ModuleType:
     """Load the query_metrics (governance) script as a module for direct unit testing."""
     script_path = NICO_SCRIPTS / "governance" / "query_metrics.py"
     spec = importlib.util.spec_from_file_location("test_governance_query_metrics", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    with _isolated_common_imports():
+        spec.loader.exec_module(module)
+    return module
+
+
+def _load_host_health_script() -> ModuleType:
+    """Load the query_host_health script as a module for direct unit testing."""
+    script_path = NICO_SCRIPTS / "health" / "query_host_health.py"
+    spec = importlib.util.spec_from_file_location("test_query_host_health", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    with _isolated_common_imports():
+        spec.loader.exec_module(module)
+    return module
+
+
+def _load_health_aggregation_script() -> ModuleType:
+    """Load the query_health_aggregation script as a module for direct unit testing."""
+    script_path = NICO_SCRIPTS / "health" / "query_health_aggregation.py"
+    spec = importlib.util.spec_from_file_location("test_query_health_aggregation", script_path)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     with _isolated_common_imports():
@@ -219,7 +242,13 @@ def test_forge_get_all_extracts_result_key_from_wrapped_response(monkeypatch: py
 
 @pytest.mark.parametrize(
     "step_name",
-    ["verify_ingestion", "check_dpu_health", "query_governance_metrics"],
+    [
+        "verify_ingestion",
+        "check_dpu_health",
+        "query_governance_metrics",
+        "query_host_health",
+        "query_health_aggregation",
+    ],
 )
 def test_nico_bare_metal_config_exposes_api_base_setting(step_name: str) -> None:
     """The shipped NICo bare_metal config should pass a configurable API base to scripts."""
@@ -239,6 +268,8 @@ def test_nico_bare_metal_config_exposes_api_base_setting(step_name: str) -> None
         ("verify_ingestion.py", _load_ingestion_script),
         ("check_dpu_health.py", _load_dpu_health_script),
         ("query_metrics.py", _load_governance_metrics_script),
+        ("query_host_health.py", _load_host_health_script),
+        ("query_health_aggregation.py", _load_health_aggregation_script),
     ],
 )
 def test_nico_scripts_require_api_base(
@@ -454,6 +485,36 @@ def _run_governance_script(
     return payload
 
 
+# ---------------------------------------------------------------------------
+# query_host_health (CAP05-01) script
+# ---------------------------------------------------------------------------
+
+
+def _run_script(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    *,
+    script_name: str,
+    machines: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Drive a NICo health script with mocked auth/API and return its JSON output."""
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(module, "forge_get_all", lambda *args, **kwargs: machines)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [script_name, "--org", "test-org", "--site-id", "site-1", "--api-base", "http://127.0.0.1:8080/v2/org"],
+    )
+
+    exit_code = module.main()
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0, payload
+    return payload
+
+
 def test_governance_script_classifies_each_status_bucket(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -548,6 +609,118 @@ def test_governance_script_output_satisfies_validation_contract(
     assert check._passed is True, check._error
 
 
+def test_host_health_script_categorizes_probes(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Health probes should be mapped into GPU/thermal/memory categories."""
+    module = _load_host_health_script()
+    machines = [
+        {
+            "id": "m-1",
+            "status": "Ready",
+            "metadata": {"dmiData": {"chassisSerial": "SER-1"}},
+            "health": {
+                "observedAt": None,
+                "successes": [
+                    {"id": "GpuRemappedRows", "target": "GPU0"},
+                    {"id": "Temperature", "target": "CPU1 Temp"},
+                    {"id": "MemoryEcc", "target": "DIMM_A1"},
+                    {"id": "BgpDaemonEnabled", "target": None},
+                ],
+                "alerts": [],
+            },
+        }
+    ]
+
+    payload = _run_script(module, monkeypatch, capsys, script_name="query_host_health.py", machines=machines)
+
+    assert payload["success"] is True
+    assert payload["hosts_checked"] == 1
+    host = payload["hosts"][0]
+    assert host["host_id"] == "m-1"
+    assert host["chassis_serial"] == "SER-1"
+    cats = host["categories"]
+    assert cats["gpu"] == {"present": True, "healthy": True, "probes": ["GpuRemappedRows"], "alerts": []}
+    assert cats["thermal"]["present"] is True and cats["thermal"]["probes"] == ["Temperature"]
+    assert cats["memory"]["present"] is True and cats["memory"]["probes"] == ["MemoryEcc"]
+
+
+def test_host_health_script_flags_category_alert(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An alert on a GPU target should mark the gpu category unhealthy."""
+    module = _load_host_health_script()
+    machines = [
+        {
+            "id": "m-2",
+            "status": "Error",
+            "health": {
+                "successes": None,
+                "alerts": [{"id": "GpuXidError", "target": "GPU3", "message": "Xid 79"}],
+            },
+        }
+    ]
+
+    payload = _run_script(module, monkeypatch, capsys, script_name="query_host_health.py", machines=machines)
+
+    cats = payload["hosts"][0]["categories"]
+    assert cats["gpu"]["present"] is True
+    assert cats["gpu"]["healthy"] is False
+    assert cats["gpu"]["alerts"][0]["message"] == "Xid 79"
+    # No thermal or memory probes were returned for this host.
+    assert cats["thermal"] == {"present": False, "healthy": True, "probes": [], "alerts": []}
+
+
+def test_host_health_script_computes_observation_age(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A valid observedAt timestamp yields a non-negative age in seconds."""
+    module = _load_host_health_script()
+    from datetime import datetime, timedelta
+
+    observed = (datetime.now(UTC) - timedelta(seconds=42)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    machines = [{"id": "m-3", "status": "Ready", "health": {"observedAt": observed, "successes": [], "alerts": []}}]
+
+    payload = _run_script(module, monkeypatch, capsys, script_name="query_host_health.py", machines=machines)
+
+    age = payload["hosts"][0]["observed_age_seconds"]
+    assert isinstance(age, int)
+    assert 40 <= age <= 120
+
+
+def test_host_health_script_output_satisfies_validation_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """End-to-end: NICo host-health JSON should pass HostHealthCheck."""
+    from isvtest.validations.health import HostHealthCheck
+
+    module = _load_host_health_script()
+    machines = [
+        {
+            "id": "m-1",
+            "status": "Ready",
+            "health": {
+                "successes": [
+                    {"id": "GpuRemappedRows", "target": "GPU0"},
+                    {"id": "Temperature", "target": "GPU0 Temp"},
+                    {"id": "GpuMemoryEcc", "target": "GPU0"},
+                ],
+                "alerts": [],
+            },
+        }
+    ]
+
+    payload = _run_script(module, monkeypatch, capsys, script_name="query_host_health.py", machines=machines)
+
+    check = HostHealthCheck(config={"step_output": payload})
+    check.run()
+    assert check._passed is True, check._error
+
+
 def test_governance_script_surfaces_api_errors(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -581,3 +754,57 @@ def test_governance_script_surfaces_api_errors(
     assert exit_code == 1
     assert payload["success"] is False
     assert "simulated outage" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# query_health_aggregation (CAP05-02) script
+# ---------------------------------------------------------------------------
+
+
+def test_health_aggregation_script_groups_by_instance_type(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Machines should aggregate per instanceTypeId with consistent counts."""
+    module = _load_health_aggregation_script()
+    machines = [
+        {"id": "m-1", "status": "Ready", "instanceTypeId": "it-a", "health": {"alerts": []}},
+        {"id": "m-2", "status": "InUse", "instanceTypeId": "it-a", "health": {"alerts": []}},
+        {"id": "m-3", "status": "Error", "instanceTypeId": "it-a", "health": {"alerts": []}},
+        {"id": "m-4", "status": "Ready", "instanceTypeId": "it-b", "health": {"alerts": [{"id": "FanSpeed"}]}},
+        {"id": "m-5", "status": "Ready", "instanceTypeId": None, "health": {"alerts": []}},
+        # Decommissioned machines are excluded from the live fleet entirely.
+        {"id": "m-6", "status": "Decommissioned", "instanceTypeId": "it-a", "health": {"alerts": []}},
+    ]
+
+    payload = _run_script(module, monkeypatch, capsys, script_name="query_health_aggregation.py", machines=machines)
+
+    assert payload["aggregation_level"] == "nodegroup"
+    groups = {g["group_id"]: g for g in payload["groups"]}
+    assert groups["it-a"]["total"] == 3
+    assert groups["it-a"]["healthy"] == 2
+    assert groups["it-a"]["unhealthy"] == 1
+    assert groups["it-a"]["status"] == "Degraded"
+    assert groups["it-a"]["unhealthy_hosts"] == ["m-3"]
+    assert groups["it-b"]["status"] == "Degraded"  # alert -> unhealthy
+    assert groups["unassigned"]["total"] == 1 and groups["unassigned"]["status"] == "Healthy"
+
+
+def test_health_aggregation_script_output_satisfies_validation_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """End-to-end: NICo aggregation JSON should pass HealthAggregationCheck."""
+    from isvtest.validations.health import HealthAggregationCheck
+
+    module = _load_health_aggregation_script()
+    machines = [
+        {"id": "m-1", "status": "Ready", "instanceTypeId": "it-a", "health": {"alerts": []}},
+        {"id": "m-2", "status": "Error", "instanceTypeId": "it-a", "health": {"alerts": []}},
+    ]
+
+    payload = _run_script(module, monkeypatch, capsys, script_name="query_health_aggregation.py", machines=machines)
+
+    check = HealthAggregationCheck(config={"step_output": payload})
+    check.run()
+    assert check._passed is True, check._error

--- a/isvctl/tests/test_nico_provider.py
+++ b/isvctl/tests/test_nico_provider.py
@@ -640,6 +640,7 @@ def test_host_health_script_categorizes_probes(
     host = payload["hosts"][0]
     assert host["host_id"] == "m-1"
     assert host["chassis_serial"] == "SER-1"
+    assert host["health_present"] is True
     cats = host["categories"]
     assert cats["gpu"] == {"present": True, "healthy": True, "probes": ["GpuRemappedRows"], "alerts": []}
     assert cats["thermal"]["present"] is True and cats["thermal"]["probes"] == ["Temperature"]
@@ -754,6 +755,47 @@ def test_governance_script_surfaces_api_errors(
     assert exit_code == 1
     assert payload["success"] is False
     assert "simulated outage" in payload["error"]
+
+
+def test_host_health_real_world_bmc_sensors_pass_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A healthy NICo host (BmcSensor probes, no memory probe) passes by default.
+
+    Mirrors a live NICo site where machine health surfaces BMC sensors (mapped
+    to thermal/gpu by target) but no dedicated memory probe. With the default
+    config (require_present false), the absent memory category must not fail.
+    """
+    from isvtest.validations.health import HostHealthCheck
+
+    module = _load_host_health_script()
+    machines = [
+        {
+            "id": "m-1",
+            "status": "Ready",
+            "health": {
+                "observedAt": None,
+                "successes": [
+                    {"id": "BmcSensor", "target": "GPU0_Temp", "message": "temperature 'GPU0_Temp': OK"},
+                    {"id": "BmcSensor", "target": "FAN1", "message": "fan 'FAN1': OK"},
+                    {"id": "BgpDaemonEnabled", "target": None},
+                ],
+                "alerts": [],
+            },
+        }
+    ]
+
+    payload = _run_script(module, monkeypatch, capsys, script_name="query_host_health.py", machines=machines)
+
+    host = payload["hosts"][0]
+    assert host["health_present"] is True
+    assert host["categories"]["thermal"]["present"] is True
+    assert host["categories"]["memory"]["present"] is False
+
+    check = HostHealthCheck(config={"step_output": payload})
+    check.run()
+    assert check._passed is True, check._error
 
 
 # ---------------------------------------------------------------------------

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -41,6 +41,10 @@ from isvtest.validations.generic import (
 from isvtest.validations.governance import (
     GovernanceMetricsCheck,
 )
+from isvtest.validations.health import (
+    HealthAggregationCheck,
+    HostHealthCheck,
+)
 from isvtest.validations.host import (
     CloudInitCheck,
     ContainerRuntimeCheck,
@@ -157,6 +161,8 @@ __all__ = [
     "FloatingIpCheck",
     "GovernanceMetricsCheck",
     "GpuOperatorInstalledCheck",
+    "HealthAggregationCheck",
+    "HostHealthCheck",
     "InsecureProtocolsCheck",
     "InstanceCreatedCheck",
     "InstanceListCheck",

--- a/isvtest/src/isvtest/validations/health.py
+++ b/isvtest/src/isvtest/validations/health.py
@@ -46,20 +46,27 @@ def _host_label(host: dict[str, Any]) -> str:
 
 
 class HostHealthCheck(BaseValidation):
-    """Validate the per-host health API returns GPU, thermal, and memory health.
+    """Validate the per-host health API returns a fresh, healthy report.
 
-    For every host, asserts that the health API surfaces a signal for each
-    required category (default GPU state, thermal status, memory health) and
-    that none of those categories are alerting. Optionally enforces that the
-    health observation is recent ("real-time") via ``max_observation_age_seconds``.
+    NICo (and similar providers) expose host health as an alert-driven report:
+    a healthy subsystem is simply the absence of an alert, so a passing probe
+    per category is not guaranteed. This check therefore asserts, for every
+    host, that the health API returns a report and that any health categories
+    it does surface (GPU state, thermal status, memory health) are not
+    alerting. Category *coverage* can additionally be required via
+    ``require_present`` for providers whose API enumerates every category.
 
     Config:
         step_output: Step output containing per-host health data.
-        required_categories: Categories that must be present and healthy
-            (default: ["gpu", "thermal", "memory"]).
+        required_categories: Categories to evaluate (default: ["gpu", "thermal",
+            "memory"]). A category that is present must be healthy; a missing
+            one only fails when ``require_present`` is true.
+        require_report: Whether each host must return a health report at all
+            (default: true) -- the baseline "the per-host health API works"
+            assertion.
         require_present: Whether each required category must expose at least one
-            probe (default: true). When false, a category with no probes is
-            treated as "nothing to fail" rather than a coverage gap.
+            probe (default: false). Enable for providers whose health API
+            enumerates GPU/thermal/memory coverage explicitly.
         max_observation_age_seconds: When set, each host's health observation
             must be no older than this many seconds (default: None = freshness
             not enforced).
@@ -73,6 +80,7 @@ class HostHealthCheck(BaseValidation):
             host_id: str
             chassis_serial: str -- debug aid only, may be empty
             status: str
+            health_present: bool -- the API returned any health data for the host
             observed_age_seconds: int | None -- age of the health observation
             categories: dict[str, dict]:
                 <category>:
@@ -82,12 +90,12 @@ class HostHealthCheck(BaseValidation):
                     alerts: list[dict] -- alerting probes ({id, message})
     """
 
-    description: ClassVar[str] = "Check per-host health API returns GPU, thermal, and memory health"
+    description: ClassVar[str] = "Check per-host health API returns a fresh, healthy report"
     timeout: ClassVar[int] = 120
     labels: ClassVar[tuple[str, ...]] = ("bare_metal", "health")
 
     def run(self) -> None:
-        """Validate per-host category coverage, category health, and freshness."""
+        """Validate per-host report presence, category health, coverage, and freshness."""
         step_output = self.config.get("step_output", {})
 
         if not step_output.get("success"):
@@ -100,7 +108,8 @@ class HostHealthCheck(BaseValidation):
             return
 
         required_categories = self.config.get("required_categories", list(DEFAULT_REQUIRED_CATEGORIES))
-        require_present = self.config.get("require_present", True)
+        require_report = self.config.get("require_report", True)
+        require_present = self.config.get("require_present", False)
         max_age = self.config.get("max_observation_age_seconds")
 
         # Maps each failing host label to a short reason for the summary line.
@@ -109,6 +118,23 @@ class HostHealthCheck(BaseValidation):
         for host in hosts:
             label = _host_label(host)
             categories = host.get("categories") or {}
+
+            # Baseline: the per-host health API must return a report at all.
+            if require_report:
+                if not host.get("health_present"):
+                    self.report_subtest(
+                        f"host_{label}_report",
+                        passed=False,
+                        message=f"Host {label}: health API returned no report",
+                    )
+                    failed.setdefault(label, "no health report")
+                    # No report means there is nothing further to evaluate.
+                    continue
+                self.report_subtest(
+                    f"host_{label}_report",
+                    passed=True,
+                    message=f"Host {label}: health report returned",
+                )
 
             for category in required_categories:
                 summary = categories.get(category) or {}
@@ -130,7 +156,7 @@ class HostHealthCheck(BaseValidation):
                             f"host_{label}_{category}",
                             passed=True,
                             skipped=True,
-                            message=f"Host {label}: no {category} signal (require_present disabled)",
+                            message=f"Host {label}: no {category} signal returned (coverage not enforced)",
                         )
                     continue
 
@@ -181,7 +207,7 @@ class HostHealthCheck(BaseValidation):
             failed_desc = ", ".join(f"{lbl} ({reason})" for lbl, reason in failed.items())
             self.set_failed(f"Host health issues on {len(failed)}/{total} host(s): {failed_desc}")
         else:
-            self.set_passed(f"All {total} host(s) report healthy {', '.join(required_categories)} via the health API")
+            self.set_passed(f"All {total} host(s) return a healthy report via the per-host health API")
 
 
 class HealthAggregationCheck(BaseValidation):

--- a/isvtest/src/isvtest/validations/health.py
+++ b/isvtest/src/isvtest/validations/health.py
@@ -1,0 +1,312 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unified Health API validations (requirement CAP05).
+
+Two provider-agnostic checks that assert a cloud's health API surfaces the
+signals NVIDIA requires:
+
+- ``HostHealthCheck`` (CAP05-01): the per-host health API returns real-time
+  GPU state, thermal status, and memory health for every host.
+- ``HealthAggregationCheck`` (CAP05-02): health can be rolled up to a
+  primitive level (cluster, nodegroup, or reservation) with internally
+  consistent counts.
+
+Both validations only inspect provider-neutral JSON produced by a step script,
+so any provider that emits the documented fields can reuse them.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from isvtest.core.validation import BaseValidation
+
+# Health categories a per-host health API must surface for CAP05-01. The step
+# script is responsible for mapping provider-specific probes into these
+# categories; the validation only checks the resulting per-category summary.
+DEFAULT_REQUIRED_CATEGORIES: tuple[str, ...] = ("gpu", "thermal", "memory")
+
+
+def _host_label(host: dict[str, Any]) -> str:
+    """Human-facing identifier for a host record."""
+    return host.get("host_id") or host.get("machine_id") or host.get("chassis_serial") or "unknown"
+
+
+class HostHealthCheck(BaseValidation):
+    """Validate the per-host health API returns GPU, thermal, and memory health.
+
+    For every host, asserts that the health API surfaces a signal for each
+    required category (default GPU state, thermal status, memory health) and
+    that none of those categories are alerting. Optionally enforces that the
+    health observation is recent ("real-time") via ``max_observation_age_seconds``.
+
+    Config:
+        step_output: Step output containing per-host health data.
+        required_categories: Categories that must be present and healthy
+            (default: ["gpu", "thermal", "memory"]).
+        require_present: Whether each required category must expose at least one
+            probe (default: true). When false, a category with no probes is
+            treated as "nothing to fail" rather than a coverage gap.
+        max_observation_age_seconds: When set, each host's health observation
+            must be no older than this many seconds (default: None = freshness
+            not enforced).
+
+    Step output (from query_host_health.py):
+        success: bool
+        platform: str
+        site_id: str
+        hosts_checked: int
+        hosts: list[dict]:
+            host_id: str
+            chassis_serial: str -- debug aid only, may be empty
+            status: str
+            observed_age_seconds: int | None -- age of the health observation
+            categories: dict[str, dict]:
+                <category>:
+                    present: bool -- the API surfaced at least one probe
+                    healthy: bool -- no alerts in this category
+                    probes: list[str] -- probe IDs contributing to this category
+                    alerts: list[dict] -- alerting probes ({id, message})
+    """
+
+    description: ClassVar[str] = "Check per-host health API returns GPU, thermal, and memory health"
+    timeout: ClassVar[int] = 120
+    labels: ClassVar[tuple[str, ...]] = ("bare_metal", "health")
+
+    def run(self) -> None:
+        """Validate per-host category coverage, category health, and freshness."""
+        step_output = self.config.get("step_output", {})
+
+        if not step_output.get("success"):
+            self.set_failed(f"Host health step failed: {step_output.get('error', 'Unknown error')}")
+            return
+
+        hosts = step_output.get("hosts", [])
+        if not hosts:
+            self.set_failed("No hosts found in step output")
+            return
+
+        required_categories = self.config.get("required_categories", list(DEFAULT_REQUIRED_CATEGORIES))
+        require_present = self.config.get("require_present", True)
+        max_age = self.config.get("max_observation_age_seconds")
+
+        # Maps each failing host label to a short reason for the summary line.
+        failed: dict[str, str] = {}
+
+        for host in hosts:
+            label = _host_label(host)
+            categories = host.get("categories") or {}
+
+            for category in required_categories:
+                summary = categories.get(category) or {}
+                present = bool(summary.get("present"))
+                healthy = bool(summary.get("healthy"))
+                probes = summary.get("probes") or []
+                alerts = summary.get("alerts") or []
+
+                if not present:
+                    if require_present:
+                        self.report_subtest(
+                            f"host_{label}_{category}",
+                            passed=False,
+                            message=f"Host {label}: no {category} health signal returned by the API",
+                        )
+                        failed.setdefault(label, f"missing {category}")
+                    else:
+                        self.report_subtest(
+                            f"host_{label}_{category}",
+                            passed=True,
+                            skipped=True,
+                            message=f"Host {label}: no {category} signal (require_present disabled)",
+                        )
+                    continue
+
+                if not healthy:
+                    alert_msgs = (
+                        "; ".join(f"{a.get('id', '?')}: {a.get('message', '?')}" for a in alerts)
+                        if alerts
+                        else "alerting (no detail)"
+                    )
+                    self.report_subtest(
+                        f"host_{label}_{category}",
+                        passed=False,
+                        message=f"Host {label}: {category} unhealthy -- {alert_msgs}",
+                    )
+                    failed.setdefault(label, f"{category} unhealthy")
+                else:
+                    self.report_subtest(
+                        f"host_{label}_{category}",
+                        passed=True,
+                        message=f"Host {label}: {category} healthy ({len(probes)} probe(s))",
+                    )
+
+            if max_age is not None:
+                age = host.get("observed_age_seconds")
+                if age is None:
+                    self.report_subtest(
+                        f"host_{label}_freshness",
+                        passed=False,
+                        message=f"Host {label}: health API returned no observation timestamp",
+                    )
+                    failed.setdefault(label, "no observation timestamp")
+                elif age > max_age:
+                    self.report_subtest(
+                        f"host_{label}_freshness",
+                        passed=False,
+                        message=f"Host {label}: health observed {age}s ago, exceeds max {max_age}s",
+                    )
+                    failed.setdefault(label, f"stale ({age}s)")
+                else:
+                    self.report_subtest(
+                        f"host_{label}_freshness",
+                        passed=True,
+                        message=f"Host {label}: health observed {age}s ago",
+                    )
+
+        total = len(hosts)
+        if failed:
+            failed_desc = ", ".join(f"{lbl} ({reason})" for lbl, reason in failed.items())
+            self.set_failed(f"Host health issues on {len(failed)}/{total} host(s): {failed_desc}")
+        else:
+            self.set_passed(f"All {total} host(s) report healthy {', '.join(required_categories)} via the health API")
+
+
+class HealthAggregationCheck(BaseValidation):
+    """Validate primitive-level health aggregation (cluster/nodegroup/reservation).
+
+    Asserts that the health API can roll host health up to a higher-level
+    primitive and that each group's counts are internally consistent
+    (``healthy + unhealthy == total``, non-negative) and that the reported
+    aggregate status agrees with the counts. Optionally requires every group
+    to be fully healthy.
+
+    Config:
+        step_output: Step output containing aggregated health groups.
+        min_groups: Minimum number of groups expected (default: 1).
+        require_all_healthy: Whether every group must be fully healthy
+            (default: false -- a degraded group is reported but not fatal).
+
+    Step output (from query_health_aggregation.py):
+        success: bool
+        platform: str
+        site_id: str
+        aggregation_level: str -- e.g. "nodegroup" | "reservation" | "cluster"
+        groups: list[dict]:
+            group_id: str
+            group_type: str
+            name: str
+            total: int
+            healthy: int
+            unhealthy: int
+            status: str -- "Healthy" when unhealthy == 0, else "Degraded"
+            unhealthy_hosts: list[str]
+    """
+
+    description: ClassVar[str] = "Check primitive-level health aggregation is exposed and consistent"
+    timeout: ClassVar[int] = 120
+    labels: ClassVar[tuple[str, ...]] = ("bare_metal", "health")
+
+    def run(self) -> None:
+        """Validate aggregation presence, per-group count consistency, and status."""
+        step_output = self.config.get("step_output", {})
+
+        if not step_output.get("success"):
+            self.set_failed(f"Health aggregation step failed: {step_output.get('error', 'Unknown error')}")
+            return
+
+        level = step_output.get("aggregation_level")
+        if not level:
+            self.set_failed("Health aggregation step output is missing 'aggregation_level'")
+            return
+
+        groups = step_output.get("groups")
+        if not isinstance(groups, list):
+            self.set_failed("Health aggregation step output is missing the 'groups' list")
+            return
+
+        min_groups = self._parse_positive_int("min_groups", default=1)
+        if min_groups is None:
+            return
+
+        if len(groups) < min_groups:
+            self.set_failed(f"Expected at least {min_groups} aggregation group(s), got {len(groups)}")
+            return
+
+        require_all_healthy = self.config.get("require_all_healthy", False)
+
+        inconsistent: list[str] = []
+        degraded: list[str] = []
+
+        for group in groups:
+            name = group.get("name") or group.get("group_id") or "unknown"
+            total = group.get("total")
+            healthy = group.get("healthy")
+            unhealthy = group.get("unhealthy")
+            status = group.get("status")
+
+            if not all(isinstance(v, int) and not isinstance(v, bool) for v in (total, healthy, unhealthy)):
+                self.report_subtest(
+                    f"group_{name}_counts",
+                    passed=False,
+                    message=f"Group {name}: non-integer counts (total={total}, healthy={healthy}, unhealthy={unhealthy})",
+                )
+                inconsistent.append(name)
+                continue
+
+            counts_ok = healthy >= 0 and unhealthy >= 0 and total >= 0 and (healthy + unhealthy == total)
+            expected_status = "Healthy" if unhealthy == 0 else "Degraded"
+            status_ok = status == expected_status
+
+            if not counts_ok or not status_ok:
+                problems = []
+                if not counts_ok:
+                    problems.append(
+                        f"counts don't reconcile (healthy {healthy} + unhealthy {unhealthy} != total {total})"
+                    )
+                if not status_ok:
+                    problems.append(f"status {status!r} != expected {expected_status!r}")
+                self.report_subtest(
+                    f"group_{name}_counts",
+                    passed=False,
+                    message=f"Group {name}: {'; '.join(problems)}",
+                )
+                inconsistent.append(name)
+                continue
+
+            self.report_subtest(
+                f"group_{name}_counts",
+                passed=True,
+                message=f"Group {name}: {healthy}/{total} healthy ({status})",
+            )
+
+            if unhealthy > 0:
+                degraded.append(f"{name} ({unhealthy}/{total} unhealthy)")
+
+        if inconsistent:
+            self.set_failed(
+                f"Health aggregation is inconsistent for {len(inconsistent)}/{len(groups)} group(s): "
+                f"{', '.join(inconsistent)}"
+            )
+            return
+
+        if require_all_healthy and degraded:
+            self.set_failed(f"{len(degraded)} aggregation group(s) degraded: {', '.join(degraded)}")
+            return
+
+        summary = f"{len(groups)} {level}-level group(s) aggregated consistently"
+        if degraded:
+            summary += f"; {len(degraded)} degraded: {', '.join(degraded)}"
+        self.set_passed(summary)

--- a/isvtest/src/isvtest/validations/health.py
+++ b/isvtest/src/isvtest/validations/health.py
@@ -34,11 +34,6 @@ from typing import Any, ClassVar
 
 from isvtest.core.validation import BaseValidation
 
-# Health categories a per-host health API must surface for CAP05-01. The step
-# script is responsible for mapping provider-specific probes into these
-# categories; the validation only checks the resulting per-category summary.
-DEFAULT_REQUIRED_CATEGORIES: tuple[str, ...] = ("gpu", "thermal", "memory")
-
 
 def _host_label(host: dict[str, Any]) -> str:
     """Human-facing identifier for a host record."""
@@ -46,27 +41,28 @@ def _host_label(host: dict[str, Any]) -> str:
 
 
 class HostHealthCheck(BaseValidation):
-    """Validate the per-host health API returns a fresh, healthy report.
+    """Validate the per-host health API returns a fresh, alert-free report.
 
-    NICo (and similar providers) expose host health as an alert-driven report:
-    a healthy subsystem is simply the absence of an alert, so a passing probe
-    per category is not guaranteed. This check therefore asserts, for every
-    host, that the health API returns a report and that any health categories
-    it does surface (GPU state, thermal status, memory health) are not
-    alerting. Category *coverage* can additionally be required via
-    ``require_present`` for providers whose API enumerates every category.
+    NICo exposes host health as an alert-driven report keyed on probe IDs
+    (``BmcSensor``, ``BmcLeakDetection``, ``HeartbeatTimeout``, ...) and alert
+    ``classifications`` (``SensorCritical``, ``Leak``, ...): a healthy subsystem
+    is simply the absence of an alert. This check asserts, for every host, that
+    the per-host health API returns a report and that the host carries no
+    blocking alerts. By default *any* alert is blocking; set
+    ``fail_on_classifications`` to narrow that to specific severities.
 
     Config:
         step_output: Step output containing per-host health data.
-        required_categories: Categories to evaluate (default: ["gpu", "thermal",
-            "memory"]). A category that is present must be healthy; a missing
-            one only fails when ``require_present`` is true.
         require_report: Whether each host must return a health report at all
             (default: true) -- the baseline "the per-host health API works"
             assertion.
-        require_present: Whether each required category must expose at least one
-            probe (default: false). Enable for providers whose health API
-            enumerates GPU/thermal/memory coverage explicitly.
+        fail_on_classifications: Optional list of alert classifications that are
+            blocking (e.g. ["SensorCritical", "SensorFailure", "Leak"]). When
+            omitted (default), ANY alert fails the host, matching how
+            DpuHealthCheck and HardwareIngestionCheck treat alerts.
+        require_probes: Optional list of probe IDs that must be present for each
+            host (default: [] = coverage not enforced). Use to require specific
+            signals, e.g. ["BmcSensor"] or ["BmcLeakDetection"].
         max_observation_age_seconds: When set, each host's health observation
             must be no older than this many seconds (default: None = freshness
             not enforced).
@@ -81,21 +77,28 @@ class HostHealthCheck(BaseValidation):
             chassis_serial: str -- debug aid only, may be empty
             status: str
             health_present: bool -- the API returned any health data for the host
+            healthy: bool -- no alerts at all
             observed_age_seconds: int | None -- age of the health observation
-            categories: dict[str, dict]:
-                <category>:
-                    present: bool -- the API surfaced at least one probe
-                    healthy: bool -- no alerts in this category
-                    probes: list[str] -- probe IDs contributing to this category
-                    alerts: list[dict] -- alerting probes ({id, message})
+            probe_ids: list[str] -- distinct probe IDs the API returned
+            alerts: list[dict] -- {id, target, message, classifications}
+            components: dict -- informational GPU/thermal/memory/cooling breakdown
     """
 
-    description: ClassVar[str] = "Check per-host health API returns a fresh, healthy report"
+    description: ClassVar[str] = "Check per-host health API returns a fresh, alert-free report"
     timeout: ClassVar[int] = 120
     labels: ClassVar[tuple[str, ...]] = ("bare_metal", "health")
 
+    def _blocking_alerts(self, host: dict[str, Any], fail_on: list[str] | None) -> list[dict[str, Any]]:
+        """Return the host alerts that count as blocking under the config."""
+        alerts = host.get("alerts") or []
+        if fail_on is None:
+            # Default: any alert is blocking (parity with the other BM checks).
+            return list(alerts)
+        wanted = set(fail_on)
+        return [a for a in alerts if wanted.intersection(a.get("classifications") or [])]
+
     def run(self) -> None:
-        """Validate per-host report presence, category health, coverage, and freshness."""
+        """Validate per-host report presence, absence of alerts, coverage, and freshness."""
         step_output = self.config.get("step_output", {})
 
         if not step_output.get("success"):
@@ -107,9 +110,9 @@ class HostHealthCheck(BaseValidation):
             self.set_failed("No hosts found in step output")
             return
 
-        required_categories = self.config.get("required_categories", list(DEFAULT_REQUIRED_CATEGORIES))
         require_report = self.config.get("require_report", True)
-        require_present = self.config.get("require_present", False)
+        fail_on_classifications = self.config.get("fail_on_classifications")
+        require_probes = self.config.get("require_probes", [])
         max_age = self.config.get("max_observation_age_seconds")
 
         # Maps each failing host label to a short reason for the summary line.
@@ -117,7 +120,6 @@ class HostHealthCheck(BaseValidation):
 
         for host in hosts:
             label = _host_label(host)
-            categories = host.get("categories") or {}
 
             # Baseline: the per-host health API must return a report at all.
             if require_report:
@@ -133,50 +135,47 @@ class HostHealthCheck(BaseValidation):
                 self.report_subtest(
                     f"host_{label}_report",
                     passed=True,
-                    message=f"Host {label}: health report returned",
+                    message=f"Host {label}: health report returned ({len(host.get('probe_ids') or [])} probe(s))",
                 )
 
-            for category in required_categories:
-                summary = categories.get(category) or {}
-                present = bool(summary.get("present"))
-                healthy = bool(summary.get("healthy"))
-                probes = summary.get("probes") or []
-                alerts = summary.get("alerts") or []
+            # Alerts: by default any alert is blocking; otherwise only those whose
+            # classifications match fail_on_classifications.
+            blocking = self._blocking_alerts(host, fail_on_classifications)
+            if blocking:
+                detail = "; ".join(
+                    f"{a.get('id', '?')}[{','.join(a.get('classifications') or []) or 'unclassified'}]: "
+                    f"{a.get('message', '?')}"
+                    for a in blocking
+                )
+                self.report_subtest(
+                    f"host_{label}_alerts",
+                    passed=False,
+                    message=f"Host {label}: {len(blocking)} alert(s) -- {detail}",
+                )
+                alert_ids = ", ".join(sorted({a.get("id", "?") for a in blocking}))
+                failed.setdefault(label, f"alerts: {alert_ids}")
+            else:
+                self.report_subtest(
+                    f"host_{label}_alerts",
+                    passed=True,
+                    message=f"Host {label}: no {'blocking ' if fail_on_classifications else ''}alerts",
+                )
 
-                if not present:
-                    if require_present:
-                        self.report_subtest(
-                            f"host_{label}_{category}",
-                            passed=False,
-                            message=f"Host {label}: no {category} health signal returned by the API",
-                        )
-                        failed.setdefault(label, f"missing {category}")
-                    else:
-                        self.report_subtest(
-                            f"host_{label}_{category}",
-                            passed=True,
-                            skipped=True,
-                            message=f"Host {label}: no {category} signal returned (coverage not enforced)",
-                        )
-                    continue
-
-                if not healthy:
-                    alert_msgs = (
-                        "; ".join(f"{a.get('id', '?')}: {a.get('message', '?')}" for a in alerts)
-                        if alerts
-                        else "alerting (no detail)"
-                    )
+            if require_probes:
+                present = set(host.get("probe_ids") or [])
+                missing = [p for p in require_probes if p not in present]
+                if missing:
                     self.report_subtest(
-                        f"host_{label}_{category}",
+                        f"host_{label}_probes",
                         passed=False,
-                        message=f"Host {label}: {category} unhealthy -- {alert_msgs}",
+                        message=f"Host {label}: missing required probe(s): {', '.join(missing)}",
                     )
-                    failed.setdefault(label, f"{category} unhealthy")
+                    failed.setdefault(label, f"missing probes {', '.join(missing)}")
                 else:
                     self.report_subtest(
-                        f"host_{label}_{category}",
+                        f"host_{label}_probes",
                         passed=True,
-                        message=f"Host {label}: {category} healthy ({len(probes)} probe(s))",
+                        message=f"Host {label}: required probe(s) present: {', '.join(require_probes)}",
                     )
 
             if max_age is not None:

--- a/isvtest/tests/test_health.py
+++ b/isvtest/tests/test_health.py
@@ -26,19 +26,19 @@ from isvtest.validations.health import HealthAggregationCheck, HostHealthCheck
 # ---------------------------------------------------------------------------
 
 
-def _category(
+def _alert(
     *,
-    present: bool = True,
-    healthy: bool = True,
-    probes: list[str] | None = None,
-    alerts: list[dict[str, Any]] | None = None,
+    probe_id: str = "BmcSensor",
+    target: str = "",
+    message: str = "",
+    classifications: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Build a single per-category health summary."""
+    """Build a single host health alert record."""
     return {
-        "present": present,
-        "healthy": healthy,
-        "probes": probes if probes is not None else (["probe"] if present else []),
-        "alerts": alerts or [],
+        "id": probe_id,
+        "target": target,
+        "message": message,
+        "classifications": classifications or [],
     }
 
 
@@ -48,22 +48,19 @@ def _host(
     status: str = "Ready",
     health_present: bool = True,
     observed_age_seconds: int | None = 10,
-    categories: dict[str, dict[str, Any]] | None = None,
+    probe_ids: list[str] | None = None,
+    alerts: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build a per-host health record."""
-    if categories is None:
-        categories = {
-            "gpu": _category(),
-            "thermal": _category(),
-            "memory": _category(),
-        }
     return {
         "host_id": host_id,
         "chassis_serial": f"SER-{host_id}",
         "status": status,
         "health_present": health_present,
+        "healthy": not alerts,
         "observed_age_seconds": observed_age_seconds,
-        "categories": categories,
+        "probe_ids": probe_ids if probe_ids is not None else ["BmcSensor", "BgpDaemonEnabled"],
+        "alerts": alerts or [],
     }
 
 
@@ -136,45 +133,15 @@ def _aggregation_output(
 class TestHostHealthCheck:
     """Tests for HostHealthCheck validation."""
 
-    def test_all_categories_present_and_healthy(self) -> None:
-        """A host that surfaces healthy GPU/thermal/memory health passes."""
+    def test_healthy_host_passes(self) -> None:
+        """A host with a fresh report and no alerts passes."""
         check = HostHealthCheck(config={"step_output": _host_health_output()})
         check.run()
         assert check._passed is True, check._error
-        # report + gpu + thermal + memory subtests, all passing.
+        # report + alerts subtests, both passing.
         subtests = [r for r in check._subtest_results if r["name"].startswith("host_m-001_")]
-        assert len(subtests) == 4
+        assert {r["name"] for r in subtests} == {"host_m-001_report", "host_m-001_alerts"}
         assert all(r["passed"] for r in subtests)
-
-    def test_missing_category_is_not_fatal_by_default(self) -> None:
-        """A missing category is informational by default (NICo alert-driven model)."""
-        categories = {"gpu": _category(), "thermal": _category(), "memory": _category(present=False)}
-        check = HostHealthCheck(config={"step_output": _host_health_output(hosts=[_host(categories=categories)])})
-        check.run()
-        assert check._passed is True, check._error
-        mem = next(r for r in check._subtest_results if r["name"] == "host_m-001_memory")
-        assert mem["skipped"] is True
-
-    def test_missing_report_fails(self) -> None:
-        """A host the health API returns nothing for fails the baseline check."""
-        host = _host(health_present=False)
-        check = HostHealthCheck(config={"step_output": _host_health_output(hosts=[host])})
-        check.run()
-        assert check._passed is False
-        assert "no health report" in check._error
-        report = next(r for r in check._subtest_results if r["name"] == "host_m-001_report")
-        assert report["passed"] is False
-
-    def test_report_with_no_categories_passes(self) -> None:
-        """A fresh report with no recognized categories still passes by default."""
-        categories = {
-            "gpu": _category(present=False),
-            "thermal": _category(present=False),
-            "memory": _category(present=False),
-        }
-        check = HostHealthCheck(config={"step_output": _host_health_output(hosts=[_host(categories=categories)])})
-        check.run()
-        assert check._passed is True, check._error
 
     def test_step_failure(self) -> None:
         """A failed step is reported with its error detail."""
@@ -190,49 +157,107 @@ class TestHostHealthCheck:
         assert check._passed is False
         assert "No hosts" in check._error
 
-    def test_missing_required_category_fails_when_required(self) -> None:
-        """With require_present enabled, a host missing the memory signal fails coverage."""
-        categories = {"gpu": _category(), "thermal": _category(), "memory": _category(present=False)}
-        check = HostHealthCheck(
-            config={
-                "step_output": _host_health_output(hosts=[_host(categories=categories)]),
-                "require_present": True,
-            }
+    def test_missing_report_fails(self) -> None:
+        """A host the health API returns nothing for fails the baseline check."""
+        host = _host(health_present=False, probe_ids=[])
+        check = HostHealthCheck(config={"step_output": _host_health_output(hosts=[host])})
+        check.run()
+        assert check._passed is False
+        assert "no health report" in check._error
+        report = next(r for r in check._subtest_results if r["name"] == "host_m-001_report")
+        assert report["passed"] is False
+
+    def test_any_alert_fails_by_default(self) -> None:
+        """By default any alert (regardless of classification) fails the host."""
+        host = _host(alerts=[_alert(probe_id="HeartbeatTimeout", message="dpu agent silent")])
+        check = HostHealthCheck(config={"step_output": _host_health_output(hosts=[host])})
+        check.run()
+        assert check._passed is False
+        assert "HeartbeatTimeout" in check._error
+        alerts_sub = next(r for r in check._subtest_results if r["name"] == "host_m-001_alerts")
+        assert alerts_sub["passed"] is False
+        assert "HeartbeatTimeout" in alerts_sub["message"]
+
+    def test_leak_detection_alert_fails(self) -> None:
+        """A liquid-cooling leak (BmcLeakDetection/Leak) fails the host."""
+        host = _host(
+            probe_ids=["BmcSensor", "BmcLeakDetection"],
+            alerts=[
+                _alert(
+                    probe_id="BmcLeakDetection",
+                    target="RackLeakDetector_1",
+                    message="Leak detector reports leak",
+                    classifications=["Leak"],
+                )
+            ],
         )
+        check = HostHealthCheck(config={"step_output": _host_health_output(hosts=[host])})
         check.run()
         assert check._passed is False
-        assert "missing memory" in check._error
-        mem = next(r for r in check._subtest_results if r["name"] == "host_m-001_memory")
-        assert mem["passed"] is False
+        alerts_sub = next(r for r in check._subtest_results if r["name"] == "host_m-001_alerts")
+        assert alerts_sub["passed"] is False
+        assert "BmcLeakDetection" in alerts_sub["message"]
+        assert "Leak" in alerts_sub["message"]
 
-    def test_alerting_category_fails(self) -> None:
-        """A present-but-alerting category fails and names the alert."""
-        categories = {
-            "gpu": _category(),
-            "thermal": _category(healthy=False, probes=[], alerts=[{"id": "Temperature", "message": "overtemp"}]),
-            "memory": _category(),
-        }
-        check = HostHealthCheck(config={"step_output": _host_health_output(hosts=[_host(categories=categories)])})
-        check.run()
-        assert check._passed is False
-        assert "thermal unhealthy" in check._error
-        thermal = next(r for r in check._subtest_results if r["name"] == "host_m-001_thermal")
-        assert thermal["passed"] is False
-        assert "overtemp" in thermal["message"]
-
-    def test_required_categories_override(self) -> None:
-        """Only the configured categories are required."""
-        categories = {"gpu": _category(), "thermal": _category(present=False), "memory": _category(present=False)}
+    def test_fail_on_classifications_scopes_failures(self) -> None:
+        """With fail_on_classifications set, only matching alerts are blocking."""
+        host = _host(
+            alerts=[
+                _alert(probe_id="BmcSensor", message="warn", classifications=["SensorWarning"]),
+            ],
+        )
         check = HostHealthCheck(
             config={
-                "step_output": _host_health_output(hosts=[_host(categories=categories)]),
-                "required_categories": ["gpu"],
+                "step_output": _host_health_output(hosts=[host]),
+                "fail_on_classifications": ["SensorCritical", "SensorFailure", "Leak"],
             }
         )
         check.run()
         assert check._passed is True, check._error
-        names = {r["name"] for r in check._subtest_results}
-        assert names == {"host_m-001_report", "host_m-001_gpu"}
+        alerts_sub = next(r for r in check._subtest_results if r["name"] == "host_m-001_alerts")
+        assert alerts_sub["passed"] is True
+
+    def test_fail_on_classifications_catches_matching_alert(self) -> None:
+        """A matching classification still fails when fail_on_classifications is set."""
+        host = _host(
+            alerts=[_alert(probe_id="BmcSensor", message="crit", classifications=["SensorCritical"])],
+        )
+        check = HostHealthCheck(
+            config={
+                "step_output": _host_health_output(hosts=[host]),
+                "fail_on_classifications": ["SensorCritical"],
+            }
+        )
+        check.run()
+        assert check._passed is False
+        assert "BmcSensor" in check._error
+
+    def test_require_probes_coverage(self) -> None:
+        """require_probes enforces that specific probe IDs are present."""
+        host = _host(probe_ids=["BgpDaemonEnabled"])
+        check = HostHealthCheck(
+            config={
+                "step_output": _host_health_output(hosts=[host]),
+                "require_probes": ["BmcSensor"],
+            }
+        )
+        check.run()
+        assert check._passed is False
+        assert "missing probes BmcSensor" in check._error
+        probes_sub = next(r for r in check._subtest_results if r["name"] == "host_m-001_probes")
+        assert probes_sub["passed"] is False
+
+    def test_require_probes_present_passes(self) -> None:
+        """require_probes passes when the required probe IDs are present."""
+        host = _host(probe_ids=["BmcSensor", "BgpDaemonEnabled"])
+        check = HostHealthCheck(
+            config={
+                "step_output": _host_health_output(hosts=[host]),
+                "require_probes": ["BmcSensor"],
+            }
+        )
+        check.run()
+        assert check._passed is True, check._error
 
     def test_freshness_stale_fails(self) -> None:
         """An observation older than max_observation_age_seconds fails."""

--- a/isvtest/tests/test_health.py
+++ b/isvtest/tests/test_health.py
@@ -46,6 +46,7 @@ def _host(
     *,
     host_id: str = "m-001",
     status: str = "Ready",
+    health_present: bool = True,
     observed_age_seconds: int | None = 10,
     categories: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
@@ -60,6 +61,7 @@ def _host(
         "host_id": host_id,
         "chassis_serial": f"SER-{host_id}",
         "status": status,
+        "health_present": health_present,
         "observed_age_seconds": observed_age_seconds,
         "categories": categories,
     }
@@ -139,9 +141,40 @@ class TestHostHealthCheck:
         check = HostHealthCheck(config={"step_output": _host_health_output()})
         check.run()
         assert check._passed is True, check._error
+        # report + gpu + thermal + memory subtests, all passing.
         subtests = [r for r in check._subtest_results if r["name"].startswith("host_m-001_")]
-        assert len(subtests) == 3
+        assert len(subtests) == 4
         assert all(r["passed"] for r in subtests)
+
+    def test_missing_category_is_not_fatal_by_default(self) -> None:
+        """A missing category is informational by default (NICo alert-driven model)."""
+        categories = {"gpu": _category(), "thermal": _category(), "memory": _category(present=False)}
+        check = HostHealthCheck(config={"step_output": _host_health_output(hosts=[_host(categories=categories)])})
+        check.run()
+        assert check._passed is True, check._error
+        mem = next(r for r in check._subtest_results if r["name"] == "host_m-001_memory")
+        assert mem["skipped"] is True
+
+    def test_missing_report_fails(self) -> None:
+        """A host the health API returns nothing for fails the baseline check."""
+        host = _host(health_present=False)
+        check = HostHealthCheck(config={"step_output": _host_health_output(hosts=[host])})
+        check.run()
+        assert check._passed is False
+        assert "no health report" in check._error
+        report = next(r for r in check._subtest_results if r["name"] == "host_m-001_report")
+        assert report["passed"] is False
+
+    def test_report_with_no_categories_passes(self) -> None:
+        """A fresh report with no recognized categories still passes by default."""
+        categories = {
+            "gpu": _category(present=False),
+            "thermal": _category(present=False),
+            "memory": _category(present=False),
+        }
+        check = HostHealthCheck(config={"step_output": _host_health_output(hosts=[_host(categories=categories)])})
+        check.run()
+        assert check._passed is True, check._error
 
     def test_step_failure(self) -> None:
         """A failed step is reported with its error detail."""
@@ -157,29 +190,20 @@ class TestHostHealthCheck:
         assert check._passed is False
         assert "No hosts" in check._error
 
-    def test_missing_required_category_fails(self) -> None:
-        """A host missing the memory signal fails coverage."""
+    def test_missing_required_category_fails_when_required(self) -> None:
+        """With require_present enabled, a host missing the memory signal fails coverage."""
         categories = {"gpu": _category(), "thermal": _category(), "memory": _category(present=False)}
-        check = HostHealthCheck(config={"step_output": _host_health_output(hosts=[_host(categories=categories)])})
+        check = HostHealthCheck(
+            config={
+                "step_output": _host_health_output(hosts=[_host(categories=categories)]),
+                "require_present": True,
+            }
+        )
         check.run()
         assert check._passed is False
         assert "missing memory" in check._error
         mem = next(r for r in check._subtest_results if r["name"] == "host_m-001_memory")
         assert mem["passed"] is False
-
-    def test_missing_category_allowed_when_require_present_false(self) -> None:
-        """With require_present disabled, a missing category is skipped, not failed."""
-        categories = {"gpu": _category(), "thermal": _category(), "memory": _category(present=False)}
-        check = HostHealthCheck(
-            config={
-                "step_output": _host_health_output(hosts=[_host(categories=categories)]),
-                "require_present": False,
-            }
-        )
-        check.run()
-        assert check._passed is True, check._error
-        mem = next(r for r in check._subtest_results if r["name"] == "host_m-001_memory")
-        assert mem["skipped"] is True
 
     def test_alerting_category_fails(self) -> None:
         """A present-but-alerting category fails and names the alert."""
@@ -208,7 +232,7 @@ class TestHostHealthCheck:
         check.run()
         assert check._passed is True, check._error
         names = {r["name"] for r in check._subtest_results}
-        assert names == {"host_m-001_gpu"}
+        assert names == {"host_m-001_report", "host_m-001_gpu"}
 
     def test_freshness_stale_fails(self) -> None:
         """An observation older than max_observation_age_seconds fails."""

--- a/isvtest/tests/test_health.py
+++ b/isvtest/tests/test_health.py
@@ -1,0 +1,349 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the unified health API validations (CAP05-01, CAP05-02)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from isvtest.validations.health import HealthAggregationCheck, HostHealthCheck
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _category(
+    *,
+    present: bool = True,
+    healthy: bool = True,
+    probes: list[str] | None = None,
+    alerts: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a single per-category health summary."""
+    return {
+        "present": present,
+        "healthy": healthy,
+        "probes": probes if probes is not None else (["probe"] if present else []),
+        "alerts": alerts or [],
+    }
+
+
+def _host(
+    *,
+    host_id: str = "m-001",
+    status: str = "Ready",
+    observed_age_seconds: int | None = 10,
+    categories: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a per-host health record."""
+    if categories is None:
+        categories = {
+            "gpu": _category(),
+            "thermal": _category(),
+            "memory": _category(),
+        }
+    return {
+        "host_id": host_id,
+        "chassis_serial": f"SER-{host_id}",
+        "status": status,
+        "observed_age_seconds": observed_age_seconds,
+        "categories": categories,
+    }
+
+
+def _host_health_output(
+    *,
+    success: bool = True,
+    hosts: list[dict[str, Any]] | None = None,
+    error: str = "",
+) -> dict[str, Any]:
+    """Build a per-host health step output."""
+    if hosts is None:
+        hosts = [_host()]
+    return {
+        "success": success,
+        "platform": "nico",
+        "site_id": "test-site-001",
+        "hosts_checked": len(hosts),
+        "hosts": hosts,
+        "error": error,
+    }
+
+
+def _group(
+    *,
+    name: str = "it-1",
+    total: int = 4,
+    healthy: int = 4,
+    unhealthy: int = 0,
+    status: str | None = None,
+    unhealthy_hosts: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build an aggregation group record."""
+    return {
+        "group_id": name,
+        "group_type": "instance_type",
+        "name": name,
+        "total": total,
+        "healthy": healthy,
+        "unhealthy": unhealthy,
+        "status": status if status is not None else ("Healthy" if unhealthy == 0 else "Degraded"),
+        "unhealthy_hosts": unhealthy_hosts or [],
+    }
+
+
+def _aggregation_output(
+    *,
+    success: bool = True,
+    aggregation_level: str = "nodegroup",
+    groups: list[dict[str, Any]] | None = None,
+    error: str = "",
+) -> dict[str, Any]:
+    """Build a health aggregation step output."""
+    if groups is None:
+        groups = [_group()]
+    return {
+        "success": success,
+        "platform": "nico",
+        "site_id": "test-site-001",
+        "aggregation_level": aggregation_level,
+        "groups": groups,
+        "error": error,
+    }
+
+
+# ===========================================================================
+# HostHealthCheck tests (CAP05-01)
+# ===========================================================================
+
+
+class TestHostHealthCheck:
+    """Tests for HostHealthCheck validation."""
+
+    def test_all_categories_present_and_healthy(self) -> None:
+        """A host that surfaces healthy GPU/thermal/memory health passes."""
+        check = HostHealthCheck(config={"step_output": _host_health_output()})
+        check.run()
+        assert check._passed is True, check._error
+        subtests = [r for r in check._subtest_results if r["name"].startswith("host_m-001_")]
+        assert len(subtests) == 3
+        assert all(r["passed"] for r in subtests)
+
+    def test_step_failure(self) -> None:
+        """A failed step is reported with its error detail."""
+        check = HostHealthCheck(config={"step_output": _host_health_output(success=False, error="API timeout")})
+        check.run()
+        assert check._passed is False
+        assert "API timeout" in check._error
+
+    def test_no_hosts(self) -> None:
+        """An empty host list fails -- nothing was validated."""
+        check = HostHealthCheck(config={"step_output": _host_health_output(hosts=[])})
+        check.run()
+        assert check._passed is False
+        assert "No hosts" in check._error
+
+    def test_missing_required_category_fails(self) -> None:
+        """A host missing the memory signal fails coverage."""
+        categories = {"gpu": _category(), "thermal": _category(), "memory": _category(present=False)}
+        check = HostHealthCheck(config={"step_output": _host_health_output(hosts=[_host(categories=categories)])})
+        check.run()
+        assert check._passed is False
+        assert "missing memory" in check._error
+        mem = next(r for r in check._subtest_results if r["name"] == "host_m-001_memory")
+        assert mem["passed"] is False
+
+    def test_missing_category_allowed_when_require_present_false(self) -> None:
+        """With require_present disabled, a missing category is skipped, not failed."""
+        categories = {"gpu": _category(), "thermal": _category(), "memory": _category(present=False)}
+        check = HostHealthCheck(
+            config={
+                "step_output": _host_health_output(hosts=[_host(categories=categories)]),
+                "require_present": False,
+            }
+        )
+        check.run()
+        assert check._passed is True, check._error
+        mem = next(r for r in check._subtest_results if r["name"] == "host_m-001_memory")
+        assert mem["skipped"] is True
+
+    def test_alerting_category_fails(self) -> None:
+        """A present-but-alerting category fails and names the alert."""
+        categories = {
+            "gpu": _category(),
+            "thermal": _category(healthy=False, probes=[], alerts=[{"id": "Temperature", "message": "overtemp"}]),
+            "memory": _category(),
+        }
+        check = HostHealthCheck(config={"step_output": _host_health_output(hosts=[_host(categories=categories)])})
+        check.run()
+        assert check._passed is False
+        assert "thermal unhealthy" in check._error
+        thermal = next(r for r in check._subtest_results if r["name"] == "host_m-001_thermal")
+        assert thermal["passed"] is False
+        assert "overtemp" in thermal["message"]
+
+    def test_required_categories_override(self) -> None:
+        """Only the configured categories are required."""
+        categories = {"gpu": _category(), "thermal": _category(present=False), "memory": _category(present=False)}
+        check = HostHealthCheck(
+            config={
+                "step_output": _host_health_output(hosts=[_host(categories=categories)]),
+                "required_categories": ["gpu"],
+            }
+        )
+        check.run()
+        assert check._passed is True, check._error
+        names = {r["name"] for r in check._subtest_results}
+        assert names == {"host_m-001_gpu"}
+
+    def test_freshness_stale_fails(self) -> None:
+        """An observation older than max_observation_age_seconds fails."""
+        host = _host(observed_age_seconds=600)
+        check = HostHealthCheck(
+            config={
+                "step_output": _host_health_output(hosts=[host]),
+                "max_observation_age_seconds": 300,
+            }
+        )
+        check.run()
+        assert check._passed is False
+        assert "stale" in check._error
+        freshness = next(r for r in check._subtest_results if r["name"] == "host_m-001_freshness")
+        assert freshness["passed"] is False
+
+    def test_freshness_fresh_passes(self) -> None:
+        """A recent observation passes the freshness subtest."""
+        check = HostHealthCheck(
+            config={
+                "step_output": _host_health_output(hosts=[_host(observed_age_seconds=30)]),
+                "max_observation_age_seconds": 300,
+            }
+        )
+        check.run()
+        assert check._passed is True, check._error
+        freshness = next(r for r in check._subtest_results if r["name"] == "host_m-001_freshness")
+        assert freshness["passed"] is True
+
+    def test_freshness_missing_timestamp_fails(self) -> None:
+        """When freshness is enforced, a missing timestamp is a failure."""
+        check = HostHealthCheck(
+            config={
+                "step_output": _host_health_output(hosts=[_host(observed_age_seconds=None)]),
+                "max_observation_age_seconds": 300,
+            }
+        )
+        check.run()
+        assert check._passed is False
+        assert "no observation timestamp" in check._error
+
+    def test_freshness_not_enforced_by_default(self) -> None:
+        """Without max_observation_age_seconds, a null timestamp does not fail."""
+        check = HostHealthCheck(config={"step_output": _host_health_output(hosts=[_host(observed_age_seconds=None)])})
+        check.run()
+        assert check._passed is True, check._error
+        assert not any(r["name"].endswith("_freshness") for r in check._subtest_results)
+
+
+# ===========================================================================
+# HealthAggregationCheck tests (CAP05-02)
+# ===========================================================================
+
+
+class TestHealthAggregationCheck:
+    """Tests for HealthAggregationCheck validation."""
+
+    def test_consistent_groups_pass(self) -> None:
+        """Internally consistent, fully healthy groups pass."""
+        check = HealthAggregationCheck(config={"step_output": _aggregation_output()})
+        check.run()
+        assert check._passed is True, check._error
+        assert "nodegroup-level group" in check._output
+
+    def test_degraded_group_passes_but_is_reported(self) -> None:
+        """A degraded group is reported in the summary but is not fatal by default."""
+        groups = [_group(total=4, healthy=3, unhealthy=1, unhealthy_hosts=["m-x"])]
+        check = HealthAggregationCheck(config={"step_output": _aggregation_output(groups=groups)})
+        check.run()
+        assert check._passed is True, check._error
+        assert "degraded" in check._output
+
+    def test_require_all_healthy_fails_on_degraded(self) -> None:
+        """With require_all_healthy, any degraded group fails the check."""
+        groups = [_group(total=4, healthy=3, unhealthy=1, unhealthy_hosts=["m-x"])]
+        check = HealthAggregationCheck(
+            config={"step_output": _aggregation_output(groups=groups), "require_all_healthy": True}
+        )
+        check.run()
+        assert check._passed is False
+        assert "degraded" in check._error
+
+    def test_step_failure(self) -> None:
+        """A failed step is reported with its error detail."""
+        check = HealthAggregationCheck(config={"step_output": _aggregation_output(success=False, error="API down")})
+        check.run()
+        assert check._passed is False
+        assert "API down" in check._error
+
+    def test_missing_aggregation_level(self) -> None:
+        """A missing aggregation_level field fails."""
+        output = _aggregation_output()
+        output["aggregation_level"] = ""
+        check = HealthAggregationCheck(config={"step_output": output})
+        check.run()
+        assert check._passed is False
+        assert "aggregation_level" in check._error
+
+    def test_missing_groups_list(self) -> None:
+        """A non-list groups field fails."""
+        output = _aggregation_output()
+        output["groups"] = None
+        check = HealthAggregationCheck(config={"step_output": output})
+        check.run()
+        assert check._passed is False
+        assert "groups" in check._error
+
+    def test_min_groups_not_met(self) -> None:
+        """Fewer groups than min_groups fails."""
+        check = HealthAggregationCheck(config={"step_output": _aggregation_output(groups=[]), "min_groups": 1})
+        check.run()
+        assert check._passed is False
+        assert "at least 1" in check._error
+
+    def test_inconsistent_counts_fail(self) -> None:
+        """Counts that do not reconcile fail the group subtest."""
+        groups = [_group(total=4, healthy=2, unhealthy=1, status="Degraded")]
+        check = HealthAggregationCheck(config={"step_output": _aggregation_output(groups=groups)})
+        check.run()
+        assert check._passed is False
+        assert "inconsistent" in check._error
+
+    def test_status_mismatch_fails(self) -> None:
+        """A status that disagrees with the counts fails."""
+        groups = [_group(total=4, healthy=4, unhealthy=0, status="Degraded")]
+        check = HealthAggregationCheck(config={"step_output": _aggregation_output(groups=groups)})
+        check.run()
+        assert check._passed is False
+        assert "inconsistent" in check._error
+
+    def test_non_integer_counts_fail(self) -> None:
+        """Non-integer counts (e.g. null) are reported as inconsistent."""
+        groups = [_group()]
+        groups[0]["unhealthy"] = None
+        check = HealthAggregationCheck(config={"step_output": _aggregation_output(groups=groups)})
+        check.run()
+        assert check._passed is False
+        assert "inconsistent" in check._error


### PR DESCRIPTION
## Summary
Adds the M6 **CAP05 "Unified Health APIs"** checks (follow-up to NICo #450), validated end-to-end on the NICo provider.
- **`HostHealthCheck`** (CAP05-01): per host, asserts the health API returns a report (`require_report`) and the host has **no blocking alerts**. Any alert is blocking by default (parity with `DpuHealthCheck`); `fail_on_classifications` scopes severity, `require_probes` enforces specific probe IDs, `max_observation_age_seconds` enforces freshness.
- **`HealthAggregationCheck`** (CAP05-02): rolls host health up to the NICo InstanceType/nodegroup with consistent counts and a matching aggregate `status`.
- **Scripts** (`providers/nico/scripts/health/`): `query_host_health.py` emits `probe_ids`, `alerts` (+`classifications`), `healthy`, freshness, and an informational gpu/thermal/memory/**cooling** breakdown; `query_health_aggregation.py` aggregates by `instanceTypeId`.
- **Wiring**: opt-in `query_host_health` / `query_health_aggregation` steps in `bare_metal.yaml` + NICo config; README documents the fields.
Grounded in NICo's alert-driven model (`health_probe_ids.md`, `Probe`/`Classification` enums): hardware health is `BmcSensor` + `BmcLeakDetection` with classifications like `SensorCritical`/`Leak`, not a GPU/thermal/memory taxonomy. **Leak detection** is recognized as health (no leak-specific issue exists).
Ships unreleased (`released_tests.json` untouched); run with `ISVTEST_INCLUDE_UNRELEASED=1`.
## Testing
- `make test`, `make lint`, `uvx pre-commit run -a`, `make demo-test` — all pass.
- Live NICo site: `host_health` + `health_aggregation` PASS across 20 machines (aggregation flags the site's one `Error` host).
- Mock NICo: healthy site passes; injected `BmcLeakDetection`/`Leak` fails the host and degrades its nodegroup.

Closes #254
Closes #255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-host health reporting and validation (probe/component breakdown, alert classifications, observation freshness).
  * Aggregated health summaries by instance type with healthy/degraded status and group counts.
  * New validation checks exposed for use in suites: HostHealthCheck and HealthAggregationCheck.

* **Documentation**
  * Suite docs updated to include the host-health and health-aggregation validation steps (provider-optional).

* **Tests**
  * Expanded unit and end-to-end tests covering host and aggregation behaviors and pass/fail scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->