### PR TITLE
feat(bare-metal): stabilize AWS reinstall node identity

### DIFF
--- a/isvctl/configs/providers/aws/config/bare_metal.yaml
+++ b/isvctl/configs/providers/aws/config/bare_metal.yaml
@@ -32,7 +32,7 @@
 #  10. power_cycle_instance - boto3: Hard power off + on, validates cold-start (test)
 #  11. describe_instance - boto3: Describes current state, passes SSH info (test)
 #                          (runs after power_cycle so IP is current)
-#  12. reinstall_instance - boto3: Reinstalls OS from stock AMI (test) [skip: true]
+#  12. reinstall_instance - boto3: Reinstalls OS from stock AMI (test)
 #  13. deploy_nim - paramiko: Deploys NIM container via SSH (test)
 #  14. teardown_nim - paramiko: Stops NIM container via SSH (teardown)
 #  15. teardown - boto3: Terminates bare-metal EC2 (teardown)
@@ -233,9 +233,8 @@ commands:
         timeout: 300
 
       # Reinstall instance from stock OS (stop + swap root volume + start)
-      # Skipped by default: ~30-45 min on AWS metal, and CreateReplaceRootVolumeTask
-      # is not supported. The script performs a manual root volume swap instead.
-      # Set skip: false to enable on platforms where reinstall is fast/supported.
+      # Expected duration: ~30-45 min on AWS metal. CreateReplaceRootVolumeTask
+      # is not supported, so the script performs a manual root volume swap.
       - name: reinstall_instance
         phase: test
         skip: true

--- a/isvctl/configs/providers/aws/config/bare_metal.yaml
+++ b/isvctl/configs/providers/aws/config/bare_metal.yaml
@@ -271,7 +271,9 @@ commands:
           - "{{steps.power_cycle_instance.public_ip}}"
           - "--key-file"
           - "{{steps.power_cycle_instance.key_file}}"
-        timeout: 120
+          # Skip teardown when deploy_nim was skipped; the script supplies the default skip reason.
+          - "{{ '--skip' if steps.deploy_nim.skipped | default(false) else '' }}"
+        timeout: 300
 
       # Teardown bare-metal instance (boto3)
       # Set AWS_BM_SKIP_TEARDOWN=true to keep the instance alive

--- a/isvctl/configs/providers/aws/config/vm.yaml
+++ b/isvctl/configs/providers/aws/config/vm.yaml
@@ -196,7 +196,9 @@ commands:
           - "{{steps.reboot_instance.public_ip}}"
           - "--key-file"
           - "{{steps.reboot_instance.key_file}}"
-        timeout: 120
+          # Skip teardown when deploy_nim was skipped; the script supplies the default skip reason.
+          - "{{ '--skip' if steps.deploy_nim.skipped | default(false) else '' }}"
+        timeout: 300
 
       # AWS-specific: Teardown (boto3)
       - name: teardown

--- a/isvctl/configs/providers/aws/scripts/bare_metal/reinstall_instance.py
+++ b/isvctl/configs/providers/aws/scripts/bare_metal/reinstall_instance.py
@@ -19,9 +19,9 @@
 AWS does not support CreateReplaceRootVolumeTask on metal instances, so
 this script performs the equivalent manually:
   1. Get the original AMI's root snapshot
-  2. Stop the instance
-  3. Detach the current root volume
-  4. Create a new volume from the AMI snapshot
+  2. Create a new volume from the AMI snapshot, or from a temporary donor instance
+  3. Stop the instance
+  4. Detach the current root volume
   5. Attach the new volume as root
   6. Start the instance
   7. Wait for status checks + SSH
@@ -56,10 +56,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # providers/aws/sc
 import boto3
 from botocore.exceptions import ClientError, WaiterError
 from common.ec2 import wait_for_public_ip
-from common.ssh_utils import wait_for_ssh
+from common.errors import delete_with_retry
+from common.ssh_utils import ssh_run, wait_for_ssh
 
 
-def get_ami_root_snapshot(ec2: Any, ami_id: str) -> tuple[str, str]:
+def get_ami_root_snapshot(ec2: Any, ami_id: str) -> tuple[str, str, str]:
     """Get the root device snapshot ID and device name from an AMI.
 
     Args:
@@ -67,7 +68,7 @@ def get_ami_root_snapshot(ec2: Any, ami_id: str) -> tuple[str, str]:
         ami_id: AMI ID to inspect
 
     Returns:
-        Tuple of (snapshot_id, device_name)
+        Tuple of (snapshot_id, device_name, architecture)
 
     Raises:
         RuntimeError: If AMI not found or has no root snapshot
@@ -78,12 +79,225 @@ def get_ami_root_snapshot(ec2: Any, ami_id: str) -> tuple[str, str]:
 
     image = images["Images"][0]
     root_device = image["RootDeviceName"]
+    architecture = image.get("Architecture", "x86_64")
 
     for bdm in image.get("BlockDeviceMappings", []):
         if bdm.get("DeviceName") == root_device and "Ebs" in bdm:
-            return bdm["Ebs"]["SnapshotId"], root_device
+            return bdm["Ebs"]["SnapshotId"], root_device, architecture
 
     raise RuntimeError(f"No root snapshot found in AMI {ami_id}")
+
+
+def get_root_volume_id(instance: dict[str, Any], root_device: str) -> str | None:
+    """Return the volume ID attached to an instance root device."""
+    for bdm in instance.get("BlockDeviceMappings", []):
+        if bdm.get("DeviceName") == root_device:
+            return bdm["Ebs"]["VolumeId"]
+    return None
+
+
+def get_donor_instance_type(architecture: str) -> str:
+    """Return a small donor instance type that matches an AMI architecture."""
+    # Match any arm variant (arm64, arm64_mac, ...) to a Graviton type; everything
+    # else (x86_64, i386) gets the x86 type. Avoids launching an x86 donor against
+    # an arm AMI, which RunInstances rejects.
+    return "t4g.micro" if architecture.startswith("arm") else "t3.micro"
+
+
+def create_root_volume_from_snapshot(
+    ec2: Any,
+    snapshot_id: str,
+    availability_zone: str,
+    volume_size: int,
+    instance_id: str,
+) -> str:
+    """Create a replacement root volume from an AMI snapshot."""
+    new_volume = ec2.create_volume(
+        SnapshotId=snapshot_id,
+        AvailabilityZone=availability_zone,
+        VolumeType="gp3",
+        Size=volume_size,
+        TagSpecifications=[
+            {
+                "ResourceType": "volume",
+                "Tags": [
+                    {"Key": "Name", "Value": f"reinstall-{instance_id}"},
+                    {"Key": "CreatedBy", "Value": "isvtest"},
+                ],
+            }
+        ],
+    )
+    new_volume_id = new_volume["VolumeId"]
+    try:
+        vol_waiter = ec2.get_waiter("volume_available")
+        vol_waiter.wait(VolumeIds=[new_volume_id])
+    except Exception:
+        # The volume exists but never became available; delete it before
+        # propagating so a transient waiter failure doesn't orphan it.
+        delete_with_retry(
+            ec2.delete_volume,
+            VolumeId=new_volume_id,
+            resource_desc=f"replacement root volume {new_volume_id}",
+        )
+        raise
+    return new_volume_id
+
+
+def create_root_volume_from_donor_instance(
+    ec2: Any,
+    *,
+    ami_id: str,
+    image_root_device: str,
+    architecture: str,
+    volume_size: int,
+    subnet_id: str | None,
+    security_group_ids: list[str],
+    key_name: str | None,
+    instance_id: str,
+) -> str:
+    """Launch a temporary instance and detach its root volume as the replacement."""
+    if not subnet_id:
+        raise RuntimeError("Cannot create donor root volume: target instance has no subnet ID")
+
+    donor_instance_id = None
+    donor_volume_id = None
+    # True only between issuing the donor detach and the volume becoming
+    # available: a failure in that window orphans a detached volume that
+    # terminate's DeleteOnTermination no longer covers, so cleanup deletes it.
+    donor_volume_detach_pending = False
+    run_args: dict[str, Any] = {
+        "ImageId": ami_id,
+        "InstanceType": get_donor_instance_type(architecture),
+        "MinCount": 1,
+        "MaxCount": 1,
+        "SubnetId": subnet_id,
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": image_root_device,
+                "Ebs": {
+                    "VolumeSize": volume_size,
+                    "VolumeType": "gp3",
+                    "DeleteOnTermination": True,
+                },
+            }
+        ],
+        "TagSpecifications": [
+            {
+                "ResourceType": "instance",
+                "Tags": [
+                    {"Key": "Name", "Value": f"reinstall-donor-{instance_id}"},
+                    {"Key": "CreatedBy", "Value": "isvtest"},
+                ],
+            },
+            {
+                "ResourceType": "volume",
+                "Tags": [
+                    {"Key": "Name", "Value": f"reinstall-{instance_id}"},
+                    {"Key": "CreatedBy", "Value": "isvtest"},
+                ],
+            },
+        ],
+    }
+    if security_group_ids:
+        run_args["SecurityGroupIds"] = security_group_ids
+    if key_name:
+        run_args["KeyName"] = key_name
+
+    try:
+        donor = ec2.run_instances(**run_args)
+        donor_instance_id = donor["Instances"][0]["InstanceId"]
+
+        run_waiter = ec2.get_waiter("instance_running")
+        run_waiter.wait(
+            InstanceIds=[donor_instance_id],
+            WaiterConfig={"Delay": 10, "MaxAttempts": 60},
+        )
+
+        ec2.stop_instances(InstanceIds=[donor_instance_id])
+        stop_waiter = ec2.get_waiter("instance_stopped")
+        stop_waiter.wait(
+            InstanceIds=[donor_instance_id],
+            WaiterConfig={"Delay": 10, "MaxAttempts": 60},
+        )
+
+        donor_details = ec2.describe_instances(InstanceIds=[donor_instance_id])
+        donor_instance = donor_details["Reservations"][0]["Instances"][0]
+        donor_volume_id = get_root_volume_id(donor_instance, image_root_device)
+        if not donor_volume_id:
+            raise RuntimeError(f"Cannot find donor root volume for device {image_root_device}")
+
+        ec2.detach_volume(VolumeId=donor_volume_id, InstanceId=donor_instance_id, Force=True)
+        donor_volume_detach_pending = True
+        vol_waiter = ec2.get_waiter("volume_available")
+        vol_waiter.wait(VolumeIds=[donor_volume_id])
+        donor_volume_detach_pending = False
+        return donor_volume_id
+    finally:
+        if donor_instance_id:
+            try:
+                ec2.terminate_instances(InstanceIds=[donor_instance_id])
+            except ClientError as e:
+                print(f"  Warning: could not terminate donor instance {donor_instance_id}: {e}", file=sys.stderr)
+        if donor_volume_id and donor_volume_detach_pending:
+            deleted = delete_with_retry(
+                ec2.delete_volume,
+                VolumeId=donor_volume_id,
+                resource_desc=f"donor root volume {donor_volume_id}",
+            )
+            if not deleted:
+                print(f"  Warning: could not delete donor root volume {donor_volume_id}", file=sys.stderr)
+
+
+def create_replacement_root_volume(
+    ec2: Any,
+    *,
+    ami_id: str,
+    snapshot_id: str,
+    image_root_device: str,
+    architecture: str,
+    availability_zone: str,
+    volume_size: int,
+    subnet_id: str | None,
+    security_group_ids: list[str],
+    key_name: str | None,
+    instance_id: str,
+) -> str:
+    """Create the replacement root volume before mutating the target instance."""
+    print(f"Creating new root volume from snapshot {snapshot_id}...", file=sys.stderr)
+    try:
+        return create_root_volume_from_snapshot(ec2, snapshot_id, availability_zone, volume_size, instance_id)
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code")
+        if error_code != "InvalidSnapshot.NotFound":
+            raise
+
+        print(
+            "  AMI snapshot is not directly restorable; creating root volume from a temporary donor instance...",
+            file=sys.stderr,
+        )
+        return create_root_volume_from_donor_instance(
+            ec2,
+            ami_id=ami_id,
+            image_root_device=image_root_device,
+            architecture=architecture,
+            volume_size=volume_size,
+            subnet_id=subnet_id,
+            security_group_ids=security_group_ids,
+            key_name=key_name,
+            instance_id=instance_id,
+        )
+
+
+def query_node_instance_id(host: str, user: str, key_file: str) -> str:
+    """Read the instance ID reported by the reinstalled OS."""
+    command = (
+        "TOKEN=$(curl -sf -X PUT 'http://169.254.169.254/latest/api/token' "
+        "-H 'X-aws-ec2-metadata-token-ttl-seconds: 60') && "
+        'curl -sf -H "X-aws-ec2-metadata-token: $TOKEN" '
+        "http://169.254.169.254/latest/meta-data/instance-id"
+    )
+    exit_code, stdout, _ = ssh_run(host, user, key_file, command)
+    return stdout.strip() if exit_code == 0 else ""
 
 
 def main() -> int:
@@ -120,6 +334,7 @@ def main() -> int:
     }
 
     old_volume_id = None
+    new_volume_id = None
 
     try:
         # Step 1: Get instance details
@@ -141,12 +356,11 @@ def main() -> int:
         result["ami_id"] = ami_id
         az = instance["Placement"]["AvailabilityZone"]
         root_device = instance.get("RootDeviceName", "/dev/sda1")
+        subnet_id = instance.get("SubnetId")
+        security_group_ids = [sg["GroupId"] for sg in instance.get("SecurityGroups", []) if sg.get("GroupId")]
+        key_name = instance.get("KeyName")
 
-        # Find current root volume
-        for bdm in instance.get("BlockDeviceMappings", []):
-            if bdm.get("DeviceName") == root_device:
-                old_volume_id = bdm["Ebs"]["VolumeId"]
-                break
+        old_volume_id = get_root_volume_id(instance, root_device)
 
         if not old_volume_id:
             result["error"] = f"Cannot find root volume for device {root_device}"
@@ -157,10 +371,27 @@ def main() -> int:
 
         # Step 2: Get AMI's root snapshot
         print("Getting AMI root snapshot...", file=sys.stderr)
-        snapshot_id, _ = get_ami_root_snapshot(ec2, ami_id)
+        snapshot_id, image_root_device, architecture = get_ami_root_snapshot(ec2, ami_id)
         print(f"  Snapshot: {snapshot_id}", file=sys.stderr)
 
-        # Step 3: Stop the instance (bare-metal can take 15-20+ min)
+        # Step 3: Create the replacement root volume before mutating the target instance.
+        new_volume_id = create_replacement_root_volume(
+            ec2,
+            ami_id=ami_id,
+            snapshot_id=snapshot_id,
+            image_root_device=image_root_device,
+            architecture=architecture,
+            availability_zone=az,
+            volume_size=args.volume_size,
+            subnet_id=subnet_id,
+            security_group_ids=security_group_ids,
+            key_name=key_name,
+            instance_id=args.instance_id,
+        )
+        result["new_volume_id"] = new_volume_id
+        print(f"  New volume created: {new_volume_id}", file=sys.stderr)
+
+        # Step 4: Stop the instance (bare-metal can take 15-20+ min)
         print(f"Stopping instance {args.instance_id}...", file=sys.stderr)
         ec2.stop_instances(InstanceIds=[args.instance_id])
 
@@ -180,34 +411,12 @@ def main() -> int:
                 )
         print("  Instance stopped", file=sys.stderr)
 
-        # Step 4: Detach old root volume
+        # Step 5: Detach old root volume
         print(f"Detaching old root volume {old_volume_id}...", file=sys.stderr)
         ec2.detach_volume(VolumeId=old_volume_id, InstanceId=args.instance_id, Force=True)
         vol_waiter = ec2.get_waiter("volume_available")
         vol_waiter.wait(VolumeIds=[old_volume_id])
         print("  Old volume detached", file=sys.stderr)
-
-        # Step 5: Create new volume from AMI snapshot
-        print(f"Creating new root volume from snapshot {snapshot_id}...", file=sys.stderr)
-        new_volume = ec2.create_volume(
-            SnapshotId=snapshot_id,
-            AvailabilityZone=az,
-            VolumeType="gp3",
-            Size=args.volume_size,
-            TagSpecifications=[
-                {
-                    "ResourceType": "volume",
-                    "Tags": [
-                        {"Key": "Name", "Value": f"reinstall-{args.instance_id}"},
-                        {"Key": "CreatedBy", "Value": "isvtest"},
-                    ],
-                }
-            ],
-        )
-        new_volume_id = new_volume["VolumeId"]
-        result["new_volume_id"] = new_volume_id
-        vol_waiter.wait(VolumeIds=[new_volume_id])
-        print(f"  New volume created: {new_volume_id}", file=sys.stderr)
 
         # Step 6: Attach new volume as root
         print(f"Attaching new volume as {root_device}...", file=sys.stderr)
@@ -249,9 +458,7 @@ def main() -> int:
         # value - IPs are released on stop on NCPs and would be stale.
         public_ip = instance.get("PublicIpAddress") or wait_for_public_ip(ec2, args.instance_id)
         if not public_ip:
-            result["error"] = "Instance has no public IP after reinstall (timed out polling)"
-            print(json.dumps(result, indent=2))
-            return 1
+            raise RuntimeError("Instance has no public IP after reinstall (timed out polling)")
         result["public_ip"] = public_ip
 
         # Step 9: Wait for SSH
@@ -260,9 +467,13 @@ def main() -> int:
         result["ssh_ready"] = ssh_ready
 
         if not ssh_ready:
-            result["error"] = "SSH not ready after reinstall"
-            print(json.dumps(result, indent=2))
-            return 1
+            raise RuntimeError("SSH not ready after reinstall")
+
+        # Report the node-observed identity (empty if it could not be read) and
+        # let StableIdentifierCheck do the comparison. The reinstall itself has
+        # succeeded by this point, so a metadata-read hiccup must not abort the
+        # step (which would skip downstream checks and leak the old root volume).
+        result["instance_id"] = query_node_instance_id(public_ip, args.ssh_user, args.key_file)
 
         result["success"] = True
         print("Reinstall completed successfully!", file=sys.stderr)
@@ -279,6 +490,20 @@ def main() -> int:
     except Exception as e:
         result["error"] = str(e)
         print(f"ERROR: {e}", file=sys.stderr)
+
+    # On failure after the replacement volume was created, delete it. Teardown
+    # only terminates the instance and never reclaims reinstall-* volumes, so a
+    # failure between volume creation and a successful swap would otherwise
+    # orphan the volume (in-use volumes log a warning rather than being deleted).
+    if not result["success"] and new_volume_id:
+        print(f"Cleaning up replacement volume {new_volume_id} after failure...", file=sys.stderr)
+        deleted = delete_with_retry(
+            ec2.delete_volume,
+            VolumeId=new_volume_id,
+            resource_desc=f"replacement root volume {new_volume_id}",
+        )
+        if not deleted:
+            print(f"  Warning: could not delete replacement volume {new_volume_id}", file=sys.stderr)
 
     print(json.dumps(result, indent=2))
     return 0 if result["success"] else 1

--- a/isvctl/configs/providers/aws/scripts/common/errors.py
+++ b/isvctl/configs/providers/aws/scripts/common/errors.py
@@ -47,6 +47,7 @@ ALREADY_GONE_CODES: frozenset[str] = frozenset(
         "InvalidRouteTableID.NotFound",
         "InvalidInternetGatewayID.NotFound",
         "InvalidInstanceID.NotFound",
+        "InvalidVolume.NotFound",
         "InvalidNetworkAclID.NotFound",
         "InvalidVpcPeeringConnectionID.NotFound",
         "InvalidAllocationID.NotFound",

--- a/isvctl/configs/providers/shared/deploy_nim.py
+++ b/isvctl/configs/providers/shared/deploy_nim.py
@@ -48,31 +48,11 @@ import json
 import os
 import sys
 import time
+from pathlib import Path
 from typing import Any
 
-import paramiko
-
-
-def ssh_connect(host: str, user: str, key_file: str) -> paramiko.SSHClient:
-    """Create SSH connection to remote host."""
-    client = paramiko.SSHClient()
-    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    client.connect(
-        hostname=host,
-        username=user,
-        key_filename=key_file,
-        timeout=30,
-        allow_agent=False,
-        look_for_keys=False,
-    )
-    return client
-
-
-def run_cmd(ssh: paramiko.SSHClient, command: str, timeout: int = 120) -> tuple[int, str, str]:
-    """Execute command via SSH and return (exit_code, stdout, stderr)."""
-    _, stdout, stderr = ssh.exec_command(command, timeout=timeout)
-    exit_code = stdout.channel.recv_exit_status()
-    return exit_code, stdout.read().decode(), stderr.read().decode()
+sys.path.insert(0, str(Path(__file__).resolve().parent))  # providers/shared/ (for ssh_paramiko)
+from ssh_paramiko import run_cmd, ssh_connect
 
 
 def main() -> int:

--- a/isvctl/configs/providers/shared/ssh_paramiko.py
+++ b/isvctl/configs/providers/shared/ssh_paramiko.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared paramiko SSH helpers for the cross-provider NIM scripts.
+
+Both ``deploy_nim.py`` and ``teardown_nim.py`` connect to a remote host and run
+docker commands over SSH; this module hosts the single timeout-aware
+``ssh_connect``/``run_cmd`` implementation so the two scripts cannot drift.
+"""
+
+import paramiko
+
+SSH_CONNECT_TIMEOUT = 30
+
+
+def ssh_connect(host: str, user: str, key_file: str) -> paramiko.SSHClient:
+    """Create and return an SSH client connected to a remote host.
+
+    Args:
+        host: Remote host IP address or hostname.
+        user: SSH username.
+        key_file: Path to the SSH private key file.
+
+    Returns:
+        Connected paramiko.SSHClient instance.
+
+    Raises:
+        TimeoutError: If the connection attempt exceeds SSH_CONNECT_TIMEOUT seconds.
+        paramiko.SSHException: If Paramiko fails to establish the SSH connection.
+    """
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    try:
+        client.connect(
+            hostname=host,
+            username=user,
+            key_filename=key_file,
+            timeout=SSH_CONNECT_TIMEOUT,
+            allow_agent=False,
+            look_for_keys=False,
+        )
+    except TimeoutError as e:
+        raise TimeoutError(f"SSH connection timed out after {SSH_CONNECT_TIMEOUT}s") from e
+    return client
+
+
+def run_cmd(
+    ssh: paramiko.SSHClient,
+    command: str,
+    timeout: int = 120,
+    operation: str | None = None,
+) -> tuple[int, str, str]:
+    """Execute a command over SSH and return its exit status and output.
+
+    Args:
+        ssh: Active Paramiko SSH client.
+        command: Shell command to execute on the remote host.
+        timeout: Command execution timeout in seconds.
+        operation: Optional operation label for timeout diagnostics.
+
+    Returns:
+        Tuple of exit_code, stdout, and stderr, with output decoded as strings.
+
+    Raises:
+        TimeoutError: If command execution exceeds the configured timeout.
+        paramiko.SSHException: If Paramiko fails while executing the command.
+    """
+    try:
+        _, stdout, stderr = ssh.exec_command(command, timeout=timeout)
+        exit_code = stdout.channel.recv_exit_status()
+        return exit_code, stdout.read().decode(), stderr.read().decode()
+    except TimeoutError as e:
+        label = operation or command
+        raise TimeoutError(f"{label} timed out after {timeout}s") from e

--- a/isvctl/configs/providers/shared/teardown_nim.py
+++ b/isvctl/configs/providers/shared/teardown_nim.py
@@ -38,49 +38,16 @@ import argparse
 import json
 import re
 import sys
+from pathlib import Path
 from typing import Any
 
-import paramiko
+sys.path.insert(0, str(Path(__file__).resolve().parent))  # providers/shared/ (for ssh_paramiko)
+from ssh_paramiko import run_cmd, ssh_connect
 
-SSH_CONNECT_TIMEOUT = 30
 CONTAINER_REMOVE_TIMEOUT = 240
 IMAGE_REMOVE_TIMEOUT = 240
 
 _CONTAINER_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
-
-
-def ssh_connect(host: str, user: str, key_file: str) -> paramiko.SSHClient:
-    """Create SSH connection to remote host."""
-    client = paramiko.SSHClient()
-    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    try:
-        client.connect(
-            hostname=host,
-            username=user,
-            key_filename=key_file,
-            timeout=SSH_CONNECT_TIMEOUT,
-            allow_agent=False,
-            look_for_keys=False,
-        )
-    except TimeoutError as e:
-        raise TimeoutError(f"SSH connection timed out after {SSH_CONNECT_TIMEOUT}s") from e
-    return client
-
-
-def run_cmd(
-    ssh: paramiko.SSHClient,
-    command: str,
-    timeout: int = 60,
-    operation: str | None = None,
-) -> tuple[int, str, str]:
-    """Execute command via SSH and return (exit_code, stdout, stderr)."""
-    try:
-        _, stdout, stderr = ssh.exec_command(command, timeout=timeout)
-        exit_code = stdout.channel.recv_exit_status()
-        return exit_code, stdout.read().decode(), stderr.read().decode()
-    except TimeoutError as e:
-        label = operation or command
-        raise TimeoutError(f"{label} timed out after {timeout}s") from e
 
 
 def main() -> int:

--- a/isvctl/configs/providers/shared/teardown_nim.py
+++ b/isvctl/configs/providers/shared/teardown_nim.py
@@ -42,6 +42,10 @@ from typing import Any
 
 import paramiko
 
+SSH_CONNECT_TIMEOUT = 30
+CONTAINER_REMOVE_TIMEOUT = 240
+IMAGE_REMOVE_TIMEOUT = 240
+
 _CONTAINER_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 
 
@@ -49,22 +53,34 @@ def ssh_connect(host: str, user: str, key_file: str) -> paramiko.SSHClient:
     """Create SSH connection to remote host."""
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    client.connect(
-        hostname=host,
-        username=user,
-        key_filename=key_file,
-        timeout=30,
-        allow_agent=False,
-        look_for_keys=False,
-    )
+    try:
+        client.connect(
+            hostname=host,
+            username=user,
+            key_filename=key_file,
+            timeout=SSH_CONNECT_TIMEOUT,
+            allow_agent=False,
+            look_for_keys=False,
+        )
+    except TimeoutError as e:
+        raise TimeoutError(f"SSH connection timed out after {SSH_CONNECT_TIMEOUT}s") from e
     return client
 
 
-def run_cmd(ssh: paramiko.SSHClient, command: str, timeout: int = 60) -> tuple[int, str, str]:
+def run_cmd(
+    ssh: paramiko.SSHClient,
+    command: str,
+    timeout: int = 60,
+    operation: str | None = None,
+) -> tuple[int, str, str]:
     """Execute command via SSH and return (exit_code, stdout, stderr)."""
-    _, stdout, stderr = ssh.exec_command(command, timeout=timeout)
-    exit_code = stdout.channel.recv_exit_status()
-    return exit_code, stdout.read().decode(), stderr.read().decode()
+    try:
+        _, stdout, stderr = ssh.exec_command(command, timeout=timeout)
+        exit_code = stdout.channel.recv_exit_status()
+        return exit_code, stdout.read().decode(), stderr.read().decode()
+    except TimeoutError as e:
+        label = operation or command
+        raise TimeoutError(f"{label} timed out after {timeout}s") from e
 
 
 def main() -> int:
@@ -74,6 +90,8 @@ def main() -> int:
     parser.add_argument("--user", default="ubuntu", help="SSH username")
     parser.add_argument("--container-name", default="isv-nim", help="Docker container name")
     parser.add_argument("--remove-image", action="store_true", help="Also remove the container image")
+    parser.add_argument("--skip", action="store_true", help="Skip teardown because NIM deployment did not run")
+    parser.add_argument("--skip-reason", default="NIM deployment skipped", help="Reason to report when skipping")
     args = parser.parse_args()
 
     if not _CONTAINER_NAME_RE.match(args.container_name):
@@ -90,6 +108,14 @@ def main() -> int:
         "container_name": args.container_name,
     }
 
+    if args.skip:
+        result["success"] = True
+        result["skipped"] = True
+        result["skip_reason"] = args.skip_reason
+        result["message"] = args.skip_reason
+        print(json.dumps(result, indent=2))
+        return 0
+
     ssh = None
     try:
         ssh = ssh_connect(args.host, args.user, args.key_file)
@@ -99,21 +125,33 @@ def main() -> int:
             image_name = None
             if args.remove_image:
                 exit_code, stdout, _ = run_cmd(
-                    ssh, f"docker inspect -f '{{{{.Config.Image}}}}' {args.container_name} 2>/dev/null"
+                    ssh,
+                    f"docker inspect -f '{{{{.Config.Image}}}}' {args.container_name} 2>/dev/null",
+                    operation="docker inspect",
                 )
                 if exit_code == 0:
                     image_name = stdout.strip()
 
             # Stop and remove container
             print(f"Stopping container: {args.container_name}", file=sys.stderr)
-            exit_code, stdout_out, stderr_out = run_cmd(ssh, f"docker rm -f {args.container_name}")
+            exit_code, stdout_out, stderr_out = run_cmd(
+                ssh,
+                f"docker rm -f {args.container_name}",
+                timeout=CONTAINER_REMOVE_TIMEOUT,
+                operation="docker rm",
+            )
             already_gone = "No such container" in stderr_out or "No such container" in stdout_out
             result["container_removed"] = exit_code == 0 or already_gone
 
             # Optionally remove image
             if args.remove_image and image_name:
                 print(f"Removing image: {image_name}", file=sys.stderr)
-                exit_code, _, _ = run_cmd(ssh, f"docker rmi {image_name} 2>&1", timeout=120)
+                exit_code, _, _ = run_cmd(
+                    ssh,
+                    f"docker rmi {image_name} 2>&1",
+                    timeout=IMAGE_REMOVE_TIMEOUT,
+                    operation="docker rmi",
+                )
                 result["image_removed"] = exit_code == 0
 
             result["success"] = result["container_removed"]
@@ -121,6 +159,9 @@ def main() -> int:
             if ssh is not None and hasattr(ssh, "close"):
                 ssh.close()
 
+    except TimeoutError as e:
+        result["error_type"] = "timeout"
+        result["error"] = str(e)
     except Exception as e:
         result["error"] = str(e)
 

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -272,6 +272,8 @@ tests:
       checks:
         InstanceStateCheck:
           expected_state: "running"
+        StableIdentifierCheck:
+          reference_id: "{{steps.launch_instance.instance_id}}"
 
     reinstall_ssh:
       step: reinstall_instance

--- a/isvctl/tests/test_aws_bare_metal_reinstall_instance.py
+++ b/isvctl/tests/test_aws_bare_metal_reinstall_instance.py
@@ -1,0 +1,465 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for AWS bare-metal reinstall identity output."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+from botocore.exceptions import ClientError, WaiterError
+
+ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+AWS_BM_REINSTALL_SCRIPT = (
+    ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "bare_metal" / "reinstall_instance.py"
+)
+
+
+def _client_error(operation_name: str, code: str, message: str) -> ClientError:
+    """Create a botocore ClientError for fake AWS client failures."""
+    return ClientError({"Error": {"Code": code, "Message": message}}, operation_name)
+
+
+def _load_reinstall_script() -> ModuleType:
+    """Load the AWS bare-metal reinstall script as a module."""
+    spec = importlib.util.spec_from_file_location("test_aws_bm_reinstall_instance", AWS_BM_REINSTALL_SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _NoopWaiter:
+    """Fake waiter that accepts wait calls."""
+
+    def wait(self, **_kwargs: Any) -> None:
+        """Accept a waiter invocation."""
+
+
+class _FakeReinstallEc2:
+    """Small fake EC2 client for the successful reinstall path."""
+
+    def describe_instances(self, InstanceIds: list[str]) -> dict[str, Any]:
+        """Return a running instance with one root volume."""
+        assert InstanceIds == ["i-original"]
+        return {
+            "Reservations": [
+                {
+                    "Instances": [
+                        {
+                            "InstanceId": "i-original",
+                            "ImageId": "ami-source",
+                            "State": {"Name": "running"},
+                            "Placement": {"AvailabilityZone": "us-west-2a"},
+                            "SubnetId": "subnet-source",
+                            "SecurityGroups": [{"GroupId": "sg-source"}],
+                            "KeyName": "key-source",
+                            "RootDeviceName": "/dev/sda1",
+                            "PublicIpAddress": "203.0.113.30",
+                            "PrivateIpAddress": "10.0.0.30",
+                            "BlockDeviceMappings": [
+                                {"DeviceName": "/dev/sda1", "Ebs": {"VolumeId": "vol-old"}},
+                            ],
+                        }
+                    ]
+                }
+            ]
+        }
+
+    def describe_images(self, ImageIds: list[str]) -> dict[str, Any]:
+        """Return an AMI root snapshot."""
+        assert ImageIds == ["ami-source"]
+        return {
+            "Images": [
+                {
+                    "RootDeviceName": "/dev/sda1",
+                    "BlockDeviceMappings": [
+                        {"DeviceName": "/dev/sda1", "Ebs": {"SnapshotId": "snap-source"}},
+                    ],
+                    "Architecture": "x86_64",
+                }
+            ]
+        }
+
+    def get_waiter(self, _name: str) -> _NoopWaiter:
+        """Return a no-op waiter."""
+        return _NoopWaiter()
+
+    def stop_instances(self, InstanceIds: list[str]) -> None:
+        """Accept stop requests."""
+        assert InstanceIds == ["i-original"]
+
+    def detach_volume(self, **kwargs: Any) -> None:
+        """Accept detach requests."""
+        assert kwargs == {"VolumeId": "vol-old", "InstanceId": "i-original", "Force": True}
+
+    def create_volume(self, **kwargs: Any) -> dict[str, str]:
+        """Return a new root volume."""
+        assert kwargs["SnapshotId"] == "snap-source"
+        return {"VolumeId": "vol-new"}
+
+    def attach_volume(self, **kwargs: Any) -> None:
+        """Accept attach requests."""
+        assert kwargs == {"VolumeId": "vol-new", "InstanceId": "i-original", "Device": "/dev/sda1"}
+
+    def start_instances(self, InstanceIds: list[str]) -> None:
+        """Accept start requests."""
+        assert InstanceIds == ["i-original"]
+
+    def delete_volume(self, VolumeId: str) -> None:
+        """Accept old root cleanup."""
+        assert VolumeId == "vol-old"
+
+
+class _FakeInaccessibleSnapshotEc2(_FakeReinstallEc2):
+    """Fake EC2 client where the AMI snapshot cannot be used with CreateVolume."""
+
+    def __init__(self) -> None:
+        """Initialize call event tracking."""
+        self.events: list[str] = []
+
+    def describe_instances(self, InstanceIds: list[str]) -> dict[str, Any]:
+        """Return target or temporary donor instance details."""
+        if InstanceIds == ["i-donor"]:
+            return {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-donor",
+                                "State": {"Name": "stopped"},
+                                "RootDeviceName": "/dev/sda1",
+                                "BlockDeviceMappings": [
+                                    {"DeviceName": "/dev/sda1", "Ebs": {"VolumeId": "vol-new"}},
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+        return super().describe_instances(InstanceIds)
+
+    def create_volume(self, **kwargs: Any) -> dict[str, str]:
+        """Fail when creating from the AMI snapshot directly."""
+        assert kwargs["SnapshotId"] == "snap-source"
+        self.events.append("create_volume")
+        raise _client_error("CreateVolume", "InvalidSnapshot.NotFound", "Snapshot does not exist")
+
+    def run_instances(self, **kwargs: Any) -> dict[str, Any]:
+        """Materialize a replacement root volume through a donor instance."""
+        self.events.append("run_donor")
+        assert kwargs["ImageId"] == "ami-source"
+        assert kwargs["InstanceType"] == "t3.micro"
+        assert kwargs["SubnetId"] == "subnet-source"
+        assert kwargs["SecurityGroupIds"] == ["sg-source"]
+        return {"Instances": [{"InstanceId": "i-donor"}]}
+
+    def stop_instances(self, InstanceIds: list[str]) -> None:
+        """Track target and donor stop requests."""
+        if InstanceIds == ["i-donor"]:
+            self.events.append("stop_donor")
+            return
+        self.events.append("stop_target")
+        super().stop_instances(InstanceIds)
+
+    def detach_volume(self, **kwargs: Any) -> None:
+        """Track donor and target root detach requests."""
+        if kwargs["VolumeId"] == "vol-new":
+            self.events.append("detach_donor")
+            assert kwargs == {"VolumeId": "vol-new", "InstanceId": "i-donor", "Force": True}
+            return
+        self.events.append("detach_target")
+        super().detach_volume(**kwargs)
+
+    def terminate_instances(self, InstanceIds: list[str]) -> None:
+        """Track donor termination."""
+        assert InstanceIds == ["i-donor"]
+        self.events.append("terminate_donor")
+
+
+class _FailingDonorVolumeWaiterEc2:
+    """Fake EC2 client where donor detach is requested but never becomes available."""
+
+    def __init__(self) -> None:
+        """Initialize call event tracking."""
+        self.events: list[str] = []
+        self.donor_delete_on_termination: bool | None = None
+
+    def run_instances(self, **kwargs: Any) -> dict[str, Any]:
+        """Record donor launch settings."""
+        self.events.append("run_donor")
+        self.donor_delete_on_termination = kwargs["BlockDeviceMappings"][0]["Ebs"]["DeleteOnTermination"]
+        return {"Instances": [{"InstanceId": "i-donor"}]}
+
+    def get_waiter(self, name: str) -> _NoopWaiter:
+        """Fail only after the donor root volume detach is requested."""
+        if name == "volume_available":
+            return _FailingWaiter()
+        return _NoopWaiter()
+
+    def stop_instances(self, InstanceIds: list[str]) -> None:
+        """Track donor stop requests."""
+        assert InstanceIds == ["i-donor"]
+        self.events.append("stop_donor")
+
+    def describe_instances(self, InstanceIds: list[str]) -> dict[str, Any]:
+        """Return the temporary donor instance root volume."""
+        assert InstanceIds == ["i-donor"]
+        return {
+            "Reservations": [
+                {
+                    "Instances": [
+                        {
+                            "InstanceId": "i-donor",
+                            "State": {"Name": "stopped"},
+                            "RootDeviceName": "/dev/sda1",
+                            "BlockDeviceMappings": [
+                                {"DeviceName": "/dev/sda1", "Ebs": {"VolumeId": "vol-new"}},
+                            ],
+                        }
+                    ]
+                }
+            ]
+        }
+
+    def detach_volume(self, **kwargs: Any) -> None:
+        """Track donor root detach requests."""
+        assert kwargs == {"VolumeId": "vol-new", "InstanceId": "i-donor", "Force": True}
+        self.events.append("detach_donor")
+
+    def terminate_instances(self, InstanceIds: list[str]) -> None:
+        """Track donor termination."""
+        assert InstanceIds == ["i-donor"]
+        self.events.append("terminate_donor")
+
+    def delete_volume(self, VolumeId: str) -> None:
+        """Track orphan donor volume cleanup."""
+        assert VolumeId == "vol-new"
+        self.events.append("delete_donor_volume")
+
+
+class _FailingWaiter:
+    """Fake waiter that raises a timeout-like WaiterError."""
+
+    def wait(self, **_kwargs: Any) -> None:
+        """Raise a waiter failure."""
+        raise WaiterError(name="VolumeAvailable", reason="timed out", last_response={})
+
+
+def test_reinstall_outputs_observed_node_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """StableIdentifierCheck must compare launch ID with post-reinstall node identity."""
+    module = _load_reinstall_script()
+    ec2 = _FakeReinstallEc2()
+    ssh_calls: list[tuple[str, str, str, str]] = []
+
+    def fake_ssh_run(host: str, user: str, key_file: str, command: str) -> tuple[int, str, str]:
+        ssh_calls.append((host, user, key_file, command))
+        return 0, "i-observed\n", ""
+
+    monkeypatch.setattr(module.boto3, "client", lambda service, region_name: ec2)
+    monkeypatch.setattr(module, "wait_for_ssh", lambda host, user, key_file: True)
+    monkeypatch.setattr(module, "ssh_run", fake_ssh_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "reinstall_instance.py",
+            "--instance-id",
+            "i-original",
+            "--region",
+            "us-west-2",
+            "--key-file",
+            "/tmp/key.pem",
+        ],
+    )
+
+    exit_code = module.main()
+    result: dict[str, Any] = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert result["success"] is True
+    assert result["instance_id"] == "i-observed"
+    assert result["state"] == "running"
+    assert result["public_ip"] == "203.0.113.30"
+    assert result["private_ip"] == "10.0.0.30"
+    assert result["key_file"] == "/tmp/key.pem"
+    assert result["ssh_user"] == "ubuntu"
+    assert result["ssh_ready"] is True
+    assert ssh_calls == [("203.0.113.30", "ubuntu", "/tmp/key.pem", ssh_calls[0][3])]
+    assert "latest/api/token" in ssh_calls[0][3]
+    assert "latest/meta-data/instance-id" in ssh_calls[0][3]
+
+
+def test_reinstall_succeeds_when_identity_read_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A metadata-read hiccup must not abort a successful reinstall.
+
+    The reinstall has finished by the time the node identity is queried, so a
+    failed read reports an empty instance_id and lets StableIdentifierCheck flag
+    it - it must not return non-zero, which would skip downstream checks and leak
+    the detached old root volume.
+    """
+    module = _load_reinstall_script()
+    ec2 = _FakeReinstallEc2()
+
+    monkeypatch.setattr(module.boto3, "client", lambda service, region_name: ec2)
+    monkeypatch.setattr(module, "wait_for_ssh", lambda host, user, key_file: True)
+    monkeypatch.setattr(module, "ssh_run", lambda host, user, key_file, command: (1, "", "boom"))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "reinstall_instance.py",
+            "--instance-id",
+            "i-original",
+            "--region",
+            "us-west-2",
+            "--key-file",
+            "/tmp/key.pem",
+        ],
+    )
+
+    exit_code = module.main()
+    result: dict[str, Any] = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert result["success"] is True
+    assert result["instance_id"] == ""
+
+
+def test_reinstall_uses_donor_volume_when_ami_snapshot_is_not_restorable(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Public AMI launch can work even when its backing snapshot is not directly restorable."""
+    module = _load_reinstall_script()
+    ec2 = _FakeInaccessibleSnapshotEc2()
+
+    monkeypatch.setattr(module.boto3, "client", lambda service, region_name: ec2)
+    monkeypatch.setattr(module, "wait_for_ssh", lambda host, user, key_file: True)
+    monkeypatch.setattr(module, "ssh_run", lambda host, user, key_file, command: (0, "i-original\n", ""))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "reinstall_instance.py",
+            "--instance-id",
+            "i-original",
+            "--region",
+            "us-west-2",
+            "--key-file",
+            "/tmp/key.pem",
+        ],
+    )
+
+    exit_code = module.main()
+    result: dict[str, Any] = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert result["success"] is True
+    assert result["new_volume_id"] == "vol-new"
+    assert ec2.events[:4] == ["create_volume", "run_donor", "stop_donor", "detach_donor"]
+    assert ec2.events.index("stop_target") > ec2.events.index("detach_donor")
+
+
+def test_donor_volume_is_cleaned_up_when_detach_waiter_fails() -> None:
+    """A donor root volume must not be orphaned when detach never completes."""
+    module = _load_reinstall_script()
+    ec2 = _FailingDonorVolumeWaiterEc2()
+
+    with pytest.raises(WaiterError):
+        module.create_root_volume_from_donor_instance(
+            ec2,
+            ami_id="ami-source",
+            image_root_device="/dev/sda1",
+            architecture="x86_64",
+            volume_size=200,
+            subnet_id="subnet-source",
+            security_group_ids=["sg-source"],
+            key_name="key-source",
+            instance_id="i-original",
+        )
+
+    assert ec2.donor_delete_on_termination is True
+    assert ec2.events == [
+        "run_donor",
+        "stop_donor",
+        "detach_donor",
+        "terminate_donor",
+        "delete_donor_volume",
+    ]
+
+
+class _FakeFailingReinstallEc2(_FakeReinstallEc2):
+    """Fake EC2 client that records deleted volumes for failure-cleanup tests."""
+
+    def __init__(self) -> None:
+        """Initialize deleted-volume tracking."""
+        self.deleted_volumes: list[str] = []
+
+    def delete_volume(self, VolumeId: str) -> None:
+        """Record any volume deletion (replacement cleanup or old-volume cleanup)."""
+        self.deleted_volumes.append(VolumeId)
+
+
+def test_reinstall_deletes_replacement_volume_when_swap_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A failure after the replacement volume is created must not orphan it.
+
+    The volume is created before the target is mutated, so a later failure
+    (here SSH never comes up) must delete it - teardown only terminates the
+    instance and never reclaims reinstall-* volumes.
+    """
+    module = _load_reinstall_script()
+    ec2 = _FakeFailingReinstallEc2()
+
+    monkeypatch.setattr(module.boto3, "client", lambda service, region_name: ec2)
+    monkeypatch.setattr(module, "wait_for_ssh", lambda host, user, key_file: False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "reinstall_instance.py",
+            "--instance-id",
+            "i-original",
+            "--region",
+            "us-west-2",
+            "--key-file",
+            "/tmp/key.pem",
+        ],
+    )
+
+    exit_code = module.main()
+    result: dict[str, Any] = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert result["success"] is False
+    assert result["error"] == "SSH not ready after reinstall"
+    # The newly created replacement volume is reclaimed; the old volume is not
+    # deleted because post-success cleanup never runs.
+    assert ec2.deleted_volumes == ["vol-new"]

--- a/isvctl/tests/test_aws_delete_retry.py
+++ b/isvctl/tests/test_aws_delete_retry.py
@@ -65,6 +65,7 @@ class TestDeleteWithRetry:
             "InvalidSubnet.NotFound",
             "InvalidRouteTableID.NotFound",
             "InvalidInstanceID.NotFound",
+            "InvalidVolume.NotFound",
             "NoSuchEntity",
         }
         assert must_have <= ALREADY_GONE_CODES

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -934,6 +934,40 @@ class TestMissingStepRefDetection:
         # "--region" stripped (matching previous behavior for explicit defaults).
         assert results.steps[0].success
 
+    def test_deploy_nim_skip_condition_renders_teardown_skip_args(self) -> None:
+        """Conditional NIM teardown args render only when deploy_nim skipped."""
+        executor = StepExecutor()
+        context = Context(RunConfig())
+        context.set_step_output("deploy_nim", {"success": True, "skipped": True})
+
+        rendered = executor._render_args(
+            [
+                "{{ '--skip' if steps.deploy_nim.skipped | default(false) else '' }}",
+                "{{ '--skip-reason' if steps.deploy_nim.skipped | default(false) else '' }}",
+                "{{ 'NIM deployment skipped' if steps.deploy_nim.skipped | default(false) else '' }}",
+            ],
+            context,
+        )
+
+        assert rendered == ["--skip", "--skip-reason", "NIM deployment skipped"]
+
+    def test_deploy_nim_skip_condition_drops_args_when_not_skipped(self) -> None:
+        """Conditional NIM teardown args are dropped when deploy_nim ran."""
+        executor = StepExecutor()
+        context = Context(RunConfig())
+        context.set_step_output("deploy_nim", {"success": True, "skipped": False})
+
+        rendered = executor._render_args(
+            [
+                "{{ '--skip' if steps.deploy_nim.skipped | default(false) else '' }}",
+                "{{ '--skip-reason' if steps.deploy_nim.skipped | default(false) else '' }}",
+                "{{ 'NIM deployment skipped' if steps.deploy_nim.skipped | default(false) else '' }}",
+            ],
+            context,
+        )
+
+        assert rendered == []
+
     def test_inline_empty_template_value_keeps_flag_value_pair(self) -> None:
         """Empty optional values stay attached when YAML uses ``--flag={{value}}``."""
         executor = StepExecutor()

--- a/isvctl/tests/test_shared_teardown_nim.py
+++ b/isvctl/tests/test_shared_teardown_nim.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the shared NIM teardown script."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+
+def _load_teardown_nim() -> ModuleType:
+    """Load the shared teardown_nim.py script as a module."""
+    script_path = Path(__file__).resolve().parents[1] / "configs" / "providers" / "shared" / "teardown_nim.py"
+    spec = importlib.util.spec_from_file_location("shared_teardown_nim", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_container_remove_uses_teardown_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """NIM container removal should not inherit the short generic SSH timeout."""
+    module = _load_teardown_nim()
+    calls: list[tuple[str, int]] = []
+
+    class FakeSSH:
+        """Minimal SSH object accepted by teardown_nim.main."""
+
+        def close(self) -> None:
+            """Close fake SSH client."""
+
+    def fake_run_cmd(
+        _ssh: FakeSSH,
+        command: str,
+        timeout: int = 60,
+        operation: str | None = None,
+    ) -> tuple[int, str, str]:
+        _ = operation
+        calls.append((command, timeout))
+        return 0, "isv-nim\n", ""
+
+    monkeypatch.setattr(module, "ssh_connect", lambda *_args: FakeSSH())
+    monkeypatch.setattr(module, "run_cmd", fake_run_cmd)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["teardown_nim.py", "--host", "192.0.2.10", "--key-file", "/tmp/key.pem"],
+    )
+
+    assert module.main() == 0
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["success"] is True
+    remove_calls = [(command, timeout) for command, timeout in calls if command.startswith("docker rm -f")]
+    assert remove_calls == [("docker rm -f isv-nim", 240)]
+
+
+def test_timeout_error_names_failed_operation() -> None:
+    """A remote command timeout should say which operation timed out."""
+    module = _load_teardown_nim()
+
+    class TimeoutSSH:
+        """SSH stub that times out while starting a remote command."""
+
+        def exec_command(self, _command: str, timeout: int | None = None) -> tuple[Any, Any, Any]:
+            raise TimeoutError("timed out")
+
+    with pytest.raises(TimeoutError, match="docker rm timed out after 240s"):
+        module.run_cmd(TimeoutSSH(), "docker rm -f isv-nim", timeout=240, operation="docker rm")
+
+
+def test_skip_returns_success_without_ssh(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Teardown should be a no-op when the NIM deploy step was skipped."""
+    module = _load_teardown_nim()
+
+    def fail_connect(*_args: str) -> None:
+        raise AssertionError("ssh_connect should not be called")
+
+    monkeypatch.setattr(module, "ssh_connect", fail_connect)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "teardown_nim.py",
+            "--host",
+            "192.0.2.10",
+            "--key-file",
+            "/tmp/key.pem",
+            "--skip",
+            "--skip-reason",
+            "NIM deployment skipped",
+        ],
+    )
+
+    assert module.main() == 0
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["success"] is True
+    assert output["skipped"] is True
+    assert output["skip_reason"] == "NIM deployment skipped"
+    assert output["message"] == "NIM deployment skipped"


### PR DESCRIPTION
## Summary

- Harden the AWS bare-metal `reinstall_instance` root-volume swap: create the replacement volume before stopping the target, clean it up on failed swaps, fall back to a temporary donor instance when the AMI snapshot is not directly restorable, and poll the fresh public IP before SSH validation.
- Wire `StableIdentifierCheck` into the bare-metal reinstall validation so the launched instance ID is compared with the node identity reported by the reinstalled OS.
- Tighten related cleanup behavior by treating `InvalidVolume.NotFound` as already gone and by making NIM teardown a clean skip when NIM deploy was skipped, with a shared timeout-aware Paramiko helper for deploy/teardown.

Closes #197

## Verification

- [x] `make test`
- [x] `make lint`
- [x] `make demo-test`
- [x] `uvx pre-commit run -a`
- [x] `git diff --check origin/main...HEAD`
- [x] AWS reinstall tested on a live AWS bare-metal instance; the reinstall completed and the post-reinstall node identity remained stable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bare-metal reinstall gains fallback path to create a replacement root volume when snapshots aren’t restorable
  * Teardown can be conditionally skipped with a provided skip reason
  * Added verification of instance identity after reinstall

* **Bug Fixes**
  * Improved cleanup and error handling to avoid orphaned replacement/donor volumes

* **Refactor**
  * Shared SSH helpers extracted for reuse across validation/teardown scripts

* **Tests**
  * New tests covering reinstall scenarios, teardown skip behavior, timeouts, and cleanup logic

* **Documentation**
  * Clarified reinstall notes and expected durations for steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->