### PR TITLE
feat(k8s): validate EKS clusters in shared VPC

### DIFF
--- a/isvctl/configs/providers/aws/config/eks.yaml
+++ b/isvctl/configs/providers/aws/config/eks.yaml
@@ -53,6 +53,24 @@ commands:
           TF_VAR_gpu_node_instance_types: '["g5.2xlarge"]'
           TF_VAR_gpu_node_desired_size: "1"
 
+      # K8S26-01: prove a second EKS cluster can coexist in the same AWS
+      # account and VPC as the primary cluster. The script reads the primary
+      # Terraform state, applies a secondary EKS module with isolated local
+      # state, waits for a Ready node in the secondary cluster, and emits the
+      # multi_cluster JSON contract consumed by K8sMultiClusterSameVpcCheck.
+      - name: create_test_shared_vpc_cluster
+        phase: setup
+        command: "../scripts/eks/create_shared_vpc_cluster.sh"
+        output_schema: multi_cluster
+        requires_available_validations:
+          - K8sMultiClusterSameVpcCheck
+        timeout: 1800
+        env:
+          TF_AUTO_APPROVE: "true"
+          SHARED_VPC_CLUSTER_STATE_FILE: "terraform.tfstate"
+          TF_VAR_node_desired_size: "1"
+          TF_VAR_node_instance_types: '["m6i.large"]'
+
       # Exercise the node-pool create path twice to prove separate CPU and GPU
       # pools can coexist in the same cluster with independent node counts
       # (K8S06). Each pool keeps its own Terraform state via
@@ -135,6 +153,16 @@ commands:
           TF_AUTO_APPROVE: "true"
           NODE_POOL_STATE_FILE: "terraform-gpu.tfstate"
 
+      # Destroy the secondary shared-VPC cluster before the primary cluster
+      # teardown removes the shared subnets and VPC.
+      - name: destroy_test_shared_vpc_cluster
+        phase: teardown
+        command: "../scripts/eks/destroy_shared_vpc_cluster.sh"
+        timeout: 1800
+        env:
+          TF_AUTO_APPROVE: "true"
+          SHARED_VPC_CLUSTER_STATE_FILE: "terraform.tfstate"
+
       - name: teardown
         phase: teardown
         command: "../scripts/eks/teardown.sh"
@@ -146,6 +174,11 @@ tests:
   description: "AWS EKS GPU cluster validation"
 
   validations:
+    k8s_multi_cluster:
+      checks:
+        K8sMultiClusterSameVpcCheck:
+          step: create_test_shared_vpc_cluster
+
     kubernetes:
       checks:
         K8sNodeCountCheck:

--- a/isvctl/configs/providers/aws/scripts/eks/create_shared_vpc_cluster.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/create_shared_vpc_cluster.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create a secondary EKS cluster in the primary cluster's VPC.
+#
+# Applies ./terraform-shared-vpc-cluster/ against the existing primary cluster
+# state and emits a JSON payload matching the `multi_cluster` output schema.
+# The validation consumes only this JSON, so AWS-specific API calls remain in
+# this provider script.
+#
+# Environment variables:
+#   TF_AUTO_APPROVE                    - "true" to skip approval (default: false)
+#   SHARED_VPC_CLUSTER_STATE_FILE      - Local Terraform state filename within
+#                                        terraform-shared-vpc-cluster/ (default
+#                                        "terraform.tfstate")
+#   SECONDARY_CLUSTER_READY_TIMEOUT    - Seconds to wait for a Ready node
+#                                        (default 900)
+#   SECONDARY_CLUSTER_POLL_INTERVAL    - Poll interval in seconds (default 10)
+#   TF_VAR_*                           - Terraform variables for the secondary
+#                                        cluster module
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TF_DIR="${SCRIPT_DIR}/terraform-shared-vpc-cluster"
+CLUSTER_TF_DIR="${SCRIPT_DIR}/terraform"
+STATE_FILE="${SHARED_VPC_CLUSTER_STATE_FILE:-terraform.tfstate}"
+
+if [[ -z "${STATE_FILE}" ]] \
+    || [[ "${STATE_FILE}" == .* ]] \
+    || [[ "${STATE_FILE}" == *"/"* ]] \
+    || [[ "${STATE_FILE}" == *".."* ]] \
+    || [[ "${STATE_FILE}" == \~* ]] \
+    || [[ ! "${STATE_FILE}" =~ ^[A-Za-z0-9._-]+\.tfstate$ ]]; then
+    echo "Error: SHARED_VPC_CLUSTER_STATE_FILE must be a local .tfstate filename using only letters, numbers, dots, underscores, and hyphens." >&2
+    exit 1
+fi
+
+if ! command -v terraform &> /dev/null; then
+    echo "Error: terraform not found - install from https://terraform.io" >&2
+    exit 1
+fi
+if ! command -v aws &> /dev/null; then
+    echo "Error: AWS CLI not found" >&2
+    exit 1
+fi
+if ! command -v kubectl &> /dev/null; then
+    echo "Error: kubectl not found" >&2
+    exit 1
+fi
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq not found" >&2
+    exit 1
+fi
+if [ ! -f "${CLUSTER_TF_DIR}/terraform.tfstate" ]; then
+    echo "Error: primary cluster state not found at ${CLUSTER_TF_DIR}/terraform.tfstate" >&2
+    echo "Run the EKS setup step first." >&2
+    exit 1
+fi
+if ! aws sts get-caller-identity &> /dev/null 2>&1; then
+    echo "Error: AWS credentials not configured" >&2
+    exit 1
+fi
+
+ready_nodes_for_cluster() {
+    local cluster_name="$1"
+    local region="$2"
+    local kubeconfig_path="$3"
+
+    KUBECONFIG="${kubeconfig_path}" aws eks update-kubeconfig \
+        --name "${cluster_name}" \
+        --region "${region}" \
+        --alias "${cluster_name}" > /dev/null
+
+    KUBECONFIG="${kubeconfig_path}" kubectl get nodes -o json \
+        | jq '[.items[] | select(any(.status.conditions[]?; .type == "Ready" and .status == "True"))] | length'
+}
+
+wait_for_secondary_ready_nodes() {
+    local cluster_name="$1"
+    local region="$2"
+    local timeout="${SECONDARY_CLUSTER_READY_TIMEOUT:-900}"
+    local poll_interval="${SECONDARY_CLUSTER_POLL_INTERVAL:-10}"
+    local kubeconfig_path
+    local ready_nodes
+    local elapsed=0
+
+    kubeconfig_path="$(mktemp)"
+
+    while [ "${elapsed}" -le "${timeout}" ]; do
+        ready_nodes="$(ready_nodes_for_cluster "${cluster_name}" "${region}" "${kubeconfig_path}" 2>/dev/null || echo "0")"
+        if [ "${ready_nodes}" -ge 1 ]; then
+            echo "${ready_nodes}"
+            rm -f "${kubeconfig_path}"
+            return 0
+        fi
+        echo "Waiting for secondary cluster node readiness (${ready_nodes} Ready node(s))..." >&2
+        sleep "${poll_interval}"
+        elapsed=$((elapsed + poll_interval))
+    done
+
+    echo "Error: secondary cluster '${cluster_name}' did not report a Ready node within ${timeout}s" >&2
+    rm -f "${kubeconfig_path}"
+    return 1
+}
+
+PRIMARY_CLUSTER_NAME=$(terraform -chdir="${CLUSTER_TF_DIR}" output -raw cluster_name)
+AWS_REGION=$(terraform -chdir="${CLUSTER_TF_DIR}" output -raw region)
+
+echo "" >&2
+echo "========================================" >&2
+echo "  Creating secondary EKS shared-VPC cluster" >&2
+echo "========================================" >&2
+echo "  primary cluster: ${PRIMARY_CLUSTER_NAME}" >&2
+echo "  region: ${AWS_REGION}" >&2
+echo "  state file: ${STATE_FILE}" >&2
+echo "" >&2
+
+cd "${TF_DIR}"
+
+echo "Initializing Terraform..." >&2
+terraform init >&2
+
+TF_AUTO_APPROVE="${TF_AUTO_APPROVE:-false}"
+if [ "${TF_AUTO_APPROVE}" = "true" ]; then
+    terraform apply -auto-approve -state="${STATE_FILE}" >&2
+else
+    terraform apply -state="${STATE_FILE}" >&2
+fi
+
+SECONDARY_CLUSTER_NAME=$(terraform output -state="${STATE_FILE}" -raw cluster_name)
+
+cd - > /dev/null
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+PRIMARY_INFO=$(aws eks describe-cluster --name "${PRIMARY_CLUSTER_NAME}" --region "${AWS_REGION}" --output json)
+SECONDARY_INFO=$(aws eks describe-cluster --name "${SECONDARY_CLUSTER_NAME}" --region "${AWS_REGION}" --output json)
+
+PRIMARY_STATUS=$(echo "${PRIMARY_INFO}" | jq -r '.cluster.status // empty')
+PRIMARY_VPC_ID=$(echo "${PRIMARY_INFO}" | jq -r '.cluster.resourcesVpcConfig.vpcId // empty')
+SECONDARY_STATUS=$(echo "${SECONDARY_INFO}" | jq -r '.cluster.status // empty')
+SECONDARY_VPC_ID=$(echo "${SECONDARY_INFO}" | jq -r '.cluster.resourcesVpcConfig.vpcId // empty')
+
+SECONDARY_READY_NODES=$(wait_for_secondary_ready_nodes "${SECONDARY_CLUSTER_NAME}" "${AWS_REGION}")
+
+jq -n \
+    --arg tenancy_id "${ACCOUNT_ID}" \
+    --arg network_id "${PRIMARY_VPC_ID}" \
+    --arg primary_name "${PRIMARY_CLUSTER_NAME}" \
+    --arg primary_status "${PRIMARY_STATUS}" \
+    --arg primary_vpc_id "${PRIMARY_VPC_ID}" \
+    --arg secondary_name "${SECONDARY_CLUSTER_NAME}" \
+    --arg secondary_status "${SECONDARY_STATUS}" \
+    --arg secondary_vpc_id "${SECONDARY_VPC_ID}" \
+    --argjson secondary_ready_nodes "${SECONDARY_READY_NODES}" \
+    '{
+      success: true,
+      platform: "kubernetes",
+      test_id: "K8S26-01",
+      tenancy_id: $tenancy_id,
+      network_id: $network_id,
+      clusters: [
+        {
+          name: $primary_name,
+          role: "primary",
+          tenancy_id: $tenancy_id,
+          network_id: $primary_vpc_id,
+          status: $primary_status
+        },
+        {
+          name: $secondary_name,
+          role: "secondary",
+          tenancy_id: $tenancy_id,
+          network_id: $secondary_vpc_id,
+          status: $secondary_status,
+          ready_node_count: $secondary_ready_nodes
+        }
+      ]
+    }'

--- a/isvctl/configs/providers/aws/scripts/eks/destroy_shared_vpc_cluster.sh
+++ b/isvctl/configs/providers/aws/scripts/eks/destroy_shared_vpc_cluster.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Destroy the secondary EKS shared-VPC cluster created by
+# create_shared_vpc_cluster.sh.
+#
+# Environment variables:
+#   TF_AUTO_APPROVE               - "true" to skip confirmation (default: false)
+#   SHARED_VPC_CLUSTER_STATE_FILE - Local Terraform state filename within
+#                                   terraform-shared-vpc-cluster/ (default
+#                                   "terraform.tfstate")
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TF_DIR="${SCRIPT_DIR}/terraform-shared-vpc-cluster"
+STATE_FILE="${SHARED_VPC_CLUSTER_STATE_FILE:-terraform.tfstate}"
+
+if [[ -z "${STATE_FILE}" ]] \
+    || [[ "${STATE_FILE}" == .* ]] \
+    || [[ "${STATE_FILE}" == *"/"* ]] \
+    || [[ "${STATE_FILE}" == *".."* ]] \
+    || [[ "${STATE_FILE}" == \~* ]] \
+    || [[ ! "${STATE_FILE}" =~ ^[A-Za-z0-9._-]+\.tfstate$ ]]; then
+    echo "Error: SHARED_VPC_CLUSTER_STATE_FILE must be a local .tfstate filename using only letters, numbers, dots, underscores, and hyphens." >&2
+    exit 1
+fi
+
+if [ ! -f "${TF_DIR}/${STATE_FILE}" ]; then
+    echo "No shared-VPC cluster state found at ${TF_DIR}/${STATE_FILE}; nothing to destroy." >&2
+    cat << 'EOF'
+{
+  "success": true,
+  "platform": "kubernetes",
+  "message": "Shared-VPC cluster state absent - nothing to destroy",
+  "resources_deleted": []
+}
+EOF
+    exit 0
+fi
+
+if ! command -v terraform &> /dev/null; then
+    echo "Error: terraform not found - install from https://terraform.io" >&2
+    exit 1
+fi
+
+cd "${TF_DIR}"
+
+echo "" >&2
+echo "========================================" >&2
+echo "  Destroying secondary EKS shared-VPC cluster" >&2
+echo "  state file: ${STATE_FILE}" >&2
+echo "========================================" >&2
+
+if [ ! -d ".terraform" ]; then
+    terraform init >&2
+fi
+
+TF_AUTO_APPROVE="${TF_AUTO_APPROVE:-false}"
+if [ "${TF_AUTO_APPROVE}" = "true" ]; then
+    terraform destroy -auto-approve -state="${STATE_FILE}" >&2
+else
+    terraform destroy -state="${STATE_FILE}" >&2
+fi
+
+cat << 'EOF'
+{
+  "success": true,
+  "platform": "kubernetes",
+  "message": "Secondary shared-VPC cluster destroyed",
+  "resources_deleted": ["aws_eks_cluster", "aws_eks_node_group", "aws_ec2_tag"]
+}
+EOF

--- a/isvctl/configs/providers/aws/scripts/eks/terraform-shared-vpc-cluster/.gitignore
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform-shared-vpc-cluster/.gitignore
@@ -1,0 +1,30 @@
+# Terraform state files
+*.tfstate
+*.tfstate.backup
+*.tfstate.lock.info
+
+# Terraform cache
+.terraform/
+.terraform.lock.hcl
+
+# Crash logs
+crash.log
+crash.*.log
+
+# User-specific variables (may contain sensitive data)
+terraform.tfvars
+*.auto.tfvars
+
+# Override files
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# CLI configuration files
+.terraformrc
+terraform.rc
+
+# Plan files
+*.tfplan
+tfplan

--- a/isvctl/configs/providers/aws/scripts/eks/terraform-shared-vpc-cluster/main.tf
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform-shared-vpc-cluster/main.tf
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Secondary EKS Cluster in the Primary Cluster's VPC
+#
+# This module reads the primary cluster's local Terraform state from
+# ../terraform/terraform.tfstate, reuses its VPC/private subnets, and creates a
+# second EKS cluster with one CPU-only managed node group. The module has its
+# own local state so the shared-VPC proof can be created and destroyed before
+# the primary cluster teardown.
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "cluster" {
+  backend = "local"
+  config = {
+    path = "../terraform/terraform.tfstate"
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  primary_cluster_name = data.terraform_remote_state.cluster.outputs.cluster_name
+  region               = var.region != "" ? var.region : data.terraform_remote_state.cluster.outputs.region
+  kubernetes_version = (
+    var.kubernetes_version != ""
+    ? var.kubernetes_version
+    : data.terraform_remote_state.cluster.outputs.cluster_version
+  )
+  cluster_name = (
+    var.cluster_name != ""
+    ? var.cluster_name
+    : substr("${local.primary_cluster_name}-shared-vpc", 0, 63)
+  )
+  endpoint_public_access_cidrs = (
+    length(var.cluster_endpoint_public_access_cidrs) > 0
+    ? var.cluster_endpoint_public_access_cidrs
+    : try(data.terraform_remote_state.cluster.outputs.cluster_endpoint_public_access_cidrs, ["203.0.113.0/24"])
+  )
+  vpc_id          = data.terraform_remote_state.cluster.outputs.vpc_id
+  private_subnets = data.terraform_remote_state.cluster.outputs.private_subnets
+
+  tags = {
+    ClusterName    = local.cluster_name
+    Environment    = var.environment
+    PrimaryCluster = local.primary_cluster_name
+    TestID         = "K8S26-01"
+  }
+}
+
+provider "aws" {
+  region = local.region
+
+  default_tags {
+    tags = {
+      Environment = var.environment
+      Project     = "isv-lab-tools"
+      ManagedBy   = "terraform"
+      Component   = "shared-vpc-cluster"
+      TestID      = "K8S26-01"
+    }
+  }
+}
+
+resource "aws_ec2_tag" "secondary_cluster_private_subnets" {
+  for_each = toset(local.private_subnets)
+
+  resource_id = each.value
+  key         = "kubernetes.io/cluster/${local.cluster_name}"
+  value       = "shared"
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.0"
+
+  cluster_name    = local.cluster_name
+  cluster_version = local.kubernetes_version
+
+  cluster_endpoint_public_access       = true
+  cluster_endpoint_private_access      = true
+  cluster_endpoint_public_access_cidrs = local.endpoint_public_access_cidrs
+
+  bootstrap_self_managed_addons = false
+
+  vpc_id     = local.vpc_id
+  subnet_ids = local.private_subnets
+
+  control_plane_subnet_ids = local.private_subnets
+
+  enable_cluster_creator_admin_permissions = true
+
+  node_security_group_additional_rules = {
+    ingress_self_all = {
+      description = "Node to node all ports/protocols"
+      protocol    = "-1"
+      from_port   = 0
+      to_port     = 0
+      type        = "ingress"
+      self        = true
+    }
+    ingress_cluster_all = {
+      description                   = "Cluster to node all ports/protocols"
+      protocol                      = "-1"
+      from_port                     = 0
+      to_port                       = 0
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
+    egress_all = {
+      description = "Node all egress"
+      protocol    = "-1"
+      from_port   = 0
+      to_port     = 0
+      type        = "egress"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  }
+
+  cluster_addons = {
+    coredns = {
+      most_recent = true
+    }
+    kube-proxy = {
+      most_recent = true
+    }
+    vpc-cni = {
+      most_recent    = true
+      before_compute = true
+      configuration_values = jsonencode({
+        env = {
+          ENABLE_PREFIX_DELEGATION = "true"
+          WARM_PREFIX_TARGET       = "1"
+        }
+      })
+    }
+  }
+
+  eks_managed_node_groups = {
+    secondary_cpu = {
+      name           = var.node_group_name
+      instance_types = var.node_instance_types
+      ami_type       = var.node_ami_type
+      capacity_type  = var.node_capacity_type
+
+      min_size     = var.node_desired_size
+      max_size     = var.node_desired_size
+      desired_size = var.node_desired_size
+
+      subnet_ids = local.private_subnets
+
+      labels = {
+        role                              = "system"
+        "isv.ncp.validation/cluster-role" = "secondary"
+      }
+
+      iam_role_additional_policies = {
+        AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+      }
+    }
+  }
+
+  tags = local.tags
+
+  depends_on = [aws_ec2_tag.secondary_cluster_private_subnets]
+}

--- a/isvctl/configs/providers/aws/scripts/eks/terraform-shared-vpc-cluster/outputs.tf
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform-shared-vpc-cluster/outputs.tf
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "cluster_name" {
+  description = "Secondary EKS cluster name."
+  value       = module.eks.cluster_name
+}
+
+output "cluster_arn" {
+  description = "Secondary EKS cluster ARN."
+  value       = module.eks.cluster_arn
+}
+
+output "cluster_endpoint" {
+  description = "Secondary EKS API endpoint."
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_version" {
+  description = "Secondary EKS Kubernetes version."
+  value       = module.eks.cluster_version
+}
+
+output "region" {
+  description = "AWS region."
+  value       = local.region
+}
+
+output "tenancy_id" {
+  description = "AWS account ID."
+  value       = data.aws_caller_identity.current.account_id
+}
+
+output "vpc_id" {
+  description = "Shared VPC ID reused from the primary cluster."
+  value       = local.vpc_id
+}
+
+output "private_subnets" {
+  description = "Private subnet IDs reused from the primary cluster."
+  value       = local.private_subnets
+}
+
+output "node_group_name" {
+  description = "Secondary cluster CPU node group name."
+  value       = var.node_group_name
+}

--- a/isvctl/configs/providers/aws/scripts/eks/terraform-shared-vpc-cluster/variables.tf
+++ b/isvctl/configs/providers/aws/scripts/eks/terraform-shared-vpc-cluster/variables.tf
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "region" {
+  description = "AWS region. Leave empty to use the primary cluster state's region."
+  type        = string
+  default     = ""
+}
+
+variable "environment" {
+  description = "Deployment environment tag, used for default tags."
+  type        = string
+  default     = "dev"
+}
+
+variable "cluster_name" {
+  description = "Secondary EKS cluster name. Leave empty to derive from the primary cluster name."
+  type        = string
+  default     = ""
+}
+
+variable "kubernetes_version" {
+  description = "Secondary cluster Kubernetes version. Leave empty to match the primary cluster."
+  type        = string
+  default     = ""
+}
+
+variable "cluster_endpoint_public_access_cidrs" {
+  description = "CIDR blocks allowed to access the secondary EKS API endpoint. Defaults to the primary cluster output."
+  type        = list(string)
+  default     = []
+}
+
+variable "node_group_name" {
+  description = "Name of the secondary cluster's CPU-only managed node group."
+  type        = string
+  default     = "shared-vpc-cpu"
+  validation {
+    condition     = length(var.node_group_name) > 0 && length(var.node_group_name) <= 63
+    error_message = "node_group_name must be 1..63 characters."
+  }
+}
+
+variable "node_instance_types" {
+  description = "CPU-only instance types for the secondary cluster managed node group."
+  type        = list(string)
+  default     = ["m6i.large"]
+  validation {
+    condition     = length(var.node_instance_types) > 0
+    error_message = "node_instance_types must not be empty."
+  }
+}
+
+variable "node_ami_type" {
+  description = "EKS AMI type for the secondary CPU-only managed node group."
+  type        = string
+  default     = "AL2023_x86_64_STANDARD"
+}
+
+variable "node_capacity_type" {
+  description = "Secondary node group capacity type: ON_DEMAND or SPOT."
+  type        = string
+  default     = "ON_DEMAND"
+  validation {
+    condition     = contains(["ON_DEMAND", "SPOT"], var.node_capacity_type)
+    error_message = "node_capacity_type must be ON_DEMAND or SPOT."
+  }
+}
+
+variable "node_desired_size" {
+  description = "CPU node count for the secondary cluster. min/max are pinned to this value."
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.node_desired_size >= 1 && var.node_desired_size <= 50 && floor(var.node_desired_size) == var.node_desired_size
+    error_message = "node_desired_size must be an integer in [1, 50]."
+  }
+}

--- a/isvctl/src/isvctl/config/output_schemas.py
+++ b/isvctl/src/isvctl/config/output_schemas.py
@@ -143,6 +143,9 @@ STEP_SCHEMA_MAPPING: dict[str, str | None] = {
     "update_node_pool": "node_pool",
     "destroy_test_node_pool": "teardown",
     "destroy_node_pool": "teardown",
+    # Multi-cluster operations
+    "create_test_shared_vpc_cluster": "multi_cluster",
+    "destroy_test_shared_vpc_cluster": "teardown",
 }
 
 # Common fields present in all outputs
@@ -920,6 +923,60 @@ OUTPUT_SCHEMAS: dict[str, dict[str, Any]] = {
         "properties": COMMON_PROPERTIES,
         "additionalProperties": True,
         "description": "Generic schema for unrecognized step names",
+    },
+    # =========================================================================
+    # Multi-cluster schemas
+    # =========================================================================
+    "multi_cluster": {
+        "type": "object",
+        "required": [
+            "success",
+            "platform",
+            "test_id",
+            "tenancy_id",
+            "network_id",
+            "clusters",
+        ],
+        "properties": {
+            **COMMON_PROPERTIES,
+            "test_id": {"type": "string", "description": "Validation test identifier"},
+            "tenancy_id": {"type": "string", "minLength": 1, "description": "Cloud account or tenancy identifier"},
+            "network_id": {"type": "string", "minLength": 1, "description": "Shared network/VPC identifier"},
+            "clusters": {
+                "type": "array",
+                "minItems": 2,
+                "items": {
+                    "type": "object",
+                    "required": ["name", "tenancy_id", "network_id", "status"],
+                    "properties": {
+                        "name": {"type": "string", "minLength": 1, "description": "Cluster name"},
+                        "role": {
+                            "type": "string",
+                            "description": "Optional provider role label for this cluster",
+                        },
+                        "tenancy_id": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Cloud account or tenancy identifier for this cluster",
+                        },
+                        "network_id": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Network/VPC identifier reported by this cluster",
+                        },
+                        "status": {"type": "string", "minLength": 1, "description": "Cluster lifecycle status"},
+                        "ready_node_count": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": "Ready node count for this cluster when available",
+                        },
+                    },
+                    "additionalProperties": True,
+                },
+                "description": "Clusters participating in the shared-network proof",
+            },
+        },
+        "additionalProperties": True,
     },
     # =========================================================================
     # Node pool schemas (Terraform or Cluster API provisioned)

--- a/isvctl/src/isvctl/config/schema.py
+++ b/isvctl/src/isvctl/config/schema.py
@@ -86,6 +86,13 @@ class StepConfig(BaseModel):
     env: dict[str, str] = Field(default_factory=dict, description="Additional environment variables")
     working_dir: str | None = Field(default=None, description="Working directory for command execution")
     skip: bool = Field(default=False, description="Skip this step")
+    requires_available_validations: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Validation names that must be available after release filtering for this step to run. "
+            "Unreleased validations are available only when ISVTEST_INCLUDE_UNRELEASED=1."
+        ),
+    )
     continue_on_failure: bool = Field(default=False, description="Continue to next step even if this step fails")
     phase: str = Field(
         default="setup",

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -37,6 +37,7 @@ from isvtest.core.resolution import (
     ValidationEntry,
     get_entry_phase,
     parse_validations,
+    resolve_class_key,
     resolve_entries,
 )
 from isvtest.main import run_validations_via_pytest
@@ -300,6 +301,30 @@ def _has_explicit_pytest_selection(extra_pytest_args: list[str] | None) -> bool:
     )
 
 
+def _apply_step_validation_gates(steps: list[Any], released_tests: set[str] | None) -> list[Any]:
+    """Mark steps skipped when their required validations are unavailable."""
+    if released_tests is None:
+        return steps
+
+    gated_steps: list[Any] = []
+    for step in steps:
+        required_validations = getattr(step, "requires_available_validations", [])
+        unavailable = [
+            validation for validation in required_validations if resolve_class_key(validation, released_tests) is None
+        ]
+        if not unavailable:
+            gated_steps.append(step)
+            continue
+        skipped_step = step.model_copy(update={"skip": True})
+        logger.info(
+            "Skipping step '%s' because required validation(s) are unavailable: %s",
+            skipped_step.name,
+            ", ".join(unavailable),
+        )
+        gated_steps.append(skipped_step)
+    return gated_steps
+
+
 class Orchestrator:
     """Orchestrates the full test lifecycle using step-based execution.
 
@@ -417,6 +442,12 @@ class Orchestrator:
                 ],
             )
 
+        released_tests = load_released_test_filter()
+        if released_tests is None:
+            logger.info(f"Including unreleased validations because {INCLUDE_UNRELEASED_ENV} is enabled")
+
+        steps = _apply_step_validation_gates(steps, released_tests)
+
         config_phases = self.config.get_phases(platform)
         logger.info(f"Configured phases: {config_phases}")
 
@@ -453,9 +484,6 @@ class Orchestrator:
             all_validations = self.config.tests.validations
         validation_entries = parse_validations(all_validations)
         resolved_validations_by_index: dict[int, ResolvedEntry] = {}
-        released_tests = load_released_test_filter()
-        if released_tests is None:
-            logger.info(f"Including unreleased validations because {INCLUDE_UNRELEASED_ENV} is enabled")
 
         exclude_labels: list[str] = []
         exclude_tests: list[str] = []

--- a/isvctl/tests/test_aws_eks_shared_vpc_cluster_scripts.py
+++ b/isvctl/tests/test_aws_eks_shared_vpc_cluster_scripts.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for AWS EKS shared-VPC cluster helper scripts."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+AWS_EKS_DIR = Path(__file__).resolve().parents[1] / "configs" / "providers" / "aws" / "scripts" / "eks"
+
+
+@pytest.mark.parametrize("script_name", ["create_shared_vpc_cluster.sh", "destroy_shared_vpc_cluster.sh"])
+@pytest.mark.parametrize("state_file", ["../terraform.tfstate", "/tmp/shared-vpc-cluster.tfstate"])
+def test_shared_vpc_cluster_scripts_reject_state_file_paths(script_name: str, state_file: str) -> None:
+    """Shared-cluster state overrides must stay local to terraform-shared-vpc-cluster/."""
+    env = {**os.environ, "SHARED_VPC_CLUSTER_STATE_FILE": state_file}
+
+    completed = subprocess.run(
+        ["bash", str(AWS_EKS_DIR / script_name)],
+        capture_output=True,
+        check=False,
+        env=env,
+        text=True,
+    )
+
+    assert completed.returncode == 1
+    assert "SHARED_VPC_CLUSTER_STATE_FILE must be a local .tfstate filename" in completed.stderr

--- a/isvctl/tests/test_merger.py
+++ b/isvctl/tests/test_merger.py
@@ -513,7 +513,25 @@ class TestImportEndToEnd:
 
         # Separate CPU and GPU node pools are created with independent state
         # files and instance types (K8S06), each validated by its own check.
-        steps_by_name = {s["name"]: s for s in result["commands"]["kubernetes"]["steps"]}
+        steps = result["commands"]["kubernetes"]["steps"]
+        steps_by_name = {s["name"]: s for s in steps}
+        step_names = [step["name"] for step in steps]
+        assert "create_test_shared_vpc_cluster" in steps_by_name
+        assert "destroy_test_shared_vpc_cluster" in steps_by_name
+        assert (
+            step_names.index("setup")
+            < step_names.index("create_test_shared_vpc_cluster")
+            < step_names.index("create_test_node_pool")
+        )
+        assert (
+            step_names.index("destroy_test_gpu_node_pool")
+            < step_names.index("destroy_test_shared_vpc_cluster")
+            < step_names.index("teardown")
+        )
+        assert steps_by_name["create_test_shared_vpc_cluster"]["output_schema"] == "multi_cluster"
+        assert steps_by_name["create_test_shared_vpc_cluster"]["requires_available_validations"] == [
+            "K8sMultiClusterSameVpcCheck"
+        ]
         cpu_create = steps_by_name["create_test_node_pool"]["env"]
         gpu_create = steps_by_name["create_test_gpu_node_pool"]["env"]
         assert cpu_create["NODE_POOL_STATE_FILE"] != gpu_create["NODE_POOL_STATE_FILE"]
@@ -527,6 +545,8 @@ class TestImportEndToEnd:
         node_pool_checks = validations["k8s_node_pools"]
         checked_steps = {next(iter(entry.values()))["step"] for entry in node_pool_checks}
         assert {"create_test_node_pool", "create_test_gpu_node_pool", "update_test_node_pool"} <= checked_steps
+        multi_cluster_check = validations["k8s_multi_cluster"]["checks"]["K8sMultiClusterSameVpcCheck"]
+        assert multi_cluster_check["step"] == "create_test_shared_vpc_cluster"
 
         config = RunConfig.model_validate(result)
         context = Context(config)

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -177,6 +177,69 @@ EOF
         assert result.inventory is not None
         assert "setup_cluster" in result.inventory
 
+    def test_unavailable_validation_gate_skips_setup_step(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Steps gated on unreleased validations must not execute by default."""
+        monkeypatch.setattr("isvctl.orchestrator.loop.load_released_test_filter", lambda: {"ReleasedCheck"})
+        config = RunConfig(
+            commands={
+                "kubernetes": PlatformCommands(
+                    steps=[
+                        StepConfig(
+                            name="unreleased_setup",
+                            command="false",
+                            phase="setup",
+                            requires_available_validations=["NewCheck"],
+                        ),
+                    ]
+                )
+            },
+            tests=ValidationConfig(platform="kubernetes"),
+        )
+
+        result = Orchestrator(config).run(phases=[Phase.SETUP])
+
+        assert result.success
+        assert result.phases[0].details
+        step = result.phases[0].details["steps"][0]
+        assert step["name"] == "unreleased_setup"
+        assert step["error"] == "Step skipped"
+        assert result.inventory is not None
+        assert "unreleased_setup" not in result.inventory
+
+    def test_validation_gate_allows_step_when_unreleased_checks_are_included(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The same gate opens when the release filter is disabled."""
+        monkeypatch.setattr("isvctl.orchestrator.loop.load_released_test_filter", lambda: None)
+        script_path = _write_script(
+            tmp_path,
+            "setup.sh",
+            '#!/bin/bash\necho \'{"success": true, "platform": "kubernetes"}\'\n',
+        )
+        config = RunConfig(
+            commands={
+                "kubernetes": PlatformCommands(
+                    steps=[
+                        StepConfig(
+                            name="unreleased_setup",
+                            command=script_path,
+                            phase="setup",
+                            requires_available_validations=["NewCheck"],
+                        ),
+                    ]
+                )
+            },
+            tests=ValidationConfig(platform="kubernetes"),
+        )
+
+        result = Orchestrator(config).run(phases=[Phase.SETUP])
+
+        assert result.success
+        assert result.inventory is not None
+        assert "unreleased_setup" in result.inventory
+
     def test_run_setup_phase_command_failure(self) -> None:
         """Test setup phase with command failure."""
         config = RunConfig(

--- a/isvctl/tests/test_schema.py
+++ b/isvctl/tests/test_schema.py
@@ -15,6 +15,7 @@
 
 """Tests for Pydantic schema models and output schema registry."""
 
+import copy
 from typing import Any, ClassVar
 
 import pytest
@@ -305,6 +306,7 @@ class TestOutputSchemaMapping:
             ("provision_cluster", "cluster"),
             ("create_cluster", "cluster"),
             ("create_network", "network"),
+            ("create_test_shared_vpc_cluster", "multi_cluster"),
             ("launch_instance", "instance"),
             ("teardown", "teardown"),
             ("create_access_key", "access_key"),
@@ -380,6 +382,31 @@ class TestOutputSchemaValidation:
         },
     }
 
+    MULTI_CLUSTER_OUTPUT: ClassVar[dict[str, Any]] = {
+        "success": True,
+        "platform": "kubernetes",
+        "test_id": "K8S26-01",
+        "tenancy_id": "123456789012",
+        "network_id": "vpc-123",
+        "clusters": [
+            {
+                "name": "isvtest-eks-dev",
+                "role": "primary",
+                "tenancy_id": "123456789012",
+                "network_id": "vpc-123",
+                "status": "ACTIVE",
+            },
+            {
+                "name": "isvtest-eks-dev-shared-vpc",
+                "role": "secondary",
+                "tenancy_id": "123456789012",
+                "network_id": "vpc-123",
+                "status": "ACTIVE",
+                "ready_node_count": 1,
+            },
+        ],
+    }
+
     @staticmethod
     def _backend_switch_fabric_output() -> dict[str, Any]:
         """Return a backend switch fabric schema payload.
@@ -449,6 +476,21 @@ class TestOutputSchemaValidation:
         """EKS setup.sh output has top-level node_count and must pass cluster schema."""
         is_valid, errors = validate_output(self.EKS_SETUP_OUTPUT, "cluster")
         assert is_valid, f"EKS output failed 'cluster' schema: {errors}"
+
+    def test_multi_cluster_output_passes_schema(self) -> None:
+        """K8S26-01 shared-VPC cluster output must pass the multi_cluster schema."""
+        is_valid, errors = validate_output(self.MULTI_CLUSTER_OUTPUT, "multi_cluster")
+        assert is_valid, f"Multi-cluster output failed 'multi_cluster' schema: {errors}"
+
+    def test_multi_cluster_output_passes_without_cluster_roles(self) -> None:
+        """K8S26-01 proves cluster coexistence without requiring role labels."""
+        output = copy.deepcopy(self.MULTI_CLUSTER_OUTPUT)
+        for cluster in output["clusters"]:
+            cluster.pop("role")
+
+        is_valid, errors = validate_output(output, "multi_cluster")
+
+        assert is_valid, f"Multi-cluster output without roles failed 'multi_cluster' schema: {errors}"
 
     @pytest.mark.parametrize(
         "field_name",

--- a/isvtest/src/isvtest/validations/k8s_multi_cluster.py
+++ b/isvtest/src/isvtest/validations/k8s_multi_cluster.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Multi-cluster Kubernetes checks over provider step output."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from numbers import Integral, Rational
+from typing import Any, ClassVar
+
+from isvtest.core.validation import BaseValidation
+
+
+class K8sMultiClusterSameVpcCheck(BaseValidation):
+    """Verify two or more Kubernetes clusters coexist in one tenancy and VPC.
+
+    The validation is intentionally provider-neutral and reads only
+    ``step_output``. Provider scripts must emit the tenancy/account ID, shared
+    VPC/network ID, and a ``clusters`` array with each cluster's name,
+    tenancy, network, status, and optional role/Ready-node metadata.
+    """
+
+    description: ClassVar[str] = "Verify multiple Kubernetes clusters share the same tenancy and VPC."
+    labels: ClassVar[tuple[str, ...]] = ("kubernetes",)
+
+    def run(self) -> None:
+        """Validate the multi-cluster proof emitted by the bound setup step."""
+        step_output = self.config.get("step_output")
+        if not isinstance(step_output, dict):
+            self.set_failed("Missing step_output for multi-cluster validation")
+            return
+
+        if step_output.get("success") is False:
+            self.set_failed(str(step_output.get("error") or step_output.get("message") or "Step reported failure"))
+            return
+
+        tenancy_id = _required_string(step_output.get("tenancy_id"), "tenancy_id")
+        if tenancy_id is None:
+            self.set_failed("Missing or empty tenancy_id in step output")
+            return
+        network_id = _required_string(step_output.get("network_id"), "network_id")
+        if network_id is None:
+            self.set_failed("Missing or empty network_id in step output")
+            return
+
+        clusters = step_output.get("clusters")
+        if not isinstance(clusters, list):
+            self.set_failed("Missing or invalid clusters list in step output")
+            return
+        if len(clusters) < 2:
+            self.set_failed(f"Expected at least 2 clusters, got {len(clusters)}")
+            return
+
+        parsed_clusters: list[dict[str, Any]] = []
+        seen_names: set[str] = set()
+        tenancy_ids: set[str] = set()
+        network_ids: set[str] = set()
+        inactive: list[str] = []
+
+        for index, cluster in enumerate(clusters):
+            if not isinstance(cluster, dict):
+                self.set_failed(f"Cluster entry {index} must be an object")
+                return
+
+            name = _required_string(cluster.get("name"), f"clusters[{index}].name")
+            if name is None:
+                self.set_failed(f"Cluster entry {index} missing name")
+                return
+            if name in seen_names:
+                self.set_failed(f"Duplicate cluster name: {name}")
+                return
+            seen_names.add(name)
+
+            cluster_tenancy = _required_string(cluster.get("tenancy_id"), f"{name}.tenancy_id")
+            if cluster_tenancy is None:
+                self.set_failed(f"Cluster {name} missing tenancy_id")
+                return
+            cluster_network = _required_string(cluster.get("network_id"), f"{name}.network_id")
+            if cluster_network is None:
+                self.set_failed(f"Cluster {name} missing network_id")
+                return
+
+            tenancy_ids.add(cluster_tenancy)
+            network_ids.add(cluster_network)
+
+            status = str(cluster.get("status") or "").strip().upper()
+            if status != "ACTIVE":
+                inactive.append(f"{name}={status or '<missing>'}")
+
+            parsed_clusters.append(cluster)
+
+        if tenancy_ids != {tenancy_id}:
+            self.set_failed(f"Mixed tenancy IDs: top-level {tenancy_id}, clusters {sorted(tenancy_ids)}")
+            return
+        if network_ids != {network_id}:
+            self.set_failed(f"Mixed network IDs: top-level {network_id}, clusters {sorted(network_ids)}")
+            return
+        if inactive:
+            self.set_failed(f"Cluster(s) not ACTIVE: {', '.join(inactive)}")
+            return
+
+        ready_counts: list[int] = []
+        for cluster in parsed_clusters:
+            if "ready_node_count" not in cluster:
+                continue
+            name = str(cluster.get("name"))
+            ready_node_count = _non_negative_int(cluster.get("ready_node_count"), f"{name}.ready_node_count")
+            if ready_node_count is None:
+                self.set_failed(f"Cluster {name} has invalid ready_node_count")
+                return
+            if ready_node_count < 1:
+                self.set_failed(f"Cluster {name} has no Ready node")
+                return
+            ready_counts.append(ready_node_count)
+
+        ready_message = f"; Ready nodes reported: {sum(ready_counts)}" if ready_counts else ""
+        self.set_passed(
+            f"{len(parsed_clusters)} cluster(s) ACTIVE in tenancy {tenancy_id} and VPC {network_id}{ready_message}"
+        )
+
+
+def _required_string(value: Any, _field: str) -> str | None:
+    """Return a stripped non-empty string, or ``None`` when missing/invalid."""
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _non_negative_int(value: Any, _field: str) -> int | None:
+    """Return a non-negative integer, rejecting bools and non-integral values."""
+    if isinstance(value, bool):
+        return None
+
+    if isinstance(value, Integral):
+        parsed = int(value)
+    elif isinstance(value, float):
+        if not value.is_integer():
+            return None
+        parsed = int(value)
+    elif isinstance(value, Decimal):
+        if not value.is_finite() or value != value.to_integral_value():
+            return None
+        parsed = int(value)
+    elif isinstance(value, Rational):
+        if value.denominator != 1:
+            return None
+        parsed = int(value)
+    elif isinstance(value, str):
+        stripped = value.strip()
+        signless = stripped[1:] if stripped.startswith(("+", "-")) else stripped
+        if not signless.isdecimal():
+            return None
+        parsed = int(stripped)
+    else:
+        return None
+
+    if parsed < 0:
+        return None
+    return parsed

--- a/isvtest/tests/test_k8s_multi_cluster.py
+++ b/isvtest/tests/test_k8s_multi_cluster.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for multi-cluster Kubernetes step-output validation."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+from isvtest.validations.k8s_multi_cluster import K8sMultiClusterSameVpcCheck
+
+
+def _valid_output() -> dict[str, Any]:
+    """Return a valid K8S26-01 multi-cluster step output."""
+    return {
+        "success": True,
+        "platform": "kubernetes",
+        "test_id": "K8S26-01",
+        "tenancy_id": "123456789012",
+        "network_id": "vpc-123",
+        "clusters": [
+            {
+                "name": "isvtest-eks-dev",
+                "role": "primary",
+                "tenancy_id": "123456789012",
+                "network_id": "vpc-123",
+                "status": "ACTIVE",
+            },
+            {
+                "name": "isvtest-eks-dev-shared-vpc",
+                "role": "secondary",
+                "tenancy_id": "123456789012",
+                "network_id": "vpc-123",
+                "status": "ACTIVE",
+                "ready_node_count": 1,
+            },
+        ],
+    }
+
+
+def _run_check(step_output: dict[str, Any]) -> K8sMultiClusterSameVpcCheck:
+    """Run the validation against ``step_output`` and return the check object."""
+    check = K8sMultiClusterSameVpcCheck(config={"step_output": step_output})
+    check.run()
+    return check
+
+
+def test_passes_for_two_active_clusters_in_same_tenancy_and_vpc() -> None:
+    """Two distinct active clusters in one tenancy/VPC pass."""
+    check = _run_check(_valid_output())
+
+    assert check.passed, check.message
+    assert "2 cluster(s)" in check.message
+    assert "vpc-123" in check.message
+
+
+def test_fails_when_tenancy_id_is_missing() -> None:
+    """The step output must prove tenancy/account identity."""
+    output = _valid_output()
+    output.pop("tenancy_id")
+
+    check = _run_check(output)
+
+    assert not check.passed
+    assert "tenancy_id" in check.message
+
+
+def test_fails_when_network_id_is_missing() -> None:
+    """The step output must prove the shared VPC/network ID."""
+    output = _valid_output()
+    output.pop("network_id")
+
+    check = _run_check(output)
+
+    assert not check.passed
+    assert "network_id" in check.message
+
+
+def test_fails_with_fewer_than_two_clusters() -> None:
+    """K8S26-01 requires at least two clusters."""
+    output = _valid_output()
+    output["clusters"] = output["clusters"][:1]
+
+    check = _run_check(output)
+
+    assert not check.passed
+    assert "at least 2 clusters" in check.message
+
+
+def test_fails_with_duplicate_cluster_names() -> None:
+    """Cluster names must be distinct."""
+    output = _valid_output()
+    output["clusters"][1]["name"] = output["clusters"][0]["name"]
+
+    check = _run_check(output)
+
+    assert not check.passed
+    assert "Duplicate cluster name" in check.message
+
+
+def test_fails_when_any_cluster_is_not_active() -> None:
+    """Every reported cluster must be ACTIVE."""
+    output = _valid_output()
+    output["clusters"][1]["status"] = "CREATING"
+
+    check = _run_check(output)
+
+    assert not check.passed
+    assert "not ACTIVE" in check.message
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    [
+        ("tenancy_id", "999999999999", "Mixed tenancy IDs"),
+        ("network_id", "vpc-456", "Mixed network IDs"),
+    ],
+)
+def test_fails_when_cluster_identity_fields_do_not_match_top_level(
+    field: str,
+    value: str,
+    expected: str,
+) -> None:
+    """Cluster-level tenancy/VPC fields must agree with the top-level proof."""
+    output = _valid_output()
+    output["clusters"][1][field] = value
+
+    check = _run_check(output)
+
+    assert not check.passed
+    assert expected in check.message
+
+
+def test_fails_when_secondary_cluster_has_no_ready_nodes() -> None:
+    """The secondary cluster must have at least one Ready node."""
+    output = _valid_output()
+    output["clusters"][1]["ready_node_count"] = 0
+
+    check = _run_check(output)
+
+    assert not check.passed
+    assert "Cluster" in check.message
+    assert "Ready node" in check.message
+
+
+@pytest.mark.parametrize("ready_node_count", [1.5, "1.5"])
+def test_fails_when_secondary_cluster_has_fractional_ready_nodes(ready_node_count: float | str) -> None:
+    """The secondary cluster ready-node count must be integral."""
+    output = _valid_output()
+    output["clusters"][1]["ready_node_count"] = ready_node_count
+
+    check = _run_check(output)
+
+    assert not check.passed
+    assert "ready_node_count" in check.message
+
+
+def test_passes_when_no_secondary_cluster_is_reported() -> None:
+    """K8S26 proves two clusters share a VPC regardless of role labels."""
+    output = deepcopy(_valid_output())
+    output["clusters"][1]["role"] = "primary"
+
+    check = _run_check(output)
+
+    assert check.passed, check.message


### PR DESCRIPTION
## Summary

- Adds `K8sMultiClusterSameVpcCheck`, a provider-neutral Kubernetes validation that proves two or more clusters are ACTIVE in the same tenancy/account and VPC/network, with optional Ready-node evidence.
- Extends the AWS EKS provider config with a secondary shared-VPC cluster setup/teardown path, backed by isolated Terraform state and a dedicated Terraform module/script pair.
- Wires the new `multi_cluster` output schema and release-filter gating so the shared-VPC setup step only runs when `K8sMultiClusterSameVpcCheck` is available, and adds coverage for config schema, merger behavior, orchestrator filtering, scripts, and validation behavior.

Closes #277

## Verification

- [x] `make test` -- 918 package tests + 68 script tests passed
- [x] `make lint`
- [x] `make demo-test`
- [x] `uvx pre-commit run -a`
- [x] `git diff --check origin/main...HEAD`
- [x] Tested live on AWS EKS `ISVTEST_INCLUDE_UNRELEASED=1 uv run isvctl test run \
    -f isvctl/configs/providers/aws/config/eks.yaml \
    --no-upload \
    --verbose \
    -- \
    -s -v -k K8sMultiClusterSameVpcCheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enables testing of multi-cluster Kubernetes deployments in AWS EKS environments
  * New validation to verify multiple clusters operate correctly and share the same VPC network
  * Enhanced test provisioning for secondary EKS cluster configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->