### PR TITLE
feat(security): add CAP04 capacity checks

### DIFF
--- a/isvctl/configs/providers/aws/config/security.yaml
+++ b/isvctl/configs/providers/aws/config/security.yaml
@@ -43,6 +43,8 @@
 #  15. OIDC User Auth          - Probe configured OIDC-protected platform endpoint (SEC01-01)
 #  16. Short-Lived Credentials - Verify STS issues node + workload creds with bounded TTL (SEC02-01)
 #  17. Tenant Isolation        - Verify hard tenant isolation across network, data, compute and storage (SEC11-01)
+#  18. Capacity Grouping       - Verify reservations are grouped and tenant-pinned (CAP04-01)
+#  19. Topology Block          - Verify topology block atomic allocation boundaries (CAP04-02)
 #
 # Note: SEC12-* (BMC) tests cannot be fully validated on AWS because the
 # Nitro/hypervisor BMC plane is provider-hidden. The references inspect the
@@ -262,6 +264,102 @@ commands:
         args: ["--region", "{{region}}"]
         timeout: 600
 
+      # CAP04-01: Capacity reservation grouping and tenant pinning.
+      - name: capacity_reservation_grouping
+        phase: test
+        command: "python3 ../scripts/capacity/reservation_grouping.py"
+        requires_available_validations:
+          - CapacityReservationGroupingCheck
+        args:
+          - "--region"
+          - "{{region}}"
+          - "--instance-type"
+          - "{{capacity_instance_type}}"
+          - "--availability-zone={{capacity_availability_zone}}"
+          - "--resource-group-name"
+          - "{{capacity_resource_group_name}}"
+          - "--reservation-count"
+          - "{{capacity_reservation_count}}"
+        timeout: 300
+
+      # CAP04-02: Topology block atomic allocation.
+      - name: topology_block_atomic_allocation
+        phase: test
+        command: "python3 ../scripts/capacity/topology_block_atomic_allocation.py"
+        requires_available_validations:
+          - CapacityTopologyBlockAtomicAllocationCheck
+        args:
+          - "--region"
+          - "{{region}}"
+          - "--tenant-id={{tenant_id}}"
+          - "--topology-block-id"
+          - "{{topology_block_id}}"
+          - "--instance-type"
+          - "{{capacity_instance_type}}"
+          - "--instance-platform"
+          - "{{instance_platform}}"
+          - "--availability-zone={{topology_availability_zone}}"
+          - "--placement-group"
+          - "{{placement_group}}"
+          - "--requested-nodes"
+          - "{{requested_compute}}"
+          - "--requested-network"
+          - "{{requested_network}}"
+          - "--requested-storage"
+          - "{{requested_storage}}"
+          - "{{topology_skip_destroy_flag}}"
+        timeout: 1800
+
+      # Sweep CAP04-02 topology block resources (instances, reservation,
+      # placement group) tagged for this block. The in-run step self-cleans in
+      # its finally block; this teardown step reclaims resources left behind
+      # when AWS_CAPACITY_SKIP_DESTROY=true (a no-op while that flag is set, so
+      # a later standalone `--phase teardown` without it does the cleanup).
+      - name: topology_block_teardown
+        phase: teardown
+        command: "python3 ../scripts/capacity/topology_block_atomic_allocation.py"
+        requires_available_validations:
+          - CapacityTopologyBlockAtomicAllocationCheck
+        args:
+          - "--teardown"
+          - "--region"
+          - "{{region}}"
+          - "--topology-block-id"
+          - "{{topology_block_id}}"
+          - "--instance-type"
+          - "{{capacity_instance_type}}"
+          - "--availability-zone={{topology_availability_zone}}"
+          - "--placement-group"
+          - "{{placement_group}}"
+          - "--requested-nodes"
+          - "{{requested_compute}}"
+          - "--requested-network"
+          - "{{requested_network}}"
+          - "--requested-storage"
+          - "{{requested_storage}}"
+          - "{{topology_skip_destroy_flag}}"
+        timeout: 600
+
+      # Cancel CAP04-01 reservations and delete the Resource Group only when
+      # this run created it. AWS_CAPACITY_SKIP_DESTROY=true makes this a no-op
+      # so resources can be inspected and torn down later.
+      - name: capacity_teardown
+        phase: teardown
+        command: "python3 ../scripts/capacity/reservation_grouping.py"
+        requires_available_validations:
+          - CapacityReservationGroupingCheck
+        args:
+          - "--teardown"
+          - "--region"
+          - "{{region}}"
+          - "--resource-group-name"
+          - "{{capacity_resource_group_name}}"
+          - "--created-reservation-id={{ steps.capacity_reservation_grouping.created_reservation_id | default('', true) }}"
+          - "{{ steps.capacity_reservation_grouping.reservation_created | default(false) | ternary('--reservation-created', '') }}"
+          - "{{ steps.capacity_reservation_grouping.resource_group_created | default(false) | ternary('--delete-group', '') }}"
+          - "{{capacity_skip_destroy_flag}}"
+        timeout: 300
+
       # Teardown: Safety-net sweep for leftover IAM users + SEC11 fixture.
       # 300s budget covers worst-case instance-terminated waiter
       # (5s delay * 60 attempts) plus VPC dependency unwinding when a
@@ -278,6 +376,20 @@ tests:
 
   settings:
     region: "us-west-2"
+    tenant_id: "{{env.AWS_ACCOUNT_ID | default('', true)}}"
+    topology_block_id: "aws-cap04-block"
+    capacity_instance_type: "m6i.large"
+    instance_platform: "Linux/UNIX"
+    capacity_availability_zone: ""
+    topology_availability_zone: "{{env.AWS_AVAILABILITY_ZONE | default('', true)}}"
+    placement_group: "aws-cap04-block-pg"
+    capacity_resource_group_name: "isv-capacity-cap04"
+    capacity_reservation_count: 1
+    requested_compute: 2
+    requested_network: 1
+    requested_storage: 0
+    capacity_skip_destroy_flag: "{{(env.AWS_CAPACITY_SKIP_DESTROY == 'true') | ternary('--skip-destroy', '')}}"
+    topology_skip_destroy_flag: "{{(env.AWS_CAPACITY_SKIP_DESTROY == 'true') | ternary('--skip-destroy', '')}}"
     oidc_issuer_url: "{{env.OIDC_ISSUER_URL | default('', true)}}"
     oidc_audience: "{{env.OIDC_AUDIENCE | default('', true)}}"
     oidc_target_url: "{{env.OIDC_TARGET_URL | default('', true)}}"

--- a/isvctl/configs/providers/aws/scripts/capacity/reservation_grouping.py
+++ b/isvctl/configs/providers/aws/scripts/capacity/reservation_grouping.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verify AWS capacity can be grouped and pinned to one account.
+
+The script creates an EC2 Capacity Reservation with targeted matching and tags
+it into an AWS Resource Group. It emits the provider-neutral capacity
+reservation JSON contract consumed by ``CapacityReservationGroupingCheck``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import boto3
+from botocore.exceptions import ClientError
+from common.ec2 import candidate_availability_zones
+from common.errors import classify_aws_error, delete_with_retry, handle_aws_errors
+
+CAP_GROUP_TAG = "isv-capacity-group"
+CAP_PURPOSE_TAG = "CAP"
+CAPACITY_SHORTAGE_CODES = frozenset({"InsufficientInstanceCapacity"})
+
+
+def _tag_specifications(group_name: str, account_id: str) -> list[dict[str, Any]]:
+    """Build capacity reservation tags used for stable resource grouping."""
+    return [
+        {
+            "ResourceType": "capacity-reservation",
+            "Tags": [
+                {"Key": "Name", "Value": group_name},
+                {"Key": "CreatedBy", "Value": "isvtest"},
+                {"Key": CAP_PURPOSE_TAG, "Value": "capacity-reservation-grouping"},
+                {"Key": CAP_GROUP_TAG, "Value": group_name},
+                {"Key": "isv-account-id", "Value": account_id},
+            ],
+        }
+    ]
+
+
+def _resource_group_query(group_name: str) -> dict[str, str]:
+    """Build a Resource Groups tag query for CAP-tagged reservations."""
+    return {
+        "Type": "TAG_FILTERS_1_0",
+        "Query": json.dumps(
+            {
+                "ResourceTypeFilters": ["AWS::EC2::CapacityReservation"],
+                "TagFilters": [
+                    {"Key": "CreatedBy", "Values": ["isvtest"]},
+                    {"Key": CAP_GROUP_TAG, "Values": [group_name]},
+                ],
+            }
+        ),
+    }
+
+
+def _is_capacity_shortage(error: Exception) -> bool:
+    """Return whether an AWS error indicates no allocatable capacity in an AZ."""
+    if not isinstance(error, ClientError):
+        return False
+    return str(error.response.get("Error", {}).get("Code", "")) in CAPACITY_SHORTAGE_CODES
+
+
+def _ensure_resource_group(resource_groups: Any, group_name: str) -> tuple[str, bool]:
+    """Create or resolve the Resource Group used to group CAP resources.
+
+    Returns the group ARN and whether this call created it. A pre-existing group
+    is resolved rather than created, so callers can avoid deleting a group they
+    did not create during cleanup.
+    """
+    try:
+        response = resource_groups.create_group(
+            Name=group_name,
+            Description="ISV capacity reservation grouping validation",
+            ResourceQuery=_resource_group_query(group_name),
+            Tags={"CreatedBy": "isvtest", "purpose": "capacity-reservation-grouping"},
+        )
+        return str(response["Group"]["GroupArn"]), True
+    except ClientError as error:
+        code = error.response.get("Error", {}).get("Code", "")
+        message = error.response.get("Error", {}).get("Message", "")
+        if code == "BadRequestException" and "exist" in message.lower():
+            response = resource_groups.get_group(GroupName=group_name)
+            return str(response["Group"]["GroupArn"]), False
+        raise
+
+
+def _create_capacity_reservation(
+    ec2: Any,
+    *,
+    instance_type: str,
+    availability_zone: str,
+    reservation_count: int,
+    group_name: str,
+    account_id: str,
+) -> dict[str, Any]:
+    """Create a targeted EC2 Capacity Reservation for the requested instance type."""
+    response = ec2.create_capacity_reservation(
+        InstanceType=instance_type,
+        InstancePlatform="Linux/UNIX",
+        AvailabilityZone=availability_zone,
+        InstanceCount=reservation_count,
+        InstanceMatchCriteria="targeted",
+        TagSpecifications=_tag_specifications(group_name, account_id),
+    )
+    return dict(response["CapacityReservation"])
+
+
+def _describe_capacity_reservation(ec2: Any, reservation_id: str) -> dict[str, Any]:
+    """Describe an existing capacity reservation."""
+    response = ec2.describe_capacity_reservations(CapacityReservationIds=[reservation_id])
+    reservations = response.get("CapacityReservations", [])
+    if not reservations:
+        raise RuntimeError(f"Capacity reservation {reservation_id} was not found")
+    return dict(reservations[0])
+
+
+def _contract_from_reservation(reservation: dict[str, Any], account_id: str) -> dict[str, Any]:
+    """Build the provider-neutral capacity reservation grouping contract."""
+    reservation_id = str(reservation.get("CapacityReservationId") or "")
+    owner_id = str(reservation.get("OwnerId") or "")
+    instance_type = str(reservation.get("InstanceType") or "")
+    pinned = reservation.get("InstanceMatchCriteria") == "targeted"
+
+    resources: list[dict[str, Any]] = []
+    if reservation_id:
+        resources.append(
+            {
+                "resource_id": reservation_id,
+                "resource_type": "compute",
+                "account_id": owner_id,
+                "pinned": pinned,
+            }
+        )
+    if instance_type:
+        resources.append(
+            {
+                "resource_id": instance_type,
+                "resource_type": "instance_type",
+                "account_id": owner_id,
+                "pinned": pinned,
+            }
+        )
+
+    isolation_enforced = bool(owner_id == account_id and resources and pinned)
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "aws",
+        "reservation_id": reservation_id,
+        "account_id": account_id,
+        "resources": resources,
+        "pinned": pinned,
+        "isolation_enforced": isolation_enforced,
+    }
+
+    if not reservation_id:
+        result["error"] = "AWS response did not include a capacity reservation id"
+    elif owner_id != account_id:
+        result["error"] = f"Capacity reservation owner account {owner_id!r} does not match caller {account_id!r}"
+    elif not pinned:
+        result["error"] = "Capacity reservation must use targeted matching"
+    else:
+        result["success"] = True
+    return result
+
+
+_INACTIVE_RESERVATION_STATES = frozenset({"cancelled", "expired", "failed"})
+
+
+def run(
+    *,
+    ec2: Any,
+    sts: Any,
+    resource_groups: Any,
+    region: str,
+    instance_type: str,
+    availability_zone: str,
+    resource_group_name: str,
+    reservation_count: int,
+    reservation_id: str = "",
+) -> dict[str, Any]:
+    """Create/inspect the capacity reservation and return the grouping contract.
+
+    Resource cleanup is handled by :func:`run_teardown` in the teardown phase,
+    not here, so a failed validation does not also trigger a destroy. The output
+    carries ``resource_group_created`` so the teardown step only deletes a group
+    this run created (a pre-existing group is preserved).
+    """
+    group_created = False
+    reservation_created = False
+    created_reservation_id = ""
+    try:
+        account_id = str(sts.get_caller_identity()["Account"])
+        candidate_azs = candidate_availability_zones(ec2, availability_zone, instance_type)
+        _, group_created = _ensure_resource_group(resource_groups, resource_group_name)
+
+        if not reservation_id:
+            last_capacity_error: Exception | None = None
+            for selected_az in candidate_azs:
+                try:
+                    created = _create_capacity_reservation(
+                        ec2,
+                        instance_type=instance_type,
+                        availability_zone=selected_az,
+                        reservation_count=reservation_count,
+                        group_name=resource_group_name,
+                        account_id=account_id,
+                    )
+                    break
+                except Exception as error:
+                    if availability_zone.strip() or not _is_capacity_shortage(error):
+                        raise
+                    last_capacity_error = error
+            else:
+                if last_capacity_error is not None:
+                    raise last_capacity_error
+                raise RuntimeError(f"No AWS availability zones offer {instance_type}")
+            reservation_id = str(created.get("CapacityReservationId") or "")
+            if not reservation_id:
+                raise RuntimeError("AWS response did not include a capacity reservation id")
+            reservation_created = True
+            created_reservation_id = reservation_id
+
+        # Read AWS's persisted reservation state rather than the create echo, so
+        # the grouping/pinning contract reflects what AWS actually stored.
+        reservation = _describe_capacity_reservation(ec2, reservation_id)
+        result = _contract_from_reservation(reservation, account_id)
+    except Exception as error:
+        error_type, error_message = classify_aws_error(error)
+        result = {
+            "success": False,
+            "platform": "aws",
+            "error_type": error_type,
+            "error": error_message,
+        }
+
+    # Surface teardown wiring on every path so the teardown step can clean up
+    # whatever was created, even after a validation failure.
+    result["resource_group_created"] = group_created
+    result["reservation_created"] = reservation_created
+    result["created_reservation_id"] = created_reservation_id
+    return result
+
+
+def run_teardown(
+    *,
+    ec2: Any,
+    resource_groups: Any,
+    resource_group_name: str,
+    delete_group: bool,
+    reservation_created: bool = False,
+    created_reservation_id: str = "",
+) -> dict[str, Any]:
+    """Cancel reservations tagged for this group and optionally delete the group.
+
+    Reservations are located by their CAP group tag. When ``created_reservation_id``
+    identifies the reservation this run created, cancellation is narrowed to it -
+    and a stale id without ``reservation_created`` is not enough to authorize it -
+    so an in-run teardown never cancels a reservation a concurrent run created
+    under the same group tag. When no created-reservation id is supplied (e.g. a
+    standalone ``--phase teardown`` after AWS_CAPACITY_SKIP_DESTROY, where the
+    setup step output is not in context), teardown falls back to cancelling every
+    reservation tagged for this group so deferred cleanup does not leak them.
+
+    The group is only deleted when ``delete_group`` is set (i.e. this run created
+    it), preserving a group that pre-existed.
+    """
+    errors: list[str] = []
+    try:
+        response = ec2.describe_capacity_reservations(
+            Filters=[{"Name": f"tag:{CAP_GROUP_TAG}", "Values": [resource_group_name]}]
+        )
+    except Exception as error:
+        errors.append(f"describe capacity reservations for {resource_group_name}: {error}")
+        response = {}
+
+    for reservation in response.get("CapacityReservations", []):
+        reservation_id = str(reservation.get("CapacityReservationId") or "")
+        state = str(reservation.get("State") or "")
+        if not reservation_id or state in _INACTIVE_RESERVATION_STATES:
+            continue
+        # Narrow to the reservation this run created when its id is known;
+        # otherwise (standalone teardown) sweep all reservations carrying the
+        # group tag rather than leaking them.
+        if created_reservation_id and (not reservation_created or reservation_id != created_reservation_id):
+            continue
+        if not delete_with_retry(
+            ec2.cancel_capacity_reservation,
+            CapacityReservationId=reservation_id,
+            resource_desc=f"capacity reservation {reservation_id}",
+        ):
+            errors.append(f"cancel capacity reservation {reservation_id}")
+
+    if delete_group and not delete_with_retry(
+        resource_groups.delete_group,
+        GroupName=resource_group_name,
+        resource_desc=f"resource group {resource_group_name}",
+    ):
+        errors.append(f"delete resource group {resource_group_name}")
+
+    result: dict[str, Any] = {"success": not errors, "platform": "aws"}
+    if errors:
+        result["cleanup_errors"] = errors
+        result["error"] = "Capacity reservation teardown failed"
+    return result
+
+
+@handle_aws_errors
+def main() -> int:
+    """Parse arguments, run the AWS capacity check, and print JSON."""
+    parser = argparse.ArgumentParser(description="Validate AWS capacity reservation grouping")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--instance-type", default="g4dn.metal")
+    parser.add_argument("--availability-zone", default="")
+    parser.add_argument("--resource-group-name", default="isv-capacity-cap04")
+    parser.add_argument("--reservation-count", type=int, default=1)
+    parser.add_argument(
+        "--reservation-id", default="", help="Inspect an existing capacity reservation instead of creating one"
+    )
+    parser.add_argument("--teardown", action="store_true", help="Cancel/delete resources from a prior run")
+    parser.add_argument("--delete-group", action="store_true", help="Delete the Resource Group during teardown")
+    parser.add_argument(
+        "--reservation-created", action="store_true", help="Allow cleanup of the setup-created reservation"
+    )
+    parser.add_argument("--created-reservation-id", default="", help="Only cancel the reservation created by setup")
+    parser.add_argument("--skip-destroy", action="store_true", help="No-op teardown; preserve created resources")
+    args = parser.parse_args()
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+    resource_groups = boto3.client("resource-groups", region_name=args.region)
+
+    if args.teardown:
+        if args.skip_destroy:
+            result: dict[str, Any] = {"success": True, "platform": "aws", "skipped": "AWS_CAPACITY_SKIP_DESTROY set"}
+        else:
+            result = run_teardown(
+                ec2=ec2,
+                resource_groups=resource_groups,
+                resource_group_name=args.resource_group_name,
+                delete_group=args.delete_group,
+                reservation_created=args.reservation_created,
+                created_reservation_id=args.created_reservation_id,
+            )
+    else:
+        result = run(
+            ec2=ec2,
+            sts=boto3.client("sts", region_name=args.region),
+            resource_groups=resource_groups,
+            region=args.region,
+            instance_type=args.instance_type,
+            availability_zone=args.availability_zone,
+            resource_group_name=args.resource_group_name,
+            reservation_count=args.reservation_count,
+            reservation_id=args.reservation_id,
+        )
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/aws/scripts/capacity/topology_block_atomic_allocation.py
+++ b/isvctl/configs/providers/aws/scripts/capacity/topology_block_atomic_allocation.py
@@ -1,0 +1,580 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS capacity reservation topology block atomic allocation reference implementation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import boto3
+from botocore.exceptions import ClientError
+from common.ec2 import candidate_availability_zones, get_ubuntu_ami
+from common.errors import TRANSIENT_AWS_CODES, classify_aws_error
+
+TEST_NAME = "topology_block_atomic_allocation"
+# Capacity-exhaustion codes the shared classifier does not model; everything
+# else delegates to ``classify_aws_error`` so this check shares the suite's
+# error vocabulary instead of inventing its own.
+CAPACITY_UNAVAILABLE_CODES = frozenset(
+    {
+        "InsufficientInstanceCapacity",
+        "InsufficientReservedInstanceCapacity",
+        "InstanceLimitExceeded",
+        "MaxSpotInstanceCountExceeded",
+    }
+)
+INSTANCE_ALREADY_GONE_CODES = frozenset({"InvalidInstanceID.NotFound"})
+CAPACITY_RESERVATION_ALREADY_GONE_CODES = frozenset({"InvalidCapacityReservationId.NotFound"})
+PLACEMENT_GROUP_ALREADY_GONE_CODES = frozenset({"InvalidPlacementGroup.Unknown"})
+PLACEMENT_GROUP_RETRYABLE_DELETE_CODES = TRANSIENT_AWS_CODES | frozenset(
+    {
+        "DependencyViolation",
+        "InvalidPlacementGroup.InUse",
+    }
+)
+PLACEMENT_GROUP_DELETE_ATTEMPTS = 10
+PLACEMENT_GROUP_DELETE_BACKOFF_SECONDS = 3.0
+# Reservation/instance states that need no teardown action.
+INACTIVE_RESERVATION_STATES = frozenset({"cancelled", "expired", "failed"})
+TERMINAL_INSTANCE_STATES = frozenset({"terminated"})
+
+
+def _positive_int(value: str) -> int:
+    """Parse a positive integer argparse value."""
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be >= 1")
+    return parsed
+
+
+def _non_negative_int(value: str) -> int:
+    """Parse a non-negative integer argparse value."""
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("value must be >= 0")
+    return parsed
+
+
+def _classify_error(exc: Exception) -> tuple[str, str]:
+    """Classify an error via the shared AWS classifier, flagging capacity exhaustion.
+
+    Reuses :func:`classify_aws_error` so this check reports the same
+    ``error_type`` vocabulary as the rest of the suite, and only adds the
+    capacity-specific ``capacity_unavailable`` type the shared helper does not
+    model.
+    """
+    if isinstance(exc, ClientError):
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in CAPACITY_UNAVAILABLE_CODES:
+            return "capacity_unavailable", classify_aws_error(exc)[1]
+    return classify_aws_error(exc)
+
+
+def _cleanup_call(
+    fn: Any,
+    *,
+    action: str,
+    gone_codes: frozenset[str] = frozenset(),
+    retry_codes: frozenset[str] = TRANSIENT_AWS_CODES,
+    attempts: int = 3,
+    backoff_seconds: float = 2.0,
+    **kwargs: Any,
+) -> str | None:
+    """Run one cleanup API call, retrying transient or eventually-consistent failures."""
+    for attempt in range(1, attempts + 1):
+        try:
+            fn(**kwargs)
+            return None
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if code in gone_codes:
+                return None
+            if code in retry_codes and attempt < attempts:
+                time.sleep(backoff_seconds * attempt)
+                continue
+            return f"{action}: {classify_aws_error(exc)[1]}"
+        except Exception as exc:
+            return f"{action}: {type(exc).__name__}: {exc}"
+
+
+def _failure(error: str, *, error_type: str) -> dict[str, Any]:
+    """Build a concise failure payload."""
+    return {
+        "success": False,
+        "platform": "aws",
+        "test_name": TEST_NAME,
+        "error_type": error_type,
+        "error": error,
+    }
+
+
+def _validate_supported_resource_counts(args: argparse.Namespace) -> None:
+    """Reject AWS resource counts this reference implementation cannot model."""
+    if args.requested_network > 1:
+        raise ValueError("requested_network must be 0 or 1 for AWS topology block allocations")
+    if args.requested_storage != 0:
+        raise ValueError("requested_storage must be 0 for AWS topology block allocations")
+
+
+def _is_capacity_unavailable(error: Exception) -> bool:
+    """Return whether an AWS error indicates no allocatable capacity in this AZ."""
+    if not isinstance(error, ClientError):
+        return False
+    return str(error.response.get("Error", {}).get("Code", "")) in CAPACITY_UNAVAILABLE_CODES
+
+
+def _instance_owner_account(instance: dict[str, Any]) -> str | None:
+    """Return the OwnerAccount tag an instance was launched with, if present."""
+    for tag in instance.get("Tags", []):
+        if tag.get("Key") == "OwnerAccount":
+            return tag.get("Value")
+    return None
+
+
+def _tags(args: argparse.Namespace, account_id: str) -> list[dict[str, str]]:
+    """Return common AWS resource tags for CAP resources."""
+    return [
+        {"Key": "CreatedBy", "Value": "isvtest"},
+        {"Key": "TestName", "Value": TEST_NAME},
+        {"Key": "OwnerAccount", "Value": account_id},
+        {"Key": "TopologyBlock", "Value": args.topology_block_id},
+    ]
+
+
+def build_contract(
+    args: argparse.Namespace,
+    *,
+    account_id: str,
+    reservation_id: str,
+    instances: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build the provider-neutral capacity reservation contract from EC2 instance data."""
+    requested = {
+        "compute": args.requested_nodes,
+        "network": args.requested_network,
+        "storage": args.requested_storage,
+    }
+    full_compute_allocation = len(instances) == args.requested_nodes
+    allocated = {
+        "compute": len(instances),
+        "network": 1 if full_compute_allocation and args.requested_network > 0 else 0,
+        "storage": 0,
+    }
+    performance_domains = {
+        f"{instance.get('InstanceType', '')}/{instance.get('Placement', {}).get('AvailabilityZone', '')}/"
+        f"{instance.get('Placement', {}).get('GroupName', '')}"
+        for instance in instances
+    }
+    resources = [
+        {
+            "resource_id": instance.get("InstanceId", ""),
+            "resource_type": "compute",
+            "tenant_id": account_id,
+            "topology_block_id": args.topology_block_id,
+            "performance_domain": next(iter(performance_domains)) if len(performance_domains) == 1 else "mixed",
+            "isolation_boundary": account_id,
+        }
+        for instance in instances
+    ]
+    if allocated["network"]:
+        resources.append(
+            {
+                "resource_id": args.placement_group,
+                "resource_type": "network",
+                "tenant_id": account_id,
+                "topology_block_id": args.topology_block_id,
+                "performance_domain": next(iter(performance_domains)) if len(performance_domains) == 1 else "mixed",
+                "isolation_boundary": account_id,
+            }
+        )
+
+    allocated_as_unit = allocated == requested
+    homogeneous = len(performance_domains) == 1 and all(
+        instance.get("Placement", {}).get("GroupName") == args.placement_group for instance in instances
+    )
+    # Derive isolation from observed instance ownership rather than asserting it:
+    # every launched instance must carry the tenant's OwnerAccount tag, so a
+    # launch that lands outside the tenant boundary fails the contract instead
+    # of being silently reported as isolated.
+    owner_accounts = {_instance_owner_account(instance) for instance in instances}
+    isolation_enforced = bool(instances) and owner_accounts == {account_id}
+    success = allocated_as_unit and homogeneous and isolation_enforced
+    return {
+        "success": success,
+        "platform": "aws",
+        "test_name": TEST_NAME,
+        "topology_block": {
+            "block_id": args.topology_block_id,
+            "reservation_id": reservation_id,
+            "tenant_id": account_id,
+            "allocated_as_unit": allocated_as_unit,
+            "partial_allocation": not allocated_as_unit,
+            "homogeneous": homogeneous,
+            "isolation_enforced": isolation_enforced,
+            "requested": requested,
+            "allocated": allocated,
+            "resources": resources,
+        },
+    }
+
+
+def _terminate_instances(ec2: Any, instance_ids: list[str]) -> list[str]:
+    """Terminate instances (retrying transient throttling) and wait for drain."""
+    errors: list[str] = []
+    # Retry the terminate call on transient throttling so a single 429 does
+    # not leak instances; the waiter then blocks until they drain.
+    error = _cleanup_call(
+        ec2.terminate_instances,
+        action="terminate_instances",
+        gone_codes=INSTANCE_ALREADY_GONE_CODES,
+        InstanceIds=instance_ids,
+    )
+    if error:
+        errors.append(error)
+    else:
+        try:
+            ec2.get_waiter("instance_terminated").wait(InstanceIds=instance_ids)
+        except Exception as exc:
+            errors.append(f"instance_terminated waiter: {type(exc).__name__}: {exc}")
+    return errors
+
+
+def _cancel_reservation(ec2: Any, reservation_id: str) -> str | None:
+    """Cancel a capacity reservation, treating an already-gone id as success."""
+    return _cleanup_call(
+        ec2.cancel_capacity_reservation,
+        action="cancel_capacity_reservation",
+        gone_codes=CAPACITY_RESERVATION_ALREADY_GONE_CODES,
+        CapacityReservationId=reservation_id,
+    )
+
+
+def _delete_placement_group(ec2: Any, placement_group: str) -> str | None:
+    """Delete the cluster placement group, retrying while instances drain."""
+    return _cleanup_call(
+        ec2.delete_placement_group,
+        action="delete_placement_group",
+        gone_codes=PLACEMENT_GROUP_ALREADY_GONE_CODES,
+        retry_codes=PLACEMENT_GROUP_RETRYABLE_DELETE_CODES,
+        attempts=PLACEMENT_GROUP_DELETE_ATTEMPTS,
+        backoff_seconds=PLACEMENT_GROUP_DELETE_BACKOFF_SECONDS,
+        GroupName=placement_group,
+    )
+
+
+def cleanup(
+    ec2: Any,
+    *,
+    instance_ids: list[str],
+    reservation_id: str,
+    placement_group: str,
+) -> list[str]:
+    """Best-effort cleanup for capacity reservation AWS resources."""
+    errors: list[str] = []
+    if instance_ids:
+        errors.extend(_terminate_instances(ec2, instance_ids))
+    if reservation_id:
+        error = _cancel_reservation(ec2, reservation_id)
+        if error:
+            errors.append(error)
+    if placement_group:
+        error = _delete_placement_group(ec2, placement_group)
+        if error:
+            errors.append(error)
+    return errors
+
+
+def _block_tag_filters(topology_block_id: str) -> list[dict[str, Any]]:
+    """EC2 tag filters that select this run's CAP04 topology block resources."""
+    return [
+        {"Name": "tag:CreatedBy", "Values": ["isvtest"]},
+        {"Name": "tag:TestName", "Values": [TEST_NAME]},
+        {"Name": "tag:TopologyBlock", "Values": [topology_block_id]},
+    ]
+
+
+def _tagged_active_instance_ids(ec2: Any, topology_block_id: str) -> list[str]:
+    """Find non-terminated instances tagged for this topology block."""
+    described = ec2.describe_instances(Filters=_block_tag_filters(topology_block_id))
+    return [
+        instance["InstanceId"]
+        for reservation in described.get("Reservations", [])
+        for instance in reservation.get("Instances", [])
+        if instance.get("InstanceId") and instance.get("State", {}).get("Name") not in TERMINAL_INSTANCE_STATES
+    ]
+
+
+def _tagged_active_reservation_ids(ec2: Any, topology_block_id: str) -> list[str]:
+    """Find active capacity reservations tagged for this topology block."""
+    described = ec2.describe_capacity_reservations(Filters=_block_tag_filters(topology_block_id))
+    return [
+        reservation["CapacityReservationId"]
+        for reservation in described.get("CapacityReservations", [])
+        if reservation.get("CapacityReservationId") and reservation.get("State") not in INACTIVE_RESERVATION_STATES
+    ]
+
+
+def run_teardown(ec2: Any, *, topology_block_id: str, placement_group: str) -> dict[str, Any]:
+    """Sweep CAP04 topology resources tagged for this block (deferred cleanup).
+
+    Unlike the in-run ``finally`` cleanup - which deletes the exact ids this
+    process created - this path runs in a standalone ``--phase teardown`` after
+    AWS_CAPACITY_SKIP_DESTROY, where those ids are no longer in context. It
+    therefore locates instances and the reservation by their TopologyBlock tag
+    so the launched (and billable) resources are not leaked.
+    """
+    errors: list[str] = []
+    try:
+        instance_ids = _tagged_active_instance_ids(ec2, topology_block_id)
+    except Exception as exc:
+        errors.append(f"describe_instances for {topology_block_id}: {type(exc).__name__}: {exc}")
+        instance_ids = []
+    try:
+        reservation_ids = _tagged_active_reservation_ids(ec2, topology_block_id)
+    except Exception as exc:
+        errors.append(f"describe_capacity_reservations for {topology_block_id}: {type(exc).__name__}: {exc}")
+        reservation_ids = []
+
+    if instance_ids:
+        errors.extend(_terminate_instances(ec2, instance_ids))
+    for reservation_id in reservation_ids:
+        error = _cancel_reservation(ec2, reservation_id)
+        if error:
+            errors.append(error)
+    if placement_group:
+        error = _delete_placement_group(ec2, placement_group)
+        if error:
+            errors.append(error)
+
+    result: dict[str, Any] = {"success": not errors, "platform": "aws", "test_name": TEST_NAME}
+    if errors:
+        result["cleanup_errors"] = errors
+        result["error_type"] = "cleanup_failed"
+        result["error"] = "Topology block teardown failed"
+    return result
+
+
+def _create_placement_group(ec2: Any, args: argparse.Namespace, account_id: str) -> None:
+    """Create the cluster placement group used as the performance domain."""
+    ec2.create_placement_group(
+        GroupName=args.placement_group,
+        Strategy="cluster",
+        TagSpecifications=[
+            {
+                "ResourceType": "placement-group",
+                "Tags": _tags(args, account_id),
+            }
+        ],
+    )
+
+
+def _placement_group_arn(ec2: Any, placement_group: str) -> str:
+    """Resolve the ARN for an existing EC2 placement group."""
+    response = ec2.describe_placement_groups(GroupNames=[placement_group])
+    groups = response.get("PlacementGroups", [])
+    if not groups or not groups[0].get("GroupArn"):
+        raise RuntimeError(f"Could not resolve placement group ARN for {placement_group}")
+    return groups[0]["GroupArn"]
+
+
+def _create_capacity_reservation(ec2: Any, args: argparse.Namespace, account_id: str) -> str:
+    """Create a targeted EC2 Capacity Reservation."""
+    placement_group_arn = _placement_group_arn(ec2, args.placement_group)
+    response = ec2.create_capacity_reservation(
+        InstanceType=args.instance_type,
+        InstancePlatform=args.instance_platform,
+        AvailabilityZone=args.availability_zone,
+        PlacementGroupArn=placement_group_arn,
+        InstanceCount=args.requested_nodes,
+        InstanceMatchCriteria="targeted",
+        TagSpecifications=[
+            {
+                "ResourceType": "capacity-reservation",
+                "Tags": _tags(args, account_id),
+            }
+        ],
+    )
+    return response["CapacityReservation"]["CapacityReservationId"]
+
+
+def _create_capacity_reservation_in_available_az(
+    ec2: Any,
+    args: argparse.Namespace,
+    account_id: str,
+    candidate_azs: list[str],
+) -> str:
+    """Create the reservation, trying supported AZs after capacity shortages."""
+    last_capacity_error: Exception | None = None
+    for selected_az in candidate_azs:
+        args.availability_zone = selected_az
+        try:
+            return _create_capacity_reservation(ec2, args, account_id)
+        except Exception as error:
+            if len(candidate_azs) == 1 or not _is_capacity_unavailable(error):
+                raise
+            last_capacity_error = error
+
+    if last_capacity_error is not None:
+        raise last_capacity_error
+    raise RuntimeError(f"No AWS availability zones offer {args.instance_type}")
+
+
+def _launch_instances(
+    ec2: Any,
+    args: argparse.Namespace,
+    *,
+    account_id: str,
+    reservation_id: str,
+    launched_instance_ids: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Launch instances bound to the reservation and placement group."""
+    ami_id = args.ami_id or get_ubuntu_ami(ec2, args.instance_type)
+    if not ami_id:
+        raise RuntimeError(f"Could not find an AMI for {args.instance_type}")
+
+    response = ec2.run_instances(
+        ImageId=ami_id,
+        InstanceType=args.instance_type,
+        MinCount=args.requested_nodes,
+        MaxCount=args.requested_nodes,
+        CapacityReservationSpecification={
+            "CapacityReservationTarget": {
+                "CapacityReservationId": reservation_id,
+            }
+        },
+        Placement={
+            "AvailabilityZone": args.availability_zone,
+            "GroupName": args.placement_group,
+        },
+        TagSpecifications=[
+            {
+                "ResourceType": "instance",
+                "Tags": _tags(args, account_id),
+            }
+        ],
+    )
+    instance_ids = [instance["InstanceId"] for instance in response.get("Instances", [])]
+    if launched_instance_ids is not None:
+        launched_instance_ids.extend(instance_ids)
+    if not instance_ids:
+        return []
+
+    ec2.get_waiter("instance_running").wait(InstanceIds=instance_ids)
+    described = ec2.describe_instances(InstanceIds=instance_ids)
+    return [
+        instance
+        for reservation in described.get("Reservations", [])
+        for instance in reservation.get("Instances", [])
+        if instance.get("InstanceId") in instance_ids
+    ]
+
+
+def main() -> int:
+    """Run the AWS capacity reservation topology block atomic allocation check."""
+    parser = argparse.ArgumentParser(description="Validate AWS atomic topology block allocation")
+    parser.add_argument("--region", default=os.environ.get("AWS_REGION", "us-west-2"))
+    parser.add_argument("--tenant-id", default="", help="AWS account ID; resolved from STS when empty")
+    parser.add_argument("--topology-block-id", required=True, help="Provider-neutral topology block ID")
+    parser.add_argument("--instance-type", required=True, help="EC2 instance type")
+    parser.add_argument("--instance-platform", default="Linux/UNIX", help="EC2 Capacity Reservation platform")
+    parser.add_argument("--availability-zone", required=True, help="Availability zone for the reserved block")
+    parser.add_argument("--placement-group", required=True, help="Cluster placement group name")
+    parser.add_argument("--requested-nodes", type=_positive_int, required=True, help="Requested compute nodes")
+    parser.add_argument(
+        "--requested-network", type=_non_negative_int, required=True, help="Requested network resources"
+    )
+    parser.add_argument(
+        "--requested-storage", type=_non_negative_int, required=True, help="Requested storage resources"
+    )
+    parser.add_argument("--ami-id", default="", help="Optional AMI ID; auto-detected when omitted")
+    parser.add_argument("--skip-destroy", action="store_true", help="Leave AWS resources in place for debugging")
+    parser.add_argument(
+        "--teardown",
+        action="store_true",
+        help="Sweep resources tagged for this topology block instead of allocating",
+    )
+    args = parser.parse_args()
+
+    if args.teardown:
+        if args.skip_destroy:
+            result = {
+                "success": True,
+                "platform": "aws",
+                "test_name": TEST_NAME,
+                "skipped": "AWS_CAPACITY_SKIP_DESTROY set",
+            }
+        else:
+            ec2 = boto3.client("ec2", region_name=args.region)
+            result = run_teardown(ec2, topology_block_id=args.topology_block_id, placement_group=args.placement_group)
+        print(json.dumps(result, indent=2))
+        return 0 if result.get("success") is True else 1
+
+    ec2: Any | None = None
+    reservation_id = ""
+    placement_group = ""
+    instance_ids: list[str] = []
+    result: dict[str, Any]
+
+    try:
+        _validate_supported_resource_counts(args)
+        ec2 = boto3.client("ec2", region_name=args.region)
+        sts = boto3.client("sts", region_name=args.region)
+        account_id = args.tenant_id or sts.get_caller_identity()["Account"]
+        candidate_azs = candidate_availability_zones(ec2, args.availability_zone, args.instance_type)
+        _create_placement_group(ec2, args, account_id)
+        placement_group = args.placement_group
+        reservation_id = _create_capacity_reservation_in_available_az(ec2, args, account_id, candidate_azs)
+        instances = _launch_instances(
+            ec2,
+            args,
+            account_id=account_id,
+            reservation_id=reservation_id,
+            launched_instance_ids=instance_ids,
+        )
+        result = build_contract(args, account_id=account_id, reservation_id=reservation_id, instances=instances)
+    except Exception as exc:
+        error_type, error_message = _classify_error(exc)
+        result = _failure(error_message, error_type=error_type)
+    finally:
+        if not args.skip_destroy and ec2 is not None:
+            cleanup_errors = cleanup(
+                ec2,
+                instance_ids=instance_ids,
+                reservation_id=reservation_id,
+                placement_group=placement_group,
+            )
+            if cleanup_errors:
+                result["cleanup_errors"] = cleanup_errors
+                if result.get("success") is True:
+                    result["success"] = False
+                    result["error_type"] = "cleanup_failed"
+                    result["error"] = "Topology block cleanup failed"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result.get("success") is True else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/aws/scripts/common/ec2.py
+++ b/isvctl/configs/providers/aws/scripts/common/ec2.py
@@ -487,14 +487,18 @@ def get_ubuntu_ami(ec2: Any, instance_type: str) -> str | None:
         if architecture == "arm64"
         else "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
     )
-    response = ec2.describe_images(
-        Owners=["099720109477"],  # Canonical
-        Filters=[
-            {"Name": "name", "Values": [name_pattern]},
-            {"Name": "state", "Values": ["available"]},
-            {"Name": "architecture", "Values": [architecture]},
-        ],
-    )
+    try:
+        response = ec2.describe_images(
+            Owners=["099720109477"],  # Canonical
+            Filters=[
+                {"Name": "name", "Values": [name_pattern]},
+                {"Name": "state", "Values": ["available"]},
+                {"Name": "architecture", "Values": [architecture]},
+            ],
+        )
+    except ClientError as e:
+        print(f"Warning: Could not get Ubuntu AMI: {e}", file=sys.stderr)
+        return None
     images = sorted(response.get("Images", []), key=lambda image: image["CreationDate"], reverse=True)
     return images[0]["ImageId"] if images else None
 

--- a/isvctl/configs/providers/aws/scripts/common/ec2.py
+++ b/isvctl/configs/providers/aws/scripts/common/ec2.py
@@ -155,6 +155,33 @@ def get_supported_azs(ec2: Any, instance_type: str) -> set[str]:
         return set()
 
 
+def candidate_availability_zones(ec2: Any, availability_zone: str, instance_type: str) -> list[str]:
+    """Return the requested AZ, or all AZs offering the instance type when unpinned.
+
+    A non-empty ``availability_zone`` pins the result to that single zone. An
+    empty value falls back to every supported AZ (sorted) so callers can retry
+    across zones after a capacity shortage.
+
+    Args:
+        ec2: Boto3 EC2 client.
+        availability_zone: Requested AZ, or "" to auto-select supported zones.
+        instance_type: EC2 instance type the AZ must offer.
+
+    Returns:
+        Ordered list of candidate availability zones.
+
+    Raises:
+        RuntimeError: If no AZ offers the instance type when none was pinned.
+    """
+    if availability_zone.strip():
+        return [availability_zone.strip()]
+
+    supported = get_supported_azs(ec2, instance_type)
+    if not supported:
+        raise RuntimeError(f"No AWS availability zones offer {instance_type}")
+    return sorted(supported)
+
+
 def get_default_vpc_and_subnets(
     ec2: Any,
     instance_type: str,
@@ -440,6 +467,36 @@ def get_amazon_linux_ami(ec2: Any) -> str | None:
     except ClientError as e:
         print(f"Warning: Could not get Amazon Linux AMI: {e}", file=sys.stderr)
         return None
+
+
+def get_ubuntu_ami(ec2: Any, instance_type: str) -> str | None:
+    """Get the latest Canonical Ubuntu 22.04 (Jammy) AMI for an instance type.
+
+    Selects the AMI matching the instance type's architecture (x86_64 vs arm64).
+
+    Args:
+        ec2: Boto3 EC2 client.
+        instance_type: EC2 instance type (used to detect architecture).
+
+    Returns:
+        AMI ID or None if not found.
+    """
+    architecture = get_architecture_for_instance_type(instance_type)
+    name_pattern = (
+        "ubuntu/images/hvm-ssd-gp3/ubuntu-jammy-22.04-arm64-server-*"
+        if architecture == "arm64"
+        else "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
+    )
+    response = ec2.describe_images(
+        Owners=["099720109477"],  # Canonical
+        Filters=[
+            {"Name": "name", "Values": [name_pattern]},
+            {"Name": "state", "Values": ["available"]},
+            {"Name": "architecture", "Values": [architecture]},
+        ],
+    )
+    images = sorted(response.get("Images", []), key=lambda image: image["CreationDate"], reverse=True)
+    return images[0]["ImageId"] if images else None
 
 
 def get_architecture_for_instance_type(instance_type: str) -> str:

--- a/isvctl/configs/providers/my-isv/config/security.yaml
+++ b/isvctl/configs/providers/my-isv/config/security.yaml
@@ -40,6 +40,8 @@
 #   SEC08-01: Management API audit-log entry metadata (AuditLogEntryCheck)
 #   SEC08-02: Audit-log retention >= 30 days (AuditLogRetentionCheck)
 #   SEC11-01: Hard tenant isolation across network/data/compute/storage (TenantIsolationCheck)
+#   CAP04-01: Capacity reservation grouping and tenant pinning (CapacityReservationGroupingCheck)
+#   CAP04-02: Topology block atomic allocation (CapacityTopologyBlockAtomicAllocationCheck)
 #
 # Usage:
 #   uv run isvctl test run -f isvctl/configs/providers/my-isv/config/security.yaml
@@ -161,6 +163,38 @@ commands:
         args: ["--region", "{{region}}"]
         timeout: 60
 
+      - name: capacity_reservation_grouping
+        phase: test
+        command: "python ../scripts/capacity/reservation_grouping.py"
+        requires_available_validations:
+          - CapacityReservationGroupingCheck
+        args:
+          - "--account-id"
+          - "{{tenant_id}}"
+          - "--reservation-id"
+          - "{{reservation_id}}"
+          - "--resource-count"
+          - "{{reservation_count}}"
+        timeout: 60
+
+      - name: topology_block_atomic_allocation
+        phase: test
+        command: "python ../scripts/capacity/topology_block_atomic_allocation.py"
+        requires_available_validations:
+          - CapacityTopologyBlockAtomicAllocationCheck
+        args:
+          - "--tenant-id"
+          - "{{tenant_id}}"
+          - "--topology-block-id"
+          - "{{topology_block_id}}"
+          - "--requested-compute"
+          - "{{requested_compute}}"
+          - "--requested-network"
+          - "{{requested_network}}"
+          - "--requested-storage"
+          - "{{requested_storage}}"
+        timeout: 60
+
       - name: teardown
         phase: teardown
         command: "python ../scripts/security/teardown.py"
@@ -174,3 +208,10 @@ tests:
   settings:
     region: "my-isv-region-1"
     insecure_protocols_endpoints: "{{env.EDGE_ENDPOINTS | default('', true)}}"
+    tenant_id: "{{env.MY_ISV_TENANT_ID | default('demo-tenant', true)}}"
+    reservation_id: "demo-capacity-reservation"
+    reservation_count: 2
+    topology_block_id: "demo-topology-block"
+    requested_compute: 2
+    requested_network: 1
+    requested_storage: 0

--- a/isvctl/configs/providers/my-isv/scripts/README.md
+++ b/isvctl/configs/providers/my-isv/scripts/README.md
@@ -34,7 +34,7 @@ template, then fill in the TODOs.
 | `network/` | 18 | [`suites/network.yaml`](../../../suites/network.yaml) | [`config/network.yaml`](../config/network.yaml) | [`providers/aws/scripts/network/`](../../aws/scripts/network/) |
 | `observability/` | 1 | [`suites/observability.yaml`](../../../suites/observability.yaml) | [`config/observability.yaml`](../config/observability.yaml) | [`providers/aws/scripts/observability/`](../../aws/scripts/observability/) |
 | `image-registry/` | 7 | [`suites/image-registry.yaml`](../../../suites/image-registry.yaml) | [`config/image-registry.yaml`](../config/image-registry.yaml) | [`providers/aws/scripts/image-registry/`](../../aws/scripts/image-registry/) |
-| `security/` | 17 | [`suites/security.yaml`](../../../suites/security.yaml) | [`config/security.yaml`](../config/security.yaml) | [`providers/aws/scripts/security/`](../../aws/scripts/security/) |
+| `security/` | 19 | [`suites/security.yaml`](../../../suites/security.yaml) | [`config/security.yaml`](../config/security.yaml) | [`providers/aws/scripts/security/`](../../aws/scripts/security/), [`providers/aws/scripts/capacity/`](../../aws/scripts/capacity/) |
 | `k8s/` | 9 shell | [`suites/k8s.yaml`](../../../suites/k8s.yaml) | - | [`providers/aws/scripts/eks/`](../../aws/scripts/eks/) |
 | `slurm/` | 2 shell | [`suites/slurm.yaml`](../../../suites/slurm.yaml) | - | - |
 

--- a/isvctl/configs/providers/my-isv/scripts/capacity/reservation_grouping.py
+++ b/isvctl/configs/providers/my-isv/scripts/capacity/reservation_grouping.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Capacity reservation grouping test - template."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+# ISVCTL_DEMO_MODE=1 enables demo-success output (used by `make demo-test`).
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+
+
+def _positive_int(value: str) -> int:
+    """Parse a positive integer argparse value."""
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be >= 1")
+    return parsed
+
+
+def _payload(args: argparse.Namespace, *, success: bool) -> dict[str, Any]:
+    """Build the capacity reservation JSON contract."""
+    result: dict[str, Any] = {
+        "success": success,
+        "platform": "my-isv",
+        "test_name": "capacity_reservation_grouping",
+    }
+    if success:
+        result.update(
+            {
+                "reservation_id": args.reservation_id,
+                "account_id": args.account_id,
+                "resources": [
+                    {
+                        "resource_id": f"demo-capacity-{index}",
+                        "resource_type": "compute",
+                        "account_id": args.account_id,
+                        "pinned": True,
+                    }
+                    for index in range(1, args.resource_count + 1)
+                ],
+                "pinned": True,
+                "isolation_enforced": True,
+            }
+        )
+    else:
+        # TODO: Replace this block with your platform's implementation.
+        # Query the reservation, verify all grouped resources are pinned to
+        # the requested account, then populate the JSON contract above.
+        result["error"] = "Not implemented - replace with your platform's capacity reservation grouping API calls"
+    return result
+
+
+def main() -> int:
+    """Run the template or demo capacity reservation check."""
+    parser = argparse.ArgumentParser(description="Validate capacity reservation grouping")
+    parser.add_argument("--account-id", required=True, help="Tenant/account that owns the reserved resources")
+    parser.add_argument("--reservation-id", required=True, help="Reservation or allocation identifier")
+    parser.add_argument("--resource-count", type=_positive_int, required=True, help="Grouped resource count")
+    args = parser.parse_args()
+
+    result = _payload(args, success=DEMO_MODE)
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/my-isv/scripts/capacity/topology_block_atomic_allocation.py
+++ b/isvctl/configs/providers/my-isv/scripts/capacity/topology_block_atomic_allocation.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Topology block atomic allocation test for capacity reservations - template."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+# ISVCTL_DEMO_MODE=1 enables demo-success output (used by `make demo-test`).
+DEMO_MODE = os.environ.get("ISVCTL_DEMO_MODE") == "1"
+
+
+def _non_negative_int(value: str) -> int:
+    """Parse a non-negative integer argparse value."""
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("value must be >= 0")
+    return parsed
+
+
+def _resources(tenant_id: str, block_id: str, compute: int, network: int, storage: int) -> list[dict[str, str]]:
+    """Build deterministic demo resource records for the neutral contract."""
+    resources: list[dict[str, str]] = []
+    for index in range(1, compute + 1):
+        resources.append(
+            {
+                "resource_id": f"demo-node-{index}",
+                "resource_type": "compute",
+                "tenant_id": tenant_id,
+                "topology_block_id": block_id,
+                "performance_domain": "demo-performance-domain",
+                "isolation_boundary": tenant_id,
+            }
+        )
+    for index in range(1, network + 1):
+        resources.append(
+            {
+                "resource_id": f"demo-fabric-{index}",
+                "resource_type": "network",
+                "tenant_id": tenant_id,
+                "topology_block_id": block_id,
+                "performance_domain": "demo-performance-domain",
+                "isolation_boundary": tenant_id,
+            }
+        )
+    for index in range(1, storage + 1):
+        resources.append(
+            {
+                "resource_id": f"demo-storage-{index}",
+                "resource_type": "storage",
+                "tenant_id": tenant_id,
+                "topology_block_id": block_id,
+                "performance_domain": "demo-performance-domain",
+                "isolation_boundary": tenant_id,
+            }
+        )
+    return resources
+
+
+def _payload(args: argparse.Namespace, *, success: bool) -> dict[str, Any]:
+    """Build the CAP04-02 JSON contract."""
+    requested = {
+        "compute": args.requested_compute,
+        "network": args.requested_network,
+        "storage": args.requested_storage,
+    }
+    result: dict[str, Any] = {
+        "success": success,
+        "platform": "my-isv",
+        "test_name": "topology_block_atomic_allocation",
+    }
+    if success:
+        result["topology_block"] = {
+            "block_id": args.topology_block_id,
+            "reservation_id": "demo-reservation",
+            "tenant_id": args.tenant_id,
+            "allocated_as_unit": True,
+            "partial_allocation": False,
+            "homogeneous": True,
+            "isolation_enforced": True,
+            "requested": requested,
+            "allocated": requested,
+            "resources": _resources(
+                args.tenant_id,
+                args.topology_block_id,
+                args.requested_compute,
+                args.requested_network,
+                args.requested_storage,
+            ),
+        }
+    else:
+        # TODO: Replace this block with your platform's implementation.
+        # Query the topology block allocation, verify it was allocated as one
+        # homogeneous unit, then populate the JSON contract above.
+        result["error"] = "Not implemented - replace with your platform's capacity reservation API calls"
+    return result
+
+
+def main() -> int:
+    """Run the template or demo CAP04-02 check."""
+    parser = argparse.ArgumentParser(description="Validate atomic topology block allocation")
+    parser.add_argument("--tenant-id", required=True, help="Tenant/account that owns the reserved block")
+    parser.add_argument("--topology-block-id", required=True, help="Topology block identifier")
+    parser.add_argument(
+        "--requested-compute", type=_non_negative_int, required=True, help="Requested compute resources"
+    )
+    parser.add_argument(
+        "--requested-network", type=_non_negative_int, required=True, help="Requested network resources"
+    )
+    parser.add_argument(
+        "--requested-storage", type=_non_negative_int, required=True, help="Requested storage resources"
+    )
+    args = parser.parse_args()
+
+    result = _payload(args, success=DEMO_MODE)
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -179,7 +179,60 @@ Validations use `sinfo`/`srun` directly: partitions, GPU allocation, job schedul
 | `oidc_user_auth_test` | test | `providers/my-isv/scripts/security/oidc_user_auth_test.py` | OIDC issuer metadata and protected endpoint token acceptance/rejection |
 | `short_lived_credentials_test` | test | `providers/my-isv/scripts/security/short_lived_credentials_test.py` | SEC02-01: workloads and nodes receive credentials with finite, bounded TTL |
 | `tenant_isolation_test` | test | `providers/my-isv/scripts/security/tenant_isolation_test.py` | SEC11-01: hard tenant isolation across network/data/compute/storage |
+| `capacity_reservation_grouping` | test | `providers/my-isv/scripts/capacity/reservation_grouping.py` | CAP04-01: capacity is logically grouped and pinned to one account/tenant |
+| `topology_block_atomic_allocation` | test | `providers/my-isv/scripts/capacity/topology_block_atomic_allocation.py` | CAP04-02: topology block allocation is atomic, homogeneous, and isolated |
 | `teardown` | teardown | `providers/my-isv/scripts/security/teardown.py` | Cleanup test resources |
+
+`capacity_reservation_grouping` verifies CAP04-01. Provider scripts must emit this minimal JSON contract:
+
+```json
+{
+  "success": true,
+  "platform": "provider",
+  "reservation_id": "reservation-or-allocation-id",
+  "account_id": "account-id",
+  "resources": [
+    {
+      "resource_id": "resource-id",
+      "resource_type": "compute|network|storage|ip_block|instance_type",
+      "account_id": "account-id",
+      "pinned": true
+    }
+  ],
+  "pinned": true,
+  "isolation_enforced": true
+}
+```
+
+`topology_block_atomic_allocation` verifies CAP04-02. Provider scripts must emit this minimal JSON contract:
+
+```json
+{
+  "success": true,
+  "platform": "provider",
+  "topology_block": {
+    "block_id": "block-id",
+    "reservation_id": "reservation-or-allocation-id",
+    "tenant_id": "tenant-id",
+    "allocated_as_unit": true,
+    "partial_allocation": false,
+    "homogeneous": true,
+    "isolation_enforced": true,
+    "requested": {"compute": 2, "network": 1, "storage": 0},
+    "allocated": {"compute": 2, "network": 1, "storage": 0},
+    "resources": [
+      {
+        "resource_id": "resource-id",
+        "resource_type": "compute|network|storage",
+        "tenant_id": "tenant-id",
+        "topology_block_id": "block-id",
+        "performance_domain": "performance-domain-id",
+        "isolation_boundary": "tenant-id"
+      }
+    ]
+  }
+}
+```
 
 ## Related Documentation
 

--- a/isvctl/configs/suites/security.yaml
+++ b/isvctl/configs/suites/security.yaml
@@ -40,6 +40,12 @@ tests:
 
   settings:
     region: ""
+    min_resources: 1
+    tenant_id: "{{env.NCP_TENANT_ID | default('', true)}}"
+    topology_block_id: "isv-cap04-block"
+    requested_compute: 2
+    requested_network: 1
+    requested_storage: 0
 
   # ─── Validations ─────────────────────────────────────────────────
   # These are PROVIDER-AGNOSTIC. They only check JSON field names/values.
@@ -138,6 +144,22 @@ tests:
       checks:
         TenantIsolationCheck:
           step: tenant_isolation_test
+
+    # Verify capacity is logically grouped and pinned to one tenant/account
+    # boundary.
+    capacity_reservation_grouping:
+      checks:
+        CapacityReservationGroupingCheck:
+          step: capacity_reservation_grouping
+          min_resources: "{{min_resources}}"
+
+    # Verify a topology block is allocated as one atomic unit with homogeneous
+    # performance and one tenant isolation boundary.
+    topology_block_atomic_allocation:
+      step: topology_block_atomic_allocation
+      checks:
+        CapacityTopologyBlockAtomicAllocationCheck:
+          min_resources: 2
 
     teardown_checks:
       step: teardown

--- a/isvctl/tests/test_aws_capacity_atomic_allocation.py
+++ b/isvctl/tests/test_aws_capacity_atomic_allocation.py
@@ -1,0 +1,897 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the AWS capacity reservation topology block script."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+from botocore.exceptions import ClientError
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = (
+    ROOT / "isvctl" / "configs" / "providers" / "aws" / "scripts" / "capacity" / "topology_block_atomic_allocation.py"
+)
+
+
+def _load_script() -> ModuleType:
+    """Load the AWS capacity script as a module."""
+    spec = importlib.util.spec_from_file_location("aws_capacity_atomic", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(**overrides: Any) -> SimpleNamespace:
+    """Build script args with valid defaults."""
+    values = {
+        "tenant_id": "123456789012",
+        "topology_block_id": "isv-cap04-block",
+        "requested_nodes": 2,
+        "requested_network": 1,
+        "requested_storage": 0,
+        "instance_type": "g4dn.metal",
+        "instance_platform": "Linux/UNIX",
+        "availability_zone": "us-west-2a",
+        "placement_group": "isv-cap04-pg",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _instance(
+    instance_id: str, *, account_id: str = "123456789012", group_name: str = "isv-cap04-pg"
+) -> dict[str, Any]:
+    """Build a minimal EC2 instance description."""
+    return {
+        "InstanceId": instance_id,
+        "InstanceType": "g4dn.metal",
+        "Placement": {
+            "AvailabilityZone": "us-west-2a",
+            "GroupName": group_name,
+        },
+        "Tags": [
+            {"Key": "OwnerAccount", "Value": account_id},
+            {"Key": "CreatedBy", "Value": "isvtest"},
+        ],
+    }
+
+
+class _FakeWaiter:
+    """Fake EC2 waiter that records terminated instance waits."""
+
+    def __init__(self, actions: list[tuple[str, Any]]) -> None:
+        self._actions = actions
+
+    def wait(self, **kwargs: Any) -> None:
+        """Record the waiter call."""
+        self._actions.append(("wait", kwargs))
+
+
+class _FailingWaiter:
+    """Fake EC2 waiter that records a wait and then fails."""
+
+    def __init__(self, actions: list[tuple[str, Any]], exc: Exception) -> None:
+        self._actions = actions
+        self._exc = exc
+
+    def wait(self, **kwargs: Any) -> None:
+        """Record the waiter call and raise the configured exception."""
+        self._actions.append(("wait", kwargs))
+        raise self._exc
+
+
+class _FakeEc2Cleanup:
+    """Fake EC2 client for cleanup sequencing."""
+
+    def __init__(self) -> None:
+        self.actions: list[tuple[str, Any]] = []
+
+    def terminate_instances(self, **kwargs: Any) -> None:
+        """Record termination."""
+        self.actions.append(("terminate_instances", kwargs))
+
+    def get_waiter(self, name: str) -> _FakeWaiter:
+        """Return a fake waiter."""
+        self.actions.append(("get_waiter", name))
+        return _FakeWaiter(self.actions)
+
+    def cancel_capacity_reservation(self, **kwargs: Any) -> None:
+        """Record capacity reservation cancelation."""
+        self.actions.append(("cancel_capacity_reservation", kwargs))
+
+    def delete_placement_group(self, **kwargs: Any) -> None:
+        """Record placement group deletion."""
+        self.actions.append(("delete_placement_group", kwargs))
+
+
+class _FakeEc2PlacementGroupEventuallyReleased:
+    """Fake EC2 client where placement group deletion needs one retry."""
+
+    def __init__(self) -> None:
+        self.actions: list[tuple[str, Any]] = []
+        self.delete_attempts = 0
+
+    def cancel_capacity_reservation(self, **kwargs: Any) -> None:
+        """Record capacity reservation cancelation."""
+        self.actions.append(("cancel_capacity_reservation", kwargs))
+
+    def delete_placement_group(self, **kwargs: Any) -> None:
+        """Fail once with in-use, then record successful placement-group deletion."""
+        self.delete_attempts += 1
+        self.actions.append(("delete_placement_group", kwargs))
+        if self.delete_attempts == 1:
+            raise ClientError(
+                {"Error": {"Code": "InvalidPlacementGroup.InUse", "Message": "placement group is still in use"}},
+                "DeletePlacementGroup",
+            )
+
+
+class _FakeEc2Reservation:
+    """Fake EC2 client for creating a placement-group-bound capacity reservation."""
+
+    def __init__(self) -> None:
+        """Initialize the fake client."""
+        self.capacity_reservation_kwargs: dict[str, Any] = {}
+
+    def describe_placement_groups(self, GroupNames: list[str]) -> dict[str, Any]:
+        """Return the placement group ARN for the requested group."""
+        assert GroupNames == ["isv-cap04-pg"]
+        return {
+            "PlacementGroups": [
+                {
+                    "GroupName": "isv-cap04-pg",
+                    "GroupArn": "arn:aws:ec2:us-west-2:123456789012:placement-group/isv-cap04-pg",
+                }
+            ]
+        }
+
+    def create_capacity_reservation(self, **kwargs: Any) -> dict[str, Any]:
+        """Record the requested capacity reservation."""
+        self.capacity_reservation_kwargs = kwargs
+        return {"CapacityReservation": {"CapacityReservationId": "cr-123"}}
+
+
+class _FakeEc2AzFallback:
+    """Fake EC2 client where the first supported AZ has no capacity."""
+
+    def __init__(self) -> None:
+        """Initialize recorded actions and attempted reservation AZs."""
+        self.actions: list[tuple[str, Any]] = []
+        self.create_attempts: list[str] = []
+
+    def describe_instance_type_offerings(self, LocationType: str, Filters: list[dict[str, Any]]) -> dict[str, Any]:
+        """Return supported AZs for the requested instance type."""
+        assert LocationType == "availability-zone"
+        assert Filters == [{"Name": "instance-type", "Values": ["g4dn.metal"]}]
+        return {
+            "InstanceTypeOfferings": [
+                {"Location": "us-west-2a"},
+                {"Location": "us-west-2b"},
+            ]
+        }
+
+    def create_placement_group(self, **kwargs: Any) -> None:
+        """Record placement group creation."""
+        self.actions.append(("create_placement_group", kwargs))
+
+    def describe_placement_groups(self, GroupNames: list[str]) -> dict[str, Any]:
+        """Return a placement group ARN."""
+        self.actions.append(("describe_placement_groups", {"GroupNames": GroupNames}))
+        return {
+            "PlacementGroups": [
+                {
+                    "GroupName": "isv-cap04-pg",
+                    "GroupArn": "arn:aws:ec2:us-west-2:123456789012:placement-group/isv-cap04-pg",
+                }
+            ]
+        }
+
+    def create_capacity_reservation(self, **kwargs: Any) -> dict[str, Any]:
+        """Fail in us-west-2a and succeed in us-west-2b."""
+        availability_zone = kwargs["AvailabilityZone"]
+        self.create_attempts.append(availability_zone)
+        self.actions.append(("create_capacity_reservation", kwargs))
+        if availability_zone == "us-west-2a":
+            raise ClientError(
+                {"Error": {"Code": "InsufficientInstanceCapacity", "Message": "Insufficient capacity."}},
+                "CreateCapacityReservation",
+            )
+        assert availability_zone == "us-west-2b"
+        return {"CapacityReservation": {"CapacityReservationId": "cr-123"}}
+
+    def run_instances(self, **kwargs: Any) -> dict[str, Any]:
+        """Return launched instance IDs in the successful fallback AZ."""
+        self.actions.append(("run_instances", kwargs))
+        assert kwargs["Placement"]["AvailabilityZone"] == "us-west-2b"
+        return {"Instances": [{"InstanceId": "i-1"}, {"InstanceId": "i-2"}]}
+
+    def get_waiter(self, name: str) -> _FakeWaiter:
+        """Return a fake waiter."""
+        self.actions.append(("get_waiter", name))
+        return _FakeWaiter(self.actions)
+
+    def describe_instances(self, InstanceIds: list[str]) -> dict[str, Any]:
+        """Return running instances in the successful fallback AZ."""
+        self.actions.append(("describe_instances", {"InstanceIds": InstanceIds}))
+        return {"Reservations": [{"Instances": [_instance("i-1"), _instance("i-2")]}]}
+
+    def terminate_instances(self, **kwargs: Any) -> None:
+        """Record termination."""
+        self.actions.append(("terminate_instances", kwargs))
+
+    def cancel_capacity_reservation(self, **kwargs: Any) -> None:
+        """Record capacity reservation cancelation."""
+        self.actions.append(("cancel_capacity_reservation", kwargs))
+
+    def delete_placement_group(self, **kwargs: Any) -> None:
+        """Record placement group deletion."""
+        self.actions.append(("delete_placement_group", kwargs))
+
+
+class _FakeEc2LaunchWaiterFailure:
+    """Fake EC2 client where instances launch but the running waiter fails."""
+
+    def __init__(self) -> None:
+        self.actions: list[tuple[str, Any]] = []
+
+    def create_placement_group(self, **kwargs: Any) -> None:
+        """Record placement group creation."""
+        self.actions.append(("create_placement_group", kwargs))
+
+    def describe_placement_groups(self, GroupNames: list[str]) -> dict[str, Any]:
+        """Return a placement group ARN."""
+        self.actions.append(("describe_placement_groups", {"GroupNames": GroupNames}))
+        return {
+            "PlacementGroups": [
+                {
+                    "GroupName": "isv-cap04-pg",
+                    "GroupArn": "arn:aws:ec2:us-west-2:123456789012:placement-group/isv-cap04-pg",
+                }
+            ]
+        }
+
+    def create_capacity_reservation(self, **kwargs: Any) -> dict[str, Any]:
+        """Record capacity reservation creation."""
+        self.actions.append(("create_capacity_reservation", kwargs))
+        return {"CapacityReservation": {"CapacityReservationId": "cr-123"}}
+
+    def run_instances(self, **kwargs: Any) -> dict[str, Any]:
+        """Return launched instance IDs."""
+        self.actions.append(("run_instances", kwargs))
+        return {"Instances": [{"InstanceId": "i-1"}, {"InstanceId": "i-2"}]}
+
+    def get_waiter(self, name: str) -> _FakeWaiter | _FailingWaiter:
+        """Fail only the running waiter."""
+        self.actions.append(("get_waiter", name))
+        if name == "instance_running":
+            return _FailingWaiter(self.actions, TimeoutError("instance running timed out"))
+        return _FakeWaiter(self.actions)
+
+    def terminate_instances(self, **kwargs: Any) -> None:
+        """Record termination."""
+        self.actions.append(("terminate_instances", kwargs))
+
+    def cancel_capacity_reservation(self, **kwargs: Any) -> None:
+        """Record capacity reservation cancelation."""
+        self.actions.append(("cancel_capacity_reservation", kwargs))
+
+    def delete_placement_group(self, **kwargs: Any) -> None:
+        """Record placement group deletion."""
+        self.actions.append(("delete_placement_group", kwargs))
+
+
+class _FakeEc2SuccessfulAllocationCleanupFailure:
+    """Fake EC2 client where allocation succeeds but cleanup fails."""
+
+    def __init__(self) -> None:
+        """Initialize recorded actions."""
+        self.actions: list[tuple[str, Any]] = []
+
+    def create_placement_group(self, **kwargs: Any) -> None:
+        """Record placement group creation."""
+        self.actions.append(("create_placement_group", kwargs))
+
+    def describe_placement_groups(self, GroupNames: list[str]) -> dict[str, Any]:
+        """Return a placement group ARN."""
+        self.actions.append(("describe_placement_groups", {"GroupNames": GroupNames}))
+        return {
+            "PlacementGroups": [
+                {
+                    "GroupName": "isv-cap04-pg",
+                    "GroupArn": "arn:aws:ec2:us-west-2:123456789012:placement-group/isv-cap04-pg",
+                }
+            ]
+        }
+
+    def create_capacity_reservation(self, **kwargs: Any) -> dict[str, Any]:
+        """Record capacity reservation creation."""
+        self.actions.append(("create_capacity_reservation", kwargs))
+        return {"CapacityReservation": {"CapacityReservationId": "cr-123"}}
+
+    def run_instances(self, **kwargs: Any) -> dict[str, Any]:
+        """Return launched instance IDs."""
+        self.actions.append(("run_instances", kwargs))
+        return {"Instances": [{"InstanceId": "i-1"}, {"InstanceId": "i-2"}]}
+
+    def get_waiter(self, name: str) -> _FakeWaiter:
+        """Return a fake waiter."""
+        self.actions.append(("get_waiter", name))
+        return _FakeWaiter(self.actions)
+
+    def describe_instances(self, InstanceIds: list[str]) -> dict[str, Any]:
+        """Return running instances after successful launch."""
+        self.actions.append(("describe_instances", {"InstanceIds": InstanceIds}))
+        return {"Reservations": [{"Instances": [_instance("i-1"), _instance("i-2")]}]}
+
+    def terminate_instances(self, **kwargs: Any) -> None:
+        """Fail termination after recording it."""
+        self.actions.append(("terminate_instances", kwargs))
+        raise RuntimeError("termination denied")
+
+    def cancel_capacity_reservation(self, **kwargs: Any) -> None:
+        """Record capacity reservation cancelation."""
+        self.actions.append(("cancel_capacity_reservation", kwargs))
+
+    def delete_placement_group(self, **kwargs: Any) -> None:
+        """Record placement group deletion."""
+        self.actions.append(("delete_placement_group", kwargs))
+
+
+class _FakeStsSuccess:
+    """Fake STS client that returns a stable account ID."""
+
+    def get_caller_identity(self) -> dict[str, Any]:
+        """Return the fake AWS account identity."""
+        return {"Account": "123456789012"}
+
+
+class _FakeStsFailure:
+    """Fake STS client that fails account lookup."""
+
+    def get_caller_identity(self) -> dict[str, Any]:
+        """Raise the configured STS access error."""
+        raise ClientError({"Error": {"Code": "AccessDenied", "Message": "denied"}}, "GetCallerIdentity")
+
+
+def test_build_contract_success() -> None:
+    """AWS helper should emit the provider-neutral contract on full allocation."""
+    module = _load_script()
+    contract = module.build_contract(
+        _args(),
+        account_id="123456789012",
+        reservation_id="cr-123",
+        instances=[_instance("i-1"), _instance("i-2")],
+    )
+
+    assert contract["success"] is True
+    block = contract["topology_block"]
+    assert block["allocated_as_unit"] is True
+    assert block["partial_allocation"] is False
+    assert block["allocated"] == {"compute": 2, "network": 1, "storage": 0}
+    assert {resource["performance_domain"] for resource in block["resources"]} == {"g4dn.metal/us-west-2a/isv-cap04-pg"}
+
+
+def test_build_contract_detects_partial_allocation() -> None:
+    """Fewer launched instances than requested should be partial allocation."""
+    module = _load_script()
+    contract = module.build_contract(
+        _args(),
+        account_id="123456789012",
+        reservation_id="cr-123",
+        instances=[_instance("i-1")],
+    )
+
+    assert contract["success"] is False
+    assert contract["topology_block"]["allocated_as_unit"] is False
+    assert contract["topology_block"]["partial_allocation"] is True
+
+
+def test_build_contract_detects_mixed_placement_group() -> None:
+    """Instances outside the placement group break performance homogeneity."""
+    module = _load_script()
+    contract = module.build_contract(
+        _args(),
+        account_id="123456789012",
+        reservation_id="cr-123",
+        instances=[_instance("i-1"), _instance("i-2", group_name="other-pg")],
+    )
+
+    assert contract["success"] is False
+    assert contract["topology_block"]["homogeneous"] is False
+
+
+def test_build_contract_fails_when_instance_owned_by_other_account() -> None:
+    """isolation_enforced is derived from instance ownership, not asserted."""
+    module = _load_script()
+    contract = module.build_contract(
+        _args(),
+        account_id="123456789012",
+        reservation_id="cr-123",
+        instances=[_instance("i-1"), _instance("i-2", account_id="999999999999")],
+    )
+
+    assert contract["success"] is False
+    assert contract["topology_block"]["isolation_enforced"] is False
+
+
+def test_build_contract_does_not_claim_unsupported_resource_counts_allocated() -> None:
+    """AWS contract counters must stay in sync with the resource records."""
+    module = _load_script()
+    contract = module.build_contract(
+        _args(requested_network=2, requested_storage=1),
+        account_id="123456789012",
+        reservation_id="cr-123",
+        instances=[_instance("i-1"), _instance("i-2")],
+    )
+
+    block = contract["topology_block"]
+    assert contract["success"] is False
+    assert block["allocated"] == {"compute": 2, "network": 1, "storage": 0}
+    assert [resource["resource_type"] for resource in block["resources"]].count("network") == 1
+    assert [resource["resource_type"] for resource in block["resources"]].count("storage") == 0
+
+
+def test_cleanup_terminates_instances_before_canceling_reservation() -> None:
+    """AWS cleanup should drain instances before removing reservation and placement group."""
+    module = _load_script()
+    ec2 = _FakeEc2Cleanup()
+
+    errors = module.cleanup(
+        ec2,
+        instance_ids=["i-1", "i-2"],
+        reservation_id="cr-123",
+        placement_group="isv-cap04-pg",
+    )
+
+    assert errors == []
+    assert ec2.actions == [
+        ("terminate_instances", {"InstanceIds": ["i-1", "i-2"]}),
+        ("get_waiter", "instance_terminated"),
+        ("wait", {"InstanceIds": ["i-1", "i-2"]}),
+        ("cancel_capacity_reservation", {"CapacityReservationId": "cr-123"}),
+        ("delete_placement_group", {"GroupName": "isv-cap04-pg"}),
+    ]
+
+
+def test_cleanup_retries_placement_group_delete_after_capacity_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Placement group release is eventually consistent after reservation cancelation."""
+    module = _load_script()
+    ec2 = _FakeEc2PlacementGroupEventuallyReleased()
+    monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
+
+    errors = module.cleanup(
+        ec2,
+        instance_ids=[],
+        reservation_id="cr-123",
+        placement_group="isv-cap04-pg",
+    )
+
+    assert errors == []
+    assert ec2.actions == [
+        ("cancel_capacity_reservation", {"CapacityReservationId": "cr-123"}),
+        ("delete_placement_group", {"GroupName": "isv-cap04-pg"}),
+        ("delete_placement_group", {"GroupName": "isv-cap04-pg"}),
+    ]
+
+
+def test_capacity_reservation_is_scoped_to_placement_group_arn() -> None:
+    """AWS capacity reservation must be created inside the cluster placement group."""
+    module = _load_script()
+    ec2 = _FakeEc2Reservation()
+
+    reservation_id = module._create_capacity_reservation(ec2, _args(), "123456789012")
+
+    assert reservation_id == "cr-123"
+    assert (
+        ec2.capacity_reservation_kwargs["PlacementGroupArn"]
+        == "arn:aws:ec2:us-west-2:123456789012:placement-group/isv-cap04-pg"
+    )
+
+
+def test_main_retries_supported_azs_after_capacity_shortage(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Blank topology AZ should try another supported AZ after a capacity shortage."""
+    module = _load_script()
+    ec2 = _FakeEc2AzFallback()
+
+    def fake_client(service: str, region_name: str) -> Any:
+        """Return fake AWS clients by service name."""
+        assert region_name == "us-west-2"
+        if service == "ec2":
+            return ec2
+        if service == "sts":
+            return _FakeStsSuccess()
+        raise AssertionError(f"unexpected service: {service}")
+
+    monkeypatch.setattr(module.boto3, "client", fake_client)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "topology_block_atomic_allocation.py",
+            "--region",
+            "us-west-2",
+            "--topology-block-id",
+            "isv-cap04-block",
+            "--instance-type",
+            "g4dn.metal",
+            "--availability-zone",
+            "",
+            "--placement-group",
+            "isv-cap04-pg",
+            "--requested-nodes",
+            "2",
+            "--requested-network",
+            "1",
+            "--requested-storage",
+            "0",
+            "--ami-id",
+            "ami-123",
+        ],
+    )
+
+    exit_code = module.main()
+    payload: dict[str, Any] = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["success"] is True
+    assert ec2.create_attempts == ["us-west-2a", "us-west-2b"]
+
+
+def test_main_emits_failure_json_when_sts_account_lookup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """STS lookup failures should stay inside the provider JSON contract."""
+    module = _load_script()
+
+    def fake_client(service: str, region_name: str) -> Any:
+        """Return fake AWS clients by service name."""
+        assert region_name == "us-west-2"
+        if service == "ec2":
+            return _FakeEc2Cleanup()
+        if service == "sts":
+            return _FakeStsFailure()
+        raise AssertionError(f"unexpected service: {service}")
+
+    monkeypatch.setattr(module.boto3, "client", fake_client)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "topology_block_atomic_allocation.py",
+            "--region",
+            "us-west-2",
+            "--topology-block-id",
+            "isv-cap04-block",
+            "--instance-type",
+            "g4dn.metal",
+            "--availability-zone",
+            "us-west-2a",
+            "--placement-group",
+            "isv-cap04-pg",
+            "--requested-nodes",
+            "2",
+            "--requested-network",
+            "1",
+            "--requested-storage",
+            "0",
+        ],
+    )
+
+    exit_code = module.main()
+    payload: dict[str, Any] = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert payload["platform"] == "aws"
+    assert payload["test_name"] == "topology_block_atomic_allocation"
+    assert payload["error_type"] == "access_denied"
+
+
+def test_main_cleans_up_launched_instances_when_running_waiter_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Instances must be cleanup-visible as soon as run_instances returns."""
+    module = _load_script()
+    ec2 = _FakeEc2LaunchWaiterFailure()
+
+    def fake_client(service: str, region_name: str) -> Any:
+        """Return fake AWS clients by service name."""
+        assert region_name == "us-west-2"
+        if service == "ec2":
+            return ec2
+        if service == "sts":
+            return _FakeStsSuccess()
+        raise AssertionError(f"unexpected service: {service}")
+
+    monkeypatch.setattr(module.boto3, "client", fake_client)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "topology_block_atomic_allocation.py",
+            "--region",
+            "us-west-2",
+            "--topology-block-id",
+            "isv-cap04-block",
+            "--instance-type",
+            "g4dn.metal",
+            "--availability-zone",
+            "us-west-2a",
+            "--placement-group",
+            "isv-cap04-pg",
+            "--requested-nodes",
+            "2",
+            "--requested-network",
+            "1",
+            "--requested-storage",
+            "0",
+            "--ami-id",
+            "ami-123",
+        ],
+    )
+
+    exit_code = module.main()
+    payload: dict[str, Any] = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert payload["error_type"] == "unknown_error"
+    assert ("terminate_instances", {"InstanceIds": ["i-1", "i-2"]}) in ec2.actions
+
+
+def test_main_fails_when_cleanup_after_successful_allocation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Cleanup errors after a successful allocation should fail the step."""
+    module = _load_script()
+    ec2 = _FakeEc2SuccessfulAllocationCleanupFailure()
+
+    def fake_client(service: str, region_name: str) -> Any:
+        """Return fake AWS clients by service name."""
+        assert region_name == "us-west-2"
+        if service == "ec2":
+            return ec2
+        if service == "sts":
+            return _FakeStsSuccess()
+        raise AssertionError(f"unexpected service: {service}")
+
+    monkeypatch.setattr(module.boto3, "client", fake_client)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "topology_block_atomic_allocation.py",
+            "--region",
+            "us-west-2",
+            "--topology-block-id",
+            "isv-cap04-block",
+            "--instance-type",
+            "g4dn.metal",
+            "--availability-zone",
+            "us-west-2a",
+            "--placement-group",
+            "isv-cap04-pg",
+            "--requested-nodes",
+            "2",
+            "--requested-network",
+            "1",
+            "--requested-storage",
+            "0",
+            "--ami-id",
+            "ami-123",
+        ],
+    )
+
+    exit_code = module.main()
+    payload: dict[str, Any] = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert payload["error_type"] == "cleanup_failed"
+    assert payload["error"] == "Topology block cleanup failed"
+    assert any("terminate_instances" in error for error in payload["cleanup_errors"])
+
+
+@pytest.mark.parametrize(
+    ("requested_network", "requested_storage", "expected_error"),
+    [
+        ("2", "0", "requested_network must be 0 or 1"),
+        ("1", "1", "requested_storage must be 0"),
+    ],
+)
+def test_main_rejects_unsupported_resource_counts_before_cloud_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    requested_network: str,
+    requested_storage: str,
+    expected_error: str,
+) -> None:
+    """Unsupported AWS resource counts should fail before creating cloud resources."""
+    module = _load_script()
+
+    def fake_client(service: str, region_name: str) -> Any:
+        """Fail the test if validation reaches cloud client construction."""
+        raise AssertionError(f"unexpected {service} client in {region_name}")
+
+    monkeypatch.setattr(module.boto3, "client", fake_client)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "topology_block_atomic_allocation.py",
+            "--region",
+            "us-west-2",
+            "--topology-block-id",
+            "isv-cap04-block",
+            "--instance-type",
+            "g4dn.metal",
+            "--availability-zone",
+            "us-west-2a",
+            "--placement-group",
+            "isv-cap04-pg",
+            "--requested-nodes",
+            "2",
+            "--requested-network",
+            requested_network,
+            "--requested-storage",
+            requested_storage,
+            "--ami-id",
+            "ami-123",
+        ],
+    )
+
+    exit_code = module.main()
+    payload: dict[str, Any] = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert payload["error_type"] == "unknown_error"
+    assert expected_error in payload["error"]
+
+
+class _FakeEc2TeardownSweep:
+    """Fake EC2 client that resolves CAP04 topology resources by tag for teardown."""
+
+    def __init__(
+        self,
+        *,
+        instances: list[dict[str, Any]] | None = None,
+        reservations: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self._instances = instances or []
+        self._reservations = reservations or []
+        self.cancelled: list[str] = []
+        self.terminated: list[list[str]] = []
+        self.deleted_groups: list[str] = []
+        self.filters: list[list[dict[str, Any]]] = []
+
+    def describe_instances(self, Filters: list[dict[str, Any]]) -> dict[str, Any]:
+        """Return tagged instances; record the filter for assertions."""
+        self.filters.append(Filters)
+        return {"Reservations": [{"Instances": self._instances}]}
+
+    def describe_capacity_reservations(self, Filters: list[dict[str, Any]]) -> dict[str, Any]:
+        """Return tagged capacity reservations."""
+        return {"CapacityReservations": self._reservations}
+
+    def terminate_instances(self, InstanceIds: list[str]) -> None:
+        """Record terminated instances."""
+        self.terminated.append(InstanceIds)
+
+    def get_waiter(self, name: str) -> _FakeWaiter:
+        """Return a no-op waiter."""
+        return _FakeWaiter([])
+
+    def cancel_capacity_reservation(self, CapacityReservationId: str) -> None:
+        """Record cancelled reservations."""
+        self.cancelled.append(CapacityReservationId)
+
+    def delete_placement_group(self, GroupName: str) -> None:
+        """Record deleted placement groups."""
+        self.deleted_groups.append(GroupName)
+
+
+def test_run_teardown_sweeps_tagged_instances_reservation_and_group() -> None:
+    """Standalone teardown reclaims the instances, reservation, and placement group by tag."""
+    module = _load_script()
+    ec2 = _FakeEc2TeardownSweep(
+        instances=[
+            {"InstanceId": "i-1", "State": {"Name": "running"}},
+            {"InstanceId": "i-2", "State": {"Name": "running"}},
+        ],
+        reservations=[{"CapacityReservationId": "cr-1", "State": "active"}],
+    )
+
+    result = module.run_teardown(ec2, topology_block_id="isv-cap04-block", placement_group="isv-cap04-pg")
+
+    assert result["success"] is True
+    assert ec2.terminated == [["i-1", "i-2"]]
+    assert ec2.cancelled == ["cr-1"]
+    assert ec2.deleted_groups == ["isv-cap04-pg"]
+    assert ec2.filters[0] == [
+        {"Name": "tag:CreatedBy", "Values": ["isvtest"]},
+        {"Name": "tag:TestName", "Values": [module.TEST_NAME]},
+        {"Name": "tag:TopologyBlock", "Values": ["isv-cap04-block"]},
+    ]
+
+
+def test_run_teardown_skips_terminated_instances_and_inactive_reservations() -> None:
+    """Teardown ignores already-terminated instances and terminal reservations."""
+    module = _load_script()
+    ec2 = _FakeEc2TeardownSweep(
+        instances=[
+            {"InstanceId": "i-gone", "State": {"Name": "terminated"}},
+            {"InstanceId": "i-live", "State": {"Name": "running"}},
+        ],
+        reservations=[{"CapacityReservationId": "cr-gone", "State": "cancelled"}],
+    )
+
+    result = module.run_teardown(ec2, topology_block_id="isv-cap04-block", placement_group="isv-cap04-pg")
+
+    assert result["success"] is True
+    assert ec2.terminated == [["i-live"]]
+    assert ec2.cancelled == []
+    assert ec2.deleted_groups == ["isv-cap04-pg"]
+
+
+def test_main_teardown_is_noop_when_skip_destroy_is_set(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`--teardown --skip-destroy` preserves resources without any AWS calls."""
+    module = _load_script()
+
+    def fake_client(service: str, region_name: str) -> Any:
+        """Fail if teardown touches AWS while skip-destroy is set."""
+        raise AssertionError(f"unexpected {service} client in {region_name}")
+
+    monkeypatch.setattr(module.boto3, "client", fake_client)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "topology_block_atomic_allocation.py",
+            "--teardown",
+            "--skip-destroy",
+            "--region",
+            "us-west-2",
+            "--topology-block-id",
+            "isv-cap04-block",
+            "--instance-type",
+            "g4dn.metal",
+            "--availability-zone",
+            "us-west-2a",
+            "--placement-group",
+            "isv-cap04-pg",
+            "--requested-nodes",
+            "2",
+            "--requested-network",
+            "1",
+            "--requested-storage",
+            "0",
+        ],
+    )
+
+    exit_code = module.main()
+    payload: dict[str, Any] = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["success"] is True
+    assert payload["skipped"] == "AWS_CAPACITY_SKIP_DESTROY set"

--- a/isvctl/tests/test_aws_capacity_reservation.py
+++ b/isvctl/tests/test_aws_capacity_reservation.py
@@ -1,0 +1,519 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for AWS capacity reservation grouping script."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+from botocore.exceptions import ClientError
+
+from isvctl.config.merger import merge_yaml_files
+from isvctl.config.schema import RunConfig
+from isvctl.orchestrator.context import Context
+from isvctl.orchestrator.step_executor import StepExecutor
+
+ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+AWS_SECURITY_CONFIG = ISVCTL_ROOT / "configs" / "providers" / "aws" / "config" / "security.yaml"
+AWS_CAPACITY_SCRIPT = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "capacity" / "reservation_grouping.py"
+
+
+def _load_capacity_script() -> ModuleType:
+    """Load the AWS capacity reservation grouping script as a module."""
+    if not AWS_CAPACITY_SCRIPT.exists():
+        pytest.fail("AWS capacity reservation grouping script is not implemented")
+    spec = importlib.util.spec_from_file_location("test_aws_capacity_reservation_grouping", AWS_CAPACITY_SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _client_error(operation_name: str, code: str = "AccessDenied", message: str = "denied") -> ClientError:
+    """Create a botocore ClientError for fake AWS client failures."""
+    return ClientError({"Error": {"Code": code, "Message": message}}, operation_name)
+
+
+class _FakeSts:
+    """Fake STS client returning the caller account."""
+
+    def __init__(self, account_id: str = "123456789012") -> None:
+        """Initialize the fake account id."""
+        self.account_id = account_id
+
+    def get_caller_identity(self) -> dict[str, str]:
+        """Return a fake caller identity document."""
+        return {"Account": self.account_id}
+
+
+class _FakeResourceGroups:
+    """Fake AWS Resource Groups client."""
+
+    def __init__(self, *, already_exists: bool = False) -> None:
+        """Initialize recorded Resource Groups calls.
+
+        When ``already_exists`` is set, ``create_group`` simulates a
+        pre-existing group so the script resolves it via ``get_group``.
+        """
+        self.already_exists = already_exists
+        self.created: list[str] = []
+        self.deleted: list[str] = []
+
+    def create_group(
+        self,
+        Name: str,
+        Description: str,
+        ResourceQuery: dict[str, str],
+        Tags: dict[str, str],
+    ) -> dict[str, Any]:
+        """Record group creation and return a fake ARN."""
+        assert Description
+        assert ResourceQuery["Type"] == "TAG_FILTERS_1_0"
+        assert Tags["CreatedBy"] == "isvtest"
+        if self.already_exists:
+            raise _client_error("CreateGroup", code="BadRequestException", message="group already exists")
+        self.created.append(Name)
+        return {"Group": {"GroupArn": f"arn:aws:resource-groups:us-west-2:123456789012:group/{Name}"}}
+
+    def get_group(self, GroupName: str) -> dict[str, Any]:
+        """Resolve a pre-existing group's ARN."""
+        return {"Group": {"GroupArn": f"arn:aws:resource-groups:us-west-2:123456789012:group/{GroupName}"}}
+
+    def delete_group(self, GroupName: str) -> None:
+        """Record group deletion."""
+        self.deleted.append(GroupName)
+
+
+class _FakeEc2:
+    """Fake EC2 client for capacity reservation grouping behavior."""
+
+    def __init__(
+        self,
+        *,
+        owner_id: str = "123456789012",
+        match_criteria: str = "targeted",
+        create_error: ClientError | None = None,
+        create_errors_by_az: dict[str, ClientError] | None = None,
+        reservations: list[dict[str, Any]] | None = None,
+        expected_availability_zone: str = "us-west-2a",
+        offered_availability_zones: list[str] | None = None,
+    ) -> None:
+        """Configure capacity reservation response behavior."""
+        self.owner_id = owner_id
+        self.match_criteria = match_criteria
+        self.create_error = create_error
+        self.create_errors_by_az = create_errors_by_az or {}
+        self.reservations = reservations or []
+        self.expected_availability_zone = expected_availability_zone
+        self.offered_availability_zones = offered_availability_zones or ["us-west-2b"]
+        self.cancelled: list[str] = []
+        self.create_attempts: list[str] = []
+        self._created_reservation: dict[str, Any] | None = None
+
+    def describe_instance_type_offerings(self, LocationType: str, Filters: list[dict[str, Any]]) -> dict[str, Any]:
+        """Return fake instance type offerings by AZ."""
+        assert LocationType == "availability-zone"
+        assert Filters == [{"Name": "instance-type", "Values": ["g4dn.metal"]}]
+        return {"InstanceTypeOfferings": [{"Location": az} for az in self.offered_availability_zones]}
+
+    def create_capacity_reservation(
+        self,
+        InstanceType: str,
+        InstancePlatform: str,
+        AvailabilityZone: str,
+        InstanceCount: int,
+        InstanceMatchCriteria: str,
+        TagSpecifications: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Create a fake capacity reservation."""
+        self.create_attempts.append(AvailabilityZone)
+        if self.create_error:
+            raise self.create_error
+        if AvailabilityZone in self.create_errors_by_az:
+            raise self.create_errors_by_az[AvailabilityZone]
+        assert InstanceType == "g4dn.metal"
+        assert InstancePlatform == "Linux/UNIX"
+        assert AvailabilityZone == self.expected_availability_zone
+        assert InstanceCount == 1
+        assert InstanceMatchCriteria == "targeted"
+        assert TagSpecifications[0]["ResourceType"] == "capacity-reservation"
+        self._created_reservation = {
+            "CapacityReservationId": "cr-123",
+            "OwnerId": self.owner_id,
+            "InstanceType": InstanceType,
+            "InstanceMatchCriteria": self.match_criteria,
+            "State": "active",
+        }
+        return {"CapacityReservation": self._created_reservation}
+
+    def describe_capacity_reservations(
+        self,
+        CapacityReservationIds: list[str] | None = None,
+        Filters: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Resolve a reservation by id, or by the capacity group tag filter for teardown."""
+        if CapacityReservationIds is not None:
+            assert CapacityReservationIds == ["cr-123"]
+            reservations = [self._created_reservation] if self._created_reservation else self.reservations
+            return {
+                "CapacityReservations": [
+                    reservation
+                    for reservation in reservations
+                    if reservation and reservation.get("CapacityReservationId") in CapacityReservationIds
+                ]
+            }
+        assert Filters and Filters[0]["Name"].startswith("tag:")
+        return {"CapacityReservations": self.reservations}
+
+    def cancel_capacity_reservation(self, CapacityReservationId: str) -> None:
+        """Record capacity reservation cleanup."""
+        self.cancelled.append(CapacityReservationId)
+
+
+def _run_aws_capacity(
+    *,
+    ec2: _FakeEc2 | None = None,
+    sts: _FakeSts | None = None,
+    resource_groups: _FakeResourceGroups | None = None,
+) -> dict[str, Any]:
+    """Run the AWS capacity setup/validation step with fake clients."""
+    module = _load_capacity_script()
+    return module.run(
+        ec2=ec2 or _FakeEc2(),
+        sts=sts or _FakeSts(),
+        resource_groups=resource_groups or _FakeResourceGroups(),
+        region="us-west-2",
+        instance_type="g4dn.metal",
+        availability_zone="us-west-2a",
+        resource_group_name="cap04-test",
+        reservation_count=1,
+    )
+
+
+def _run_aws_teardown(
+    *,
+    ec2: _FakeEc2,
+    resource_groups: _FakeResourceGroups,
+    delete_group: bool,
+    reservation_created: bool = False,
+    created_reservation_id: str = "",
+) -> dict[str, Any]:
+    """Run the AWS capacity teardown step with fake clients."""
+    module = _load_capacity_script()
+    return module.run_teardown(
+        ec2=ec2,
+        resource_groups=resource_groups,
+        resource_group_name="cap04-test",
+        delete_group=delete_group,
+        reservation_created=reservation_created,
+        created_reservation_id=created_reservation_id,
+    )
+
+
+def test_aws_capacity_config_keeps_empty_availability_zone_value() -> None:
+    """Default empty availability_zone must not leave argparse with a dangling flag."""
+    config = RunConfig.model_validate(merge_yaml_files([AWS_SECURITY_CONFIG]))
+    setup_step = next(
+        step for step in config.commands["security"].steps if step.name == "capacity_reservation_grouping"
+    )
+
+    rendered = StepExecutor()._render_args(setup_step.args, Context(config))
+
+    assert "--availability-zone" not in rendered
+    assert "--availability-zone=" in rendered
+
+
+def test_aws_topology_config_keeps_empty_tenant_id_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default empty tenant_id must not leave argparse with a dangling flag."""
+    monkeypatch.delenv("AWS_ACCOUNT_ID", raising=False)
+    config = RunConfig.model_validate(merge_yaml_files([AWS_SECURITY_CONFIG]))
+    topology_step = next(
+        step for step in config.commands["security"].steps if step.name == "topology_block_atomic_allocation"
+    )
+
+    rendered = StepExecutor()._render_args(topology_step.args, Context(config))
+
+    assert "--tenant-id" not in rendered
+    assert "--tenant-id=" in rendered
+
+
+def test_aws_capacity_teardown_renders_without_setup_step_output() -> None:
+    """Standalone teardown should still run when setup did not emit output."""
+    config = RunConfig.model_validate(merge_yaml_files([AWS_SECURITY_CONFIG]))
+    teardown_step = next(step for step in config.commands["security"].steps if step.name == "capacity_teardown")
+
+    rendered = StepExecutor()._render_args(teardown_step.args, Context(config))
+
+    assert "--teardown" in rendered
+    assert "--reservation-created" not in rendered
+    assert "--delete-group" not in rendered
+    assert "--created-reservation-id=" in rendered
+
+
+def test_aws_capacity_reservation_success_outputs_neutral_contract() -> None:
+    """AWS capacity script emits grouped and pinned provider-neutral output."""
+    ec2 = _FakeEc2()
+    resource_groups = _FakeResourceGroups()
+
+    result = _run_aws_capacity(ec2=ec2, resource_groups=resource_groups)
+
+    assert result["success"] is True
+    assert result["platform"] == "aws"
+    assert result["reservation_id"] == "cr-123"
+    assert result["reservation_created"] is True
+    assert result["created_reservation_id"] == "cr-123"
+    assert result["account_id"] == "123456789012"
+    assert result["pinned"] is True
+    assert result["isolation_enforced"] is True
+    assert result["resource_group_created"] is True
+    assert result["resources"] == [
+        {
+            "resource_id": "cr-123",
+            "resource_type": "compute",
+            "account_id": "123456789012",
+            "pinned": True,
+        },
+        {
+            "resource_id": "g4dn.metal",
+            "resource_type": "instance_type",
+            "account_id": "123456789012",
+            "pinned": True,
+        },
+    ]
+    # Resource creation no longer cleans up inline; teardown is a separate phase.
+    assert ec2.cancelled == []
+    assert resource_groups.deleted == []
+
+
+def test_aws_capacity_setup_reports_preexisting_group_as_not_created() -> None:
+    """Setup must flag a pre-existing group so teardown leaves it untouched."""
+    result = _run_aws_capacity(resource_groups=_FakeResourceGroups(already_exists=True))
+
+    assert result["success"] is True
+    assert result["resource_group_created"] is False
+
+
+def test_aws_capacity_setup_reports_existing_reservation_as_not_created() -> None:
+    """Inspecting an existing reservation must not mark it as created by this run."""
+    module = _load_capacity_script()
+    ec2 = _FakeEc2(
+        reservations=[
+            {
+                "CapacityReservationId": "cr-123",
+                "OwnerId": "123456789012",
+                "InstanceType": "g4dn.metal",
+                "InstanceMatchCriteria": "targeted",
+                "State": "active",
+            }
+        ]
+    )
+
+    result = module.run(
+        ec2=ec2,
+        sts=_FakeSts(),
+        resource_groups=_FakeResourceGroups(),
+        region="us-west-2",
+        instance_type="g4dn.metal",
+        availability_zone="us-west-2a",
+        resource_group_name="cap04-test",
+        reservation_count=1,
+        reservation_id="cr-123",
+    )
+
+    assert result["success"] is True
+    assert result["reservation_created"] is False
+    assert result["created_reservation_id"] == ""
+
+
+def test_aws_capacity_selects_az_from_instance_type_offerings_when_default_empty() -> None:
+    """Default AZ selection should choose an AZ that offers the requested instance type."""
+    module = _load_capacity_script()
+    result = module.run(
+        ec2=_FakeEc2(expected_availability_zone="us-west-2b"),
+        sts=_FakeSts(),
+        resource_groups=_FakeResourceGroups(),
+        region="us-west-2",
+        instance_type="g4dn.metal",
+        availability_zone="",
+        resource_group_name="cap04-test",
+        reservation_count=1,
+    )
+
+    assert result["success"] is True
+
+
+def test_aws_capacity_retries_supported_azs_after_capacity_shortage() -> None:
+    """Default AZ selection should try another supported AZ after a capacity shortage."""
+    module = _load_capacity_script()
+    ec2 = _FakeEc2(
+        create_errors_by_az={
+            "us-west-2a": _client_error(
+                "CreateCapacityReservation",
+                code="InsufficientInstanceCapacity",
+                message="Insufficient capacity.",
+            )
+        },
+        expected_availability_zone="us-west-2b",
+        offered_availability_zones=["us-west-2a", "us-west-2b"],
+    )
+
+    result = module.run(
+        ec2=ec2,
+        sts=_FakeSts(),
+        resource_groups=_FakeResourceGroups(),
+        region="us-west-2",
+        instance_type="g4dn.metal",
+        availability_zone="",
+        resource_group_name="cap04-test",
+        reservation_count=1,
+    )
+
+    assert result["success"] is True
+    assert result["reservation_id"] == "cr-123"
+    assert ec2.create_attempts == ["us-west-2a", "us-west-2b"]
+
+
+def test_aws_capacity_teardown_cancels_reservations_and_deletes_created_group() -> None:
+    """Teardown cancels tagged active reservations and deletes a group it created."""
+    ec2 = _FakeEc2(reservations=[{"CapacityReservationId": "cr-123", "State": "active"}])
+    resource_groups = _FakeResourceGroups()
+
+    result = _run_aws_teardown(
+        ec2=ec2,
+        resource_groups=resource_groups,
+        delete_group=True,
+        reservation_created=True,
+        created_reservation_id="cr-123",
+    )
+
+    assert result["success"] is True
+    assert ec2.cancelled == ["cr-123"]
+    assert resource_groups.deleted == ["cap04-test"]
+
+
+def test_aws_capacity_teardown_preserves_same_group_reservations_not_created_by_run() -> None:
+    """Teardown must not cancel same-tag reservations from another run."""
+    ec2 = _FakeEc2(
+        reservations=[
+            {"CapacityReservationId": "cr-123", "State": "active"},
+            {"CapacityReservationId": "cr-other", "State": "active"},
+        ]
+    )
+
+    result = _run_aws_teardown(
+        ec2=ec2,
+        resource_groups=_FakeResourceGroups(),
+        delete_group=False,
+        reservation_created=True,
+        created_reservation_id="cr-123",
+    )
+
+    assert result["success"] is True
+    assert ec2.cancelled == ["cr-123"]
+
+
+def test_aws_capacity_teardown_requires_reservation_created_flag() -> None:
+    """A leaked or stale reservation id alone is not enough to authorize cleanup."""
+    ec2 = _FakeEc2(reservations=[{"CapacityReservationId": "cr-123", "State": "active"}])
+
+    result = _run_aws_teardown(
+        ec2=ec2,
+        resource_groups=_FakeResourceGroups(),
+        delete_group=False,
+        reservation_created=False,
+        created_reservation_id="cr-123",
+    )
+
+    assert result["success"] is True
+    assert ec2.cancelled == []
+
+
+def test_aws_capacity_teardown_preserves_preexisting_group() -> None:
+    """Teardown must not delete a Resource Group this run did not create."""
+    ec2 = _FakeEc2(reservations=[{"CapacityReservationId": "cr-123", "State": "active"}])
+    resource_groups = _FakeResourceGroups()
+
+    result = _run_aws_teardown(
+        ec2=ec2,
+        resource_groups=resource_groups,
+        delete_group=False,
+        reservation_created=True,
+        created_reservation_id="cr-123",
+    )
+
+    assert result["success"] is True
+    assert ec2.cancelled == ["cr-123"]
+    assert resource_groups.deleted == []
+
+
+def test_aws_capacity_teardown_skips_inactive_reservations() -> None:
+    """Teardown ignores reservations already in a terminal state."""
+    ec2 = _FakeEc2(reservations=[{"CapacityReservationId": "cr-gone", "State": "cancelled"}])
+
+    result = _run_aws_teardown(ec2=ec2, resource_groups=_FakeResourceGroups(), delete_group=True)
+
+    assert result["success"] is True
+    assert ec2.cancelled == []
+
+
+def test_aws_capacity_standalone_teardown_sweeps_tagged_reservations() -> None:
+    """Without a created-reservation id (standalone --phase teardown) every tagged
+    reservation is cancelled so AWS_CAPACITY_SKIP_DESTROY resources are not leaked."""
+    ec2 = _FakeEc2(reservations=[{"CapacityReservationId": "cr-123", "State": "active"}])
+
+    result = _run_aws_teardown(
+        ec2=ec2,
+        resource_groups=_FakeResourceGroups(),
+        delete_group=False,
+        reservation_created=False,
+        created_reservation_id="",
+    )
+
+    assert result["success"] is True
+    assert ec2.cancelled == ["cr-123"]
+
+
+def test_aws_capacity_reservation_fails_on_account_mismatch() -> None:
+    """AWS capacity script fails when the reservation owner differs from the caller account."""
+    result = _run_aws_capacity(ec2=_FakeEc2(owner_id="999999999999"))
+
+    assert result["success"] is False
+    assert result["account_id"] == "123456789012"
+    assert result["resources"][0]["account_id"] == "999999999999"
+    assert result["isolation_enforced"] is False
+    assert "owner account" in result["error"]
+
+
+def test_aws_capacity_reservation_fails_when_reservation_is_open() -> None:
+    """AWS capacity script fails when capacity reservation matching is open instead of targeted."""
+    result = _run_aws_capacity(ec2=_FakeEc2(match_criteria="open"))
+
+    assert result["success"] is False
+    assert result["pinned"] is False
+    assert "targeted" in result["error"]
+
+
+def test_aws_capacity_reservation_reports_api_failure() -> None:
+    """AWS capacity script reports AWS API failures as structured JSON."""
+    result = _run_aws_capacity(ec2=_FakeEc2(create_error=_client_error("CreateCapacityReservation")))
+
+    assert result["success"] is False
+    assert result["error_type"] == "access_denied"
+    assert "denied" in result["error"]

--- a/isvctl/tests/test_capacity_config.py
+++ b/isvctl/tests/test_capacity_config.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for capacity reservation checks in the security suite and provider wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from isvctl.config.merger import merge_yaml_files
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIGS = ROOT / "isvctl" / "configs"
+
+
+def test_security_suite_defines_capacity_validations() -> None:
+    """The provider-neutral security suite should expose capacity reservation checks."""
+    suite = merge_yaml_files([CONFIGS / "suites" / "security.yaml"])
+    validations = suite["tests"]["validations"]
+
+    assert "capacity_reservation_grouping" in validations
+    grouping = validations["capacity_reservation_grouping"]
+    assert grouping["checks"] == {
+        "CapacityReservationGroupingCheck": {
+            "step": "capacity_reservation_grouping",
+            "min_resources": "{{min_resources}}",
+        }
+    }
+
+    assert "topology_block_atomic_allocation" in validations
+    topology = validations["topology_block_atomic_allocation"]
+    assert topology["step"] == "topology_block_atomic_allocation"
+    assert topology["checks"] == {
+        "CapacityTopologyBlockAtomicAllocationCheck": {
+            "min_resources": 2,
+        }
+    }
+
+
+def test_my_isv_security_config_wires_capacity_steps() -> None:
+    """The my-isv security example should run the capacity reservation steps."""
+    merged = merge_yaml_files([CONFIGS / "providers" / "my-isv" / "config" / "security.yaml"])
+    steps = merged["commands"]["security"]["steps"]
+
+    grouping = next(item for item in steps if item["name"] == "capacity_reservation_grouping")
+    assert grouping["phase"] == "test"
+    assert grouping["command"] == "python ../scripts/capacity/reservation_grouping.py"
+    assert grouping["requires_available_validations"] == ["CapacityReservationGroupingCheck"]
+    assert "--account-id" in grouping["args"]
+    assert "{{tenant_id}}" in grouping["args"]
+
+    step = next(item for item in steps if item["name"] == "topology_block_atomic_allocation")
+
+    assert step["phase"] == "test"
+    assert step["command"] == "python ../scripts/capacity/topology_block_atomic_allocation.py"
+    assert step["requires_available_validations"] == ["CapacityTopologyBlockAtomicAllocationCheck"]
+    assert "--tenant-id" in step["args"]
+    assert "{{tenant_id}}" in step["args"]
+    assert "--requested-compute" in step["args"]
+    assert "{{requested_compute}}" in step["args"]
+
+
+def test_aws_security_config_wires_capacity_steps() -> None:
+    """The AWS security config should wire both capacity reservation steps to AWS scripts."""
+    merged = merge_yaml_files([CONFIGS / "providers" / "aws" / "config" / "security.yaml"])
+    steps = merged["commands"]["security"]["steps"]
+    settings = merged["tests"]["settings"]
+    grouping = next(item for item in steps if item["name"] == "capacity_reservation_grouping")
+    teardown = next(item for item in steps if item["name"] == "capacity_teardown")
+    topology_teardown = next(item for item in steps if item["name"] == "topology_block_teardown")
+
+    assert grouping["command"] == "python3 ../scripts/capacity/reservation_grouping.py"
+    assert grouping["requires_available_validations"] == ["CapacityReservationGroupingCheck"]
+    assert teardown["requires_available_validations"] == ["CapacityReservationGroupingCheck"]
+    assert topology_teardown["phase"] == "teardown"
+    assert topology_teardown["command"] == "python3 ../scripts/capacity/topology_block_atomic_allocation.py"
+    assert "--teardown" in topology_teardown["args"]
+    assert "{{topology_skip_destroy_flag}}" in topology_teardown["args"]
+
+    step = next(item for item in steps if item["name"] == "topology_block_atomic_allocation")
+
+    assert step["command"] == "python3 ../scripts/capacity/topology_block_atomic_allocation.py"
+    assert step["requires_available_validations"] == ["CapacityTopologyBlockAtomicAllocationCheck"]
+    assert "--capacity-reservation-id" not in step["args"]
+    assert "--instance-type" in step["args"]
+    assert "{{capacity_instance_type}}" in step["args"]
+    assert "--placement-group" in step["args"]
+    assert "{{placement_group}}" in step["args"]
+    assert "{{topology_skip_destroy_flag}}" in step["args"]
+    assert settings["topology_availability_zone"] == "{{env.AWS_AVAILABILITY_ZONE | default('', true)}}"

--- a/isvctl/tests/test_schema.py
+++ b/isvctl/tests/test_schema.py
@@ -75,6 +75,7 @@ class TestStepConfig:
         assert step.timeout == 300
         assert step.phase == "setup"
         assert step.skip is False
+        assert step.requires_available_validations == []
 
     def test_full_step(self) -> None:
         """Test creating a fully specified step config."""
@@ -87,6 +88,7 @@ class TestStepConfig:
             working_dir="/tmp",
             phase="setup",
             skip=False,
+            requires_available_validations=["NewCheck"],
             continue_on_failure=True,
             output_schema="vpc",
         )
@@ -96,6 +98,7 @@ class TestStepConfig:
         assert step.timeout == 600
         assert step.env == {"AWS_REGION": "us-west-2"}
         assert step.phase == "setup"
+        assert step.requires_available_validations == ["NewCheck"]
         assert step.continue_on_failure is True
         assert step.output_schema == "vpc"
 

--- a/isvtest/src/isvtest/validations/capacity.py
+++ b/isvtest/src/isvtest/validations/capacity.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Capacity reservation validations."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from isvtest.core.validation import BaseValidation
+
+COUNT_FIELDS: tuple[str, ...] = ("compute", "network", "storage")
+RESOURCE_FIELDS: tuple[str, ...] = (
+    "resource_id",
+    "resource_type",
+    "tenant_id",
+    "topology_block_id",
+    "performance_domain",
+    "isolation_boundary",
+)
+
+
+def _is_non_empty_string(value: object) -> bool:
+    """Return True when ``value`` is a string with non-whitespace content."""
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _is_non_negative_int(value: Any) -> bool:
+    """Return whether value is a real non-negative integer, excluding bool."""
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _resource_label(resource: dict[str, Any]) -> str:
+    """Return a stable resource label for error messages."""
+    value = resource.get("resource_id")
+    return value if isinstance(value, str) and value else "<unknown>"
+
+
+class CapacityReservationGroupingCheck(BaseValidation):
+    """Validate resources are grouped and pinned to one account or tenant.
+
+    Config:
+        step_output: Provider-neutral capacity reservation grouping output.
+        min_resources: Minimum grouped resource count. Defaults to 1.
+
+    Step output:
+        success: False when the provider script failed.
+        reservation_id: Reservation or allocation identifier.
+        account_id: Account or tenant identifier that owns the reservation.
+        resources: Grouped resources, each with account_id and pinned=true.
+        pinned: True when the reservation uses targeted/pinned matching.
+        isolation_enforced: True when the provider enforces the tenant/account boundary.
+    """
+
+    description: ClassVar[str] = "Check capacity reservation grouping and tenant pinning"
+    labels: ClassVar[tuple[str, ...]] = ("capacity", "bare_metal")
+
+    def run(self) -> None:
+        """Validate capacity reservation grouping evidence."""
+        step_output = self.config.get("step_output", {})
+        if not isinstance(step_output, dict):
+            self.set_failed("step_output must be an object")
+            return
+
+        if step_output.get("success") is not True:
+            error = step_output.get("error") or step_output.get("error_type") or "step reported failure"
+            self.set_failed(f"Capacity reservation grouping step failed: {error}")
+            return
+
+        reservation_id = step_output.get("reservation_id")
+        if not _is_non_empty_string(reservation_id):
+            self.set_failed("Missing non-empty reservation_id in step output")
+            return
+
+        account_id = step_output.get("account_id")
+        if not _is_non_empty_string(account_id):
+            self.set_failed("Missing non-empty account_id in step output")
+            return
+
+        min_resources = self._parse_positive_int("min_resources", default=1)
+        if min_resources is None:
+            return
+
+        resources = step_output.get("resources", [])
+        if not isinstance(resources, list):
+            self.set_failed("resources must be a list")
+            return
+        if len(resources) < min_resources:
+            self.set_failed(f"Only {len(resources)} grouped resource(s), minimum {min_resources} required")
+            return
+
+        account_ids = self._resource_account_ids(resources)
+        if account_ids is None:
+            return
+        unexpected_accounts = sorted(account_ids - {account_id})
+        if unexpected_accounts:
+            self.set_failed(
+                f"Grouped resources must use account_id {account_id!r}; found {', '.join(unexpected_accounts)}"
+            )
+            return
+
+        if step_output.get("pinned") is not True:
+            self.set_failed("Capacity reservation must be pinned")
+            return
+        if not self._resources_are_pinned(resources):
+            return
+
+        if step_output.get("isolation_enforced") is not True:
+            self.set_failed("Capacity reservation isolation_enforced must be true")
+            return
+
+        self.set_passed(
+            f"Capacity reservation {reservation_id} groups {len(resources)} resource(s) pinned to account {account_id}"
+        )
+
+    def _resource_account_ids(self, resources: list[Any]) -> set[str] | None:
+        """Return resource account ids, or fail when resources are malformed."""
+        account_ids: set[str] = set()
+        for index, resource in enumerate(resources):
+            if not isinstance(resource, dict):
+                self.set_failed(f"resources[{index}] must be an object")
+                return None
+            account_id = resource.get("account_id")
+            if not _is_non_empty_string(account_id):
+                self.set_failed(f"resources[{index}].account_id must be a non-empty string")
+                return None
+            account_ids.add(account_id)
+        return account_ids
+
+    def _resources_are_pinned(self, resources: list[Any]) -> bool:
+        """Return True when every grouped resource carries pinned=true."""
+        for index, resource in enumerate(resources):
+            if not isinstance(resource, dict):
+                self.set_failed(f"resources[{index}] must be an object")
+                return False
+            if resource.get("pinned") is not True:
+                resource_id = resource.get("resource_id", f"resources[{index}]")
+                self.set_failed(f"Grouped resource {resource_id!r} must be pinned")
+                return False
+        return True
+
+
+class CapacityTopologyBlockAtomicAllocationCheck(BaseValidation):
+    """Validate topology block atomic allocation.
+
+    Config:
+        step_output: Provider-neutral output from the
+            ``topology_block_atomic_allocation`` step.
+        min_resources: Minimum resource records expected in the block
+            (default: 1).
+
+    Step output:
+        success: bool
+        platform: str
+        topology_block: dict
+            block_id: str
+            reservation_id: str
+            tenant_id: str
+            allocated_as_unit: bool
+            partial_allocation: bool
+            homogeneous: bool
+            isolation_enforced: bool
+            requested: {"compute": int, "network": int, "storage": int}
+            allocated: {"compute": int, "network": int, "storage": int}
+            resources: list[dict]
+    """
+
+    description: ClassVar[str] = "Check topology block capacity is allocated as one atomic unit"
+    timeout: ClassVar[int] = 120
+    labels: ClassVar[tuple[str, ...]] = ("capacity", "bare_metal")
+
+    def run(self) -> None:
+        """Validate atomicity, resource counts, homogeneity, and isolation."""
+        step_output = self.config.get("step_output", {})
+
+        if not isinstance(step_output, dict):
+            self.set_failed("step_output must be an object")
+            return
+        if not step_output.get("success"):
+            self.set_failed(f"Capacity topology block step failed: {step_output.get('error', 'Unknown error')}")
+            return
+
+        block = step_output.get("topology_block")
+        if not isinstance(block, dict):
+            self.set_failed("Capacity step output is missing the 'topology_block' object")
+            return
+
+        min_resources = self._parse_positive_int("min_resources", default=1)
+        if min_resources is None:
+            return
+
+        resources = block.get("resources")
+        if not isinstance(resources, list) or not all(isinstance(resource, dict) for resource in resources):
+            self.set_failed("topology_block.resources must be a list of objects")
+            return
+        if len(resources) < min_resources:
+            self.set_failed(f"Expected at least {min_resources} topology block resource(s), got {len(resources)}")
+            return
+
+        failures: list[str] = []
+
+        block_id = block.get("block_id")
+        tenant_id = block.get("tenant_id")
+        reservation_id = block.get("reservation_id")
+        for key, value in (("block_id", block_id), ("tenant_id", tenant_id), ("reservation_id", reservation_id)):
+            if not _is_non_empty_string(value):
+                failures.append(f"topology_block.{key} must be a non-empty string")
+
+        atomic_ok = block.get("allocated_as_unit") is True and block.get("partial_allocation") is False
+        self.report_subtest(
+            "atomic_allocation",
+            passed=atomic_ok,
+            message="block allocated as one unit" if atomic_ok else "block reported partial allocation",
+        )
+        if not atomic_ok:
+            failures.append("topology block reported partial allocation")
+
+        requested = block.get("requested")
+        allocated = block.get("allocated")
+        counts_ok = self._validate_counts(requested, allocated, resources, failures)
+        self.report_subtest(
+            "requested_counts",
+            passed=counts_ok,
+            message=(
+                "allocated counts match requested counts and resource records"
+                if counts_ok
+                else "allocated counts do not match requested counts or resource records"
+            ),
+        )
+
+        membership_ok = self._validate_resource_membership(resources, block_id, tenant_id, failures)
+        self.report_subtest(
+            "resource_membership",
+            passed=membership_ok,
+            message=(
+                "all resources belong to the same tenant and topology block"
+                if membership_ok
+                else "resources span multiple tenants or topology blocks"
+            ),
+        )
+
+        performance_domains = {resource.get("performance_domain") for resource in resources}
+        performance_ok = block.get("homogeneous") is True and len(performance_domains) == 1
+        self.report_subtest(
+            "performance_homogeneity",
+            passed=performance_ok,
+            message=(
+                "one performance domain across resources"
+                if performance_ok
+                else "multiple performance domains across resources"
+            ),
+        )
+        if block.get("homogeneous") is not True:
+            failures.append("topology_block.homogeneous must be true")
+        if len(performance_domains) != 1:
+            failures.append(
+                f"multiple performance domains in topology block: {sorted(str(v) for v in performance_domains)}"
+            )
+
+        isolation_boundaries = {resource.get("isolation_boundary") for resource in resources}
+        isolation_ok = block.get("isolation_enforced") is True and len(isolation_boundaries) == 1
+        self.report_subtest(
+            "isolation_boundary",
+            passed=isolation_ok,
+            message=(
+                "one isolation boundary across resources"
+                if isolation_ok
+                else "multiple isolation boundaries across resources"
+            ),
+        )
+        if block.get("isolation_enforced") is not True:
+            failures.append("topology_block.isolation_enforced must be true")
+        if len(isolation_boundaries) != 1:
+            failures.append(
+                f"multiple isolation boundaries in topology block: {sorted(str(v) for v in isolation_boundaries)}"
+            )
+
+        if failures:
+            self.set_failed(f"Capacity topology block invariants violated: {'; '.join(failures)}")
+            return
+
+        self.set_passed(
+            f"Validated atomic topology block {block_id} for tenant {tenant_id} with {len(resources)} resource(s)"
+        )
+
+    def _validate_counts(
+        self,
+        requested: Any,
+        allocated: Any,
+        resources: list[dict[str, Any]],
+        failures: list[str],
+    ) -> bool:
+        """Validate requested, allocated, and resource-record counts."""
+        if not isinstance(requested, dict) or not isinstance(allocated, dict):
+            failures.append("topology_block.requested and topology_block.allocated must be objects")
+            return False
+
+        ok = True
+        resource_counts = {
+            name: sum(1 for resource in resources if resource.get("resource_type") == name) for name in COUNT_FIELDS
+        }
+        for name in COUNT_FIELDS:
+            req = requested.get(name, 0)
+            got = allocated.get(name, 0)
+            if not _is_non_negative_int(req):
+                failures.append(f"requested {name} must be a non-negative integer")
+                ok = False
+                continue
+            if not _is_non_negative_int(got):
+                failures.append(f"allocated {name} must be a non-negative integer")
+                ok = False
+                continue
+            if got != req:
+                failures.append(f"allocated {name} {got} != requested {name} {req}")
+                ok = False
+            if got != resource_counts[name]:
+                failures.append(f"allocated {name} {got} != resource records {resource_counts[name]}")
+                ok = False
+        return ok
+
+    def _validate_resource_membership(
+        self,
+        resources: list[dict[str, Any]],
+        block_id: Any,
+        tenant_id: Any,
+        failures: list[str],
+    ) -> bool:
+        """Validate per-resource shape and membership in one block and tenant."""
+        ok = True
+        for resource in resources:
+            label = _resource_label(resource)
+            for field in RESOURCE_FIELDS:
+                value = resource.get(field)
+                if not _is_non_empty_string(value):
+                    failures.append(f"{label} missing non-empty {field}")
+                    ok = False
+            if resource.get("tenant_id") != tenant_id:
+                failures.append(f"{label} tenant_id {resource.get('tenant_id')} != {tenant_id}")
+                ok = False
+            if resource.get("topology_block_id") != block_id:
+                failures.append(f"{label} topology_block_id {resource.get('topology_block_id')} != {block_id}")
+                ok = False
+        return ok

--- a/isvtest/tests/test_capacity.py
+++ b/isvtest/tests/test_capacity.py
@@ -1,0 +1,350 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for capacity reservation validations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from isvtest.validations.capacity import CapacityTopologyBlockAtomicAllocationCheck
+
+
+def _validation_cls() -> Any:
+    """Return the capacity reservation validation class under test."""
+    try:
+        # Local import turns missing-check regressions into a targeted pytest failure.
+        from isvtest.validations.capacity import CapacityReservationGroupingCheck
+    except ModuleNotFoundError:
+        pytest.fail("CapacityReservationGroupingCheck is not implemented")
+    return CapacityReservationGroupingCheck
+
+
+def _capacity_output(**overrides: Any) -> dict[str, Any]:
+    """Build a passing capacity reservation grouping step output."""
+    output: dict[str, Any] = {
+        "success": True,
+        "platform": "aws",
+        "reservation_id": "cr-123",
+        "account_id": "acct-123",
+        "resources": [
+            {
+                "resource_id": "cr-123",
+                "resource_type": "compute",
+                "account_id": "acct-123",
+                "pinned": True,
+            },
+            {
+                "resource_id": "rg-123",
+                "resource_type": "network",
+                "account_id": "acct-123",
+                "pinned": True,
+            },
+        ],
+        "pinned": True,
+        "isolation_enforced": True,
+    }
+    output.update(overrides)
+    return output
+
+
+def _run_capacity_check(step_output: dict[str, Any], **config_overrides: Any) -> dict[str, Any]:
+    """Execute the capacity reservation grouping check with the supplied step output."""
+    config = {"step_output": step_output}
+    config.update(config_overrides)
+    return _validation_cls()(config=config).execute()
+
+
+def test_capacity_reservation_grouping_passes_for_grouped_pinned_resources() -> None:
+    """Capacity grouping passes when all resources are pinned to one account."""
+    result = _run_capacity_check(_capacity_output())
+
+    assert result["passed"] is True
+    assert "cr-123" in result["output"]
+    assert "2 resource(s)" in result["output"]
+
+
+def test_capacity_reservation_grouping_requires_reservation_id() -> None:
+    """Capacity grouping fails when the reservation id is missing."""
+    result = _run_capacity_check(_capacity_output(reservation_id=""))
+
+    assert result["passed"] is False
+    assert "reservation_id" in result["error"]
+
+
+def test_capacity_reservation_grouping_requires_minimum_resource_count() -> None:
+    """Capacity grouping fails when fewer than min_resources are grouped."""
+    result = _run_capacity_check(_capacity_output(resources=[]), min_resources=1)
+
+    assert result["passed"] is False
+    assert "minimum 1" in result["error"]
+
+
+def test_capacity_reservation_grouping_rejects_mixed_account_ids() -> None:
+    """Capacity grouping fails when grouped resources belong to different accounts."""
+    resources = _capacity_output()["resources"]
+    resources[1] = {**resources[1], "account_id": "acct-999"}
+
+    result = _run_capacity_check(_capacity_output(resources=resources))
+
+    assert result["passed"] is False
+    assert "acct-999" in result["error"]
+
+
+def test_capacity_reservation_grouping_requires_pinned_reservation() -> None:
+    """Capacity grouping fails when the reservation is not pinned."""
+    result = _run_capacity_check(_capacity_output(pinned=False))
+
+    assert result["passed"] is False
+    assert "pinned" in result["error"]
+
+
+def test_capacity_reservation_grouping_requires_isolation_enforced() -> None:
+    """Capacity grouping fails when the provider does not enforce isolation."""
+    result = _run_capacity_check(_capacity_output(isolation_enforced=False))
+
+    assert result["passed"] is False
+    assert "isolation" in result["error"]
+
+
+def test_capacity_reservation_grouping_propagates_step_failure() -> None:
+    """Capacity grouping fails with the script error when the step reports failure."""
+    result = _run_capacity_check(_capacity_output(success=False, error="API rejected the reservation request"))
+
+    assert result["passed"] is False
+    assert "API rejected" in result["error"]
+
+
+def test_capacity_reservation_grouping_requires_explicit_success() -> None:
+    """Capacity grouping fails when the step omits the success flag."""
+    output = _capacity_output()
+    output.pop("success")
+
+    result = _run_capacity_check(output)
+
+    assert result["passed"] is False
+    assert "step reported failure" in result["error"]
+
+
+def _topology_resource(
+    resource_id: str,
+    *,
+    resource_type: str = "compute",
+    tenant_id: str = "tenant-a",
+    block_id: str = "block-a",
+    performance_domain: str = "pd-a",
+    isolation_boundary: str = "tenant-a",
+) -> dict[str, Any]:
+    """Build one topology-block resource record."""
+    return {
+        "resource_id": resource_id,
+        "resource_type": resource_type,
+        "tenant_id": tenant_id,
+        "topology_block_id": block_id,
+        "performance_domain": performance_domain,
+        "isolation_boundary": isolation_boundary,
+    }
+
+
+def _topology_output(
+    *,
+    success: bool = True,
+    resources: list[dict[str, Any]] | None = None,
+    requested: dict[str, int] | None = None,
+    allocated: dict[str, int] | None = None,
+    block_overrides: dict[str, Any] | None = None,
+    error: str = "",
+) -> dict[str, Any]:
+    """Build a step output with valid defaults."""
+    if resources is None:
+        resources = [
+            _topology_resource("node-1"),
+            _topology_resource("node-2"),
+            _topology_resource("fabric-1", resource_type="network"),
+        ]
+    block: dict[str, Any] = {
+        "block_id": "block-a",
+        "reservation_id": "reservation-a",
+        "tenant_id": "tenant-a",
+        "allocated_as_unit": True,
+        "partial_allocation": False,
+        "homogeneous": True,
+        "isolation_enforced": True,
+        "requested": requested or {"compute": 2, "network": 1, "storage": 0},
+        "allocated": allocated or {"compute": 2, "network": 1, "storage": 0},
+        "resources": resources,
+    }
+    if block_overrides:
+        block.update(block_overrides)
+    return {
+        "success": success,
+        "platform": "test",
+        "test_name": "topology_block_atomic_allocation",
+        "topology_block": block,
+        "error": error,
+    }
+
+
+class TestCapacityTopologyBlockAtomicAllocationCheck:
+    """Tests for topology block atomic allocation validation."""
+
+    def test_valid_atomic_block_passes(self) -> None:
+        """A complete homogeneous block with one isolation boundary passes."""
+        check = CapacityTopologyBlockAtomicAllocationCheck(config={"step_output": _topology_output()})
+
+        check.run()
+
+        assert check._passed is True, check._error
+        assert "atomic topology block" in check._output
+        assert {result["name"] for result in check._subtest_results} == {
+            "atomic_allocation",
+            "requested_counts",
+            "resource_membership",
+            "performance_homogeneity",
+            "isolation_boundary",
+        }
+        assert all(result["passed"] for result in check._subtest_results)
+
+    def test_step_failure_propagates(self) -> None:
+        """A failed provider step should fail with the provider error."""
+        check = CapacityTopologyBlockAtomicAllocationCheck(
+            config={"step_output": _topology_output(success=False, error="capacity API denied request")}
+        )
+
+        check.run()
+
+        assert check._passed is False
+        assert "capacity API denied request" in check._error
+
+    def test_partial_allocation_fails(self) -> None:
+        """A block reported as partial is not atomic."""
+        output = _topology_output(
+            block_overrides={
+                "allocated_as_unit": False,
+                "partial_allocation": True,
+            }
+        )
+        check = CapacityTopologyBlockAtomicAllocationCheck(config={"step_output": output})
+
+        check.run()
+
+        assert check._passed is False
+        assert "partial allocation" in check._error
+        atomic = next(result for result in check._subtest_results if result["name"] == "atomic_allocation")
+        assert atomic["passed"] is False
+
+    def test_requested_allocated_mismatch_fails(self) -> None:
+        """Allocated counts must exactly match requested counts."""
+        output = _topology_output(allocated={"compute": 1, "network": 1, "storage": 0})
+        check = CapacityTopologyBlockAtomicAllocationCheck(config={"step_output": output})
+
+        check.run()
+
+        assert check._passed is False
+        assert "allocated compute 1 != requested compute 2" in check._error
+        counts = next(result for result in check._subtest_results if result["name"] == "requested_counts")
+        assert counts["passed"] is False
+        # A failed subtest must not report a success-phrased message.
+        assert "do not match" in counts["message"]
+
+    def test_allocated_counts_must_match_resource_records(self) -> None:
+        """Allocated counters cannot claim resources missing from the resource list."""
+        output = _topology_output(allocated={"compute": 2, "network": 2, "storage": 0})
+        check = CapacityTopologyBlockAtomicAllocationCheck(config={"step_output": output})
+
+        check.run()
+
+        assert check._passed is False
+        assert "allocated network 2 != resource records 1" in check._error
+
+    def test_mixed_performance_domains_fail(self) -> None:
+        """All resources in an atomic topology block must share one performance domain."""
+        resources = [
+            _topology_resource("node-1"),
+            _topology_resource("node-2", performance_domain="pd-b"),
+            _topology_resource("fabric-1", resource_type="network"),
+        ]
+        check = CapacityTopologyBlockAtomicAllocationCheck(
+            config={"step_output": _topology_output(resources=resources)}
+        )
+
+        check.run()
+
+        assert check._passed is False
+        assert "multiple performance domains" in check._error
+
+    def test_mixed_isolation_boundaries_fail(self) -> None:
+        """All resources in the block must share one isolation boundary."""
+        resources = [
+            _topology_resource("node-1"),
+            _topology_resource("node-2", isolation_boundary="tenant-b"),
+            _topology_resource("fabric-1", resource_type="network"),
+        ]
+        check = CapacityTopologyBlockAtomicAllocationCheck(
+            config={"step_output": _topology_output(resources=resources)}
+        )
+
+        check.run()
+
+        assert check._passed is False
+        assert "multiple isolation boundaries" in check._error
+
+    def test_resource_outside_tenant_fails(self) -> None:
+        """A resource assigned to another tenant breaks the security boundary."""
+        resources = [
+            _topology_resource("node-1"),
+            _topology_resource("node-2", tenant_id="tenant-b"),
+            _topology_resource("fabric-1", resource_type="network"),
+        ]
+        check = CapacityTopologyBlockAtomicAllocationCheck(
+            config={"step_output": _topology_output(resources=resources)}
+        )
+
+        check.run()
+
+        assert check._passed is False
+        assert "node-2 tenant_id tenant-b != tenant-a" in check._error
+
+    def test_resource_outside_block_fails(self) -> None:
+        """Every resource must identify the same topology block."""
+        resources = [
+            _topology_resource("node-1"),
+            _topology_resource("node-2", block_id="block-b"),
+            _topology_resource("fabric-1", resource_type="network"),
+        ]
+        check = CapacityTopologyBlockAtomicAllocationCheck(
+            config={"step_output": _topology_output(resources=resources)}
+        )
+
+        check.run()
+
+        assert check._passed is False
+        assert "node-2 topology_block_id block-b != block-a" in check._error
+
+    def test_invalid_min_resources_fails(self) -> None:
+        """Config validation rejects non-positive min_resources values."""
+        check = CapacityTopologyBlockAtomicAllocationCheck(
+            config={
+                "step_output": _topology_output(),
+                "min_resources": 0,
+            }
+        )
+
+        check.run()
+
+        assert check._passed is False
+        assert "min_resources must be >= 1" in check._error


### PR DESCRIPTION
## Summary

Adds CAP04 capacity checks under the existing security suite.

## Changes

- Adds provider-neutral `CapacityReservationGroupingCheck` and `CapacityTopologyBlockAtomicAllocationCheck`.
- Wires CAP04-01 and CAP04-02 into `suites/security.yaml`, plus AWS and my-isv `security.yaml` configs.
- Adds AWS and my-isv capacity scripts for reservation grouping and topology block atomic allocation.
- Gates CAP04 steps while the new validations are unreleased, so default demo runs skip the scripts until release.
- Adds unit/config/catalog coverage and updates suite/provider documentation.

## Testing

- `uv run pytest isvtest/tests/test_capacity.py isvtest/tests/test_catalog.py isvctl/tests/test_capacity_config.py isvctl/tests/test_aws_capacity_atomic_allocation.py isvctl/tests/test_aws_capacity_reservation.py isvctl/tests/test_orchestrator_loop.py isvctl/tests/test_schema.py`
- `make demo-test`
- `make lint`
- `uvx pre-commit run -a`
- Live AWS: tested both validations successfully `ISVTEST_INCLUDE_UNRELEASED=1 uv run isvctl test run \
    -f isvctl/configs/providers/aws/config/security.yaml \
    --label capacity \
    --no-upload \
    -- -v -s`

Closes #252
Closes #253


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two capacity validations: reservation grouping (tenant pinning) and topology-block atomic allocation, with AWS reference implementations and demo-provider templates; Ubuntu AMI discovery helper added.

* **Documentation**
  * Updated suite and script docs with validation details and example provider-neutral JSON contracts.

* **Configuration**
  * Wired new capacity steps into security suites/provider configs with templated inputs and teardown flags.

* **Tests**
  * Added extensive tests for validations, AWS flows, teardown safety, retries, error mapping, and CLI output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->