### PR TITLE
feat(nico): add InfiniBand tenant-isolation and key-config validations (SDN04-04, SDN04-05)

### DIFF
--- a/isvctl/configs/providers/nico/config/bare_metal.yaml
+++ b/isvctl/configs/providers/nico/config/bare_metal.yaml
@@ -17,8 +17,8 @@
 #
 # Imports the provider-agnostic bare_metal contract and wires the NICo
 # hardware-lifecycle steps. NICo currently implements the hardware ingestion,
-# DPU health, governance-metrics, and unified host-health steps; the remaining
-# bare_metal
+# DPU health, governance-metrics, unified host-health, and InfiniBand
+# fabric-security steps; the remaining bare_metal
 # validations are skipped automatically because their steps are not defined
 # here (a future PR will wire the full lifecycle so NICo can pass the entire
 # BM suite).
@@ -36,6 +36,12 @@
 #     alert-free (CAP05-01). Leak detection (BmcLeakDetection/Leak) is included.
 #   - query_health_aggregation.py rolls host health up to the nodegroup
 #     primitive; HealthAggregationCheck validates it (CAP05-02).
+#   - query_ib_tenant_isolation.py lists InfiniBand partitions with their
+#     P_Key + owning tenant; IbTenantIsolationCheck verifies per-tenant
+#     P_Key isolation (SDN04-04).
+#   - query_ib_keys.py reports InfiniBand key configuration (P_Key from NICo,
+#     Management Key from UFM when configured); IbKeysConfiguredCheck
+#     validates the required keys (SDN04-05).
 #
 # Prerequisites:
 #   - NICO_API_BASE set to the NICo API base URL
@@ -124,6 +130,42 @@ commands:
       - name: query_health_aggregation
         phase: test
         command: "python ../scripts/health/query_health_aggregation.py"
+        args:
+          - "--org"
+          - "{{org}}"
+          - "--site-id"
+          - "{{site_id}}"
+          - "--api-base"
+          - "{{nico_api_base}}"
+        timeout: 120
+
+      # ─── InfiniBand Tenant Isolation (SDN04-04) ────────────────────
+      # Lists the site's InfiniBand partitions and reports each partition's
+      # P_Key, owning tenant, and status. IbTenantIsolationCheck verifies
+      # that each tenant's compute is scoped to its own P_Key (the subnet
+      # manager enforces P_Key membership) and that no P_Key is shared
+      # across tenants.
+      - name: query_ib_tenant_isolation
+        phase: test
+        command: "python ../scripts/infiniband/query_ib_tenant_isolation.py"
+        args:
+          - "--org"
+          - "{{org}}"
+          - "--site-id"
+          - "{{site_id}}"
+          - "--api-base"
+          - "{{nico_api_base}}"
+        timeout: 120
+
+      # ─── InfiniBand Security Keys (SDN04-05) ───────────────────────
+      # Reports InfiniBand key configuration: the P_Key from NICo's
+      # partition API and the Management Key (M_Key) from UFM's /app/smconf
+      # when UFM access is configured (UFM_ADDRESS + UFM_TOKEN). The
+      # remaining OpenSM/SHARP keys live on the UFM host and are reported as
+      # unverified. IbKeysConfiguredCheck validates the required subset.
+      - name: query_ib_keys
+        phase: test
+        command: "python ../scripts/infiniband/query_ib_keys.py"
         args:
           - "--org"
           - "{{org}}"

--- a/isvctl/configs/providers/nico/scripts/common/__init__.py
+++ b/isvctl/configs/providers/nico/scripts/common/__init__.py
@@ -21,4 +21,6 @@ any namespace-package juggling. Modules:
 
 - ``nico_client``: authenticated NICo (Forge) REST API helpers with pagination,
   URL encoding, and machine health/capability parsing utilities.
+- ``ufm_client``: minimal NVIDIA Unified Fabric Manager (UFM) REST client for
+  reading InfiniBand subnet-manager key configuration (``/app/smconf``).
 """

--- a/isvctl/configs/providers/nico/scripts/common/ufm_client.py
+++ b/isvctl/configs/providers/nico/scripts/common/ufm_client.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal NVIDIA Unified Fabric Manager (UFM) REST client.
+
+The InfiniBand subnet-manager security keys (M_Key, SM_Key, SA_Key, and the
+``m_key_per_port`` protection flag) are configured on the UFM host and are not
+surfaced by NICo's public REST API. They are, however, readable from UFM's own
+REST API at ``/app/smconf`` -- the same endpoint NICo's IbFabricMonitor uses to
+decide whether a fabric is securely configured.
+
+This client mirrors NICo's UFM auth model (``infra-controller``
+``crates/ib-fabric/src/ib/ufmclient``):
+
+- Token auth (``UFM_TOKEN``): base path ``/ufmRestV3``, ``Authorization: Basic <token>``.
+- Basic auth (``UFM_USERNAME`` / ``UFM_PASSWORD``): base path ``/ufmRest``,
+  ``Authorization: Basic <base64(user:pass)>``.
+
+UFM commonly serves a self-signed certificate, so TLS verification can be
+disabled with ``UFM_ALLOW_INSECURE=1`` (verification is on by default).
+
+Reference:
+    infra-controller crates/ib-fabric/src/ib/ufmclient/{mod.rs,rest.rs}
+    NVIDIA UFM Enterprise REST API Guide
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import ssl
+from typing import Any, NamedTuple
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+UFM_TIMEOUT_SECONDS = 30
+
+
+class UfmAuthError(RuntimeError):
+    """Raised when UFM authentication cannot be resolved."""
+
+
+class UfmAuth(NamedTuple):
+    """Resolved UFM connection: base URL, auth header, TLS posture, source label."""
+
+    base_url: str
+    auth_header: str
+    insecure: bool
+    source: str
+
+
+def _env(name: str) -> str:
+    """Return a stripped environment value or an empty string."""
+    return os.environ.get(name, "").strip()
+
+
+def ufm_configured() -> bool:
+    """Return whether enough UFM configuration is present to attempt a connection."""
+    return bool(_env("UFM_ADDRESS") and (_env("UFM_TOKEN") or (_env("UFM_USERNAME") and _env("UFM_PASSWORD"))))
+
+
+def _insecure_enabled() -> bool:
+    """Return whether TLS verification to UFM should be disabled."""
+    return _env("UFM_ALLOW_INSECURE").lower() in {"1", "true", "yes", "on"}
+
+
+def resolve_ufm_auth() -> UfmAuth:
+    """Resolve UFM REST authentication from environment variables.
+
+    Resolution order:
+    1. ``UFM_TOKEN`` (UFM access token) against the ``/ufmRestV3`` base path.
+    2. ``UFM_USERNAME`` / ``UFM_PASSWORD`` against the ``/ufmRest`` base path.
+
+    Raises:
+        UfmAuthError: when ``UFM_ADDRESS`` or credentials are missing.
+    """
+    address = _env("UFM_ADDRESS")
+    if not address:
+        raise UfmAuthError("UFM access is not configured; set UFM_ADDRESS")
+
+    parsed = urlparse(address if "://" in address else f"https://{address}")
+    if not parsed.hostname:
+        raise UfmAuthError(f"UFM_ADDRESS is not a valid URL: {address!r}")
+    scheme = parsed.scheme or "https"
+    netloc = parsed.hostname + (f":{parsed.port}" if parsed.port else "")
+
+    token = _env("UFM_TOKEN")
+    if token:
+        base_path = "ufmRestV3"
+        auth_header = f"Basic {token}"
+        source = "UFM_TOKEN"
+    else:
+        username = _env("UFM_USERNAME")
+        password = _env("UFM_PASSWORD")
+        if not (username and password):
+            raise UfmAuthError("UFM authentication is not configured; set UFM_TOKEN or UFM_USERNAME and UFM_PASSWORD")
+        base_path = "ufmRest"
+        auth_header = "Basic " + base64.b64encode(f"{username}:{password}".encode()).decode()
+        source = "UFM_USERNAME"
+
+    return UfmAuth(
+        base_url=f"{scheme}://{netloc}/{base_path}",
+        auth_header=auth_header,
+        insecure=_insecure_enabled(),
+        source=source,
+    )
+
+
+def ufm_get(path: str, auth: UfmAuth, *, timeout: int = UFM_TIMEOUT_SECONDS) -> Any:
+    """Make an authenticated GET request to a UFM REST path.
+
+    Args:
+        path: API path relative to the base path (e.g. "app/smconf").
+        auth: Resolved UFM auth.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        Parsed JSON response.
+
+    Raises:
+        HTTPError / URLError: on transport/HTTP failures.
+        UfmAuthError: when UFM signals a not-found via its ``{}``-with-200 quirk
+            or returns a non-JSON body.
+    """
+    url = f"{auth.base_url}/{path.strip('/')}"
+    req = Request(url, headers={"Authorization": auth.auth_header})
+    context = ssl._create_unverified_context() if auth.insecure else None
+
+    with urlopen(req, timeout=timeout, context=context) as resp:
+        body = resp.read().decode()
+
+    # UFM sometimes returns 200 with an empty object to mean "not found".
+    if body.strip() == "{}":
+        raise UfmAuthError(f"UFM returned an empty body for {path!r} (resource not found)")
+    try:
+        return json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        raise UfmAuthError(f"UFM response for {path!r} was not valid JSON") from e
+
+
+def get_sm_config(auth: UfmAuth, *, timeout: int = UFM_TIMEOUT_SECONDS) -> dict[str, Any]:
+    """Return the OpenSM configuration UFM exposes at ``/app/smconf``.
+
+    The response carries the subnet-manager security keys: ``m_key`` (Management
+    Key), ``sm_key``, ``sa_key``, and the ``m_key_per_port`` protection flag.
+    """
+    config = ufm_get("app/smconf", auth, timeout=timeout)
+    if not isinstance(config, dict):
+        raise UfmAuthError("UFM /app/smconf did not return an object")
+    return config
+
+
+def parse_key_value(value: Any) -> int | None:
+    """Parse a UFM key value (hex "0x10" or decimal) to an int, else None."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if not isinstance(value, str):
+        return None
+    text = value.strip().lower()
+    if not text:
+        return None
+    try:
+        return int(text, 16) if text.startswith("0x") else int(text, 10)
+    except ValueError:
+        return None
+
+
+def describe_http_error(e: HTTPError) -> str:
+    """Return a concise, body-trimmed description of a UFM HTTP error."""
+    body = ""
+    if e.fp:
+        body = e.fp.read().decode(errors="replace")[:200]
+    detail = f"HTTP {e.code}"
+    return f"{detail}: {body}" if body else detail
+
+
+def describe_url_error(e: URLError) -> str:
+    """Return a concise description of a UFM connection error."""
+    return f"connection failed: {e.reason}"

--- a/isvctl/configs/providers/nico/scripts/common/ufm_client.py
+++ b/isvctl/configs/providers/nico/scripts/common/ufm_client.py
@@ -47,7 +47,7 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
-UFM_TIMEOUT_SECONDS = 30
+UFM_TIMEOUT_SECONDS: int = 30
 
 
 class UfmAuthError(RuntimeError):

--- a/isvctl/configs/providers/nico/scripts/infiniband/query_ib_keys.py
+++ b/isvctl/configs/providers/nico/scripts/infiniband/query_ib_keys.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Report InfiniBand security-key configuration for a NICo site (SDN04-05).
+
+SDN04 requires the InfiniBand fabric to be hardened with the partition key plus
+the OpenSM / SHARP subnet-manager keys. The evidence is split across two
+sources, and this script gathers what each authoritatively exposes:
+
+- **P_Key** -- read from NICo's InfiniBand partition API. Every NICo-managed
+  partition is allocated a P_Key from the configured pool, so a partition that
+  carries a (non-default) P_Key proves the partition-key mechanism is live.
+- **Management Key (M_Key)** -- read from UFM's ``/app/smconf`` endpoint (the
+  same source NICo's IbFabricMonitor uses), when UFM access is configured. The
+  key is "configured" when ``m_key`` is non-zero and ``m_key_per_port`` is
+  enabled. The secret value is never emitted -- only the derived posture.
+
+The remaining keys (Aggregation Management / SHARP, VendorSpecific, Congestion
+Control, Node2Node, Manager2Node) are OpenSM / SHARP settings configured on the
+UFM host (see the IB runbook) and are not surfaced by the UFM REST API; they are
+reported as ``configured: null`` (unverified) with a pointer to the runbook so
+the validation neither fabricates a pass nor hard-fails for them.
+
+NICo API endpoints used:
+  GET /v2/org/{org}/carbide/infiniband-partition?siteId={site_id}
+
+UFM endpoint used (optional, when UFM_ADDRESS + credentials are set):
+  GET /ufmRest(V3)/app/smconf
+
+Auth:
+  - NICo: NICO_BEARER_TOKEN, or OIDC client_credentials.
+  - UFM (optional): UFM_ADDRESS + UFM_TOKEN, or UFM_USERNAME / UFM_PASSWORD.
+    Set UFM_ALLOW_INSECURE=1 for UFM's self-signed certificate.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "nico",
+    "site_id": "...",
+    "partitions_with_pkey": 2,
+    "keys": {
+      "p_key":            {"configured": true,  "source": "nico", "detail": "..."},
+      "management_key":   {"configured": true,  "source": "ufm",  "detail": "..."},
+      "aggregation_management_key": {"configured": null, "source": "ufm-host", "detail": "..."},
+      ...
+    }
+  }
+
+Usage:
+    NICO_BEARER_TOKEN=<token> UFM_ADDRESS=<url> UFM_TOKEN=<token> \
+        python query_ib_keys.py --org <org> --site-id <uuid> --api-base <url>
+
+    Wired via the bare_metal suite:
+      uv run isvctl test run -f isvctl/configs/providers/nico/config/bare_metal.yaml
+
+Reference:
+    infra-controller crates/ib-fabric/src/lib.rs (insecure_fabric_configuration)
+    infra-controller docs/playbooks/ib_runbook.md (M_Key / CC_Key / N2N_Key / VS_Key)
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+
+# Allow importing from sibling common/ directory
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.nico_client import NicoAuthError, forge_get_all, resolve_auth
+from common.ufm_client import (
+    UfmAuthError,
+    describe_http_error,
+    describe_url_error,
+    get_sm_config,
+    parse_key_value,
+    resolve_ufm_auth,
+    ufm_configured,
+)
+
+# UFM's default partition spans every port; its P_Key is not a tenant key.
+DEFAULT_PARTITION_PKEY = 0x7FFF
+
+# Subnet-manager / SHARP keys that are configured on the UFM host (per the IB
+# runbook) but are not exposed by the UFM REST API, so the script cannot observe
+# them. Reported as unverified rather than guessed.
+UFM_HOST_KEYS: dict[str, str] = {
+    "aggregation_management_key": "SHARP Aggregation Management Key (AM_Key)",
+    "vendor_specific_key": "VendorSpecific Key (vs_key_enable)",
+    "congestion_control_key": "Congestion Control Key (cc_key_enable)",
+    "node2node_key": "Node2Node Key (n2n_key_enable)",
+    "manager2node_key": "Manager2Node Key (SHARP)",
+}
+
+
+def _pkey_is_tenant_key(value: Any) -> bool:
+    """Return whether a partition's P_Key is a real, non-default tenant key."""
+    pkey = parse_key_value(value)
+    return pkey is not None and pkey != DEFAULT_PARTITION_PKEY
+
+
+def _management_key_entry() -> dict[str, Any]:
+    """Resolve the Management Key (M_Key) posture from UFM, when configured."""
+    if not ufm_configured():
+        return {
+            "configured": None,
+            "source": "ufm",
+            "detail": "UFM access not configured (set UFM_ADDRESS and UFM_TOKEN to verify the Management Key)",
+        }
+
+    try:
+        auth = resolve_ufm_auth()
+        smconf = get_sm_config(auth)
+    except UfmAuthError as e:
+        return {"configured": None, "source": "ufm", "detail": f"UFM query failed: {e}"}
+    except HTTPError as e:
+        return {"configured": None, "source": "ufm", "detail": f"UFM query failed: {describe_http_error(e)}"}
+    except URLError as e:
+        return {"configured": None, "source": "ufm", "detail": f"UFM query failed: {describe_url_error(e)}"}
+
+    m_key = parse_key_value(smconf.get("m_key"))
+    per_port = bool(smconf.get("m_key_per_port"))
+
+    # Mirror NICo's own secure-fabric definition: a configured Management Key is
+    # a non-zero m_key protected per-port. The secret value is never emitted.
+    if m_key in (None, 0):
+        return {"configured": False, "source": "ufm", "detail": "m_key is unset (0)"}
+    if not per_port:
+        return {"configured": False, "source": "ufm", "detail": "m_key set but m_key_per_port protection is disabled"}
+    return {"configured": True, "source": "ufm", "detail": "m_key configured with per-port protection"}
+
+
+def main() -> int:
+    """Gather InfiniBand key configuration and print the JSON contract to stdout."""
+    parser = argparse.ArgumentParser(description="Report InfiniBand security-key configuration on a NICo site")
+    parser.add_argument("--org", required=True, help="NGC org name")
+    parser.add_argument("--site-id", required=True, help="NICo site UUID")
+    parser.add_argument("--api-base", required=True, help="NICo API base URL")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "nico",
+        "site_id": args.site_id,
+        "partitions_with_pkey": 0,
+        "keys": {},
+    }
+
+    try:
+        auth = resolve_auth()
+
+        partitions = forge_get_all(
+            args.org,
+            "infiniband-partition",
+            auth.token,
+            base_url=args.api_base,
+            params={"siteId": args.site_id},
+            result_key="infinibandPartitions",
+        )
+
+        if not partitions:
+            result["success"] = True
+            result["skipped"] = True
+            result["skip_reason"] = (
+                "No InfiniBand partitions found at site; cannot evidence the P_Key. "
+                "InfiniBand may not be configured or no tenant partitions are provisioned"
+            )
+            print(json.dumps(result, indent=2))
+            return 0
+
+        partitions_with_pkey = sum(1 for p in partitions if _pkey_is_tenant_key(p.get("partitionKey")))
+        result["partitions_with_pkey"] = partitions_with_pkey
+
+        keys: dict[str, dict[str, Any]] = {
+            "p_key": {
+                "configured": partitions_with_pkey >= 1,
+                "source": "nico",
+                "detail": f"{partitions_with_pkey} partition(s) carry a P_Key",
+            },
+            "management_key": _management_key_entry(),
+        }
+        for name, label in UFM_HOST_KEYS.items():
+            keys[name] = {
+                "configured": None,
+                "source": "ufm-host",
+                "detail": f"{label} is configured on the UFM host per the IB runbook; not exposed by the UFM REST API",
+            }
+
+        result["keys"] = keys
+        result["success"] = True
+
+    except NicoAuthError as e:
+        result["error_type"] = "auth"
+        result["error"] = str(e)
+    except Exception as e:
+        result["error"] = f"{type(e).__name__}: {e}"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/nico/scripts/infiniband/query_ib_keys.py
+++ b/isvctl/configs/providers/nico/scripts/infiniband/query_ib_keys.py
@@ -93,12 +93,12 @@ from common.ufm_client import (
 )
 
 # UFM's default partition spans every port; its P_Key is not a tenant key.
-DEFAULT_PARTITION_PKEY = 0x7FFF
+DEFAULT_PARTITION_PKEY: int = 0x7FFF
 
 # A P_Key's low 15 bits are the partition number; the top bit (0x8000) is the
 # membership type. Mask it off so the all-ports default is recognized whether it
 # appears as 0x7fff (limited) or 0xffff (full member).
-PKEY_BASE_MASK = 0x7FFF
+PKEY_BASE_MASK: int = 0x7FFF
 
 # Subnet-manager / SHARP keys that are configured on the UFM host (per the IB
 # runbook) but are not exposed by the UFM REST API, so the script cannot observe

--- a/isvctl/configs/providers/nico/scripts/infiniband/query_ib_keys.py
+++ b/isvctl/configs/providers/nico/scripts/infiniband/query_ib_keys.py
@@ -95,6 +95,11 @@ from common.ufm_client import (
 # UFM's default partition spans every port; its P_Key is not a tenant key.
 DEFAULT_PARTITION_PKEY = 0x7FFF
 
+# A P_Key's low 15 bits are the partition number; the top bit (0x8000) is the
+# membership type. Mask it off so the all-ports default is recognized whether it
+# appears as 0x7fff (limited) or 0xffff (full member).
+PKEY_BASE_MASK = 0x7FFF
+
 # Subnet-manager / SHARP keys that are configured on the UFM host (per the IB
 # runbook) but are not exposed by the UFM REST API, so the script cannot observe
 # them. Reported as unverified rather than guessed.
@@ -110,7 +115,11 @@ UFM_HOST_KEYS: dict[str, str] = {
 def _pkey_is_tenant_key(value: Any) -> bool:
     """Return whether a partition's P_Key is a real, non-default tenant key."""
     pkey = parse_key_value(value)
-    return pkey is not None and pkey != DEFAULT_PARTITION_PKEY
+    if pkey is None:
+        return False
+    # Compare partition numbers (membership bit masked) so a full-member default
+    # P_Key (0xffff) is excluded just like the limited-member default (0x7fff).
+    return (pkey & PKEY_BASE_MASK) != (DEFAULT_PARTITION_PKEY & PKEY_BASE_MASK)
 
 
 def _management_key_entry() -> dict[str, Any]:

--- a/isvctl/configs/providers/nico/scripts/infiniband/query_ib_tenant_isolation.py
+++ b/isvctl/configs/providers/nico/scripts/infiniband/query_ib_tenant_isolation.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Query InfiniBand partitions for tenant-isolation evidence (SDN04-04).
+
+NICo isolates InfiniBand compute with the native P_Key partition mechanism: a
+tenant's IB interfaces are bound to a tenant-owned ``IbPartition``, each backed
+by a single P_Key that the subnet manager enforces. Ports that do not share a
+P_Key cannot exchange InfiniBand traffic, regardless of physical connectivity,
+so per-tenant-P_Key partitioning *is* the isolation boundary.
+
+This script lists the site's InfiniBand partitions and reports, per partition,
+the P_Key, owning tenant, and status. ``IbTenantIsolationCheck`` then asserts
+that every partition is tenant-scoped, no P_Key is shared across tenants, and
+no tenant partition rides the all-ports default management partition.
+
+NICo API endpoints used:
+  GET /v2/org/{org}/carbide/infiniband-partition?siteId={site_id}
+
+Auth:
+  - NICO_BEARER_TOKEN, or
+  - OIDC client_credentials via NICO_SSA_ISSUER,
+    NICO_CLIENT_ID, NICO_CLIENT_SECRET, and optional NICO_OIDC_SCOPE.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "nico",
+    "site_id": "...",
+    "partitions_checked": 2,
+    "partitions": [
+      {
+        "name": "turbo-net",
+        "partition_key": "0x1",
+        "tenant_id": "f97df110-f4de-492e-8849-4a6af68026b0",
+        "status": "Ready"
+      }
+    ]
+  }
+
+A site with no InfiniBand partitions emits a structured skip
+(``skipped`` / ``skip_reason``) so the validation does not hard-fail a fabric
+that has no tenant partitions provisioned yet.
+
+Usage:
+    NICO_BEARER_TOKEN=<token> python query_ib_tenant_isolation.py \
+        --org <org> --site-id <uuid> --api-base <url>
+
+    Wired via the bare_metal suite:
+      uv run isvctl test run -f isvctl/configs/providers/nico/config/bare_metal.yaml
+
+Reference:
+    infra-controller docs/manuals/networking/infiniband_partitioning.md
+    OpenAPI spec: InfiniBandPartition schema (partitionKey / tenantId / status)
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Allow importing from sibling common/ directory
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.nico_client import NicoAuthError, forge_get_all, resolve_auth
+
+
+def partition_record(partition: dict[str, Any]) -> dict[str, Any]:
+    """Reduce a NICo InfiniBand partition to the provider-neutral isolation fields."""
+    return {
+        "name": partition.get("name") or partition.get("partitionName") or "",
+        "partition_key": partition.get("partitionKey"),
+        "tenant_id": partition.get("tenantId") or "",
+        "status": partition.get("status", "Unknown"),
+    }
+
+
+def main() -> int:
+    """Query NICo InfiniBand partitions and print tenant-isolation JSON to stdout."""
+    parser = argparse.ArgumentParser(description="Query InfiniBand tenant isolation on a NICo site")
+    parser.add_argument("--org", required=True, help="NGC org name")
+    parser.add_argument("--site-id", required=True, help="NICo site UUID")
+    parser.add_argument("--api-base", required=True, help="NICo API base URL")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "nico",
+        "site_id": args.site_id,
+        "partitions_checked": 0,
+        "partitions": [],
+    }
+
+    try:
+        auth = resolve_auth()
+
+        partitions = forge_get_all(
+            args.org,
+            "infiniband-partition",
+            auth.token,
+            base_url=args.api_base,
+            params={"siteId": args.site_id},
+            result_key="infinibandPartitions",
+        )
+
+        if not partitions:
+            result["success"] = True
+            result["skipped"] = True
+            result["skip_reason"] = (
+                "No InfiniBand partitions found at site; InfiniBand may not be configured "
+                "or no tenant partitions are provisioned"
+            )
+            print(json.dumps(result, indent=2))
+            return 0
+
+        result["partitions"] = [partition_record(p) for p in partitions]
+        result["partitions_checked"] = len(result["partitions"])
+        result["success"] = True
+
+    except NicoAuthError as e:
+        result["error_type"] = "auth"
+        result["error"] = str(e)
+    except Exception as e:
+        result["error"] = f"{type(e).__name__}: {e}"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -112,6 +112,8 @@ For the domain / script-count / AWS-reference overview see the
 | `query_governance_metrics` | test | `providers/nico/scripts/governance/query_metrics.py` | `machine_count`, `metrics.delivered.{nodes,gpus}`, `metrics.healthy.{nodes,gpus}`, `metrics.reserved.{nodes,gpus}`, `metrics.active.{nodes,gpus}` |
 | `query_host_health` | test | `providers/nico/scripts/health/query_host_health.py` | `hosts_checked`, `hosts[].health_present`, `hosts[].healthy`, `hosts[].observed_age_seconds`, `hosts[].probe_ids`, `hosts[].alerts[].{id,target,message,classifications}`, `hosts[].components.{gpu,thermal,memory,cooling}` |
 | `query_health_aggregation` | test | `providers/nico/scripts/health/query_health_aggregation.py` | `aggregation_level`, `groups[].{total,healthy,unhealthy,status,unhealthy_hosts}` |
+| `query_ib_tenant_isolation` | test | `providers/nico/scripts/infiniband/query_ib_tenant_isolation.py` | `partitions_checked`, `partitions[].{name,partition_key,tenant_id,status}` |
+| `query_ib_keys` | test | `providers/nico/scripts/infiniband/query_ib_keys.py` | `partitions_with_pkey`, `keys.<name>.{configured,source,detail}` |
 
 ### Kubernetes (`k8s.yaml`)
 

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -366,5 +366,30 @@ tests:
         HealthAggregationCheck:
           min_groups: 1
 
+    # InfiniBand tenant isolation (SDN04-04). Verifies each tenant's IB
+    # compute is scoped to its own P_Key partition (the subnet manager only
+    # passes traffic between ports sharing a P_Key), so compute dedicated to
+    # one tenant is isolated from other customers. Only runs for providers
+    # that implement the query_ib_tenant_isolation step.
+    ib_tenant_isolation:
+      step: query_ib_tenant_isolation
+      checks:
+        IbTenantIsolationCheck:
+          min_partitions: 1
+
+    # InfiniBand security keys (SDN04-05). The full requirement covers the
+    # P_Key plus the OpenSM/SHARP subnet-manager keys (Management,
+    # Aggregation Management, VendorSpecific, CongestionControl, Node2Node,
+    # Manager2Node). required_keys is scoped to the keys NICo can observe:
+    # the P_Key (NICo partition API) and the Management Key (UFM /app/smconf,
+    # when UFM access is configured). The remaining subnet-manager keys live
+    # on the UFM host and are reported as unverified. Only runs for providers
+    # that implement the query_ib_keys step.
+    ib_keys_configured:
+      step: query_ib_keys
+      checks:
+        IbKeysConfiguredCheck:
+          required_keys: ["p_key", "management_key"]
+
   exclude:
     labels: []

--- a/isvctl/src/isvctl/redaction.py
+++ b/isvctl/src/isvctl/redaction.py
@@ -179,6 +179,8 @@ SENSITIVE_ENV_VARS: frozenset[str] = frozenset(
         # NICo
         "NICO_BEARER_TOKEN",
         "NICO_CLIENT_SECRET",
+        # UFM (InfiniBand fabric manager)
+        "UFM_TOKEN",
         # ISV
         "ISV_CLIENT_SECRET",
     }

--- a/isvctl/tests/test_nico_provider.py
+++ b/isvctl/tests/test_nico_provider.py
@@ -32,6 +32,7 @@ from urllib.parse import parse_qs
 import pytest
 from isvtest.validations.governance import GovernanceMetricsCheck
 from isvtest.validations.health import HealthAggregationCheck, HostHealthCheck
+from isvtest.validations.infiniband import IbKeysConfiguredCheck, IbTenantIsolationCheck
 
 from isvctl.config.merger import merge_yaml_files
 
@@ -134,6 +135,38 @@ def _load_health_aggregation_script() -> ModuleType:
     """Load the query_health_aggregation script as a module for direct unit testing."""
     script_path = NICO_SCRIPTS / "health" / "query_health_aggregation.py"
     spec = importlib.util.spec_from_file_location("test_query_health_aggregation", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    with _isolated_common_imports():
+        spec.loader.exec_module(module)
+    return module
+
+
+def _load_ufm_client() -> ModuleType:
+    """Load the shared UFM client module directly from the provider scripts."""
+    script_path = NICO_COMMON / "ufm_client.py"
+    spec = importlib.util.spec_from_file_location("test_ufm_client", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_ib_tenant_isolation_script() -> ModuleType:
+    """Load the query_ib_tenant_isolation script as a module for direct unit testing."""
+    script_path = NICO_SCRIPTS / "infiniband" / "query_ib_tenant_isolation.py"
+    spec = importlib.util.spec_from_file_location("test_query_ib_tenant_isolation", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    with _isolated_common_imports():
+        spec.loader.exec_module(module)
+    return module
+
+
+def _load_ib_keys_script() -> ModuleType:
+    """Load the query_ib_keys script as a module for direct unit testing."""
+    script_path = NICO_SCRIPTS / "infiniband" / "query_ib_keys.py"
+    spec = importlib.util.spec_from_file_location("test_query_ib_keys", script_path)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     with _isolated_common_imports():
@@ -856,3 +889,409 @@ def test_health_aggregation_script_output_satisfies_validation_contract(
     check = HealthAggregationCheck(config={"step_output": payload})
     check.run()
     assert check._passed is True, check._error
+
+
+# ---------------------------------------------------------------------------
+# ufm_client (UFM REST helper)
+# ---------------------------------------------------------------------------
+
+
+def test_ufm_resolve_auth_prefers_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A UFM token uses the /ufmRestV3 base path with a Basic auth header."""
+    module = _load_ufm_client()
+    monkeypatch.setenv("UFM_ADDRESS", "https://ufm.example:443")
+    monkeypatch.setenv("UFM_TOKEN", "ufm-token")
+    monkeypatch.delenv("UFM_USERNAME", raising=False)
+    monkeypatch.delenv("UFM_PASSWORD", raising=False)
+
+    auth = module.resolve_ufm_auth()
+
+    assert auth.base_url == "https://ufm.example:443/ufmRestV3"
+    assert auth.auth_header == "Basic ufm-token"
+    assert auth.source == "UFM_TOKEN"
+    assert auth.insecure is False
+
+
+def test_ufm_resolve_auth_basic_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Username/password uses the /ufmRest base path with a base64 Basic header."""
+    module = _load_ufm_client()
+    monkeypatch.setenv("UFM_ADDRESS", "ufm.example")
+    monkeypatch.delenv("UFM_TOKEN", raising=False)
+    monkeypatch.setenv("UFM_USERNAME", "admin")
+    monkeypatch.setenv("UFM_PASSWORD", "secret")
+    monkeypatch.setenv("UFM_ALLOW_INSECURE", "1")
+    expected_header = "Basic " + base64.b64encode(b"admin:secret").decode()
+
+    auth = module.resolve_ufm_auth()
+
+    assert auth.base_url == "https://ufm.example/ufmRest"
+    assert auth.auth_header == expected_header
+    assert auth.source == "UFM_USERNAME"
+    assert auth.insecure is True
+
+
+def test_ufm_resolve_auth_missing_address_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without UFM_ADDRESS, auth resolution raises."""
+    module = _load_ufm_client()
+    monkeypatch.delenv("UFM_ADDRESS", raising=False)
+    monkeypatch.setenv("UFM_TOKEN", "ufm-token")
+
+    with pytest.raises(module.UfmAuthError, match="UFM_ADDRESS"):
+        module.resolve_ufm_auth()
+
+
+def test_ufm_configured_requires_address_and_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ufm_configured is True only with an address and a credential."""
+    module = _load_ufm_client()
+    monkeypatch.delenv("UFM_TOKEN", raising=False)
+    monkeypatch.delenv("UFM_USERNAME", raising=False)
+    monkeypatch.delenv("UFM_PASSWORD", raising=False)
+
+    monkeypatch.delenv("UFM_ADDRESS", raising=False)
+    assert module.ufm_configured() is False
+
+    monkeypatch.setenv("UFM_ADDRESS", "https://ufm.example")
+    assert module.ufm_configured() is False
+
+    monkeypatch.setenv("UFM_TOKEN", "tok")
+    assert module.ufm_configured() is True
+
+
+def test_ufm_parse_key_value() -> None:
+    """Key values parse from hex/decimal; junk and bools yield None."""
+    module = _load_ufm_client()
+    assert module.parse_key_value("0x10") == 16
+    assert module.parse_key_value("16") == 16
+    assert module.parse_key_value("0x0") == 0
+    assert module.parse_key_value(8) == 8
+    assert module.parse_key_value("") is None
+    assert module.parse_key_value(None) is None
+    assert module.parse_key_value(True) is None
+    assert module.parse_key_value("nothex") is None
+
+
+def test_ufm_get_sm_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_sm_config fetches /app/smconf and returns the parsed object."""
+    module = _load_ufm_client()
+    smconf = {"subnet_prefix": "0xfe80", "m_key": "0x10", "sm_key": "0x20", "sa_key": "0x30", "m_key_per_port": True}
+    seen: dict[str, Any] = {}
+
+    def fake_urlopen(request, timeout: int = 30, context: Any = None):
+        seen["url"] = request.full_url
+        seen["authorization"] = request.get_header("Authorization")
+        return _Response(smconf)
+
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+    auth = module.UfmAuth(
+        base_url="https://ufm.example:443/ufmRestV3",
+        auth_header="Basic ufm-token",
+        insecure=False,
+        source="UFM_TOKEN",
+    )
+
+    config = module.get_sm_config(auth)
+
+    assert config == smconf
+    assert seen["url"] == "https://ufm.example:443/ufmRestV3/app/smconf"
+    assert seen["authorization"] == "Basic ufm-token"
+
+
+# ---------------------------------------------------------------------------
+# query_ib_tenant_isolation (SDN04-04) script
+# ---------------------------------------------------------------------------
+
+
+def _ib_partition(
+    *,
+    name: str,
+    partition_key: str | None,
+    tenant_id: str,
+    status: str = "Ready",
+) -> dict[str, Any]:
+    """Build a minimal NICo InfiniBand partition payload."""
+    return {"name": name, "partitionKey": partition_key, "tenantId": tenant_id, "status": status}
+
+
+def test_ib_isolation_script_maps_partition_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The script reduces NICo partitions to the neutral isolation fields."""
+    module = _load_ib_tenant_isolation_script()
+    partitions = [
+        _ib_partition(name="turbo-net", partition_key="0x1", tenant_id="tenant-a"),
+        _ib_partition(name="storage-net", partition_key="0x2", tenant_id="tenant-b"),
+    ]
+
+    payload = _run_script(module, monkeypatch, capsys, script_name="query_ib_tenant_isolation.py", machines=partitions)
+
+    assert payload["success"] is True
+    assert payload["platform"] == "nico"
+    assert payload["partitions_checked"] == 2
+    assert payload["partitions"][0] == {
+        "name": "turbo-net",
+        "partition_key": "0x1",
+        "tenant_id": "tenant-a",
+        "status": "Ready",
+    }
+
+
+def test_ib_isolation_script_skips_when_no_partitions(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An empty partition list yields a structured skip, not a failure."""
+    module = _load_ib_tenant_isolation_script()
+
+    payload = _run_script(module, monkeypatch, capsys, script_name="query_ib_tenant_isolation.py", machines=[])
+
+    assert payload["success"] is True
+    assert payload["skipped"] is True
+    assert "No InfiniBand partitions" in payload["skip_reason"]
+
+
+def test_ib_isolation_script_surfaces_api_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Exceptions from the NICo client are reported, not raised."""
+    module = _load_ib_tenant_isolation_script()
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+
+    def _boom(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("simulated outage")
+
+    monkeypatch.setattr(module, "forge_get_all", _boom)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["query_ib_tenant_isolation.py", "--org", "o", "--site-id", "s", "--api-base", "http://127.0.0.1/v2/org"],
+    )
+
+    exit_code = module.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert "simulated outage" in payload["error"]
+
+
+def test_ib_isolation_script_output_satisfies_validation_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """End-to-end: NICo isolation JSON passes IbTenantIsolationCheck."""
+    module = _load_ib_tenant_isolation_script()
+    partitions = [
+        _ib_partition(name="a", partition_key="0x1", tenant_id="tenant-a"),
+        _ib_partition(name="b", partition_key="0x2", tenant_id="tenant-b"),
+    ]
+
+    payload = _run_script(module, monkeypatch, capsys, script_name="query_ib_tenant_isolation.py", machines=partitions)
+
+    check = IbTenantIsolationCheck(config={"step_output": payload})
+    check.run()
+    assert check._passed is True, check._error
+
+
+def test_ib_isolation_shared_pkey_fails_validation_end_to_end(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """End-to-end: a P_Key shared by two tenants flows through to a failure."""
+    module = _load_ib_tenant_isolation_script()
+    partitions = [
+        _ib_partition(name="a", partition_key="0x5", tenant_id="tenant-a"),
+        _ib_partition(name="b", partition_key="0x5", tenant_id="tenant-b"),
+    ]
+
+    payload = _run_script(module, monkeypatch, capsys, script_name="query_ib_tenant_isolation.py", machines=partitions)
+
+    check = IbTenantIsolationCheck(config={"step_output": payload})
+    check.run()
+    assert check._passed is False
+    assert "shared across tenants" in check._error
+
+
+# ---------------------------------------------------------------------------
+# query_ib_keys (SDN04-05) script
+# ---------------------------------------------------------------------------
+
+
+def _run_ib_keys_script(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    *,
+    partitions: list[dict[str, Any]],
+    smconf: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Drive the IB-keys script with mocked NICo partitions and optional UFM smconf.
+
+    When ``smconf`` is None, UFM is treated as not configured.
+    """
+    module = _load_ib_keys_script()
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(module, "forge_get_all", lambda *args, **kwargs: partitions)
+
+    if smconf is None:
+        monkeypatch.setattr(module, "ufm_configured", lambda: False)
+    else:
+        monkeypatch.setattr(module, "ufm_configured", lambda: True)
+        monkeypatch.setattr(
+            module,
+            "resolve_ufm_auth",
+            lambda: SimpleNamespace(base_url="https://ufm/ufmRestV3", auth_header="Basic x", insecure=False),
+        )
+        monkeypatch.setattr(module, "get_sm_config", lambda auth: smconf)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["query_ib_keys.py", "--org", "o", "--site-id", "s", "--api-base", "http://127.0.0.1/v2/org"],
+    )
+
+    exit_code = module.main()
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0, payload
+    return payload
+
+
+def test_ib_keys_script_pkey_from_partitions(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """P_Key evidence is derived from non-default partition keys."""
+    partitions = [
+        _ib_partition(name="a", partition_key="0x1", tenant_id="tenant-a"),
+        _ib_partition(name="b", partition_key="0x2", tenant_id="tenant-b"),
+        # The default all-ports partition does not count as a tenant P_Key.
+        _ib_partition(name="management", partition_key="0x7fff", tenant_id=""),
+    ]
+
+    payload = _run_ib_keys_script(monkeypatch, capsys, partitions=partitions)
+
+    assert payload["success"] is True
+    assert payload["partitions_with_pkey"] == 2
+    assert payload["keys"]["p_key"]["configured"] is True
+    assert payload["keys"]["p_key"]["source"] == "nico"
+
+
+def test_ib_keys_script_management_key_unverified_without_ufm(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Without UFM access the Management Key is reported as unverified (null)."""
+    partitions = [_ib_partition(name="a", partition_key="0x1", tenant_id="tenant-a")]
+
+    payload = _run_ib_keys_script(monkeypatch, capsys, partitions=partitions)
+
+    mgmt = payload["keys"]["management_key"]
+    assert mgmt["configured"] is None
+    assert "UFM access not configured" in mgmt["detail"]
+    # The OpenSM/SHARP host keys are always reported as unverified.
+    assert payload["keys"]["congestion_control_key"]["configured"] is None
+    assert set(payload["keys"]) >= {
+        "p_key",
+        "management_key",
+        "aggregation_management_key",
+        "vendor_specific_key",
+        "congestion_control_key",
+        "node2node_key",
+        "manager2node_key",
+    }
+
+
+def test_ib_keys_script_management_key_configured_from_ufm(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A non-zero m_key with per-port protection marks the Management Key configured."""
+    partitions = [_ib_partition(name="a", partition_key="0x1", tenant_id="tenant-a")]
+    smconf = {"m_key": "0x771d2fe77f553d47", "sm_key": "0x20", "sa_key": "0x30", "m_key_per_port": True}
+
+    payload = _run_ib_keys_script(monkeypatch, capsys, partitions=partitions, smconf=smconf)
+
+    mgmt = payload["keys"]["management_key"]
+    assert mgmt["configured"] is True
+    assert mgmt["source"] == "ufm"
+    # The raw key value must never be emitted.
+    assert "0x771d2fe77f553d47" not in json.dumps(payload)
+
+
+def test_ib_keys_script_management_key_insecure_when_mkey_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An m_key of 0 marks the Management Key explicitly NOT configured."""
+    partitions = [_ib_partition(name="a", partition_key="0x1", tenant_id="tenant-a")]
+    smconf = {"m_key": "0x0", "sm_key": "0x20", "sa_key": "0x30", "m_key_per_port": True}
+
+    payload = _run_ib_keys_script(monkeypatch, capsys, partitions=partitions, smconf=smconf)
+
+    assert payload["keys"]["management_key"]["configured"] is False
+
+
+def test_ib_keys_script_management_key_insecure_without_per_port(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A set m_key without per-port protection is not a configured Management Key."""
+    partitions = [_ib_partition(name="a", partition_key="0x1", tenant_id="tenant-a")]
+    smconf = {"m_key": "0x10", "sm_key": "0x20", "sa_key": "0x30", "m_key_per_port": False}
+
+    payload = _run_ib_keys_script(monkeypatch, capsys, partitions=partitions, smconf=smconf)
+
+    assert payload["keys"]["management_key"]["configured"] is False
+    assert "m_key_per_port" in payload["keys"]["management_key"]["detail"]
+
+
+def test_ib_keys_script_skips_when_no_partitions(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An empty partition list yields a structured skip."""
+    payload = _run_ib_keys_script(monkeypatch, capsys, partitions=[])
+
+    assert payload["skipped"] is True
+    assert "cannot evidence the P_Key" in payload["skip_reason"]
+
+
+def test_ib_keys_script_output_satisfies_validation_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """End-to-end: NICo IB-keys JSON (with UFM) passes IbKeysConfiguredCheck."""
+    partitions = [_ib_partition(name="a", partition_key="0x1", tenant_id="tenant-a")]
+    smconf = {"m_key": "0x10", "sm_key": "0x20", "sa_key": "0x30", "m_key_per_port": True}
+
+    payload = _run_ib_keys_script(monkeypatch, capsys, partitions=partitions, smconf=smconf)
+
+    check = IbKeysConfiguredCheck(config={"step_output": payload, "required_keys": ["p_key", "management_key"]})
+    check.run()
+    assert check._passed is True, check._error
+
+
+def test_ib_keys_script_surfaces_api_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Exceptions from the NICo client are reported, not raised."""
+    module = _load_ib_keys_script()
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+
+    def _boom(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("simulated outage")
+
+    monkeypatch.setattr(module, "forge_get_all", _boom)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["query_ib_keys.py", "--org", "o", "--site-id", "s", "--api-base", "http://127.0.0.1/v2/org"],
+    )
+
+    exit_code = module.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert "simulated outage" in payload["error"]

--- a/isvctl/tests/test_nico_provider.py
+++ b/isvctl/tests/test_nico_provider.py
@@ -1176,6 +1176,23 @@ def test_ib_keys_script_pkey_from_partitions(
     assert payload["keys"]["p_key"]["source"] == "nico"
 
 
+def test_ib_keys_script_full_member_default_excluded_from_pkey_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A full-member default P_Key (0xffff) does not count as a tenant P_Key."""
+    partitions = [
+        _ib_partition(name="a", partition_key="0x1", tenant_id="tenant-a"),
+        # Full-member default partition: same partition number as 0x7fff.
+        _ib_partition(name="management", partition_key="0xffff", tenant_id=""),
+    ]
+
+    payload = _run_ib_keys_script(monkeypatch, capsys, partitions=partitions)
+
+    assert payload["partitions_with_pkey"] == 1
+    assert payload["keys"]["p_key"]["configured"] is True
+
+
 def test_ib_keys_script_management_key_unverified_without_ufm(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -61,6 +61,10 @@ from isvtest.validations.iam import (
     TenantInfoCheck,
     TenantListedCheck,
 )
+from isvtest.validations.infiniband import (
+    IbKeysConfiguredCheck,
+    IbTenantIsolationCheck,
+)
 from isvtest.validations.instance import (
     InstanceCreatedCheck,
     InstanceListCheck,
@@ -163,6 +167,8 @@ __all__ = [
     "GpuOperatorInstalledCheck",
     "HealthAggregationCheck",
     "HostHealthCheck",
+    "IbKeysConfiguredCheck",
+    "IbTenantIsolationCheck",
     "InsecureProtocolsCheck",
     "InstanceCreatedCheck",
     "InstanceListCheck",

--- a/isvtest/src/isvtest/validations/infiniband.py
+++ b/isvtest/src/isvtest/validations/infiniband.py
@@ -58,6 +58,13 @@ IB_KEY_NAMES: tuple[str, ...] = (
 # reused this P_Key would not be isolated, so it is never a valid tenant key.
 DEFAULT_PARTITION_PKEY = 0x7FFF
 
+# An InfiniBand P_Key is the partition number in the low 15 bits; the top bit
+# (0x8000) is the membership type (full vs limited member). Mask it off before
+# comparing partition identity so the all-ports default (0x7fff limited /
+# 0xffff full) is detected either way and a tenant partition seen as both
+# 0x0001 (limited) and 0x8001 (full) is recognised as the same partition.
+PKEY_BASE_MASK = 0x7FFF
+
 
 def _normalize_pkey(value: Any) -> int | None:
     """Return a P_Key as an int, accepting hex ("0x1") or decimal strings.
@@ -146,10 +153,12 @@ class IbTenantIsolationCheck(BaseValidation):
             return
 
         default_pkey = _normalize_pkey(self.config.get("default_partition_pkey", DEFAULT_PARTITION_PKEY))
+        default_base = default_pkey & PKEY_BASE_MASK if default_pkey is not None else None
 
-        # Maps a normalized P_Key to the set of distinct tenants that own a
-        # partition with that key. More than one tenant per key is an isolation
-        # breach (both tenants' ports could talk over the shared partition).
+        # Maps a partition number (membership bit masked off) to the set of
+        # distinct tenants that own a partition with that key. More than one
+        # tenant per key is an isolation breach (both tenants' ports could talk
+        # over the shared partition).
         pkey_tenants: dict[int, set[str]] = {}
         failed: list[str] = []
 
@@ -161,10 +170,13 @@ class IbTenantIsolationCheck(BaseValidation):
             tenant = tenant.strip() if isinstance(tenant, str) else ""
 
             problems: list[str] = []
+            partition_number: int | None = None
             if pkey is None:
                 problems.append("no P_Key allocated")
-            elif default_pkey is not None and pkey == default_pkey:
-                problems.append(f"reuses the default all-ports partition ({pkey_raw})")
+            else:
+                partition_number = pkey & PKEY_BASE_MASK
+                if default_base is not None and partition_number == default_base:
+                    problems.append(f"reuses the default all-ports partition ({pkey_raw})")
             if not tenant:
                 problems.append("not scoped to a tenant")
 
@@ -177,8 +189,11 @@ class IbTenantIsolationCheck(BaseValidation):
                 failed.append(f"{label} ({'; '.join(problems)})")
                 continue
 
-            # pkey/tenant are valid here -- record ownership for collision detection.
-            pkey_tenants.setdefault(pkey, set()).add(tenant)
+            # pkey/tenant are valid here -- record ownership for collision
+            # detection, keyed by partition number so membership variants of the
+            # same partition collapse together.
+            assert partition_number is not None
+            pkey_tenants.setdefault(partition_number, set()).add(tenant)
             self.report_subtest(
                 f"partition_{label}",
                 passed=True,

--- a/isvtest/src/isvtest/validations/infiniband.py
+++ b/isvtest/src/isvtest/validations/infiniband.py
@@ -56,14 +56,14 @@ IB_KEY_NAMES: tuple[str, ...] = (
 # UFM's default partition spans every port in the fabric (membership is
 # restricted to "limited" by the runbook hardening). A tenant partition that
 # reused this P_Key would not be isolated, so it is never a valid tenant key.
-DEFAULT_PARTITION_PKEY = 0x7FFF
+DEFAULT_PARTITION_PKEY: int = 0x7FFF
 
 # An InfiniBand P_Key is the partition number in the low 15 bits; the top bit
 # (0x8000) is the membership type (full vs limited member). Mask it off before
 # comparing partition identity so the all-ports default (0x7fff limited /
 # 0xffff full) is detected either way and a tenant partition seen as both
 # 0x0001 (limited) and 0x8001 (full) is recognised as the same partition.
-PKEY_BASE_MASK = 0x7FFF
+PKEY_BASE_MASK: int = 0x7FFF
 
 
 def _normalize_pkey(value: Any) -> int | None:

--- a/isvtest/src/isvtest/validations/infiniband.py
+++ b/isvtest/src/isvtest/validations/infiniband.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""InfiniBand fabric-security validations (requirement SDN04).
+
+Two provider-agnostic checks that assert an InfiniBand fabric isolates tenants
+and is hardened with the expected subnet-manager keys:
+
+- ``IbTenantIsolationCheck`` (SDN04-04): every tenant's InfiniBand compute is
+  scoped to its own P_Key partition. Because the subnet manager only permits
+  traffic between ports that share a P_Key, distinct-P_Key-per-tenant is the
+  fabric-side isolation boundary -- a host cannot bypass it. This asserts no
+  P_Key is shared across tenants and no tenant partition rides the all-ports
+  default management partition.
+- ``IbKeysConfiguredCheck`` (SDN04-05): the InfiniBand security keys (P_Key,
+  Management Key, and the OpenSM/SHARP subnet-manager keys) are configured.
+
+Both validations only inspect provider-neutral JSON produced by a step script,
+so any provider that emits the documented fields can reuse them.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+import pytest
+
+from isvtest.core.validation import BaseValidation
+
+# The InfiniBand security keys SDN04-05 expects to be configured, in the order
+# they appear in the requirement. ``p_key`` is the partition key the subnet
+# manager enforces; the rest are OpenSM / SHARP subnet-manager keys configured
+# on the UFM host (see the InfiniBand setup runbook).
+IB_KEY_NAMES: tuple[str, ...] = (
+    "p_key",
+    "management_key",
+    "aggregation_management_key",
+    "vendor_specific_key",
+    "congestion_control_key",
+    "node2node_key",
+    "manager2node_key",
+)
+
+# UFM's default partition spans every port in the fabric (membership is
+# restricted to "limited" by the runbook hardening). A tenant partition that
+# reused this P_Key would not be isolated, so it is never a valid tenant key.
+DEFAULT_PARTITION_PKEY = 0x7FFF
+
+
+def _normalize_pkey(value: Any) -> int | None:
+    """Return a P_Key as an int, accepting hex ("0x1") or decimal strings.
+
+    Returns ``None`` when the value is missing or not parseable so callers can
+    treat an unallocated/garbage P_Key as "no key" rather than crashing.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if not isinstance(value, str):
+        return None
+    text = value.strip().lower()
+    if not text:
+        return None
+    try:
+        return int(text, 16) if text.startswith("0x") else int(text, 10)
+    except ValueError:
+        return None
+
+
+class IbTenantIsolationCheck(BaseValidation):
+    """Validate InfiniBand tenant isolation via P_Key partitioning (SDN04-04).
+
+    InfiniBand isolation is enforced by the subnet manager: a host port that is
+    not a member of a P_Key cannot exchange traffic with any other member of
+    that P_Key, regardless of physical connectivity. NICo models each isolation
+    domain as a tenant-owned partition bound to a single P_Key, so verifying
+    isolation reduces to verifying the partition-to-tenant mapping:
+
+    * every partition carries a real P_Key (the subnet-manager enforcement
+      handle);
+    * every partition is owned by exactly one tenant (tenant-scoped);
+    * no P_Key is shared by two different tenants -- a shared P_Key would let
+      those tenants' compute communicate;
+    * no tenant partition reuses the all-ports default management partition.
+
+    Together these guarantee that compute dedicated to one tenant (e.g. NVIDIA)
+    is isolated from other customers on the fabric.
+
+    Config:
+        step_output: Step output containing the InfiniBand partitions.
+        min_partitions: Minimum number of partitions expected (default: 1).
+        default_partition_pkey: P_Key of the all-ports default partition that a
+            tenant partition must never reuse (default: 0x7fff).
+
+    Step output (from query_ib_tenant_isolation.py):
+        success: bool
+        platform: str
+        site_id: str
+        partitions_checked: int
+        partitions: list[dict]:
+            name: str
+            partition_key: str -- hex P_Key, e.g. "0x1"
+            tenant_id: str -- owning tenant (empty when unscoped)
+            status: str -- partition status (Ready, Provisioning, ...)
+    """
+
+    description: ClassVar[str] = "Check InfiniBand tenant isolation via per-tenant P_Key partitioning"
+    timeout: ClassVar[int] = 120
+    labels: ClassVar[tuple[str, ...]] = ("bare_metal", "security", "network", "infiniband")
+
+    def run(self) -> None:
+        """Validate per-tenant P_Key scoping and the absence of cross-tenant key sharing."""
+        step_output = self.config.get("step_output", {})
+
+        if step_output.get("skipped") is True:
+            pytest.skip(step_output.get("skip_reason") or "InfiniBand tenant isolation validation skipped")
+
+        if not step_output.get("success"):
+            self.set_failed(f"IB tenant isolation step failed: {step_output.get('error', 'Unknown error')}")
+            return
+
+        partitions = step_output.get("partitions")
+        if not isinstance(partitions, list):
+            self.set_failed("IB tenant isolation step output is missing the 'partitions' list")
+            return
+
+        min_partitions = self._parse_positive_int("min_partitions", default=1)
+        if min_partitions is None:
+            return
+
+        if len(partitions) < min_partitions:
+            self.set_failed(f"Expected at least {min_partitions} InfiniBand partition(s), got {len(partitions)}")
+            return
+
+        default_pkey = _normalize_pkey(self.config.get("default_partition_pkey", DEFAULT_PARTITION_PKEY))
+
+        # Maps a normalized P_Key to the set of distinct tenants that own a
+        # partition with that key. More than one tenant per key is an isolation
+        # breach (both tenants' ports could talk over the shared partition).
+        pkey_tenants: dict[int, set[str]] = {}
+        failed: list[str] = []
+
+        for partition in partitions:
+            label = partition.get("name") or partition.get("partition_key") or "unknown"
+            pkey_raw = partition.get("partition_key")
+            pkey = _normalize_pkey(pkey_raw)
+            tenant = partition.get("tenant_id")
+            tenant = tenant.strip() if isinstance(tenant, str) else ""
+
+            problems: list[str] = []
+            if pkey is None:
+                problems.append("no P_Key allocated")
+            elif default_pkey is not None and pkey == default_pkey:
+                problems.append(f"reuses the default all-ports partition ({pkey_raw})")
+            if not tenant:
+                problems.append("not scoped to a tenant")
+
+            if problems:
+                self.report_subtest(
+                    f"partition_{label}",
+                    passed=False,
+                    message=f"Partition {label}: {'; '.join(problems)}",
+                )
+                failed.append(f"{label} ({'; '.join(problems)})")
+                continue
+
+            # pkey/tenant are valid here -- record ownership for collision detection.
+            pkey_tenants.setdefault(pkey, set()).add(tenant)
+            self.report_subtest(
+                f"partition_{label}",
+                passed=True,
+                message=f"Partition {label}: P_Key {pkey_raw} scoped to tenant {tenant}",
+            )
+
+        # A P_Key owned by more than one tenant means those tenants are not
+        # isolated from each other on the fabric.
+        shared = {pkey: tenants for pkey, tenants in pkey_tenants.items() if len(tenants) > 1}
+        for pkey, tenants in shared.items():
+            self.report_subtest(
+                f"pkey_{pkey:#x}_exclusive",
+                passed=False,
+                message=f"P_Key {pkey:#x} is shared by {len(tenants)} tenants: {', '.join(sorted(tenants))}",
+            )
+
+        if failed or shared:
+            issues: list[str] = []
+            if failed:
+                issues.append(f"{len(failed)} misconfigured partition(s): {', '.join(failed)}")
+            if shared:
+                collisions = ", ".join(f"{pkey:#x} -> {sorted(tenants)}" for pkey, tenants in shared.items())
+                issues.append(f"{len(shared)} P_Key(s) shared across tenants: {collisions}")
+            self.set_failed(f"InfiniBand tenant isolation not enforced: {'; '.join(issues)}")
+            return
+
+        tenant_count = len({t for tenants in pkey_tenants.values() for t in tenants})
+        self.set_passed(
+            f"{len(partitions)} InfiniBand partition(s) isolate {tenant_count} tenant(s) "
+            f"with distinct, tenant-scoped P_Keys"
+        )
+
+
+class IbKeysConfiguredCheck(BaseValidation):
+    """Validate the InfiniBand security keys are configured (SDN04-05).
+
+    SDN04 requires the InfiniBand fabric to be hardened with the partition key
+    plus the OpenSM / SHARP subnet-manager keys: P_Key, Management Key (M_Key),
+    Aggregation Management Key (SHARP AM_Key), VendorSpecific Key, Congestion
+    Control Key, Node2Node Key, and Manager2Node Key.
+
+    This validation is provider-neutral: the step script reports, per key, a
+    tri-state ``configured`` flag (``true`` = verified configured, ``false`` =
+    verified NOT configured, ``null`` = could not observe via the available
+    APIs) and the check asserts every *required* key is verified configured.
+    A required key the script could not observe causes a skip rather than a
+    false pass, mirroring the other evidence-gated security checks.
+
+    The set of required keys is intentionally configurable via ``required_keys``
+    because a provider can only enforce the keys its APIs surface. The P_Key is
+    queryable from any partition API; the remaining subnet-manager keys live on
+    the UFM host and are only observable when the provider integrates with UFM.
+
+    Config:
+        step_output: Step output containing the per-key configuration evidence.
+        required_keys: Keys that must be verified configured (default: all of
+            IB_KEY_NAMES). Providers narrow this to the keys they can observe.
+
+    Step output (from query_ib_keys.py):
+        success: bool
+        platform: str
+        site_id: str
+        partitions_with_pkey: int -- partitions carrying a concrete P_Key
+        keys: dict[str, dict]:
+            <key_name>: {
+                configured: bool | None,
+                source: str,   -- where the evidence came from (e.g. "nico", "ufm")
+                detail: str,   -- human-readable explanation
+            }
+    """
+
+    description: ClassVar[str] = "Check InfiniBand security keys (P_Key, Management Key, ...) are configured"
+    timeout: ClassVar[int] = 120
+    labels: ClassVar[tuple[str, ...]] = ("bare_metal", "security", "network", "infiniband")
+
+    def run(self) -> None:
+        """Validate the required InfiniBand keys are verified configured."""
+        step_output = self.config.get("step_output", {})
+
+        if step_output.get("skipped") is True:
+            pytest.skip(step_output.get("skip_reason") or "InfiniBand key validation skipped")
+
+        if not step_output.get("success"):
+            self.set_failed(f"IB keys step failed: {step_output.get('error', 'Unknown error')}")
+            return
+
+        keys = step_output.get("keys")
+        if not isinstance(keys, dict):
+            self.set_failed("IB keys step output is missing the 'keys' object")
+            return
+
+        required = self.config.get("required_keys", list(IB_KEY_NAMES))
+        if not isinstance(required, list) or not required:
+            self.set_failed("`required_keys` must be a non-empty list")
+            return
+
+        # Concrete P_Key evidence: at least one partition must carry a P_Key.
+        partitions_with_pkey = step_output.get("partitions_with_pkey")
+        if not isinstance(partitions_with_pkey, int) or isinstance(partitions_with_pkey, bool):
+            self.set_failed("IB keys step output is missing integer 'partitions_with_pkey'")
+            return
+
+        # Report a subtest for every key the script described (required or not)
+        # so operators see the full posture, then gate pass/fail on the required
+        # subset alone.
+        not_configured: list[str] = []
+        unverified: list[str] = []
+
+        for name in sorted(keys):
+            entry = keys[name] if isinstance(keys[name], dict) else {}
+            configured = entry.get("configured")
+            detail = entry.get("detail") or ""
+            is_required = name in required
+
+            if configured is True:
+                message = f"{name}: configured ({detail})" if detail else f"{name}: configured"
+                self.report_subtest(f"key_{name}", passed=True, message=message)
+            elif configured is False:
+                self.report_subtest(f"key_{name}", passed=False, message=f"{name}: NOT configured ({detail})")
+                if is_required:
+                    not_configured.append(name)
+            else:
+                # Unknown: surface as an informational skipped subtest.
+                self.report_subtest(f"key_{name}", passed=False, skipped=True, message=f"{name}: unverified ({detail})")
+                if is_required:
+                    unverified.append(f"{name} ({detail})" if detail else name)
+
+        missing_keys = [k for k in required if k not in keys]
+        if missing_keys:
+            self.set_failed(f"IB keys step output is missing required key(s): {', '.join(missing_keys)}")
+            return
+
+        if not_configured:
+            self.set_failed(f"InfiniBand key(s) not configured: {', '.join(not_configured)}")
+            return
+
+        if partitions_with_pkey < 1:
+            self.set_failed("No InfiniBand partition carries a P_Key; the partition key is not configured")
+            return
+
+        if unverified:
+            pytest.skip(
+                f"InfiniBand key verification incomplete; could not observe required key(s): {', '.join(unverified)}"
+            )
+
+        self.set_passed(
+            f"All {len(required)} required InfiniBand key(s) configured "
+            f"({partitions_with_pkey} partition(s) carry a P_Key)"
+        )

--- a/isvtest/tests/test_infiniband.py
+++ b/isvtest/tests/test_infiniband.py
@@ -170,6 +170,25 @@ class TestIbTenantIsolationCheck:
         assert check._passed is False
         assert "default all-ports partition" in check._error
 
+    def test_full_member_default_partition_pkey_fails(self) -> None:
+        """A full-member default P_Key (0xffff) is the all-ports partition too."""
+        partitions = [_partition(name="mgmt", partition_key="0xffff", tenant_id="tenant-a")]
+        check = IbTenantIsolationCheck(config={"step_output": _isolation_output(partitions=partitions)})
+        check.run()
+        assert check._passed is False
+        assert "default all-ports partition" in check._error
+
+    def test_membership_bit_variants_collide_across_tenants(self) -> None:
+        """Same partition number with different membership bits is one partition."""
+        partitions = [
+            _partition(name="a", partition_key="0x0001", tenant_id="tenant-a"),
+            _partition(name="b", partition_key="0x8001", tenant_id="tenant-b"),
+        ]
+        check = IbTenantIsolationCheck(config={"step_output": _isolation_output(partitions=partitions)})
+        check.run()
+        assert check._passed is False
+        assert "shared across tenants" in check._error
+
     def test_shared_pkey_across_tenants_fails(self) -> None:
         """The same P_Key owned by two tenants is an isolation breach."""
         partitions = [

--- a/isvtest/tests/test_infiniband.py
+++ b/isvtest/tests/test_infiniband.py
@@ -1,0 +1,327 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the InfiniBand fabric-security validations (SDN04-04, SDN04-05)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from isvtest.validations.infiniband import IbKeysConfiguredCheck, IbTenantIsolationCheck
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _partition(
+    *,
+    name: str = "turbo-net",
+    partition_key: str | None = "0x1",
+    tenant_id: str = "tenant-a",
+    status: str = "Ready",
+) -> dict[str, Any]:
+    """Build an InfiniBand partition record."""
+    return {
+        "name": name,
+        "partition_key": partition_key,
+        "tenant_id": tenant_id,
+        "status": status,
+    }
+
+
+def _isolation_output(
+    *,
+    success: bool = True,
+    partitions: list[dict[str, Any]] | None = None,
+    error: str = "",
+) -> dict[str, Any]:
+    """Build a tenant-isolation step output."""
+    if partitions is None:
+        partitions = [
+            _partition(name="a", partition_key="0x1", tenant_id="tenant-a"),
+            _partition(name="b", partition_key="0x2", tenant_id="tenant-b"),
+        ]
+    return {
+        "success": success,
+        "platform": "nico",
+        "site_id": "test-site-001",
+        "partitions_checked": len(partitions),
+        "partitions": partitions,
+        "error": error,
+    }
+
+
+def _key(configured: bool | None, *, source: str = "nico", detail: str = "ok") -> dict[str, Any]:
+    """Build a single key-evidence record."""
+    return {"configured": configured, "source": source, "detail": detail}
+
+
+def _keys_output(
+    *,
+    success: bool = True,
+    keys: dict[str, dict[str, Any]] | None = None,
+    partitions_with_pkey: int = 2,
+    error: str = "",
+) -> dict[str, Any]:
+    """Build an IB-keys step output."""
+    if keys is None:
+        keys = {
+            "p_key": _key(True, source="nico", detail="2 partition(s) carry a P_Key"),
+            "management_key": _key(True, source="ufm", detail="m_key configured with per-port protection"),
+        }
+    return {
+        "success": success,
+        "platform": "nico",
+        "site_id": "test-site-001",
+        "partitions_with_pkey": partitions_with_pkey,
+        "keys": keys,
+        "error": error,
+    }
+
+
+# ===========================================================================
+# IbTenantIsolationCheck tests (SDN04-04)
+# ===========================================================================
+
+
+class TestIbTenantIsolationCheck:
+    """Tests for IbTenantIsolationCheck validation."""
+
+    def test_distinct_tenant_pkeys_pass(self) -> None:
+        """Per-tenant, distinct, non-default P_Keys pass."""
+        check = IbTenantIsolationCheck(config={"step_output": _isolation_output()})
+        check.run()
+        assert check._passed is True, check._error
+        assert "2 tenant(s)" in check._output
+        subtests = {r["name"] for r in check._subtest_results}
+        assert {"partition_a", "partition_b"} <= subtests
+
+    def test_step_failure(self) -> None:
+        """A failed step is reported with its error detail."""
+        check = IbTenantIsolationCheck(config={"step_output": _isolation_output(success=False, error="API timeout")})
+        check.run()
+        assert check._passed is False
+        assert "API timeout" in check._error
+
+    def test_skipped_step(self) -> None:
+        """A structured skip (no partitions) skips the validation."""
+        check = IbTenantIsolationCheck(
+            config={"step_output": {"success": True, "skipped": True, "skip_reason": "No InfiniBand partitions found"}}
+        )
+        with pytest.raises(pytest.skip.Exception, match="No InfiniBand partitions found"):
+            check.run()
+
+    def test_missing_partitions_list(self) -> None:
+        """A non-list partitions field fails."""
+        output = _isolation_output()
+        output["partitions"] = None
+        check = IbTenantIsolationCheck(config={"step_output": output})
+        check.run()
+        assert check._passed is False
+        assert "partitions" in check._error
+
+    def test_min_partitions_not_met(self) -> None:
+        """Fewer partitions than min_partitions fails."""
+        check = IbTenantIsolationCheck(
+            config={"step_output": _isolation_output(partitions=[_partition()]), "min_partitions": 2}
+        )
+        check.run()
+        assert check._passed is False
+        assert "at least 2" in check._error
+
+    def test_partition_without_pkey_fails(self) -> None:
+        """A partition with no allocated P_Key is not isolated."""
+        partitions = [_partition(name="a", partition_key=None, tenant_id="tenant-a")]
+        check = IbTenantIsolationCheck(config={"step_output": _isolation_output(partitions=partitions)})
+        check.run()
+        assert check._passed is False
+        assert "no P_Key" in check._error
+        sub = next(r for r in check._subtest_results if r["name"] == "partition_a")
+        assert sub["passed"] is False
+
+    def test_partition_without_tenant_fails(self) -> None:
+        """A partition not scoped to a tenant is not an isolation boundary."""
+        partitions = [_partition(name="a", partition_key="0x1", tenant_id="")]
+        check = IbTenantIsolationCheck(config={"step_output": _isolation_output(partitions=partitions)})
+        check.run()
+        assert check._passed is False
+        assert "not scoped to a tenant" in check._error
+
+    def test_default_partition_pkey_fails(self) -> None:
+        """A tenant partition reusing the all-ports default partition fails."""
+        partitions = [_partition(name="mgmt", partition_key="0x7fff", tenant_id="tenant-a")]
+        check = IbTenantIsolationCheck(config={"step_output": _isolation_output(partitions=partitions)})
+        check.run()
+        assert check._passed is False
+        assert "default all-ports partition" in check._error
+
+    def test_shared_pkey_across_tenants_fails(self) -> None:
+        """The same P_Key owned by two tenants is an isolation breach."""
+        partitions = [
+            _partition(name="a", partition_key="0x5", tenant_id="tenant-a"),
+            _partition(name="b", partition_key="0x5", tenant_id="tenant-b"),
+        ]
+        check = IbTenantIsolationCheck(config={"step_output": _isolation_output(partitions=partitions)})
+        check.run()
+        assert check._passed is False
+        assert "shared across tenants" in check._error
+        sub = next(r for r in check._subtest_results if r["name"].startswith("pkey_"))
+        assert sub["passed"] is False
+
+    def test_same_tenant_multiple_pkeys_pass(self) -> None:
+        """One tenant owning several distinct P_Keys is fine."""
+        partitions = [
+            _partition(name="a", partition_key="0x1", tenant_id="tenant-a"),
+            _partition(name="b", partition_key="0x2", tenant_id="tenant-a"),
+        ]
+        check = IbTenantIsolationCheck(config={"step_output": _isolation_output(partitions=partitions)})
+        check.run()
+        assert check._passed is True, check._error
+        assert "1 tenant(s)" in check._output
+
+    def test_pkey_hex_decimal_collision_detected(self) -> None:
+        """Differently-formatted keys that resolve to the same value collide."""
+        partitions = [
+            _partition(name="a", partition_key="0x10", tenant_id="tenant-a"),
+            _partition(name="b", partition_key="16", tenant_id="tenant-b"),
+        ]
+        check = IbTenantIsolationCheck(config={"step_output": _isolation_output(partitions=partitions)})
+        check.run()
+        assert check._passed is False
+        assert "shared across tenants" in check._error
+
+
+# ===========================================================================
+# IbKeysConfiguredCheck tests (SDN04-05)
+# ===========================================================================
+
+
+class TestIbKeysConfiguredCheck:
+    """Tests for IbKeysConfiguredCheck validation."""
+
+    def test_required_keys_configured_pass(self) -> None:
+        """All required keys verified configured + P_Key evidence passes."""
+        check = IbKeysConfiguredCheck(
+            config={"step_output": _keys_output(), "required_keys": ["p_key", "management_key"]}
+        )
+        check.run()
+        assert check._passed is True, check._error
+        assert "2 required InfiniBand key(s) configured" in check._output
+
+    def test_default_required_keys_includes_unverified_skips(self) -> None:
+        """With the default 7 required keys, unverified UFM-host keys cause a skip."""
+        keys = {
+            "p_key": _key(True),
+            "management_key": _key(True, source="ufm"),
+            "aggregation_management_key": _key(None, source="ufm-host", detail="not exposed"),
+            "vendor_specific_key": _key(None, source="ufm-host", detail="not exposed"),
+            "congestion_control_key": _key(None, source="ufm-host", detail="not exposed"),
+            "node2node_key": _key(None, source="ufm-host", detail="not exposed"),
+            "manager2node_key": _key(None, source="ufm-host", detail="not exposed"),
+        }
+        check = IbKeysConfiguredCheck(config={"step_output": _keys_output(keys=keys)})
+        with pytest.raises(pytest.skip.Exception, match="could not observe required key"):
+            check.run()
+
+    def test_step_failure(self) -> None:
+        """A failed step is reported with its error detail."""
+        check = IbKeysConfiguredCheck(config={"step_output": _keys_output(success=False, error="auth error")})
+        check.run()
+        assert check._passed is False
+        assert "auth error" in check._error
+
+    def test_skipped_step(self) -> None:
+        """A structured skip (no partitions) skips the validation."""
+        check = IbKeysConfiguredCheck(
+            config={"step_output": {"success": True, "skipped": True, "skip_reason": "No InfiniBand partitions"}}
+        )
+        with pytest.raises(pytest.skip.Exception, match="No InfiniBand partitions"):
+            check.run()
+
+    def test_required_key_not_configured_fails(self) -> None:
+        """A required key explicitly NOT configured fails."""
+        keys = {
+            "p_key": _key(True),
+            "management_key": _key(False, source="ufm", detail="m_key is unset (0)"),
+        }
+        check = IbKeysConfiguredCheck(
+            config={"step_output": _keys_output(keys=keys), "required_keys": ["p_key", "management_key"]}
+        )
+        check.run()
+        assert check._passed is False
+        assert "not configured: management_key" in check._error
+
+    def test_unverified_required_key_skips(self) -> None:
+        """A required key the script could not observe causes a skip, not a pass."""
+        keys = {
+            "p_key": _key(True),
+            "management_key": _key(None, source="ufm", detail="UFM access not configured"),
+        }
+        check = IbKeysConfiguredCheck(
+            config={"step_output": _keys_output(keys=keys), "required_keys": ["p_key", "management_key"]}
+        )
+        with pytest.raises(pytest.skip.Exception, match="management_key"):
+            check.run()
+
+    def test_missing_keys_object(self) -> None:
+        """A non-dict keys field fails."""
+        output = _keys_output()
+        output["keys"] = None
+        check = IbKeysConfiguredCheck(config={"step_output": output})
+        check.run()
+        assert check._passed is False
+        assert "keys" in check._error
+
+    def test_missing_required_key_entry_fails(self) -> None:
+        """A required key absent from the keys object fails."""
+        keys = {"p_key": _key(True)}
+        check = IbKeysConfiguredCheck(
+            config={"step_output": _keys_output(keys=keys), "required_keys": ["p_key", "management_key"]}
+        )
+        check.run()
+        assert check._passed is False
+        assert "missing required key(s): management_key" in check._error
+
+    def test_no_pkey_evidence_fails(self) -> None:
+        """Zero partitions carrying a P_Key fails the concrete evidence check."""
+        keys = {"p_key": _key(True), "management_key": _key(True, source="ufm")}
+        check = IbKeysConfiguredCheck(
+            config={
+                "step_output": _keys_output(keys=keys, partitions_with_pkey=0),
+                "required_keys": ["p_key", "management_key"],
+            }
+        )
+        check.run()
+        assert check._passed is False
+        assert "P_Key" in check._error
+
+    def test_missing_partitions_with_pkey_field(self) -> None:
+        """A missing integer partitions_with_pkey field fails."""
+        output = _keys_output()
+        output["partitions_with_pkey"] = None
+        check = IbKeysConfiguredCheck(config={"step_output": output, "required_keys": ["p_key"]})
+        check.run()
+        assert check._passed is False
+        assert "partitions_with_pkey" in check._error
+
+    def test_invalid_required_keys(self) -> None:
+        """An empty required_keys list is rejected."""
+        check = IbKeysConfiguredCheck(config={"step_output": _keys_output(), "required_keys": []})
+        check.run()
+        assert check._passed is False
+        assert "required_keys" in check._error


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the M6 **SDN04** InfiniBand fabric-security checks, validated end-to-end on the NICo provider. Both are provider-agnostic validations grounded in what NICo (and UFM) actually expose, following the recent NICo-validation pattern (#450/#451/#453). Ships unreleased (`released_tests.json` untouched); run with `ISVTEST_INCLUDE_UNRELEASED=1`.

- **`IbTenantIsolationCheck`** (SDN04-04): asserts each tenant's InfiniBand compute is scoped to its own P_Key partition. Because the subnet manager only passes traffic between ports that share a P_Key, distinct-P_Key-per-tenant *is* the fabric-side isolation boundary, so "compute dedicated to NVIDIA is isolated from other customers" reduces to verifying the partition→tenant mapping. Fails on a missing/default P_Key, an unscoped partition, or a P_Key shared across tenants.
- **`IbKeysConfiguredCheck`** (SDN04-05): asserts the required InfiniBand security keys are configured. Uses a tri-state per-key contract (`configured` = `true`/`false`/`null`); an unverified *required* key skips rather than passing vacuously (mirrors the other evidence-gated security checks).

**Scripts** (`providers/nico/scripts/infiniband/`):
- `query_ib_tenant_isolation.py` lists NICo IB partitions with their `partition_key` + owning `tenant_id`.
- `query_ib_keys.py` derives the **P_Key** from NICo's partition API and the **Management Key (M_Key)** from UFM `/app/smconf` via a new minimal `ufm_client` — the same source NICo's own `IbFabricMonitor` uses for its `insecure_fabric_configuration` check (`m_key` non-zero + `m_key_per_port`). The remaining OpenSM/SHARP keys (Aggregation Management, VendorSpecific, CongestionControl, Node2Node, Manager2Node) live on the UFM host per the IB runbook and are reported as unverified — never fabricated. The raw key value is never emitted.

**Wiring**: opt-in `query_ib_tenant_isolation` / `query_ib_keys` steps in the NICo `bare_metal.yaml` config + `ib_tenant_isolation` / `ib_keys_configured` validations in the `bare_metal` suite (with `required_keys` scoped to the NICo-observable set `["p_key", "management_key"]`). `UFM_TOKEN` added to secret redaction; the suite README documents the new steps. Sites with no IB partitions emit a structured skip rather than failing.

## Design notes

- The NICo public API authoritatively exposes the P_Key (`partitionKey`) and tenant ownership (`tenantId`); the subnet-manager keys live in UFM. SDN04-05 therefore verifies the P_Key (NICo) and Management Key (UFM, when `UFM_ADDRESS` + `UFM_TOKEN` are set) and transparently reports the host-only OpenSM/SHARP keys as unverified. Without UFM access the check skips rather than failing.
- P_Keys are compared by partition number with the InfiniBand membership bit (`0x8000`) masked off, so the all-ports default partition is detected whether it appears as `0x7fff` (limited member) or `0xffff` (full member), and membership variants of the same partition (`0x0001`/`0x8001`) are correctly treated as one partition when detecting a P_Key shared across tenants.

## Testing

References/evidence:

End-to-end run of both new steps through the real `isvctl` orchestrator, validated both against a local stub and against a live NICo cluster + UFM; both validations PASS:

- ✅ `uv run pytest isvtest/tests/test_infiniband.py` (24 validation unit tests)
- ✅ `uv run pytest isvctl/tests/test_nico_provider.py` (UFM client, both scripts, end-to-end contract tests)
- ✅ `make test` (all packages: 973 + scripts/tests pass)
- ✅ `make lint`
- ✅ `make demo-test` (my-isv skips the new steps as unconfigured/unreleased)
- ✅ `uvx pre-commit run -a` (ruff, yamlfmt, SPDX headers, links)
- ✅ End-to-end via the orchestrator against a local stub: both validations PASS; the UFM-host keys report as informational SKIPPED subtests.
- ✅ **Validated end-to-end against a live NICo cluster + UFM (`6.21.2-1`)**: both checks PASS, with `management_key` verified from the real UFM `/app/smconf` (non-zero `m_key` + `m_key_per_port` per-port protection) rather than skipped.
```
isvtest/src/isvtest/tests/test_validation[IbTenantIsolationCheck] 
  SUBTEST [partition_default-partition] PASSED
  SUBTEST [partition_default] PASSED
  SUBTEST [partition_default_ncx-ib-pf-cni-smoke] PASSED
  SUBTEST [partition_ncx-ib-blog-a_ib-pf-network-1] PASSED
  SUBTEST [partition_ncx-ib-blog-b_ib-pf-network-1] PASSED
  SUBTEST [partition_tenant-a_ib-pf-network-1] PASSED
  SUBTEST [partition_tenant-b_ib-pf-network-1] PASSED
PASSED
isvtest/src/isvtest/tests/test_validation[IbKeysConfiguredCheck] 
  SUBTEST [key_aggregation_management_key] SKIPPED
  SUBTEST [key_congestion_control_key] SKIPPED
  SUBTEST [key_management_key] PASSED
  SUBTEST [key_manager2node_key] SKIPPED
  SUBTEST [key_node2node_key] SKIPPED
  SUBTEST [key_p_key] PASSED
  SUBTEST [key_vendor_specific_key] SKIPPED
PASSED
```


Closes #287
Closes #288


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * InfiniBand tenant isolation validation to detect cross-tenant P_Key conflicts
  * InfiniBand security-key verification with optional UFM-backed checks
  * Added a minimal UFM REST client to support key verification

* **Documentation**
  * Added InfiniBand entries to the Bare Metal suite documentation

* **Tests**
  * Comprehensive tests for InfiniBand checks and UFM authentication/behavior

* **Chores**
  * Redaction updated to omit UFM tokens from exported contexts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->