### PR TITLE
feat(nico): add tenant-transition data sanitization validations (SEC21-04/05/06)

### DIFF
--- a/isvctl/configs/providers/nico/config/bare_metal.yaml
+++ b/isvctl/configs/providers/nico/config/bare_metal.yaml
@@ -42,6 +42,10 @@
 #   - query_ib_keys.py reports InfiniBand key configuration (P_Key from NICo,
 #     Management Key from UFM when configured); IbKeysConfiguredCheck
 #     validates the required keys (SDN04-05).
+#   - query_sanitization.py maps each machine's status + statusHistory into a
+#     neutral lifecycle token sequence; MemorySanitizationCheck (SEC21-04),
+#     GpuMemorySanitizationCheck (SEC21-05), and FirmwareResetCheck
+#     (SEC21-06/SEC22) assert hosts are sanitized between tenants.
 #
 # Prerequisites:
 #   - NICO_API_BASE set to the NICo API base URL
@@ -166,6 +170,24 @@ commands:
       - name: query_ib_keys
         phase: test
         command: "python ../scripts/infiniband/query_ib_keys.py"
+        args:
+          - "--org"
+          - "{{org}}"
+          - "--site-id"
+          - "{{site_id}}"
+          - "--api-base"
+          - "{{nico_api_base}}"
+        timeout: 120
+
+      # ─── Audit Tenant-Transition Sanitization (SEC21-04/05/06) ─────
+      # Maps each machine's status + statusHistory into a neutral lifecycle
+      # token sequence (Reset -> sanitizing, InUse -> in_use, Ready ->
+      # available) so the sanitization checks can assert no host returned to
+      # the pool without an intervening sanitizing stage. Also surfaces GPU
+      # presence and firmware identity (vendor/product/BIOS).
+      - name: query_sanitization
+        phase: test
+        command: "python ../scripts/sanitization/query_sanitization.py"
         args:
           - "--org"
           - "{{org}}"

--- a/isvctl/configs/providers/nico/scripts/sanitization/query_sanitization.py
+++ b/isvctl/configs/providers/nico/scripts/sanitization/query_sanitization.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Audit tenant-transition data sanitization for a NICo site (SEC21-04/05/06).
+
+When a tenant releases a host (the Instance is deleted), NICo runs its cleanup
+and sanitization workflow before returning the host to the allocatable pool:
+host/RAM cleanup and the UEFI MemoryOverwriteRequestControl check, NVMe/HDD
+secure erase, InfiniBand cleanup, TPM clear, and BIOS/UEFI recommit. At the
+REST level this whole workflow is the machine ``Reset`` status: a released host
+moves ``InUse -> Reset -> ... -> Ready`` and must not return to ``Ready`` (nor
+report ``isUsableByTenant``) until cleanup completes.
+
+This script reads each machine's ``status`` and ``statusHistory`` and maps the
+NICo lifecycle into a provider-neutral token sequence so the validations can
+assert that no host went from ``in_use`` back to ``available`` without an
+intervening ``sanitizing`` stage, and that no available host is still bound to
+a prior tenant. GPU presence and firmware identity (vendor / product / BIOS)
+are surfaced so the GPU-memory and firmware-reset checks can scope and report.
+
+NICo MachineStatus enum (per the upstream OpenAPI spec):
+  Initializing | Ready | Reset | Maintenance | InUse | Error | Decommissioned | Unknown
+
+NICo -> neutral lifecycle token mapping:
+  Reset -> sanitizing   (the cleanup/sanitization workflow between tenants)
+  InUse -> in_use       (assigned to and running a tenant workload)
+  Ready -> available    (allocatable to a new tenant)
+  others -> lowercased status (maintenance, initializing, error, ...)
+
+NICo API endpoints used:
+  GET /v2/org/{org}/carbide/machine?siteId={site_id}&includeMetadata=true
+
+Auth:
+  - NICO_BEARER_TOKEN, or
+  - OIDC client_credentials via NICO_SSA_ISSUER,
+    NICO_CLIENT_ID, NICO_CLIENT_SECRET, and optional NICO_OIDC_SCOPE.
+
+Required JSON output fields:
+  {
+    "success": true,
+    "platform": "nico",
+    "site_id": "...",
+    "machines_checked": 2,
+    "machines": [
+      {
+        "machine_id": "...",
+        "status": "available",
+        "available": true,
+        "in_use": false,
+        "has_gpu": true,
+        "served_tenant": true,
+        "sanitized": true,
+        "stale_tenant_binding": false,
+        "vendor": "Lenovo",
+        "product_name": "ThinkSystem SR670 V2",
+        "bios_version": "U8E122J-1.51",
+        "transitions": ["in_use", "sanitizing", "available"]
+      }
+    ]
+  }
+
+Usage:
+    NICO_BEARER_TOKEN=<token> python query_sanitization.py --org <org> --site-id <uuid> --api-base <url>
+
+    Wired via the bare_metal suite:
+      uv run isvctl test run -f isvctl/configs/providers/nico/config/bare_metal.yaml
+
+Reference:
+    Cleanup workflow: infra-controller docs/operations/tenant-lifecycle-cleanup.md
+    State machine:    infra-controller docs/architecture/state_machines/managedhost.md
+    OpenAPI spec:     rest-api/openapi/spec.yaml (Machine / MachineStatus / StatusDetail)
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Allow importing from sibling common/ directory
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.nico_client import NicoAuthError, forge_get_all, resolve_auth
+
+# Provider-neutral lifecycle tokens the validations gate on.
+IN_USE = "in_use"
+SANITIZING = "sanitizing"
+AVAILABLE = "available"
+
+# NICo MachineStatus -> neutral token. Statuses not listed are lowercased.
+STATUS_TOKENS: dict[str, str] = {
+    "InUse": IN_USE,
+    "Reset": SANITIZING,
+    "Ready": AVAILABLE,
+}
+
+# Cap the diagnostic transitions list so a long-lived host does not bloat output.
+MAX_TRANSITIONS = 20
+
+
+def status_token(status: str | None) -> str:
+    """Map a NICo machine status to its provider-neutral lifecycle token."""
+    if not status:
+        return "unknown"
+    return STATUS_TOKENS.get(status, status.lower())
+
+
+def ordered_history_statuses(machine: dict[str, Any]) -> list[str]:
+    """Return the machine's statuses in chronological order, including current.
+
+    NICo records each status change in ``statusHistory`` ({status, message,
+    created, updated}); entries are sorted by ``created`` (ISO 8601 sorts
+    lexicographically). The live ``status`` is appended when it differs from
+    the last recorded entry so the latest state is always represented.
+    """
+    history = machine.get("statusHistory") or []
+    entries = [e for e in history if isinstance(e, dict) and e.get("status")]
+    entries.sort(key=lambda e: e.get("created") or e.get("updated") or "")
+    statuses = [str(e["status"]) for e in entries]
+
+    current = machine.get("status")
+    if current and (not statuses or statuses[-1] != current):
+        statuses.append(str(current))
+    return statuses
+
+
+def evaluate_transitions(tokens: list[str]) -> tuple[bool, bool]:
+    """Return ``(served_tenant, sanitized)`` from a neutral token sequence.
+
+    ``served_tenant`` is true when the host ever ran a tenant workload
+    (``in_use``). ``sanitized`` is false when the host returned to
+    ``available`` after a tenancy without an intervening ``sanitizing`` stage.
+    """
+    served = IN_USE in tokens
+    seen_in_use_since_sanitize = False
+    sanitized = True
+    for token in tokens:
+        if token == IN_USE:
+            seen_in_use_since_sanitize = True
+        elif token == SANITIZING:
+            seen_in_use_since_sanitize = False
+        elif token == AVAILABLE and seen_in_use_since_sanitize:
+            sanitized = False
+    return served, sanitized
+
+
+def has_gpu(machine: dict[str, Any]) -> bool:
+    """Return whether the machine reports any GPU capability."""
+    capabilities = machine.get("machineCapabilities") or []
+    return any(isinstance(c, dict) and c.get("type") == "GPU" for c in capabilities)
+
+
+def machine_record(machine: dict[str, Any]) -> dict[str, Any]:
+    """Build the provider-neutral sanitization record for one NICo machine."""
+    statuses = ordered_history_statuses(machine)
+    tokens = [status_token(s) for s in statuses]
+    served, sanitized = evaluate_transitions(tokens)
+
+    current = machine.get("status")
+    usable = bool(machine.get("isUsableByTenant"))
+    assigned = bool(machine.get("instanceId")) or bool(machine.get("tenantId"))
+    is_ready = current == "Ready"
+
+    dmi = (machine.get("metadata") or {}).get("dmiData") or {}
+
+    return {
+        "machine_id": machine.get("id", ""),
+        "status": status_token(current),
+        "available": is_ready and usable and not assigned,
+        "in_use": current == "InUse",
+        "has_gpu": has_gpu(machine),
+        "served_tenant": served,
+        "sanitized": sanitized,
+        # Offered to new tenants (Ready + usable) while still bound to a prior
+        # tenant's instance -- a hard sanitization failure if it ever occurs.
+        "stale_tenant_binding": is_ready and usable and assigned,
+        "vendor": machine.get("vendor") or "",
+        "product_name": machine.get("productName") or "",
+        "bios_version": dmi.get("biosVersion") or "",
+        "transitions": tokens[-MAX_TRANSITIONS:],
+    }
+
+
+def main() -> int:
+    """Query NICo machines and print per-machine sanitization records as JSON."""
+    parser = argparse.ArgumentParser(description="Audit NICo tenant-transition sanitization")
+    parser.add_argument("--org", required=True, help="NGC org name")
+    parser.add_argument("--site-id", required=True, help="NICo site UUID")
+    parser.add_argument("--api-base", required=True, help="NICo API base URL")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "nico",
+        "site_id": args.site_id,
+        "machines_checked": 0,
+        "machines": [],
+    }
+
+    try:
+        auth = resolve_auth()
+
+        machines = forge_get_all(
+            args.org,
+            "machine",
+            auth.token,
+            base_url=args.api_base,
+            params={"siteId": args.site_id, "includeMetadata": "true"},
+            result_key="machines",
+        )
+
+        result["machines"] = [machine_record(machine) for machine in machines]
+        result["machines_checked"] = len(result["machines"])
+        result["success"] = True
+
+    except NicoAuthError as e:
+        result["error_type"] = "auth"
+        result["error"] = str(e)
+    except Exception as e:
+        result["error"] = f"{type(e).__name__}: {e}"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -114,6 +114,7 @@ For the domain / script-count / AWS-reference overview see the
 | `query_health_aggregation` | test | `providers/nico/scripts/health/query_health_aggregation.py` | `aggregation_level`, `groups[].{total,healthy,unhealthy,status,unhealthy_hosts}` |
 | `query_ib_tenant_isolation` | test | `providers/nico/scripts/infiniband/query_ib_tenant_isolation.py` | `partitions_checked`, `partitions[].{name,partition_key,tenant_id,status}` |
 | `query_ib_keys` | test | `providers/nico/scripts/infiniband/query_ib_keys.py` | `partitions_with_pkey`, `keys.<name>.{configured,source,detail}` |
+| `query_sanitization` | test | `providers/nico/scripts/sanitization/query_sanitization.py` | `machines_checked`, `machines[].{available,in_use,has_gpu,served_tenant,sanitized,stale_tenant_binding,vendor,product_name,bios_version,transitions}` |
 
 ### Kubernetes (`k8s.yaml`)
 

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -393,5 +393,27 @@ tests:
         IbKeysConfiguredCheck:
           required_keys: ["p_key", "management_key"]
 
+    # Tenant-transition data sanitization (SEC21 / SEC22). Each check asserts
+    # that a host which served a tenant is not returned to the allocatable pool
+    # until it passes through the platform's sanitizing lifecycle stage. Only
+    # runs for providers that implement the query_sanitization step.
+    #   - SEC21-04: host (RAM) memory sanitization between tenants.
+    #   - SEC21-05: SRAM/GPU memory sanitization between tenants (GPU hosts).
+    #   - SEC21-06 / SEC22: TPM clear and BIOS/UEFI recommit on transition.
+    memory_sanitization:
+      step: query_sanitization
+      checks:
+        MemorySanitizationCheck: {}
+
+    gpu_memory_sanitization:
+      step: query_sanitization
+      checks:
+        GpuMemorySanitizationCheck: {}
+
+    firmware_reset:
+      step: query_sanitization
+      checks:
+        FirmwareResetCheck: {}
+
   exclude:
     labels: []

--- a/isvctl/tests/test_nico_provider.py
+++ b/isvctl/tests/test_nico_provider.py
@@ -298,6 +298,8 @@ def test_forge_get_all_extracts_result_key_from_wrapped_response(monkeypatch: py
         "query_governance_metrics",
         "query_host_health",
         "query_health_aggregation",
+        "query_ib_tenant_isolation",
+        "query_ib_keys",
         "query_sanitization",
     ],
 )
@@ -321,6 +323,8 @@ def test_nico_bare_metal_config_exposes_api_base_setting(step_name: str) -> None
         ("query_metrics.py", _load_governance_metrics_script),
         ("query_host_health.py", _load_host_health_script),
         ("query_health_aggregation.py", _load_health_aggregation_script),
+        ("query_ib_tenant_isolation.py", _load_ib_tenant_isolation_script),
+        ("query_ib_keys.py", _load_ib_keys_script),
         ("query_sanitization.py", _load_sanitization_script),
     ],
 )

--- a/isvctl/tests/test_nico_provider.py
+++ b/isvctl/tests/test_nico_provider.py
@@ -1494,7 +1494,9 @@ def test_sanitization_script_output_satisfies_memory_check(
     bad = MemorySanitizationCheck(config={"step_output": dirty})
     bad.run()
     assert bad._passed is False
-    assert "without sanitization" in bad._error
+    assert "1/1 machine(s)" in bad._error
+    sub = next(r for r in bad._subtest_results if r["name"].startswith("memory_"))
+    assert "without sanitization" in sub["message"]
 
 
 def test_sanitization_script_output_satisfies_gpu_check(

--- a/isvctl/tests/test_nico_provider.py
+++ b/isvctl/tests/test_nico_provider.py
@@ -33,6 +33,10 @@ import pytest
 from isvtest.validations.governance import GovernanceMetricsCheck
 from isvtest.validations.health import HealthAggregationCheck, HostHealthCheck
 from isvtest.validations.infiniband import IbKeysConfiguredCheck, IbTenantIsolationCheck
+from isvtest.validations.sanitization import (
+    GpuMemorySanitizationCheck,
+    MemorySanitizationCheck,
+)
 
 from isvctl.config.merger import merge_yaml_files
 
@@ -174,6 +178,17 @@ def _load_ib_keys_script() -> ModuleType:
     return module
 
 
+def _load_sanitization_script() -> ModuleType:
+    """Load the query_sanitization script as a module for direct unit testing."""
+    script_path = NICO_SCRIPTS / "sanitization" / "query_sanitization.py"
+    spec = importlib.util.spec_from_file_location("test_query_sanitization", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    with _isolated_common_imports():
+        spec.loader.exec_module(module)
+    return module
+
+
 def test_nico_auth_prefers_explicit_bearer_token(monkeypatch: pytest.MonkeyPatch) -> None:
     """A locally supplied NICo bearer token should be the simplest auth path."""
     module = _load_nico_client()
@@ -283,6 +298,7 @@ def test_forge_get_all_extracts_result_key_from_wrapped_response(monkeypatch: py
         "query_governance_metrics",
         "query_host_health",
         "query_health_aggregation",
+        "query_sanitization",
     ],
 )
 def test_nico_bare_metal_config_exposes_api_base_setting(step_name: str) -> None:
@@ -305,6 +321,7 @@ def test_nico_bare_metal_config_exposes_api_base_setting(step_name: str) -> None
         ("query_metrics.py", _load_governance_metrics_script),
         ("query_host_health.py", _load_host_health_script),
         ("query_health_aggregation.py", _load_health_aggregation_script),
+        ("query_sanitization.py", _load_sanitization_script),
     ],
 )
 def test_nico_scripts_require_api_base(
@@ -1312,3 +1329,180 @@ def test_ib_keys_script_surfaces_api_errors(
     assert exit_code == 1
     assert payload["success"] is False
     assert "simulated outage" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# query_sanitization (SEC21-04/05/06) script
+# ---------------------------------------------------------------------------
+
+
+def _sanitization_machine(
+    *,
+    machine_id: str = "m-1",
+    status: str = "Ready",
+    history_statuses: list[str] | None = None,
+    is_usable: bool = True,
+    instance_id: str | None = None,
+    tenant_id: str | None = None,
+    gpus: int = 8,
+    bios_version: str = "U8E122J-1.51",
+) -> dict[str, Any]:
+    """Build a NICo machine payload to drive the sanitization script.
+
+    ``history_statuses`` is given oldest-first; each is converted into a
+    statusHistory entry with an increasing ``created`` timestamp.
+    """
+    if history_statuses is None:
+        history_statuses = ["InUse", "Reset", "Ready"]
+    status_history = [
+        {"status": s, "message": "", "created": f"2026-01-01T00:0{i}:00Z"} for i, s in enumerate(history_statuses)
+    ]
+    capabilities = [{"type": "GPU", "name": "H100", "count": gpus}] if gpus else []
+    return {
+        "id": machine_id,
+        "status": status,
+        "isUsableByTenant": is_usable,
+        "instanceId": instance_id,
+        "tenantId": tenant_id,
+        "vendor": "Lenovo",
+        "productName": "ThinkSystem SR670 V2",
+        "machineCapabilities": capabilities,
+        "statusHistory": status_history,
+        "metadata": {"dmiData": {"biosVersion": bios_version}},
+    }
+
+
+def test_sanitization_status_token_mapping() -> None:
+    """NICo statuses map to the provider-neutral lifecycle tokens."""
+    module = _load_sanitization_script()
+    assert module.status_token("InUse") == "in_use"
+    assert module.status_token("Reset") == "sanitizing"
+    assert module.status_token("Ready") == "available"
+    assert module.status_token("Maintenance") == "maintenance"
+    assert module.status_token(None) == "unknown"
+
+
+def test_sanitization_ordered_history_appends_current() -> None:
+    """History is sorted by created time and the live status is appended once."""
+    module = _load_sanitization_script()
+    machine = {
+        "status": "Ready",
+        "statusHistory": [
+            {"status": "Reset", "created": "2026-01-01T00:01:00Z"},
+            {"status": "InUse", "created": "2026-01-01T00:00:00Z"},
+        ],
+    }
+    assert module.ordered_history_statuses(machine) == ["InUse", "Reset", "Ready"]
+
+
+def test_sanitization_evaluate_transitions_logic() -> None:
+    """The gate flags in_use -> available without an intervening sanitizing stage."""
+    module = _load_sanitization_script()
+    assert module.evaluate_transitions(["in_use", "sanitizing", "available"]) == (True, True)
+    assert module.evaluate_transitions(["in_use", "available"]) == (True, False)
+    # maintenance between in_use and available does not satisfy the gate.
+    assert module.evaluate_transitions(["in_use", "maintenance", "available"]) == (True, False)
+    # never served a tenant -> nothing to sanitize.
+    assert module.evaluate_transitions(["initializing", "available"]) == (False, True)
+
+
+def _run_sanitization(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    machines: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Drive the sanitization script with mocked auth/API and return its JSON output."""
+    module = _load_sanitization_script()
+    return _run_script(module, monkeypatch, capsys, script_name="query_sanitization.py", machines=machines)
+
+
+def test_sanitization_script_builds_clean_record(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A host that went InUse -> Reset -> Ready is sanitized and available."""
+    payload = _run_sanitization(monkeypatch, capsys, [_sanitization_machine()])
+
+    assert payload["success"] is True
+    assert payload["machines_checked"] == 1
+    record = payload["machines"][0]
+    assert record["served_tenant"] is True
+    assert record["sanitized"] is True
+    assert record["available"] is True
+    assert record["in_use"] is False
+    assert record["has_gpu"] is True
+    assert record["stale_tenant_binding"] is False
+    assert record["bios_version"] == "U8E122J-1.51"
+    assert record["transitions"] == ["in_use", "sanitizing", "available"]
+
+
+def test_sanitization_script_flags_skipped_sanitization(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A host that went InUse -> Ready (no Reset) is flagged unsanitized."""
+    machine = _sanitization_machine(history_statuses=["InUse", "Ready"])
+    payload = _run_sanitization(monkeypatch, capsys, [machine])
+
+    record = payload["machines"][0]
+    assert record["served_tenant"] is True
+    assert record["sanitized"] is False
+
+
+def test_sanitization_script_flags_stale_tenant_binding(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A Ready+usable host still bound to an instance is a stale binding."""
+    machine = _sanitization_machine(
+        history_statuses=["InUse", "Reset", "Ready"],
+        instance_id="59bdaaff-3998-4fd9-a140-8749beeb605e",
+    )
+    payload = _run_sanitization(monkeypatch, capsys, [machine])
+
+    record = payload["machines"][0]
+    assert record["available"] is False
+    assert record["stale_tenant_binding"] is True
+
+
+def test_sanitization_script_marks_in_use_host(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A host currently InUse is not yet returned to the pool (still sanitized=true)."""
+    machine = _sanitization_machine(status="InUse", history_statuses=["Ready", "InUse"], is_usable=False)
+    payload = _run_sanitization(monkeypatch, capsys, [machine])
+
+    record = payload["machines"][0]
+    assert record["in_use"] is True
+    assert record["available"] is False
+    assert record["served_tenant"] is True
+    assert record["sanitized"] is True
+
+
+def test_sanitization_script_output_satisfies_memory_check(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """End-to-end: clean NICo JSON passes the memory check; a skipped reset fails."""
+    clean = _run_sanitization(monkeypatch, capsys, [_sanitization_machine()])
+    check = MemorySanitizationCheck(config={"step_output": clean})
+    check.run()
+    assert check._passed is True, check._error
+
+    dirty = _run_sanitization(monkeypatch, capsys, [_sanitization_machine(history_statuses=["InUse", "Ready"])])
+    bad = MemorySanitizationCheck(config={"step_output": dirty})
+    bad.run()
+    assert bad._passed is False
+    assert "without sanitization" in bad._error
+
+
+def test_sanitization_script_output_satisfies_gpu_check(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """End-to-end: a sanitized GPU host passes the GPU-memory check."""
+    payload = _run_sanitization(monkeypatch, capsys, [_sanitization_machine(gpus=8)])
+    check = GpuMemorySanitizationCheck(config={"step_output": payload})
+    check.run()
+    assert check._passed is True, check._error

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -113,6 +113,11 @@ from isvtest.validations.nim import (
     NimInferenceCheck,
     NimModelCheck,
 )
+from isvtest.validations.sanitization import (
+    FirmwareResetCheck,
+    GpuMemorySanitizationCheck,
+    MemorySanitizationCheck,
+)
 from isvtest.validations.security import (
     ApiEndpointIsolationCheck,
     AuditLogEntryCheck,
@@ -162,8 +167,10 @@ __all__ = [
     "DriverCheck",
     "FieldExistsCheck",
     "FieldValueCheck",
+    "FirmwareResetCheck",
     "FloatingIpCheck",
     "GovernanceMetricsCheck",
+    "GpuMemorySanitizationCheck",
     "GpuOperatorInstalledCheck",
     "HealthAggregationCheck",
     "HostHealthCheck",
@@ -183,6 +190,7 @@ __all__ = [
     "KmsEncryptionOptionCheck",
     "LeastPrivilegePolicyCheck",
     "LocalizedDnsCheck",
+    "MemorySanitizationCheck",
     "MfaEnforcedCheck",
     "MinimalRoleEnforcementCheck",
     "NetworkConnectivityCheck",

--- a/isvtest/src/isvtest/validations/sanitization.py
+++ b/isvtest/src/isvtest/validations/sanitization.py
@@ -131,8 +131,12 @@ class _TenantSanitizationCheck(BaseValidation):
 
         total = len(scoped)
         if failed:
-            detail = "; ".join(failed.values())
-            self.set_failed(f"{self.subject} failed for {len(failed)}/{total} machine(s): {detail}")
+            # Keep the summary concise: name a few offenders and a count. The
+            # full per-machine reason (incl. transitions) is in the subtests.
+            sample = ", ".join(list(failed)[:3])
+            more = len(failed) - min(len(failed), 3)
+            summary = f"{sample} (+{more} more)" if more else sample
+            self.set_failed(f"{self.subject} failed for {len(failed)}/{total} machine(s): {summary}")
             return
 
         self.set_passed(f"{self.subject} verified on {total} machine(s) ({served} with a prior tenancy audited)")

--- a/isvtest/src/isvtest/validations/sanitization.py
+++ b/isvtest/src/isvtest/validations/sanitization.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tenant-transition data-sanitization validations (requirement SEC21/SEC22).
+
+Three provider-agnostic checks that assert a cloud does not hand a host to a
+new tenant until it has been sanitized since the previous tenancy:
+
+- ``MemorySanitizationCheck`` (SEC21-04): host (RAM) memory is sanitized
+  between tenants.
+- ``GpuMemorySanitizationCheck`` (SEC21-05): GPU/SRAM memory is sanitized
+  between tenants (scoped to GPU-equipped hosts).
+- ``FirmwareResetCheck`` (SEC21-06 / SEC22): TPM is cleared and BIOS/UEFI is
+  recommitted during tenant transitions or hardware replacement.
+
+All three share one provider-neutral signal: a host that has served a tenant
+must pass through a dedicated *sanitizing* lifecycle stage before it becomes
+allocatable to a new tenant again. The check inspects the host's recorded
+state ``transitions`` and fails a host that went from ``in_use`` back to
+``available`` without an intervening ``sanitizing`` stage, or that is offered
+to new tenants while still bound to a prior tenant. They only inspect the
+provider-neutral JSON a step script emits, so any provider that maps its
+host lifecycle into the documented fields can reuse them.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from isvtest.core.validation import BaseValidation
+
+# Provider-neutral lifecycle tokens used in each machine's ``transitions`` list.
+IN_USE = "in_use"
+SANITIZING = "sanitizing"
+AVAILABLE = "available"
+
+
+def _machine_label(machine: dict[str, Any]) -> str:
+    """Human-facing identifier for a machine record."""
+    return machine.get("machine_id") or "unknown"
+
+
+def evaluate_sanitization(machine: dict[str, Any]) -> tuple[bool, str]:
+    """Evaluate the tenant-transition sanitization gate for one machine.
+
+    Returns ``(passed, message)``. A machine passes when:
+
+    * it has never served a tenant (nothing to sanitize), or
+    * it is currently available and not bound to a prior tenant, and every
+      recorded release passed through a ``sanitizing`` stage (the script sets
+      ``sanitized`` from the host's state ``transitions``).
+
+    A machine fails when it is offered to new tenants while still bound to a
+    prior tenant, or when it returned to ``available`` after a tenancy without
+    an intervening ``sanitizing`` stage.
+    """
+    label = _machine_label(machine)
+
+    if not machine.get("served_tenant"):
+        return True, f"{label}: no prior tenancy to sanitize (status {machine.get('status', 'unknown')})"
+
+    if machine.get("stale_tenant_binding"):
+        return False, f"{label}: available to new tenants while still bound to a prior tenant"
+
+    if not machine.get("sanitized"):
+        transitions = " -> ".join(str(t) for t in machine.get("transitions") or []) or "<none recorded>"
+        return False, f"{label}: returned to the pool without sanitization (transitions: {transitions})"
+
+    return True, f"{label}: sanitized between tenancies"
+
+
+class _TenantSanitizationCheck(BaseValidation):
+    """Shared machinery for the SEC21 tenant-transition sanitization checks.
+
+    Subclasses set ``gpu_only`` and the ``subtest_prefix`` / summary wording.
+    Each subclass keeps its own ``description`` and ``labels`` so it maps to a
+    single test ID and can be toggled independently in a suite.
+    """
+
+    timeout: ClassVar[int] = 120
+    gpu_only: ClassVar[bool] = False
+    subtest_prefix: ClassVar[str] = "machine"
+    subject: ClassVar[str] = "Memory"
+
+    def _select_machines(self, machines: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Return the machines this check applies to (all, or GPU-equipped)."""
+        if self.gpu_only:
+            return [m for m in machines if m.get("has_gpu")]
+        return machines
+
+    def run(self) -> None:
+        """Validate that every in-scope machine was sanitized between tenancies."""
+        step_output = self.config.get("step_output", {})
+
+        if not step_output.get("success"):
+            self.set_failed(f"Sanitization step failed: {step_output.get('error', 'Unknown error')}")
+            return
+
+        machines = step_output.get("machines")
+        if not isinstance(machines, list):
+            self.set_failed("Sanitization step output is missing the 'machines' list")
+            return
+
+        scoped = self._select_machines(machines)
+        if not scoped:
+            scope = "GPU-equipped " if self.gpu_only else ""
+            self.set_failed(f"No {scope}machines found in step output")
+            return
+
+        failed: dict[str, str] = {}
+        served = 0
+        for machine in scoped:
+            if machine.get("served_tenant"):
+                served += 1
+            passed, message = evaluate_sanitization(machine)
+            self.report_subtest(f"{self.subtest_prefix}_{_machine_label(machine)}", passed=passed, message=message)
+            if not passed:
+                failed[_machine_label(machine)] = message
+
+        total = len(scoped)
+        if failed:
+            detail = "; ".join(failed.values())
+            self.set_failed(f"{self.subject} failed for {len(failed)}/{total} machine(s): {detail}")
+            return
+
+        self.set_passed(f"{self.subject} verified on {total} machine(s) ({served} with a prior tenancy audited)")
+
+
+class MemorySanitizationCheck(_TenantSanitizationCheck):
+    """Validate host memory is sanitized between tenants (SEC21-04).
+
+    Asserts that every managed host that has served a tenant is not returned to
+    the allocatable pool until it has passed through the platform's sanitizing
+    (host cleanup / memory-overwrite) lifecycle stage. A host that went from
+    ``in_use`` straight back to ``available``, or that is still bound to a prior
+    tenant while available, fails.
+
+    Config:
+        step_output: Step output containing per-machine sanitization records.
+
+    Step output (from query_sanitization.py):
+        success: bool
+        platform: str
+        site_id: str
+        machines_checked: int
+        machines: list[dict]:
+            machine_id: str
+            status: str -- neutral current lifecycle token
+            available: bool -- allocatable to a new tenant now
+            in_use: bool -- currently assigned to a tenant
+            has_gpu: bool
+            served_tenant: bool -- has hosted a tenant workload
+            sanitized: bool -- every release passed through a sanitizing stage
+            stale_tenant_binding: bool -- available but still bound to a prior tenant
+            transitions: list[str] -- recent neutral lifecycle sequence
+    """
+
+    description: ClassVar[str] = "Check host memory is sanitized between tenants"
+    labels: ClassVar[tuple[str, ...]] = ("bare_metal", "security", "sanitization")
+    subject: ClassVar[str] = "Host memory sanitization"
+    subtest_prefix: ClassVar[str] = "memory"
+
+
+class GpuMemorySanitizationCheck(_TenantSanitizationCheck):
+    """Validate SRAM/GPU memory is sanitized between tenants (SEC21-05).
+
+    Identical tenant-transition gate to ``MemorySanitizationCheck`` but scoped
+    to GPU-equipped hosts, so it asserts that accelerator (GPU/SRAM) memory is
+    scrubbed by the platform's sanitizing stage before a GPU host is offered to
+    a new tenant. Fails when no GPU-equipped host is present (nothing to
+    validate).
+
+    Config:
+        step_output: Step output containing per-machine sanitization records
+            (see ``MemorySanitizationCheck`` for the schema; ``has_gpu`` selects
+            the in-scope machines).
+    """
+
+    description: ClassVar[str] = "Check SRAM/GPU memory is sanitized between tenants"
+    labels: ClassVar[tuple[str, ...]] = ("bare_metal", "security", "sanitization", "gpu")
+    subject: ClassVar[str] = "GPU memory sanitization"
+    subtest_prefix: ClassVar[str] = "gpu_memory"
+    gpu_only: ClassVar[bool] = True
+
+
+class FirmwareResetCheck(_TenantSanitizationCheck):
+    """Validate TPM and BIOS are reset during tenant transitions (SEC21-06/SEC22).
+
+    Uses the same sanitization-gate audit (TPM clear and BIOS/UEFI recommit run
+    inside the platform's sanitizing stage) and additionally surfaces, per
+    machine, the firmware identity (vendor / product / BIOS version) recorded
+    after the transition as report-only evidence. BIOS *version* policy
+    (minimum approved version per platform) remains the job of
+    ``HostSoftwareCheck.bios_baselines`` / ``tpm_baselines`` (SEC22-02).
+
+    Config:
+        step_output: Step output containing per-machine sanitization records
+            (see ``MemorySanitizationCheck``); also reads ``vendor``,
+            ``product_name``, and ``bios_version`` for the firmware evidence
+            subtest.
+    """
+
+    description: ClassVar[str] = "Check TPM/BIOS are reset during tenant transitions"
+    labels: ClassVar[tuple[str, ...]] = ("bare_metal", "security", "sanitization", "firmware")
+    subject: ClassVar[str] = "Firmware reset"
+    subtest_prefix: ClassVar[str] = "firmware"
+
+    def run(self) -> None:
+        """Validate the reset gate, then report per-machine firmware identity."""
+        super().run()
+
+        # Only emit the report-only firmware-identity subtests when the gate
+        # itself was evaluable (step succeeded and machines were present).
+        step_output = self.config.get("step_output", {})
+        machines = step_output.get("machines")
+        if not step_output.get("success") or not isinstance(machines, list):
+            return
+
+        for machine in machines:
+            label = _machine_label(machine)
+            vendor = machine.get("vendor") or "unknown"
+            product = machine.get("product_name") or "unknown"
+            bios_version = machine.get("bios_version") or "unknown"
+            self.report_subtest(
+                f"{self.subtest_prefix}_{label}_identity",
+                passed=True,
+                message=f"{label}: {vendor} {product}, BIOS {bios_version}",
+            )

--- a/isvtest/tests/test_sanitization.py
+++ b/isvtest/tests/test_sanitization.py
@@ -107,8 +107,12 @@ class TestMemorySanitizationCheck:
         check = MemorySanitizationCheck(config={"step_output": _output(machines=[machine])})
         check.run()
         assert check._passed is False
-        assert "without sanitization" in check._error
-        assert "in_use -> available" in check._error
+        # Summary stays concise (count + offending ids); the full per-machine
+        # reason (incl. transitions) is preserved in the subtest message.
+        assert "1/1 machine(s)" in check._error
+        sub = next(r for r in check._subtest_results if r["name"].startswith("memory_"))
+        assert "without sanitization" in sub["message"]
+        assert "in_use -> available" in sub["message"]
 
     def test_stale_tenant_binding_fails(self) -> None:
         """A host offered to new tenants while still bound to a prior tenant fails."""
@@ -116,7 +120,9 @@ class TestMemorySanitizationCheck:
         check = MemorySanitizationCheck(config={"step_output": _output(machines=[machine])})
         check.run()
         assert check._passed is False
-        assert "still bound to a prior tenant" in check._error
+        assert "1/1 machine(s)" in check._error
+        sub = next(r for r in check._subtest_results if r["name"].startswith("memory_"))
+        assert "still bound to a prior tenant" in sub["message"]
 
     def test_step_failure(self) -> None:
         """A failed step is reported with its error detail."""

--- a/isvtest/tests/test_sanitization.py
+++ b/isvtest/tests/test_sanitization.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the tenant-transition sanitization validations (SEC21-04/05/06)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from isvtest.validations.sanitization import (
+    FirmwareResetCheck,
+    GpuMemorySanitizationCheck,
+    MemorySanitizationCheck,
+)
+
+
+def _machine(
+    *,
+    machine_id: str = "m-001",
+    status: str = "available",
+    available: bool = True,
+    in_use: bool = False,
+    has_gpu: bool = True,
+    served_tenant: bool = True,
+    sanitized: bool = True,
+    stale_tenant_binding: bool = False,
+    vendor: str = "Lenovo",
+    product_name: str = "ThinkSystem SR670 V2",
+    bios_version: str = "U8E122J-1.51",
+    transitions: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a provider-neutral per-machine sanitization record."""
+    return {
+        "machine_id": machine_id,
+        "status": status,
+        "available": available,
+        "in_use": in_use,
+        "has_gpu": has_gpu,
+        "served_tenant": served_tenant,
+        "sanitized": sanitized,
+        "stale_tenant_binding": stale_tenant_binding,
+        "vendor": vendor,
+        "product_name": product_name,
+        "bios_version": bios_version,
+        "transitions": transitions if transitions is not None else ["in_use", "sanitizing", "available"],
+    }
+
+
+def _output(
+    *,
+    success: bool = True,
+    machines: list[dict[str, Any]] | None = None,
+    error: str = "",
+) -> dict[str, Any]:
+    """Build a sanitization step output."""
+    if machines is None:
+        machines = [_machine()]
+    return {
+        "success": success,
+        "platform": "nico",
+        "site_id": "test-site-001",
+        "machines_checked": len(machines),
+        "machines": machines,
+        "error": error,
+    }
+
+
+# ===========================================================================
+# MemorySanitizationCheck (SEC21-04)
+# ===========================================================================
+
+
+class TestMemorySanitizationCheck:
+    """Tests for MemorySanitizationCheck validation."""
+
+    def test_sanitized_fleet_passes(self) -> None:
+        """A fleet whose released hosts were all sanitized passes."""
+        check = MemorySanitizationCheck(config={"step_output": _output()})
+        check.run()
+        assert check._passed is True, check._error
+        sub = next(r for r in check._subtest_results if r["name"] == "memory_m-001")
+        assert sub["passed"] is True
+
+    def test_never_served_tenant_passes(self) -> None:
+        """A freshly ingested host with no prior tenancy passes vacuously."""
+        machine = _machine(served_tenant=False, transitions=["initializing", "available"])
+        check = MemorySanitizationCheck(config={"step_output": _output(machines=[machine])})
+        check.run()
+        assert check._passed is True, check._error
+        assert "no prior tenancy" in check._subtest_results[0]["message"]
+
+    def test_unsanitized_release_fails(self) -> None:
+        """A host returned to the pool without sanitization fails."""
+        machine = _machine(sanitized=False, transitions=["in_use", "available"])
+        check = MemorySanitizationCheck(config={"step_output": _output(machines=[machine])})
+        check.run()
+        assert check._passed is False
+        assert "without sanitization" in check._error
+        assert "in_use -> available" in check._error
+
+    def test_stale_tenant_binding_fails(self) -> None:
+        """A host offered to new tenants while still bound to a prior tenant fails."""
+        machine = _machine(stale_tenant_binding=True)
+        check = MemorySanitizationCheck(config={"step_output": _output(machines=[machine])})
+        check.run()
+        assert check._passed is False
+        assert "still bound to a prior tenant" in check._error
+
+    def test_step_failure(self) -> None:
+        """A failed step is reported with its error detail."""
+        check = MemorySanitizationCheck(config={"step_output": _output(success=False, error="API timeout")})
+        check.run()
+        assert check._passed is False
+        assert "API timeout" in check._error
+
+    def test_missing_machines_list(self) -> None:
+        """A non-list machines field fails."""
+        output = _output()
+        output["machines"] = None
+        check = MemorySanitizationCheck(config={"step_output": output})
+        check.run()
+        assert check._passed is False
+        assert "machines" in check._error
+
+    def test_no_machines_fails(self) -> None:
+        """An empty machine list fails -- nothing was validated."""
+        check = MemorySanitizationCheck(config={"step_output": _output(machines=[])})
+        check.run()
+        assert check._passed is False
+        assert "No machines" in check._error
+
+    def test_reports_all_machines_and_summary(self) -> None:
+        """One failing host fails the check while the clean host still passes."""
+        good = _machine(machine_id="m-good")
+        bad = _machine(machine_id="m-bad", sanitized=False, transitions=["in_use", "available"])
+        check = MemorySanitizationCheck(config={"step_output": _output(machines=[good, bad])})
+        check.run()
+        assert check._passed is False
+        assert "1/2 machine(s)" in check._error
+        names = {r["name"]: r["passed"] for r in check._subtest_results}
+        assert names["memory_m-good"] is True
+        assert names["memory_m-bad"] is False
+
+
+# ===========================================================================
+# GpuMemorySanitizationCheck (SEC21-05)
+# ===========================================================================
+
+
+class TestGpuMemorySanitizationCheck:
+    """Tests for GpuMemorySanitizationCheck validation."""
+
+    def test_only_gpu_hosts_are_scoped(self) -> None:
+        """Non-GPU hosts are ignored; a sanitized GPU host passes."""
+        gpu = _machine(machine_id="m-gpu", has_gpu=True)
+        cpu = _machine(machine_id="m-cpu", has_gpu=False, sanitized=False, transitions=["in_use", "available"])
+        check = GpuMemorySanitizationCheck(config={"step_output": _output(machines=[gpu, cpu])})
+        check.run()
+        # The CPU host's violation must not count -- it is out of GPU scope.
+        assert check._passed is True, check._error
+        names = {r["name"] for r in check._subtest_results}
+        assert "gpu_memory_m-gpu" in names
+        assert "gpu_memory_m-cpu" not in names
+
+    def test_no_gpu_hosts_fails(self) -> None:
+        """A fleet with no GPU-equipped host fails (nothing to validate)."""
+        cpu = _machine(machine_id="m-cpu", has_gpu=False)
+        check = GpuMemorySanitizationCheck(config={"step_output": _output(machines=[cpu])})
+        check.run()
+        assert check._passed is False
+        assert "No GPU-equipped machines" in check._error
+
+    def test_gpu_violation_fails(self) -> None:
+        """An unsanitized GPU host fails."""
+        gpu = _machine(machine_id="m-gpu", has_gpu=True, sanitized=False, transitions=["in_use", "available"])
+        check = GpuMemorySanitizationCheck(config={"step_output": _output(machines=[gpu])})
+        check.run()
+        assert check._passed is False
+        assert "GPU memory sanitization failed" in check._error
+
+
+# ===========================================================================
+# FirmwareResetCheck (SEC21-06 / SEC22)
+# ===========================================================================
+
+
+class TestFirmwareResetCheck:
+    """Tests for FirmwareResetCheck validation."""
+
+    def test_sanitized_fleet_passes_and_reports_firmware(self) -> None:
+        """A sanitized fleet passes and emits a report-only firmware identity subtest."""
+        check = FirmwareResetCheck(config={"step_output": _output()})
+        check.run()
+        assert check._passed is True, check._error
+        identity = next(r for r in check._subtest_results if r["name"] == "firmware_m-001_identity")
+        assert identity["passed"] is True
+        assert "BIOS U8E122J-1.51" in identity["message"]
+
+    def test_unsanitized_release_fails(self) -> None:
+        """A host returned without TPM/BIOS reset fails the gate."""
+        machine = _machine(sanitized=False, transitions=["in_use", "available"])
+        check = FirmwareResetCheck(config={"step_output": _output(machines=[machine])})
+        check.run()
+        assert check._passed is False
+        assert "Firmware reset failed" in check._error
+
+    def test_missing_bios_version_reports_unknown(self) -> None:
+        """A missing BIOS version is reported as unknown, not a failure."""
+        machine = _machine(bios_version="")
+        check = FirmwareResetCheck(config={"step_output": _output(machines=[machine])})
+        check.run()
+        assert check._passed is True, check._error
+        identity = next(r for r in check._subtest_results if r["name"] == "firmware_m-001_identity")
+        assert "BIOS unknown" in identity["message"]
+
+    def test_step_failure_skips_firmware_subtests(self) -> None:
+        """A failed step fails the check and emits no firmware identity subtests."""
+        check = FirmwareResetCheck(config={"step_output": _output(success=False, error="API down")})
+        check.run()
+        assert check._passed is False
+        assert not any(r["name"].endswith("_identity") for r in check._subtest_results)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds three provider-agnostic validations for the "Data Sanitization" requirement (SEC21/SEC22), wired for NICo via the `bare_metal` suite. Each asserts the same provider-neutral invariant: **a host that has served a tenant must pass through a dedicated _sanitizing_ lifecycle stage before it becomes allocatable to a new tenant again.**

- **`MemorySanitizationCheck`** (SEC21-04): host (RAM) memory is sanitized between tenants.
- **`GpuMemorySanitizationCheck`** (SEC21-05): SRAM/GPU memory is sanitized between tenants (scoped to GPU-equipped hosts).
- **`FirmwareResetCheck`** (SEC21-06 / SEC22): TPM is cleared and BIOS/UEFI is recommitted during tenant transitions or hardware replacement, plus report-only firmware identity (vendor / product / BIOS version).

The checks fail a host that went from `in_use` back to `available` without an intervening `sanitizing` stage, or that is offered to new tenants while still bound to a prior tenant.

## How it maps to NICo

NICo runs its cleanup/sanitization workflow between tenants (host/RAM cleanup + UEFI `MemoryOverwriteRequestControl`, NVMe/HDD secure erase, InfiniBand cleanup, TPM clear, BIOS/UEFI recommit). At the REST level this whole workflow is the machine `Reset` status — a released host moves `InUse -> Reset -> ... -> Ready` and must not return to `Ready` until cleanup completes (per infra-controller `docs/operations/tenant-lifecycle-cleanup.md` and the managed-host state machine).

`query_sanitization.py` reads each machine's `status` + `statusHistory` and maps the NICo lifecycle into a provider-neutral token sequence (`Reset -> sanitizing`, `InUse -> in_use`, `Ready -> available`), computing `served_tenant`, `sanitized`, `available`, and `stale_tenant_binding`, plus `has_gpu` and firmware identity. The mapping is robust to truncated history: a violation is only flagged on positive evidence of an `in_use -> available` transition without an intervening `sanitizing`.

## Changes

- `isvtest/src/isvtest/validations/sanitization.py`: new validations (shared `_TenantSanitizationCheck` base + the three checks).
- `isvtest/src/isvtest/validations/__init__.py`: register/export the three checks.
- `isvctl/configs/providers/nico/scripts/sanitization/query_sanitization.py`: NICo step that emits the neutral per-machine contract.
- `isvctl/configs/suites/bare_metal.yaml`: add `memory_sanitization`, `gpu_memory_sanitization`, `firmware_reset` validation groups (only run for providers that implement the `query_sanitization` step).
- `isvctl/configs/providers/nico/config/bare_metal.yaml`: wire the `query_sanitization` step.
- `isvctl/configs/suites/README.md`: document the step's key JSON fields.
- `isvtest/tests/test_sanitization.py` + `isvctl/tests/test_nico_provider.py`: unit tests for the validations and the NICo script (token mapping, history ordering, gate logic, record building, and end-to-end script → validation contract).
- Ships **unreleased**; `isvtest/src/isvtest/released_tests.json` intentionally untouched (new checks land in a separate release commit; exercise with `ISVTEST_INCLUDE_UNRELEASED=1`).

## Validation

Exercised end-to-end through the `isvctl` orchestrator with an echo-based step (no cloud credentials needed): a clean fleet passes all three checks and a host that went `in_use -> available` (skipping `sanitizing`) fails all three with an actionable message.

[sec21_sanitization_e2e.log](https://cursor.com/agents/bc-02fee612-1f96-44b6-a0b6-bb271159b3cc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsec21_sanitization_e2e.log)

Programmatic checks: `make test` (964 + 68 passed), `make lint` (clean), `make demo-test` (clean), `uvx pre-commit run -a` (clean).

## Issues

Closes #312
Closes #313
Closes #314

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02fee612-1f96-44b6-a0b6-bb271159b3cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02fee612-1f96-44b6-a0b6-bb271159b3cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant-transition sanitization checks for bare-metal: MemorySanitization, GpuMemorySanitization, and FirmwareReset (SEC21/SEC22).
  * New CLI sanitization audit emits per-host JSON summaries (sanitized/in_use/available, GPU presence, firmware identity).

* **Tests**
  * Extensive unit and integration tests validating sanitization logic, script output, and validation behavior across clean/failed/skipped scenarios.

* **Documentation**
  * Test-suite documentation updated to reference the new sanitization coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->