### PR TITLE
fix(security): prove KmsEncryptionOptionCheck options independently, drop the provider-managed key-id gate

### DIFF
--- a/isvctl/configs/providers/my-isv/scripts/security/kms_encryption_options_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/security/kms_encryption_options_test.py
@@ -52,8 +52,10 @@ def main() -> int:
     }
 
     # TODO: Replace this block with your platform's KMS option checks. Prove
-    # that tenants can choose both provider-managed keys and customer-managed
-    # keys, and include non-empty identifiers for both options.
+    # that tenants can choose both provider-managed and customer-managed keys.
+    # customer_managed_key_id must be a non-empty enumerable key id; the
+    # provider-managed option is proven by the provider_managed_key_available
+    # subtest (set provider_managed_key_id only if your platform exposes one).
 
     if DEMO_MODE:
         result["provider_managed_key_id"] = "my-isv-provider-managed-key"

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -504,18 +504,28 @@ class KmsEncryptionOptionCheck(BaseValidation):
         if not check_required_tests(self, required, "KMS encryption option tests failed"):
             return
 
-        provider_key_id = step_output.get("provider_managed_key_id")
-        if not isinstance(provider_key_id, str) or not provider_key_id.strip():
-            self.set_failed("KMS encryption options output missing non-empty provider-managed key evidence")
-            return
-
+        # Customer-managed (CMEK) is proven by an enumerable key id -- the
+        # portable evidence shape every CMEK-capable platform produces (AWS
+        # create_key; GCP KeyManagementServiceClient.list_crypto_keys).
         customer_key_id = step_output.get("customer_managed_key_id")
         if not isinstance(customer_key_id, str) or not customer_key_id.strip():
             self.set_failed("KMS encryption options output missing non-empty customer-managed key evidence")
             return
 
+        # Provider-managed (default at-rest) is proven by the
+        # provider_managed_key_available subtest, NOT a key id: the evidence is
+        # platform-shaped -- a listable managed-key alias where one exists, or a
+        # capability where the default key is not an enumerable resource. Record
+        # the id when the platform exposes one; do not require it.
+        provider_key_id = step_output.get("provider_managed_key_id")
+        provider_desc = (
+            provider_key_id.strip()
+            if isinstance(provider_key_id, str) and provider_key_id.strip()
+            else "available"
+        )
+
         self.set_passed(
-            f"KMS encryption options verified (provider={provider_key_id.strip()}, customer={customer_key_id.strip()})"
+            f"KMS encryption options verified (provider={provider_desc}, customer={customer_key_id.strip()})"
         )
 
 

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -519,9 +519,7 @@ class KmsEncryptionOptionCheck(BaseValidation):
         # the id when the platform exposes one; do not require it.
         provider_key_id = step_output.get("provider_managed_key_id")
         provider_desc = (
-            provider_key_id.strip()
-            if isinstance(provider_key_id, str) and provider_key_id.strip()
-            else "available"
+            provider_key_id.strip() if isinstance(provider_key_id, str) and provider_key_id.strip() else "available"
         )
 
         self.set_passed(

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -479,7 +479,10 @@ class KmsEncryptionOptionCheck(BaseValidation):
         step_output: The kms_encryption_options_test step output to check
 
     Step output:
-        provider_managed_key_id: Non-empty provider-managed key evidence
+        provider_managed_key_id: Optional provider-managed key id (may be empty
+            or absent when the platform's default at-rest key is not an
+            enumerable resource); provider-managed support is proven by the
+            provider_managed_key_available subtest, not this id
         customer_managed_key_id: Non-empty CMK evidence
         skipped: True when scoped provider-managed evidence is unavailable
         skip_reason: Human-readable skip reason when skipped is True

--- a/isvtest/tests/test_security.py
+++ b/isvtest/tests/test_security.py
@@ -593,14 +593,16 @@ def test_kms_encryption_option_check_fails_without_customer_evidence() -> None:
     assert "customer-managed key evidence" in result["error"]
 
 
-def test_kms_encryption_option_check_fails_without_provider_evidence() -> None:
-    """KmsEncryptionOptionCheck fails when provider-managed key evidence is absent."""
+def test_kms_encryption_option_check_passes_without_provider_key_id() -> None:
+    """Provider-managed proof rides the provider_managed_key_available subtest, so an
+    empty provider_managed_key_id is fine as long as the subtest passes (a platform
+    whose default-encryption key is not an enumerable resource)."""
     check = KmsEncryptionOptionCheck(config={"step_output": _kms_options_step_output(provider_managed_key_id="")})
 
     result = check.execute()
 
-    assert result["passed"] is False
-    assert "provider-managed key evidence" in result["error"]
+    assert result["passed"] is True
+    assert "provider=available" in result["output"]
 
 
 def test_kms_encryption_option_check_skips_when_step_marks_skipped() -> None:


### PR DESCRIPTION
# fix(security): prove KmsEncryptionOptionCheck options independently, drop the provider-managed key-id gate

## Summary

`KmsEncryptionOptionCheck` verifies that a platform supports both customer-managed and provider-managed encryption keys, but it gated "provider-managed supported" on a non-empty `provider_managed_key_id`. On AWS the provider-managed (platform-default) key has an enumerable id; on other platforms the default at-rest key is always-on but is not a customer-addressable resource and exposes no id to report. Requiring an id made the provider-managed half unsatisfiable for a faithful non-AWS port even when the capability is plainly present. This PR drops the id gate and proves provider-managed support via a dedicated capability subtest (`provider_managed_key_available`) instead. The customer-managed half is unchanged — it still requires a real customer-managed key id. The check passes when both capability subtests pass, independent of whether the provider-managed key is enumerable.

## What changes

- `isvtest` validator (`KmsEncryptionOptionCheck`): drop the `provider_managed_key_id` non-empty requirement; keep the customer-managed key-id requirement; require the three subtests (`provider_managed_key_available`, `customer_managed_key_available`, `both_options_supported`). Provider-managed support is proven by the capability subtest, not a key id.
- AWS oracle reference (`kms_encryption_options_test.py`): behavior unchanged — AWS still emits its provider-managed key id, now informational rather than gating.
- Validator unit tests updated.

## Verification

- **Unit tests**: the `isvtest` validator suite passes against the new contract — a provider that proves provider-managed availability via the capability subtest but reports no provider key id now passes where before it failed; the customer-managed requirement still holds.
- **AWS oracle consistency**: the AWS reference still passes (it emits the id, now informational).
- **Non-AWS (GCP) live coverage**: verified end-to-end — our GCP provider implementation ran the full security suite live and `KmsEncryptionOptionCheck` passed, emitting the three subtests plus a customer-managed key id enumerated from the platform's KMS, and omitting a provider-managed key id (the platform's default at-rest key is not an enumerable KMS resource). An independent review of the generated provider found no contract violation.

## Provenance

Single commit, DCO-signed. The validator change and the AWS-oracle reference change were authored together so the reference always satisfies the contract it defines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * KMS encryption validation: provider-managed key ID is now optional; when absent it's reported as "available" and no longer forces a failure.

* **Tests**
  * Test suite adjusted to reflect new behavior: added a passing test for blank provider key and removed the prior failing assertion for missing provider evidence.

* **Documentation**
  * Inline guidance for KMS encryption option checks clarified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->