### PR TITLE
fix(security): broaden ServiceAccountCredentialCheck to any credential source

### DIFF
--- a/isvctl/configs/providers/aws/scripts/security/sa_credential_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/sa_credential_test.py
@@ -14,11 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Verify out-of-cluster service accounts can authenticate with long-lived credentials.
+"""Verify out-of-cluster service accounts can obtain credentials and authenticate.
 
-AWS reference implementation: creates a temporary IAM user with
-programmatic access (long-lived access key), authenticates with
-STS GetCallerIdentity, then cleans up.
+The property under test is that the service account can authenticate as the
+expected identity; the credential may come from any source the platform supports
+(long-lived key, short-lived token, impersonation, workload-identity federation),
+reported in credential_source. AWS reference implementation: creates a temporary
+IAM user with programmatic access (long-lived access key, credential_source
+"long_lived_key"), authenticates with STS GetCallerIdentity, then cleans up.
 
 Usage:
     python sa_credential_test.py --region us-west-2
@@ -30,6 +33,7 @@ Output JSON:
     "test_name": "sa_credential_test",
     "authenticated": true,
     "credential_type": "access_key",
+    "credential_source": "long_lived_key",
     "identity": "arn:aws:iam::123456789012:user/isv-sa-test-xxxx",
     "expires_at": null
   }
@@ -89,6 +93,7 @@ def main() -> int:
         "test_name": "sa_credential_test",
         "authenticated": False,
         "credential_type": "",
+        "credential_source": "long_lived_key",
         "identity": "",
         "expires_at": None,
     }

--- a/isvctl/configs/providers/my-isv/scripts/security/sa_credential_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/security/sa_credential_test.py
@@ -14,11 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Service account long-lived credential test - TEMPLATE.
+"""Service account credential test - TEMPLATE.
 
-Verifies that out-of-cluster service accounts can authenticate using
-long-lived credentials (API keys, service account keys, etc.).  This
-covers the SEC03-01 requirement.
+Verifies that out-of-cluster service accounts can obtain credentials and
+authenticate as the expected identity. The credential may come from any source
+your platform supports -- a downloaded long-lived key, a short-lived token,
+service-account impersonation, or workload-identity federation (reported in
+credential_source). Covers the SEC03-01 requirement.
 
 Required JSON output fields:
   {
@@ -27,6 +29,7 @@ Required JSON output fields:
     "test_name": "sa_credential_test",
     "authenticated": true,
     "credential_type": "api_key",
+    "credential_source": "long_lived_key",
     "identity": "sa-validation-test@project.iam",
     "expires_at": null
   }
@@ -56,26 +59,28 @@ def main() -> int:
         "test_name": "sa_credential_test",
         "authenticated": False,
         "credential_type": "",
+        "credential_source": "",
         "identity": "",
         "expires_at": None,
     }
 
-    # ╔══════════════════════════════════════════════════════════════════╗
-    # ║  TODO: Replace this block with your platform's SA credential     ║
-    # ║  test.                                                           ║
-    # ║                                                                  ║
-    # ║  Example (pseudocode):                                           ║
-    # ║    sa = create_service_account("validation-test")                ║
-    # ║    key = create_long_lived_key(sa)                               ║
-    # ║    identity = authenticate_with_key(key)                         ║
-    # ║    result["authenticated"] = identity is not None                ║
-    # ║    result["credential_type"] = "service_account_key"             ║
-    # ║    result["identity"] = identity.principal                       ║
-    # ╚══════════════════════════════════════════════════════════════════╝
+    # TODO: Replace this block with your platform's SA credential test.
+    #
+    # Prove a service account can authenticate as the expected identity via any
+    # credential source your platform supports. Example (pseudocode):
+    #   sa = create_service_account("validation-test")
+    #   # long-lived key, OR a keyless source where key download is disabled:
+    #   creds = obtain_credentials(sa)        # key | impersonation | WIF | token
+    #   identity = authenticate(creds)
+    #   result["authenticated"] = identity is not None
+    #   result["credential_type"] = "service_account_key"  # or "oauth2_token", ...
+    #   result["credential_source"] = "long_lived_key"     # or "impersonation", ...
+    #   result["identity"] = identity.principal
 
     if DEMO_MODE:
         result["authenticated"] = True
         result["credential_type"] = "api_key"
+        result["credential_source"] = "long_lived_key"
         result["identity"] = "sa-validation-test@my-isv.iam"
         result["expires_at"] = None
         result["success"] = True

--- a/isvtest/src/isvtest/validations/iam.py
+++ b/isvtest/src/isvtest/validations/iam.py
@@ -147,23 +147,30 @@ class AccessKeyRejectedCheck(BaseValidation):
 
 
 class ServiceAccountCredentialCheck(BaseValidation):
-    """Validate out-of-cluster service accounts can authenticate with long-lived credentials.
+    """Validate out-of-cluster service accounts can obtain credentials and authenticate.
 
-    Verifies that service accounts intended for out-of-cluster use (CI/CD
-    pipelines, external tooling) can authenticate using long-lived credentials
-    and that the credentials grant the expected identity.
+    Verifies that a service account intended for out-of-cluster use (CI/CD
+    pipelines, external tooling) can obtain credentials and authenticate as the
+    expected identity. The credential may come from any source the platform
+    supports -- a downloaded long-lived key, a short-lived token, service-account
+    impersonation, or workload-identity federation. The property under test is
+    "the workload can authenticate as the service account," not the specific key
+    material, so a platform that disables long-lived key download (a recommended
+    hardening posture) proves this via a keyless source.
 
     Config:
         step_output: The step output to check
 
     Step output:
         authenticated: Boolean - True if SA authenticated successfully
-        credential_type: Type of credential (e.g. "api_key", "service_account_key")
+        credential_type: Type of credential (e.g. "access_key", "oauth2_token")
+        credential_source: Optional - how the credential was obtained
+            (long_lived_key | short_lived | impersonation | workload_identity)
         identity: The authenticated identity / principal
-        expires_at: Optional expiry (null/absent for truly long-lived)
+        expires_at: Optional expiry (null/absent for long-lived credentials)
     """
 
-    description: ClassVar[str] = "Check service account long-lived credential auth"
+    description: ClassVar[str] = "Check service account can obtain credentials and authenticate"
     labels: ClassVar[tuple[str, ...]] = ("iam", "security")
 
     def run(self) -> None:
@@ -188,7 +195,12 @@ class ServiceAccountCredentialCheck(BaseValidation):
         if not identity:
             self.set_failed("No 'identity' in step output")
             return
-        self.set_passed(f"Service account authenticated via {credential_type} as {identity}")
+        # credential_source is optional and informational: the property under test
+        # is that the SA can authenticate, not which credential mechanism produced
+        # the token (long_lived_key, short_lived, impersonation, workload_identity).
+        credential_source = step_output.get("credential_source")
+        via = f"{credential_type} ({credential_source})" if credential_source else credential_type
+        self.set_passed(f"Service account authenticated via {via} as {identity}")
 
 
 # =============================================================================

--- a/isvtest/tests/test_iam.py
+++ b/isvtest/tests/test_iam.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for IAM validations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from isvtest.validations.iam import ServiceAccountCredentialCheck
+
+
+def _sa_credential_output(**overrides: Any) -> dict[str, Any]:
+    """Return a valid service-account credential step output."""
+    output: dict[str, Any] = {
+        "success": True,
+        "platform": "security",
+        "test_name": "sa_credential_test",
+        "authenticated": True,
+        "credential_type": "access_key",
+        "credential_source": "long_lived_key",
+        "identity": "arn:aws:iam::123456789012:user/isv-sa-test-abcd",
+        "expires_at": None,
+    }
+    output.update(overrides)
+    return output
+
+
+def test_sa_credential_check_passes_with_long_lived_key() -> None:
+    """Passes for the AWS-style long-lived access-key source."""
+    result = ServiceAccountCredentialCheck(config={"step_output": _sa_credential_output()}).execute()
+
+    assert result["passed"] is True
+    assert "authenticated via access_key (long_lived_key)" in result["output"]
+
+
+def test_sa_credential_check_passes_with_keyless_source() -> None:
+    """Passes for a keyless source (impersonation / WIF / short-lived token) -- a platform
+    that disables long-lived key download proves authentication this way."""
+    result = ServiceAccountCredentialCheck(
+        config={
+            "step_output": _sa_credential_output(
+                credential_type="oauth2_token",
+                credential_source="impersonation",
+                expires_at="2026-06-09T01:00:00Z",
+                identity="sa-test@project.iam.gserviceaccount.com",
+            )
+        }
+    ).execute()
+
+    assert result["passed"] is True
+    assert "authenticated via oauth2_token (impersonation)" in result["output"]
+
+
+def test_sa_credential_check_passes_without_credential_source() -> None:
+    """credential_source is optional and informational; its absence does not fail."""
+    out = _sa_credential_output()
+    del out["credential_source"]
+
+    result = ServiceAccountCredentialCheck(config={"step_output": out}).execute()
+
+    assert result["passed"] is True
+    assert "authenticated via access_key as" in result["output"]
+
+
+def test_sa_credential_check_fails_when_not_authenticated() -> None:
+    """Fails when authentication did not succeed (e.g. key creation blocked by policy)."""
+    result = ServiceAccountCredentialCheck(
+        config={"step_output": _sa_credential_output(authenticated=False, error="key creation blocked")}
+    ).execute()
+
+    assert result["passed"] is False
+    assert "authentication failed" in result["error"]
+
+
+def test_sa_credential_check_fails_without_identity() -> None:
+    """Fails when no identity resolved from the credential."""
+    result = ServiceAccountCredentialCheck(config={"step_output": _sa_credential_output(identity="")}).execute()
+
+    assert result["passed"] is False
+    assert "identity" in result["error"]


### PR DESCRIPTION
# fix(security): broaden ServiceAccountCredentialCheck to any credential source

## Summary

`ServiceAccountCredentialCheck` verifies that a workload service-account credential can authenticate, but its contract was shaped around a long-lived key (AWS-style `access_key_id` / `secret_access_key` material). On hardened platforms, long-lived service-account keys are commonly disabled by org policy, and the portable way to prove a workload can authenticate is a short-lived / impersonated / workload-identity credential. This PR broadens the check so the property under test is "the service account can obtain credentials and authenticate" via ANY credential source, with an optional `credential_source` field (`long_lived_key | short_lived | impersonation | workload_identity`) surfaced for transparency. The `authenticated` / `credential_type` / `identity` assertions are unchanged; only the assumption that the credential must be a long-lived key is removed.

## Decision & rationale (for maintainer review)

We implemented the **broad** interpretation: the check proves a workload can authenticate via any credential source, and a keyless / impersonated credential conforms. Reasoning: the security property the check attests is "this service-account identity can authenticate to the platform," which a short-lived or impersonated credential satisfies just as well as a long-lived key — and on platforms that disable long-lived keys by policy, the broad interpretation is the only one a faithful port can satisfy at all.

**The narrow alternative, for you to weigh:** keep the check specifically about *long-lived key issuance* (the original AWS-shaped intent) and treat key-disabled platforms as out of scope / a documented portability gap rather than broadening the contract. We did not take this path because it makes the check unsatisfiable on key-disabled platforms, but we are surfacing it explicitly so you can adjudicate the contract's intent in review. **If you prefer the narrow reading, we'll restrict the change accordingly** — happy to follow your call here.

## What changes

- `isvtest` validator (`ServiceAccountCredentialCheck`): accept any `credential_source`; require `authenticated` / `credential_type` / `identity` (unchanged); add the optional `credential_source` field surfaced in the result.
- AWS oracle reference (`sa_credential_test.py`): annotate its credential as `credential_source: long_lived_key` — AWS behavior unchanged.
- New validator unit-test coverage (`test_iam.py`) for `ServiceAccountCredentialCheck`, which previously had none: long-lived-key, keyless, no-source, not-authenticated, and no-identity cases.

## Verification

- **Unit tests**: new `ServiceAccountCredentialCheck` validator coverage passes for both the long-lived-key and the keyless paths.
- **AWS oracle consistency**: the AWS reference passes with `credential_source: long_lived_key`.
- **Non-AWS (GCP) live coverage**: verified end-to-end — our GCP provider implementation ran the full security suite live and `ServiceAccountCredentialCheck` passed via keyless impersonation: a short-lived token minted by impersonating a target service account, identity resolved from the token, no long-lived key created. An independent review of the generated provider found no contract violation.

## Provenance

Single commit, DCO-signed. The validator change, the AWS-oracle reference change, and the new validator tests were authored together so the reference always satisfies the contract it defines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service account credential validation now supports multiple authentication mechanisms, including keyless authentication (impersonation, OAuth2), workload-identity federation, and short-lived tokens alongside long-lived keys.
  * Added credential source tracking to credential validation outputs for better authentication transparency.

* **Tests**
  * Added comprehensive test coverage for service account credential validation across multiple credential source types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->