### PR TITLE
[SUPERSEDED — please close] docs(security): clarify programmatic_access_mfa semantics

### DIFF
--- a/isvctl/configs/providers/aws/scripts/security/mfa_enforcement_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/mfa_enforcement_test.py
@@ -25,8 +25,12 @@ Tests that the AWS account enforces Multi-Factor Authentication:
   3. programmatic_access_mfa:  At least one attached customer-managed IAM policy
      contains an explicit Deny-without-MFA enforcement pattern
      (``Effect: Deny`` + ``BoolIfExists aws:MultiFactorAuthPresent = false``).
-     On AWS this condition is principal-scoped and transport-agnostic, so one
-     policy evaluation attests MFA on both API- and CLI-initiated access.
+     The pattern is transport-agnostic, so a matching policy covers both API-
+     and CLI-initiated access in a single check. This asserts that an MFA-deny
+     control *exists*; because IAM evaluates policies per principal/request, it
+     does not by itself prove every programmatic principal is in scope of that
+     deny (verifying per-principal coverage would require simulating each
+     principal, which this lightweight check does not do).
 
 Usage:
     python mfa_enforcement_test.py --region us-west-2
@@ -140,9 +144,12 @@ def _has_mfa_deny_enforcement(policy_document: dict[str, Any]) -> bool:
 def _check_mfa_policy(iam: Any, label: str) -> dict[str, Any]:
     """Scan account/customer-managed policies for MFA-enforcement conditions.
 
-    Returns the result for the programmatic_access_mfa subtest. The AWS IAM
-    condition is principal-scoped and transport-agnostic, so one evaluation
-    covers both API- and CLI-initiated programmatic access.
+    Returns the result for the programmatic_access_mfa subtest. The MFA-deny
+    condition is transport-agnostic, so a matching policy covers both API- and
+    CLI-initiated programmatic access in one check. This passes when such a
+    policy *exists*; it does not verify per-principal coverage (IAM evaluates
+    policies per request, so an existence check cannot prove every programmatic
+    principal is denied without MFA).
     """
     try:
         import urllib.parse
@@ -198,9 +205,9 @@ def main() -> int:
     result["tests"]["admin_account_mfa"] = _check_root_mfa(iam)
     result["tests"]["interactive_access_mfa"] = _check_console_users_mfa(iam)
 
-    # The AWS IAM MFA-deny condition is principal-scoped and transport-agnostic
-    # (applies to both API- and CLI-initiated calls), so one policy evaluation
-    # attests programmatic-access MFA.
+    # The MFA-deny condition is transport-agnostic (applies to both API- and
+    # CLI-initiated calls), so one policy check covers programmatic access. This
+    # asserts an MFA-deny policy exists, not that every principal is in scope.
     result["tests"]["programmatic_access_mfa"] = _check_mfa_policy(iam, "programmatic")
 
     result["interfaces_checked"] = len(result["tests"])

--- a/isvctl/configs/providers/aws/scripts/security/mfa_enforcement_test.py
+++ b/isvctl/configs/providers/aws/scripts/security/mfa_enforcement_test.py
@@ -18,15 +18,15 @@
 
 Tests that the AWS account enforces Multi-Factor Authentication:
 
-  1. root_mfa_enabled:    Root account has an MFA device attached
+  1. admin_account_mfa:        Root / admin account has an MFA device attached
      (AccountMFAEnabled from GetAccountSummary).
-  2. console_users_mfa:   Every IAM user with a console login password has
+  2. interactive_access_mfa:   Every IAM user with a console login password has
      at least one MFA device registered.
-  3. api_mfa_policy:      At least one attached customer-managed IAM policy
+  3. programmatic_access_mfa:  At least one attached customer-managed IAM policy
      contains an explicit Deny-without-MFA enforcement pattern
      (``Effect: Deny`` + ``BoolIfExists aws:MultiFactorAuthPresent = false``).
-  4. cli_mfa_policy:      Same condition covers CLI-initiated calls (the
-     condition is transport-agnostic on AWS, so this mirrors api_mfa_policy).
+     On AWS this condition is principal-scoped and transport-agnostic, so one
+     policy evaluation attests MFA on both API- and CLI-initiated access.
 
 Usage:
     python mfa_enforcement_test.py --region us-west-2
@@ -36,7 +36,7 @@ Output JSON:
     "success": true,
     "platform": "security",
     "test_name": "mfa_enforcement",
-    "interfaces_checked": 4,
+    "interfaces_checked": 3,
     "tests": { ... }
   }
 """
@@ -140,8 +140,9 @@ def _has_mfa_deny_enforcement(policy_document: dict[str, Any]) -> bool:
 def _check_mfa_policy(iam: Any, label: str) -> dict[str, Any]:
     """Scan account/customer-managed policies for MFA-enforcement conditions.
 
-    Returns a single result dict used for both api_mfa_policy and
-    cli_mfa_policy (the AWS IAM condition is transport-agnostic).
+    Returns the result for the programmatic_access_mfa subtest. The AWS IAM
+    condition is principal-scoped and transport-agnostic, so one evaluation
+    covers both API- and CLI-initiated programmatic access.
     """
     try:
         import urllib.parse
@@ -194,20 +195,13 @@ def main() -> int:
         "tests": {},
     }
 
-    result["tests"]["root_mfa_enabled"] = _check_root_mfa(iam)
-    result["tests"]["console_users_mfa"] = _check_console_users_mfa(iam)
+    result["tests"]["admin_account_mfa"] = _check_root_mfa(iam)
+    result["tests"]["interactive_access_mfa"] = _check_console_users_mfa(iam)
 
-    # AWS IAM MFA conditions are transport-agnostic (apply to both API and
-    # CLI calls), but we report them separately to match the contract's
-    # per-interface requirement.
-    policy_result = _check_mfa_policy(iam, "API/CLI")
-    result["tests"]["api_mfa_policy"] = policy_result
-    result["tests"]["cli_mfa_policy"] = {
-        "passed": policy_result["passed"],
-        "message" if policy_result["passed"] else "error": (
-            policy_result.get("message", policy_result.get("error", ""))
-        ).replace("API/CLI", "CLI"),
-    }
+    # The AWS IAM MFA-deny condition is principal-scoped and transport-agnostic
+    # (applies to both API- and CLI-initiated calls), so one policy evaluation
+    # attests programmatic-access MFA.
+    result["tests"]["programmatic_access_mfa"] = _check_mfa_policy(iam, "programmatic")
 
     result["interfaces_checked"] = len(result["tests"])
     result["success"] = all(t.get("passed") for t in result["tests"].values())

--- a/isvctl/configs/providers/my-isv/scripts/security/mfa_enforcement_test.py
+++ b/isvctl/configs/providers/my-isv/scripts/security/mfa_enforcement_test.py
@@ -24,12 +24,11 @@ Required JSON output fields:
     "success": true,
     "platform": "security",
     "test_name": "mfa_enforcement",
-    "interfaces_checked": 4,
+    "interfaces_checked": 3,
     "tests": {
-      "root_mfa_enabled":    {"passed": true},  # admin/root account has MFA
-      "console_users_mfa":   {"passed": true},  # all console users have MFA
-      "api_mfa_policy":      {"passed": true},  # API calls require MFA
-      "cli_mfa_policy":      {"passed": true}   # CLI calls require MFA
+      "admin_account_mfa":       {"passed": true},  # root/admin account requires MFA
+      "interactive_access_mfa":  {"passed": true},  # console/UI sign-in requires MFA
+      "programmatic_access_mfa": {"passed": true}   # API+CLI access is MFA-gated
     }
   }
 
@@ -58,31 +57,29 @@ def main() -> int:
         "test_name": "mfa_enforcement",
         "interfaces_checked": 0,
         "tests": {
-            "root_mfa_enabled": {"passed": False},
-            "console_users_mfa": {"passed": False},
-            "api_mfa_policy": {"passed": False},
-            "cli_mfa_policy": {"passed": False},
+            "admin_account_mfa": {"passed": False},
+            "interactive_access_mfa": {"passed": False},
+            "programmatic_access_mfa": {"passed": False},
         },
     }
 
     # ╔══════════════════════════════════════════════════════════════════╗
     # ║  TODO: Replace this block with your platform's MFA enforcement   ║
-    # ║  test.                                                           ║
+    # ║  test. Emit {"passed": bool} per outcome, attested via your      ║
+    # ║  platform's native MFA control:                                  ║
     # ║                                                                  ║
-    # ║  Example checks:                                                 ║
-    # ║    1. Verify root/admin account has MFA device attached          ║
-    # ║    2. Verify all console-login users have MFA registered         ║
-    # ║    3. Verify policies require MFA for sensitive API calls        ║
-    # ║    4. Verify CLI sessions require MFA token                      ║
+    # ║    1. admin_account_mfa       - root/admin account requires MFA  ║
+    # ║    2. interactive_access_mfa  - console/UI sign-in requires MFA  ║
+    # ║    3. programmatic_access_mfa - principal API+CLI is MFA-gated   ║
+    # ║                                 (not machine/token credentials)  ║
     # ╚══════════════════════════════════════════════════════════════════╝
 
     if DEMO_MODE:
-        result["interfaces_checked"] = 4
+        result["interfaces_checked"] = 3
         result["tests"] = {
-            "root_mfa_enabled": {"passed": True, "message": "Root MFA enabled"},
-            "console_users_mfa": {"passed": True, "message": "2/2 console users have MFA"},
-            "api_mfa_policy": {"passed": True, "message": "MFA condition in API policy"},
-            "cli_mfa_policy": {"passed": True, "message": "MFA condition in CLI policy"},
+            "admin_account_mfa": {"passed": True, "message": "Admin account MFA enabled"},
+            "interactive_access_mfa": {"passed": True, "message": "2/2 console users have MFA"},
+            "programmatic_access_mfa": {"passed": True, "message": "MFA condition in programmatic-access policy"},
         }
         result["success"] = True
     else:

--- a/isvtest/src/isvtest/validations/security.py
+++ b/isvtest/src/isvtest/validations/security.py
@@ -285,8 +285,19 @@ class MfaEnforcedCheck(BaseValidation):
         step_output: The step output to check
 
     Step output:
-        tests: dict with root_mfa_enabled, console_users_mfa,
-               api_mfa_policy, cli_mfa_policy
+        tests: dict with admin_account_mfa, interactive_access_mfa,
+               programmatic_access_mfa
+
+    Subtest semantics (platform-neutral outcomes; each platform attests them
+    via its own native control):
+        admin_account_mfa:       the root / super-admin account requires MFA.
+        interactive_access_mfa:  interactive (console / UI) sign-in requires MFA.
+        programmatic_access_mfa: programmatic (API + CLI) access by principals
+            is MFA-gated -- attested via the platform's native control (e.g. an
+            AWS IAM MFA-deny policy, or an org-level enforced-login-MFA signal
+            where human API/CLI access rides the gated session). Scoped to
+            principal (human/identity) access; it does not assert MFA on pure
+            machine/token credentials, which not all platforms gate.
     """
 
     description: ClassVar[str] = "Check admin interfaces protected by MFA"
@@ -295,10 +306,9 @@ class MfaEnforcedCheck(BaseValidation):
     def run(self) -> None:
         """Validate required MFA enforcement results from step output."""
         required = [
-            "root_mfa_enabled",
-            "console_users_mfa",
-            "api_mfa_policy",
-            "cli_mfa_policy",
+            "admin_account_mfa",
+            "interactive_access_mfa",
+            "programmatic_access_mfa",
         ]
         if not check_required_tests(self, required, "MFA enforcement tests failed"):
             return

--- a/isvtest/tests/test_security.py
+++ b/isvtest/tests/test_security.py
@@ -102,12 +102,11 @@ def _mfa_output(**overrides: Any) -> dict[str, Any]:
         "success": True,
         "platform": "security",
         "test_name": "mfa_enforcement",
-        "interfaces_checked": 4,
+        "interfaces_checked": 3,
         "tests": {
-            "root_mfa_enabled": {"passed": True, "message": "Root MFA enabled"},
-            "console_users_mfa": {"passed": True, "message": "3/3 users have MFA"},
-            "api_mfa_policy": {"passed": True, "message": "MFA condition found"},
-            "cli_mfa_policy": {"passed": True, "message": "MFA condition found"},
+            "admin_account_mfa": {"passed": True, "message": "Admin account MFA enabled"},
+            "interactive_access_mfa": {"passed": True, "message": "3/3 users have MFA"},
+            "programmatic_access_mfa": {"passed": True, "message": "MFA condition found"},
         },
     }
     base.update(overrides)
@@ -290,47 +289,38 @@ class TestMfaEnforcedCheck:
     """Tests for MfaEnforcedCheck validation."""
 
     def test_passes_all_mfa_checks(self) -> None:
-        """Happy path: all four MFA checks pass."""
+        """Happy path: all three MFA checks pass."""
         v = MfaEnforcedCheck(config={"step_output": _mfa_output()})
         result = v.execute()
         assert result["passed"] is True
-        assert "4 interfaces checked" in result["output"]
+        assert "3 interfaces checked" in result["output"]
 
-    def test_fails_when_root_mfa_disabled(self) -> None:
-        """Fail when root MFA is not enabled."""
+    def test_fails_when_admin_account_mfa_disabled(self) -> None:
+        """Fail when the admin/root account MFA is not enabled."""
         out = _mfa_output()
-        out["tests"]["root_mfa_enabled"] = {"passed": False, "error": "Root MFA off"}
+        out["tests"]["admin_account_mfa"] = {"passed": False, "error": "Admin MFA off"}
         v = MfaEnforcedCheck(config={"step_output": out})
         result = v.execute()
         assert result["passed"] is False
-        assert "root_mfa_enabled" in result["error"]
+        assert "admin_account_mfa" in result["error"]
 
-    def test_fails_when_console_users_lack_mfa(self) -> None:
-        """Fail when console users don't have MFA."""
+    def test_fails_when_interactive_access_lacks_mfa(self) -> None:
+        """Fail when interactive (console) users don't have MFA."""
         out = _mfa_output()
-        out["tests"]["console_users_mfa"] = {"passed": False, "error": "1/3 lack MFA"}
+        out["tests"]["interactive_access_mfa"] = {"passed": False, "error": "1/3 lack MFA"}
         v = MfaEnforcedCheck(config={"step_output": out})
         result = v.execute()
         assert result["passed"] is False
-        assert "console_users_mfa" in result["error"]
+        assert "interactive_access_mfa" in result["error"]
 
-    def test_fails_when_api_mfa_policy_missing(self) -> None:
-        """Fail when no API MFA policy exists."""
+    def test_fails_when_programmatic_access_mfa_missing(self) -> None:
+        """Fail when programmatic (API+CLI) access is not MFA-gated."""
         out = _mfa_output()
-        out["tests"]["api_mfa_policy"] = {"passed": False, "error": "No MFA policy"}
+        out["tests"]["programmatic_access_mfa"] = {"passed": False, "error": "No MFA policy"}
         v = MfaEnforcedCheck(config={"step_output": out})
         result = v.execute()
         assert result["passed"] is False
-        assert "api_mfa_policy" in result["error"]
-
-    def test_fails_when_cli_mfa_policy_missing(self) -> None:
-        """Fail when no CLI MFA policy exists."""
-        out = _mfa_output()
-        out["tests"]["cli_mfa_policy"] = {"passed": False, "error": "No MFA policy"}
-        v = MfaEnforcedCheck(config={"step_output": out})
-        result = v.execute()
-        assert result["passed"] is False
-        assert "cli_mfa_policy" in result["error"]
+        assert "programmatic_access_mfa" in result["error"]
 
     def test_fails_when_tests_dict_empty(self) -> None:
         """Fail when tests dict is missing."""
@@ -342,11 +332,11 @@ class TestMfaEnforcedCheck:
     def test_fails_when_tests_key_missing(self) -> None:
         """Fail when a required test key is absent."""
         out = _mfa_output()
-        del out["tests"]["cli_mfa_policy"]
+        del out["tests"]["programmatic_access_mfa"]
         v = MfaEnforcedCheck(config={"step_output": out})
         result = v.execute()
         assert result["passed"] is False
-        assert "cli_mfa_policy" in result["error"]
+        assert "programmatic_access_mfa" in result["error"]
 
     def test_uses_interfaces_checked_in_message(self) -> None:
         """Pass output should include the interfaces_checked count."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Superseded — safe to close.**

The doc-consistency change here was pushed directly onto PR #460's branch (`fix/security-rc16-mfa`) as commit `dbf941e`, so it now lives in #460 alongside the original change. This standalone PR is no longer needed and its head branch has been deleted (it can no longer be merged).

Please close this PR. The review feedback from CodeRabbit on #460 is addressed there.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40792244-a70f-4d81-ab95-64e415cfde02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40792244-a70f-4d81-ab95-64e415cfde02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

