### PR TITLE
feat(attestation): add SEC22-01 / CNP09-02 attestation validations

### DIFF
--- a/isvctl/configs/providers/nico/config/bare_metal.yaml
+++ b/isvctl/configs/providers/nico/config/bare_metal.yaml
@@ -48,6 +48,10 @@
 #     and DiskSanitizationCheck (SEC21-02) assert hosts are sanitized between
 #     tenants. The same Reset stage performs the NVMe/HDD secure erase, so the
 #     disk check gates on the same lifecycle signal as the memory check.
+#   - query_attestation.py maps control-plane SPDM and measured-boot status from
+#     nico-admin-cli into the provider-neutral attestation contract (SEC22-01 /
+#     CNP09-02). It requires operator/admin CLI credentials in addition to the
+#     tenant REST credentials used for machine enumeration.
 #
 # Prerequisites:
 #   - NICO_API_BASE set to the NICo API base URL
@@ -192,6 +196,24 @@ commands:
       - name: query_sanitization
         phase: test
         command: "python ../scripts/sanitization/query_sanitization.py"
+        args:
+          - "--org"
+          - "{{org}}"
+          - "--site-id"
+          - "{{site_id}}"
+          - "--api-base"
+          - "{{nico_api_base}}"
+        timeout: 120
+
+      # ─── Query Attestation (SEC22-01 / CNP09-02) ────────────────────
+      # Enumerates site machines via tenant REST, then reads SPDM attestation
+      # and measured-boot status from the Forge control-plane API via
+      # nico-admin-cli. The admin CLI is configured through its normal
+      # environment (NICO_ADMIN_CLI, NICO_CARBIDE_URL,
+      # NICO_FORGE_ROOT_CA_PATH, NICO_CLIENT_KEY_PATH, NICO_CLIENT_CERT_PATH).
+      - name: query_attestation
+        phase: test
+        command: "python ../scripts/attestation/query_attestation.py"
         args:
           - "--org"
           - "{{org}}"

--- a/isvctl/configs/providers/nico/scripts/attestation/query_attestation.py
+++ b/isvctl/configs/providers/nico/scripts/attestation/query_attestation.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Query NICo SPDM attestation status for bare-metal machines.
+
+NICo exposes nonce-based device attestation on the operator/control-plane Forge
+gRPC API, not on the tenant REST API. This script bridges the two surfaces:
+
+1. Use the tenant REST API to enumerate site machines.
+2. Use ``nico-admin-cli attestation spdm list`` to read control-plane SPDM
+   attestation statuses.
+3. Use ``nico-admin-cli attestation measured-boot machine show`` to read
+   measured-boot machine states.
+4. Emit the provider-neutral ``query_attestation`` contract consumed by
+   ``NonceAttestationCheck`` and ``FirmwareAttestationCheck``.
+
+The admin CLI must be configured with a Forge control-plane URL and an authorized
+client certificate. The script accepts explicit CLI TLS arguments, but also works
+when the admin CLI is configured via its standard environment variables.
+
+Measured boot state ``Measured`` means NICo matched the machine's boot
+measurements against an active golden bundle. NICo enables secure boot during
+host bring-up for these measured hosts, so this adapter treats ``Measured`` as
+both signed-firmware enforcement and successful boot-measurement attestation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+# Allow importing from sibling common/ directory
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.nico_client import NicoAuthError, forge_get_all, resolve_auth
+
+SPDM_PASSED = "SPDM_ATT_PASSED"
+MEASURED_BOOT_PASSED = "Measured"
+SUPPORTED_SPDM_STATUSES = {
+    "SPDM_ATT_IN_PROGRESS",
+    "SPDM_ATT_CANCELLED",
+    SPDM_PASSED,
+    "SPDM_ATT_FAILED",
+}
+SUPPORTED_MEASURED_BOOT_STATES = {
+    "Discovered",
+    "PendingBundle",
+    MEASURED_BOOT_PASSED,
+    "MeasuringFailed",
+}
+
+
+def _first_json_offset(text: str) -> int:
+    """Return the first likely JSON object/array offset in CLI output."""
+    candidates = [idx for idx in (text.find("["), text.find("{")) if idx >= 0]
+    return min(candidates) if candidates else -1
+
+
+def parse_json_output(text: str) -> Any:
+    """Parse JSON from admin-cli output, tolerating warning lines before it."""
+    offset = _first_json_offset(text)
+    if offset < 0:
+        raise ValueError("admin CLI output did not contain JSON")
+    return json.loads(text[offset:])
+
+
+def build_admin_cli_command(args: argparse.Namespace) -> list[str]:
+    """Build the common nico-admin-cli prefix used for control-plane attestation queries."""
+    command = [args.admin_cli, "--format", "json"]
+    optional_args = [
+        ("--carbide-url", args.carbide_url),
+        ("--forge-root-ca-path", args.forge_root_ca_path),
+        ("--client-key-path", args.client_key_path),
+        ("--client-cert-path", args.client_cert_path),
+    ]
+    for flag, value in optional_args:
+        if value:
+            command.extend([flag, value])
+    return command
+
+
+def build_spdm_command(args: argparse.Namespace) -> list[str]:
+    """Build the admin CLI command used to query SPDM attestation status."""
+    return [*build_admin_cli_command(args), "attestation", "spdm", "list"]
+
+
+def build_measured_boot_command(args: argparse.Namespace) -> list[str]:
+    """Build the admin CLI command used to query measured-boot machine states."""
+    return [*build_admin_cli_command(args), "attestation", "measured-boot", "machine", "show"]
+
+
+def run_admin_cli_json(command: list[str], *, timeout: int) -> Any:
+    """Run an admin CLI command and parse JSON from stdout."""
+    completed = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        raise RuntimeError(f"admin CLI failed with exit code {completed.returncode}: {detail}")
+    return parse_json_output(completed.stdout)
+
+
+def admin_cli_available(command: str) -> bool:
+    """Return whether the admin CLI command can be executed."""
+    if os.path.sep in command:
+        path = Path(command)
+        return path.is_file() and os.access(path, os.X_OK)
+    return shutil.which(command) is not None
+
+
+def spdm_status_map(payload: Any) -> dict[str, str]:
+    """Convert ``nico-admin-cli attestation spdm list`` JSON into machine -> status."""
+    if not isinstance(payload, list):
+        raise ValueError("SPDM list output must be a JSON list")
+
+    statuses: dict[str, str] = {}
+    for item in payload:
+        if not isinstance(item, list | tuple) or len(item) != 2:
+            raise ValueError(f"SPDM list item must be [machine_id, status], got: {item!r}")
+        machine_id, status = item
+        if not isinstance(machine_id, str) or not machine_id:
+            raise ValueError(f"SPDM list item has invalid machine_id: {item!r}")
+        if not isinstance(status, str) or status not in SUPPORTED_SPDM_STATUSES:
+            raise ValueError(f"SPDM list item has unsupported status: {item!r}")
+        statuses[machine_id] = status
+    return statuses
+
+
+def measured_boot_state_map(payload: Any) -> dict[str, str]:
+    """Convert measured-boot machine JSON into machine -> measured boot state."""
+    if not isinstance(payload, list):
+        raise ValueError("measured-boot machine output must be a JSON list")
+
+    states: dict[str, str] = {}
+    for item in payload:
+        if not isinstance(item, dict):
+            raise ValueError(f"measured-boot machine item must be an object, got: {item!r}")
+        machine_id = item.get("machine_id")
+        state = item.get("state")
+        if not isinstance(machine_id, str) or not machine_id:
+            raise ValueError(f"measured-boot machine item has invalid machine_id: {item!r}")
+        if not isinstance(state, str) or state not in SUPPORTED_MEASURED_BOOT_STATES:
+            raise ValueError(f"measured-boot machine item has unsupported state: {item!r}")
+        states[machine_id] = state
+    return states
+
+
+def machine_attestation_record(
+    machine: dict[str, Any],
+    spdm_statuses: dict[str, str],
+    measured_boot_states: dict[str, str],
+) -> dict[str, Any]:
+    """Build one provider-neutral attestation record for a NICo machine."""
+    machine_id = machine.get("id", "")
+    spdm_status = spdm_statuses.get(machine_id)
+    measured_boot_state = measured_boot_states.get(machine_id)
+    spdm_passed = spdm_status == SPDM_PASSED
+    measured_boot_passed = measured_boot_state == MEASURED_BOOT_PASSED
+
+    return {
+        "machine_id": machine_id,
+        "status": machine.get("status", "Unknown"),
+        "attestation_supported": spdm_status is not None or measured_boot_state is not None,
+        "nonce_verified": spdm_passed,
+        "attestation_signature_valid": spdm_passed,
+        "spdm_attestation_status": spdm_status or "not_found",
+        "secure_boot_enabled": measured_boot_passed,
+        "boot_measurements_attested": measured_boot_passed,
+        "measured_boot_state": measured_boot_state or "not_found",
+    }
+
+
+def main() -> int:
+    """Query tenant machines + SPDM attestation status and print JSON."""
+    parser = argparse.ArgumentParser(description="Query NICo SPDM attestation status")
+    parser.add_argument("--org", required=True, help="NGC org name")
+    parser.add_argument("--site-id", required=True, help="NICo site UUID")
+    parser.add_argument("--api-base", required=True, help="NICo tenant REST API base URL")
+    parser.add_argument(
+        "--admin-cli",
+        default=os.environ.get("NICO_ADMIN_CLI", "nico-admin-cli"),
+        help="Path to nico-admin-cli/carbide-admin-cli (default: NICO_ADMIN_CLI or nico-admin-cli)",
+    )
+    parser.add_argument("--carbide-url", default=os.environ.get("NICO_CARBIDE_URL", ""), help="Forge gRPC URL")
+    parser.add_argument(
+        "--forge-root-ca-path",
+        default=os.environ.get("NICO_FORGE_ROOT_CA_PATH", ""),
+        help="Forge root CA path for the admin CLI",
+    )
+    parser.add_argument(
+        "--client-key-path",
+        default=os.environ.get("NICO_CLIENT_KEY_PATH", ""),
+        help="Admin client key path for the admin CLI",
+    )
+    parser.add_argument(
+        "--client-cert-path",
+        default=os.environ.get("NICO_CLIENT_CERT_PATH", ""),
+        help="Admin client certificate path for the admin CLI",
+    )
+    parser.add_argument("--admin-timeout", type=int, default=30, help="Admin CLI timeout in seconds")
+    args = parser.parse_args()
+
+    result: dict[str, Any] = {
+        "success": False,
+        "platform": "nico",
+        "site_id": args.site_id,
+        "skipped": False,
+        "machines_checked": 0,
+        "machines": [],
+    }
+
+    try:
+        if not admin_cli_available(args.admin_cli):
+            result["success"] = True
+            result["skipped"] = True
+            result["skip_reason"] = (
+                f"NICo admin CLI '{args.admin_cli}' is not available; set NICO_ADMIN_CLI "
+                "or install nico-admin-cli to run attestation checks"
+            )
+            print(json.dumps(result, indent=2))
+            return 0
+
+        auth = resolve_auth()
+        machines = forge_get_all(
+            args.org,
+            "machine",
+            auth.token,
+            base_url=args.api_base,
+            params={"siteId": args.site_id},
+            result_key="machines",
+        )
+        spdm_statuses = spdm_status_map(run_admin_cli_json(build_spdm_command(args), timeout=args.admin_timeout))
+        measured_boot_states = measured_boot_state_map(
+            run_admin_cli_json(build_measured_boot_command(args), timeout=args.admin_timeout)
+        )
+
+        result["machines"] = [
+            machine_attestation_record(machine, spdm_statuses, measured_boot_states) for machine in machines
+        ]
+        result["machines_checked"] = len(result["machines"])
+        result["success"] = True
+
+    except NicoAuthError as e:
+        result["error_type"] = "auth"
+        result["error"] = str(e)
+    except Exception as e:
+        result["error"] = f"{type(e).__name__}: {e}"
+
+    print(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isvctl/configs/providers/nico/scripts/attestation/query_attestation.py
+++ b/isvctl/configs/providers/nico/scripts/attestation/query_attestation.py
@@ -69,18 +69,20 @@ SUPPORTED_MEASURED_BOOT_STATES = {
 }
 
 
-def _first_json_offset(text: str) -> int:
-    """Return the first likely JSON object/array offset in CLI output."""
-    candidates = [idx for idx in (text.find("["), text.find("{")) if idx >= 0]
-    return min(candidates) if candidates else -1
-
-
 def parse_json_output(text: str) -> Any:
     """Parse JSON from admin-cli output, tolerating warning lines before it."""
-    offset = _first_json_offset(text)
-    if offset < 0:
-        raise ValueError("admin CLI output did not contain JSON")
-    return json.loads(text[offset:])
+    decoder = json.JSONDecoder()
+    for offset, char in enumerate(text):
+        if char not in "[{":
+            continue
+        try:
+            payload, end = decoder.raw_decode(text[offset:])
+        except json.JSONDecodeError:
+            continue
+        if text[offset + end :].strip():
+            continue
+        return payload
+    raise ValueError("admin CLI output did not contain JSON")
 
 
 def build_admin_cli_command(args: argparse.Namespace) -> list[str]:

--- a/isvctl/configs/suites/README.md
+++ b/isvctl/configs/suites/README.md
@@ -115,6 +115,7 @@ For the domain / script-count / AWS-reference overview see the
 | `query_ib_tenant_isolation` | test | `providers/nico/scripts/infiniband/query_ib_tenant_isolation.py` | `partitions_checked`, `partitions[].{name,partition_key,tenant_id,status}` |
 | `query_ib_keys` | test | `providers/nico/scripts/infiniband/query_ib_keys.py` | `partitions_with_pkey`, `keys.<name>.{configured,source,detail}` |
 | `query_sanitization` | test | `providers/nico/scripts/sanitization/query_sanitization.py` | `machines_checked`, `machines[].{available,in_use,has_gpu,served_tenant,sanitized,stale_tenant_binding,vendor,product_name,bios_version,transitions}` |
+| `query_attestation` | test | `providers/nico/scripts/attestation/query_attestation.py` | `machines_checked`, `machines[].{attestation_supported,nonce_verified,attestation_signature_valid,secure_boot_enabled,boot_measurements_attested,measured_boot_state}` |
 
 ### Kubernetes (`k8s.yaml`)
 

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -425,5 +425,22 @@ tests:
       checks:
         DiskSanitizationCheck: {}
 
+    # Hardware/firmware attestation (SEC22 / CNP09). Each check asserts a host
+    # establishes a hardware root of trust. Only runs for providers that
+    # implement the query_attestation step.
+    #   - SEC22-01: each host passes a fresh nonce-based attestation (the
+    #     verifier nonce is echoed in a validly signed quote).
+    #   - CNP09-02: all firmware is cryptographically signed and its boot
+    #     measurements are attested (secure boot on, golden PCR values matched).
+    nonce_attestation:
+      step: query_attestation
+      checks:
+        NonceAttestationCheck: {}
+
+    firmware_attestation:
+      step: query_attestation
+      checks:
+        FirmwareAttestationCheck: {}
+
   exclude:
     labels: []

--- a/isvctl/tests/providers/nico/test_nico_provider.py
+++ b/isvctl/tests/providers/nico/test_nico_provider.py
@@ -679,6 +679,7 @@ def test_attestation_script_parses_admin_cli_warning_lines() -> None:
 
     payload = module.parse_json_output(
         "IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS.\n"
+        "[WARN] TLS disabled for local testing\n"
         '[["m-1", "SPDM_ATT_PASSED"]]\n'
     )
 

--- a/isvctl/tests/providers/nico/test_nico_provider.py
+++ b/isvctl/tests/providers/nico/test_nico_provider.py
@@ -30,6 +30,7 @@ from typing import Any
 from urllib.parse import parse_qs
 
 import pytest
+from isvtest.validations.attestation import FirmwareAttestationCheck, NonceAttestationCheck
 from isvtest.validations.governance import GovernanceMetricsCheck
 from isvtest.validations.health import HealthAggregationCheck, HostHealthCheck
 from isvtest.validations.infiniband import IbKeysConfiguredCheck, IbTenantIsolationCheck
@@ -140,6 +141,17 @@ def _load_health_aggregation_script() -> ModuleType:
     """Load the query_health_aggregation script as a module for direct unit testing."""
     script_path = NICO_SCRIPTS / "health" / "query_health_aggregation.py"
     spec = importlib.util.spec_from_file_location("test_query_health_aggregation", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    with _isolated_common_imports():
+        spec.loader.exec_module(module)
+    return module
+
+
+def _load_attestation_script() -> ModuleType:
+    """Load the query_attestation script as a module for direct unit testing."""
+    script_path = NICO_SCRIPTS / "attestation" / "query_attestation.py"
+    spec = importlib.util.spec_from_file_location("test_query_attestation", script_path)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     with _isolated_common_imports():
@@ -299,6 +311,7 @@ def test_forge_get_all_extracts_result_key_from_wrapped_response(monkeypatch: py
         "query_governance_metrics",
         "query_host_health",
         "query_health_aggregation",
+        "query_attestation",
         "query_ib_tenant_isolation",
         "query_ib_keys",
         "query_sanitization",
@@ -324,6 +337,7 @@ def test_nico_bare_metal_config_exposes_api_base_setting(step_name: str) -> None
         ("query_metrics.py", _load_governance_metrics_script),
         ("query_host_health.py", _load_host_health_script),
         ("query_health_aggregation.py", _load_health_aggregation_script),
+        ("query_attestation.py", _load_attestation_script),
         ("query_ib_tenant_isolation.py", _load_ib_tenant_isolation_script),
         ("query_ib_keys.py", _load_ib_keys_script),
         ("query_sanitization.py", _load_sanitization_script),
@@ -859,6 +873,254 @@ def test_host_health_leak_alert_fails_validation_end_to_end(
     check.run()
     assert check._passed is False
     assert "BmcLeakDetection" in check._error or "1 alert(s)" in check._error
+
+
+# ---------------------------------------------------------------------------
+# query_attestation (SEC22-01 SPDM) script
+# ---------------------------------------------------------------------------
+
+
+def _run_attestation_script(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    *,
+    machines: list[dict[str, Any]],
+    spdm_statuses: list[list[str]],
+    measured_boot_machines: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Drive query_attestation with mocked tenant REST + admin-cli output."""
+    module = _load_attestation_script()
+    monkeypatch.setattr(module, "admin_cli_available", lambda command: True)
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(module, "forge_get_all", lambda *args, **kwargs: machines)
+
+    if measured_boot_machines is None:
+        measured_boot_machines = [
+            {"machine_id": machine["id"], "state": "Measured", "journal": {"bundle_id": "bundle-1"}}
+            for machine in machines
+        ]
+
+    def _fake_admin_cli(command: list[str], **kwargs: Any) -> list[Any]:
+        if command[-3:] == ["attestation", "spdm", "list"]:
+            return spdm_statuses
+        if command[-4:] == ["attestation", "measured-boot", "machine", "show"]:
+            return measured_boot_machines
+        raise AssertionError(f"unexpected admin CLI command: {command}")
+
+    monkeypatch.setattr(module, "run_admin_cli_json", _fake_admin_cli)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "query_attestation.py",
+            "--org",
+            "test-org",
+            "--site-id",
+            "site-1",
+            "--api-base",
+            "http://127.0.0.1:8080/v2/org",
+            "--admin-cli",
+            "nico-admin-cli",
+            "--carbide-url",
+            "https://127.0.0.1:1079",
+        ],
+    )
+
+    exit_code = module.main()
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0, payload
+    return payload
+
+
+def test_attestation_script_maps_spdm_statuses(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """SPDM_ATT_PASSED maps to nonce/signature pass; other statuses fail."""
+    payload = _run_attestation_script(
+        monkeypatch,
+        capsys,
+        machines=[{"id": "m-pass", "status": "Ready"}, {"id": "m-fail", "status": "Ready"}],
+        spdm_statuses=[["m-pass", "SPDM_ATT_PASSED"], ["m-fail", "SPDM_ATT_FAILED"]],
+    )
+
+    assert payload["success"] is True
+    assert payload["machines_checked"] == 2
+    machines = {machine["machine_id"]: machine for machine in payload["machines"]}
+    assert machines["m-pass"]["attestation_supported"] is True
+    assert machines["m-pass"]["nonce_verified"] is True
+    assert machines["m-pass"]["attestation_signature_valid"] is True
+    assert machines["m-fail"]["attestation_supported"] is True
+    assert machines["m-fail"]["nonce_verified"] is False
+    assert machines["m-fail"]["spdm_attestation_status"] == "SPDM_ATT_FAILED"
+    assert machines["m-pass"]["secure_boot_enabled"] is True
+    assert machines["m-pass"]["boot_measurements_attested"] is True
+
+
+def test_attestation_script_reports_missing_spdm_record_as_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A tenant machine missing from SPDM status output fails as not supported/exposed."""
+    payload = _run_attestation_script(
+        monkeypatch,
+        capsys,
+        machines=[{"id": "m-missing", "status": "Ready"}],
+        spdm_statuses=[],
+        measured_boot_machines=[],
+    )
+
+    machine = payload["machines"][0]
+    assert machine["machine_id"] == "m-missing"
+    assert machine["attestation_supported"] is False
+    assert machine["nonce_verified"] is False
+    assert machine["attestation_signature_valid"] is False
+    assert machine["spdm_attestation_status"] == "not_found"
+    assert machine["measured_boot_state"] == "not_found"
+
+
+def test_attestation_script_output_satisfies_nonce_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """End-to-end: NICo SPDM JSON should pass NonceAttestationCheck."""
+    payload = _run_attestation_script(
+        monkeypatch,
+        capsys,
+        machines=[{"id": "m-pass", "status": "Ready"}],
+        spdm_statuses=[["m-pass", "SPDM_ATT_PASSED"]],
+    )
+
+    check = NonceAttestationCheck(config={"step_output": payload})
+    check.run()
+    assert check._passed is True, check._error
+
+
+def test_attestation_script_maps_measured_boot_state(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Measured boot state drives firmware attestation fields."""
+    payload = _run_attestation_script(
+        monkeypatch,
+        capsys,
+        machines=[{"id": "m-measured", "status": "Ready"}, {"id": "m-pending", "status": "Ready"}],
+        spdm_statuses=[["m-measured", "SPDM_ATT_PASSED"], ["m-pending", "SPDM_ATT_PASSED"]],
+        measured_boot_machines=[
+            {"machine_id": "m-measured", "state": "Measured", "journal": {"bundle_id": "bundle-1"}},
+            {"machine_id": "m-pending", "state": "PendingBundle", "journal": None},
+        ],
+    )
+
+    machines = {machine["machine_id"]: machine for machine in payload["machines"]}
+    assert machines["m-measured"]["secure_boot_enabled"] is True
+    assert machines["m-measured"]["boot_measurements_attested"] is True
+    assert machines["m-measured"]["measured_boot_state"] == "Measured"
+    assert machines["m-pending"]["secure_boot_enabled"] is False
+    assert machines["m-pending"]["boot_measurements_attested"] is False
+    assert machines["m-pending"]["measured_boot_state"] == "PendingBundle"
+
+
+def test_attestation_script_output_satisfies_firmware_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """End-to-end: NICo measured-boot JSON should pass FirmwareAttestationCheck."""
+    payload = _run_attestation_script(
+        monkeypatch,
+        capsys,
+        machines=[{"id": "m-measured", "status": "Ready"}],
+        spdm_statuses=[["m-measured", "SPDM_ATT_PASSED"]],
+        measured_boot_machines=[
+            {"machine_id": "m-measured", "state": "Measured", "journal": {"bundle_id": "bundle-1"}}
+        ],
+    )
+
+    check = FirmwareAttestationCheck(config={"step_output": payload})
+    check.run()
+    assert check._passed is True, check._error
+
+
+def test_attestation_script_parses_admin_cli_warning_lines() -> None:
+    """DISABLE_TLS_ENFORCEMENT warnings can precede the admin-cli JSON output."""
+    module = _load_attestation_script()
+
+    payload = module.parse_json_output(
+        "IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS.\n"
+        '[["m-1", "SPDM_ATT_PASSED"]]\n'
+    )
+
+    assert payload == [["m-1", "SPDM_ATT_PASSED"]]
+
+
+def test_attestation_script_surfaces_admin_cli_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Admin CLI failures should produce a failed step output, not an exception."""
+    module = _load_attestation_script()
+    monkeypatch.setattr(module, "admin_cli_available", lambda command: True)
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(module, "forge_get_all", lambda *args, **kwargs: [{"id": "m-1", "status": "Ready"}])
+
+    def _admin_cli_403(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("admin CLI failed with exit code 1: grpc status 403")
+
+    monkeypatch.setattr(module, "run_admin_cli_json", _admin_cli_403)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "query_attestation.py",
+            "--org",
+            "test-org",
+            "--site-id",
+            "site-1",
+            "--api-base",
+            "http://127.0.0.1:8080/v2/org",
+        ],
+    )
+
+    exit_code = module.main()
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert "grpc status 403" in payload["error"]
+
+
+def test_attestation_script_skips_when_admin_cli_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Missing nico-admin-cli should skip the step instead of failing both checks."""
+    module = _load_attestation_script()
+    monkeypatch.setattr(module, "admin_cli_available", lambda command: False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "query_attestation.py",
+            "--org",
+            "test-org",
+            "--site-id",
+            "site-1",
+            "--api-base",
+            "http://127.0.0.1:8080/v2/org",
+        ],
+    )
+
+    exit_code = module.main()
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert payload["success"] is True
+    assert payload["skipped"] is True
+    assert "nico-admin-cli" in payload["skip_reason"]
 
 
 # ---------------------------------------------------------------------------

--- a/isvctl/tests/providers/nico/test_nico_provider.py
+++ b/isvctl/tests/providers/nico/test_nico_provider.py
@@ -506,6 +506,254 @@ def test_dpu_health_script_treats_nullable_alert_fields_as_empty(
 
 
 # ---------------------------------------------------------------------------
+# query_attestation (SEC22-01 SPDM) script
+# ---------------------------------------------------------------------------
+
+
+def _run_attestation_script(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    *,
+    machines: list[dict[str, Any]],
+    spdm_statuses: list[list[str]],
+    measured_boot_machines: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Drive query_attestation with mocked tenant REST + admin-cli output."""
+    module = _load_attestation_script()
+    monkeypatch.setattr(module, "admin_cli_available", lambda command: True)
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(module, "forge_get_all", lambda *args, **kwargs: machines)
+
+    if measured_boot_machines is None:
+        measured_boot_machines = [
+            {"machine_id": machine["id"], "state": "Measured", "journal": {"bundle_id": "bundle-1"}}
+            for machine in machines
+        ]
+
+    def _fake_admin_cli(command: list[str], **kwargs: Any) -> list[Any]:
+        if command[-3:] == ["attestation", "spdm", "list"]:
+            return spdm_statuses
+        if command[-4:] == ["attestation", "measured-boot", "machine", "show"]:
+            return measured_boot_machines
+        raise AssertionError(f"unexpected admin CLI command: {command}")
+
+    monkeypatch.setattr(module, "run_admin_cli_json", _fake_admin_cli)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "query_attestation.py",
+            "--org",
+            "test-org",
+            "--site-id",
+            "site-1",
+            "--api-base",
+            "http://127.0.0.1:8080/v2/org",
+            "--admin-cli",
+            "nico-admin-cli",
+            "--carbide-url",
+            "https://127.0.0.1:1079",
+        ],
+    )
+
+    exit_code = module.main()
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0, payload
+    return payload
+
+
+def test_attestation_script_maps_spdm_statuses(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """SPDM_ATT_PASSED maps to nonce/signature pass; other statuses fail."""
+    payload = _run_attestation_script(
+        monkeypatch,
+        capsys,
+        machines=[{"id": "m-pass", "status": "Ready"}, {"id": "m-fail", "status": "Ready"}],
+        spdm_statuses=[["m-pass", "SPDM_ATT_PASSED"], ["m-fail", "SPDM_ATT_FAILED"]],
+    )
+
+    assert payload["success"] is True
+    assert payload["machines_checked"] == 2
+    machines = {machine["machine_id"]: machine for machine in payload["machines"]}
+    assert machines["m-pass"]["attestation_supported"] is True
+    assert machines["m-pass"]["nonce_verified"] is True
+    assert machines["m-pass"]["attestation_signature_valid"] is True
+    assert machines["m-fail"]["attestation_supported"] is True
+    assert machines["m-fail"]["nonce_verified"] is False
+    assert machines["m-fail"]["spdm_attestation_status"] == "SPDM_ATT_FAILED"
+    assert machines["m-pass"]["secure_boot_enabled"] is True
+    assert machines["m-pass"]["boot_measurements_attested"] is True
+
+
+def test_attestation_script_reports_missing_spdm_record_as_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A tenant machine missing from SPDM status output fails as not supported/exposed."""
+    payload = _run_attestation_script(
+        monkeypatch,
+        capsys,
+        machines=[{"id": "m-missing", "status": "Ready"}],
+        spdm_statuses=[],
+        measured_boot_machines=[],
+    )
+
+    machine = payload["machines"][0]
+    assert machine["machine_id"] == "m-missing"
+    assert machine["attestation_supported"] is False
+    assert machine["nonce_verified"] is False
+    assert machine["attestation_signature_valid"] is False
+    assert machine["spdm_attestation_status"] == "not_found"
+    assert machine["measured_boot_state"] == "not_found"
+
+
+def test_attestation_script_output_satisfies_nonce_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """End-to-end: NICo SPDM JSON should pass NonceAttestationCheck."""
+    payload = _run_attestation_script(
+        monkeypatch,
+        capsys,
+        machines=[{"id": "m-pass", "status": "Ready"}],
+        spdm_statuses=[["m-pass", "SPDM_ATT_PASSED"]],
+    )
+
+    check = NonceAttestationCheck(config={"step_output": payload})
+    check.run()
+    assert check._passed is True, check._error
+
+
+def test_attestation_script_maps_measured_boot_state(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Measured boot state drives firmware attestation fields."""
+    payload = _run_attestation_script(
+        monkeypatch,
+        capsys,
+        machines=[{"id": "m-measured", "status": "Ready"}, {"id": "m-pending", "status": "Ready"}],
+        spdm_statuses=[["m-measured", "SPDM_ATT_PASSED"], ["m-pending", "SPDM_ATT_PASSED"]],
+        measured_boot_machines=[
+            {"machine_id": "m-measured", "state": "Measured", "journal": {"bundle_id": "bundle-1"}},
+            {"machine_id": "m-pending", "state": "PendingBundle", "journal": None},
+        ],
+    )
+
+    machines = {machine["machine_id"]: machine for machine in payload["machines"]}
+    assert machines["m-measured"]["secure_boot_enabled"] is True
+    assert machines["m-measured"]["boot_measurements_attested"] is True
+    assert machines["m-measured"]["measured_boot_state"] == "Measured"
+    assert machines["m-pending"]["secure_boot_enabled"] is False
+    assert machines["m-pending"]["boot_measurements_attested"] is False
+    assert machines["m-pending"]["measured_boot_state"] == "PendingBundle"
+
+
+def test_attestation_script_output_satisfies_firmware_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """End-to-end: NICo measured-boot JSON should pass FirmwareAttestationCheck."""
+    payload = _run_attestation_script(
+        monkeypatch,
+        capsys,
+        machines=[{"id": "m-measured", "status": "Ready"}],
+        spdm_statuses=[["m-measured", "SPDM_ATT_PASSED"]],
+        measured_boot_machines=[
+            {"machine_id": "m-measured", "state": "Measured", "journal": {"bundle_id": "bundle-1"}}
+        ],
+    )
+
+    check = FirmwareAttestationCheck(config={"step_output": payload})
+    check.run()
+    assert check._passed is True, check._error
+
+
+def test_attestation_script_parses_admin_cli_warning_lines() -> None:
+    """DISABLE_TLS_ENFORCEMENT warnings can precede the admin-cli JSON output."""
+    module = _load_attestation_script()
+
+    payload = module.parse_json_output(
+        "IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS.\n"
+        '[["m-1", "SPDM_ATT_PASSED"]]\n'
+    )
+
+    assert payload == [["m-1", "SPDM_ATT_PASSED"]]
+
+
+def test_attestation_script_surfaces_admin_cli_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Admin CLI failures should produce a failed step output, not an exception."""
+    module = _load_attestation_script()
+    monkeypatch.setattr(module, "admin_cli_available", lambda command: True)
+    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
+    monkeypatch.setattr(module, "forge_get_all", lambda *args, **kwargs: [{"id": "m-1", "status": "Ready"}])
+
+    def _admin_cli_403(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("admin CLI failed with exit code 1: grpc status 403")
+
+    monkeypatch.setattr(module, "run_admin_cli_json", _admin_cli_403)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "query_attestation.py",
+            "--org",
+            "test-org",
+            "--site-id",
+            "site-1",
+            "--api-base",
+            "http://127.0.0.1:8080/v2/org",
+        ],
+    )
+
+    exit_code = module.main()
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 1
+    assert payload["success"] is False
+    assert "grpc status 403" in payload["error"]
+
+
+def test_attestation_script_skips_when_admin_cli_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Missing nico-admin-cli should skip the step instead of failing both checks."""
+    module = _load_attestation_script()
+    monkeypatch.setattr(module, "admin_cli_available", lambda command: False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "query_attestation.py",
+            "--org",
+            "test-org",
+            "--site-id",
+            "site-1",
+            "--api-base",
+            "http://127.0.0.1:8080/v2/org",
+        ],
+    )
+
+    exit_code = module.main()
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert payload["success"] is True
+    assert payload["skipped"] is True
+    assert "nico-admin-cli" in payload["skip_reason"]
+
+
+# ---------------------------------------------------------------------------
 # query_metrics (governance) script
 # ---------------------------------------------------------------------------
 
@@ -873,254 +1121,6 @@ def test_host_health_leak_alert_fails_validation_end_to_end(
     check.run()
     assert check._passed is False
     assert "BmcLeakDetection" in check._error or "1 alert(s)" in check._error
-
-
-# ---------------------------------------------------------------------------
-# query_attestation (SEC22-01 SPDM) script
-# ---------------------------------------------------------------------------
-
-
-def _run_attestation_script(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-    *,
-    machines: list[dict[str, Any]],
-    spdm_statuses: list[list[str]],
-    measured_boot_machines: list[dict[str, Any]] | None = None,
-) -> dict[str, Any]:
-    """Drive query_attestation with mocked tenant REST + admin-cli output."""
-    module = _load_attestation_script()
-    monkeypatch.setattr(module, "admin_cli_available", lambda command: True)
-    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
-    monkeypatch.setattr(module, "forge_get_all", lambda *args, **kwargs: machines)
-
-    if measured_boot_machines is None:
-        measured_boot_machines = [
-            {"machine_id": machine["id"], "state": "Measured", "journal": {"bundle_id": "bundle-1"}}
-            for machine in machines
-        ]
-
-    def _fake_admin_cli(command: list[str], **kwargs: Any) -> list[Any]:
-        if command[-3:] == ["attestation", "spdm", "list"]:
-            return spdm_statuses
-        if command[-4:] == ["attestation", "measured-boot", "machine", "show"]:
-            return measured_boot_machines
-        raise AssertionError(f"unexpected admin CLI command: {command}")
-
-    monkeypatch.setattr(module, "run_admin_cli_json", _fake_admin_cli)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "query_attestation.py",
-            "--org",
-            "test-org",
-            "--site-id",
-            "site-1",
-            "--api-base",
-            "http://127.0.0.1:8080/v2/org",
-            "--admin-cli",
-            "nico-admin-cli",
-            "--carbide-url",
-            "https://127.0.0.1:1079",
-        ],
-    )
-
-    exit_code = module.main()
-
-    captured = capsys.readouterr()
-    payload = json.loads(captured.out)
-    assert exit_code == 0, payload
-    return payload
-
-
-def test_attestation_script_maps_spdm_statuses(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """SPDM_ATT_PASSED maps to nonce/signature pass; other statuses fail."""
-    payload = _run_attestation_script(
-        monkeypatch,
-        capsys,
-        machines=[{"id": "m-pass", "status": "Ready"}, {"id": "m-fail", "status": "Ready"}],
-        spdm_statuses=[["m-pass", "SPDM_ATT_PASSED"], ["m-fail", "SPDM_ATT_FAILED"]],
-    )
-
-    assert payload["success"] is True
-    assert payload["machines_checked"] == 2
-    machines = {machine["machine_id"]: machine for machine in payload["machines"]}
-    assert machines["m-pass"]["attestation_supported"] is True
-    assert machines["m-pass"]["nonce_verified"] is True
-    assert machines["m-pass"]["attestation_signature_valid"] is True
-    assert machines["m-fail"]["attestation_supported"] is True
-    assert machines["m-fail"]["nonce_verified"] is False
-    assert machines["m-fail"]["spdm_attestation_status"] == "SPDM_ATT_FAILED"
-    assert machines["m-pass"]["secure_boot_enabled"] is True
-    assert machines["m-pass"]["boot_measurements_attested"] is True
-
-
-def test_attestation_script_reports_missing_spdm_record_as_unsupported(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """A tenant machine missing from SPDM status output fails as not supported/exposed."""
-    payload = _run_attestation_script(
-        monkeypatch,
-        capsys,
-        machines=[{"id": "m-missing", "status": "Ready"}],
-        spdm_statuses=[],
-        measured_boot_machines=[],
-    )
-
-    machine = payload["machines"][0]
-    assert machine["machine_id"] == "m-missing"
-    assert machine["attestation_supported"] is False
-    assert machine["nonce_verified"] is False
-    assert machine["attestation_signature_valid"] is False
-    assert machine["spdm_attestation_status"] == "not_found"
-    assert machine["measured_boot_state"] == "not_found"
-
-
-def test_attestation_script_output_satisfies_nonce_validation(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """End-to-end: NICo SPDM JSON should pass NonceAttestationCheck."""
-    payload = _run_attestation_script(
-        monkeypatch,
-        capsys,
-        machines=[{"id": "m-pass", "status": "Ready"}],
-        spdm_statuses=[["m-pass", "SPDM_ATT_PASSED"]],
-    )
-
-    check = NonceAttestationCheck(config={"step_output": payload})
-    check.run()
-    assert check._passed is True, check._error
-
-
-def test_attestation_script_maps_measured_boot_state(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Measured boot state drives firmware attestation fields."""
-    payload = _run_attestation_script(
-        monkeypatch,
-        capsys,
-        machines=[{"id": "m-measured", "status": "Ready"}, {"id": "m-pending", "status": "Ready"}],
-        spdm_statuses=[["m-measured", "SPDM_ATT_PASSED"], ["m-pending", "SPDM_ATT_PASSED"]],
-        measured_boot_machines=[
-            {"machine_id": "m-measured", "state": "Measured", "journal": {"bundle_id": "bundle-1"}},
-            {"machine_id": "m-pending", "state": "PendingBundle", "journal": None},
-        ],
-    )
-
-    machines = {machine["machine_id"]: machine for machine in payload["machines"]}
-    assert machines["m-measured"]["secure_boot_enabled"] is True
-    assert machines["m-measured"]["boot_measurements_attested"] is True
-    assert machines["m-measured"]["measured_boot_state"] == "Measured"
-    assert machines["m-pending"]["secure_boot_enabled"] is False
-    assert machines["m-pending"]["boot_measurements_attested"] is False
-    assert machines["m-pending"]["measured_boot_state"] == "PendingBundle"
-
-
-def test_attestation_script_output_satisfies_firmware_validation(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """End-to-end: NICo measured-boot JSON should pass FirmwareAttestationCheck."""
-    payload = _run_attestation_script(
-        monkeypatch,
-        capsys,
-        machines=[{"id": "m-measured", "status": "Ready"}],
-        spdm_statuses=[["m-measured", "SPDM_ATT_PASSED"]],
-        measured_boot_machines=[
-            {"machine_id": "m-measured", "state": "Measured", "journal": {"bundle_id": "bundle-1"}}
-        ],
-    )
-
-    check = FirmwareAttestationCheck(config={"step_output": payload})
-    check.run()
-    assert check._passed is True, check._error
-
-
-def test_attestation_script_parses_admin_cli_warning_lines() -> None:
-    """DISABLE_TLS_ENFORCEMENT warnings can precede the admin-cli JSON output."""
-    module = _load_attestation_script()
-
-    payload = module.parse_json_output(
-        "IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS.\n"
-        '[["m-1", "SPDM_ATT_PASSED"]]\n'
-    )
-
-    assert payload == [["m-1", "SPDM_ATT_PASSED"]]
-
-
-def test_attestation_script_surfaces_admin_cli_failures(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Admin CLI failures should produce a failed step output, not an exception."""
-    module = _load_attestation_script()
-    monkeypatch.setattr(module, "admin_cli_available", lambda command: True)
-    monkeypatch.setattr(module, "resolve_auth", lambda: SimpleNamespace(token="test-token"))
-    monkeypatch.setattr(module, "forge_get_all", lambda *args, **kwargs: [{"id": "m-1", "status": "Ready"}])
-
-    def _admin_cli_403(*args: Any, **kwargs: Any) -> None:
-        raise RuntimeError("admin CLI failed with exit code 1: grpc status 403")
-
-    monkeypatch.setattr(module, "run_admin_cli_json", _admin_cli_403)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "query_attestation.py",
-            "--org",
-            "test-org",
-            "--site-id",
-            "site-1",
-            "--api-base",
-            "http://127.0.0.1:8080/v2/org",
-        ],
-    )
-
-    exit_code = module.main()
-
-    captured = capsys.readouterr()
-    payload = json.loads(captured.out)
-    assert exit_code == 1
-    assert payload["success"] is False
-    assert "grpc status 403" in payload["error"]
-
-
-def test_attestation_script_skips_when_admin_cli_is_unavailable(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Missing nico-admin-cli should skip the step instead of failing both checks."""
-    module = _load_attestation_script()
-    monkeypatch.setattr(module, "admin_cli_available", lambda command: False)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "query_attestation.py",
-            "--org",
-            "test-org",
-            "--site-id",
-            "site-1",
-            "--api-base",
-            "http://127.0.0.1:8080/v2/org",
-        ],
-    )
-
-    exit_code = module.main()
-
-    captured = capsys.readouterr()
-    payload = json.loads(captured.out)
-    assert exit_code == 0
-    assert payload["success"] is True
-    assert payload["skipped"] is True
-    assert "nico-admin-cli" in payload["skip_reason"]
 
 
 # ---------------------------------------------------------------------------

--- a/isvtest/src/isvtest/validations/__init__.py
+++ b/isvtest/src/isvtest/validations/__init__.py
@@ -26,6 +26,10 @@ Validations are organized by category:
 All validations are also available via step_assertions for backward compatibility.
 """
 
+from isvtest.validations.attestation import (
+    FirmwareAttestationCheck,
+    NonceAttestationCheck,
+)
 from isvtest.validations.cluster import (
     ClusterHealthCheck,
     GpuOperatorInstalledCheck,
@@ -170,6 +174,7 @@ __all__ = [
     "DriverCheck",
     "FieldExistsCheck",
     "FieldValueCheck",
+    "FirmwareAttestationCheck",
     "FirmwareResetCheck",
     "FloatingIpCheck",
     "GovernanceMetricsCheck",
@@ -202,6 +207,7 @@ __all__ = [
     "NimInferenceCheck",
     "NimModelCheck",
     "NodeCountCheck",
+    "NonceAttestationCheck",
     "NvlinkDomainCheck",
     "OidcUserAuthCheck",
     "PerformanceCheck",

--- a/isvtest/src/isvtest/validations/attestation.py
+++ b/isvtest/src/isvtest/validations/attestation.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hardware/firmware attestation validations (requirements SEC22 / CNP09).
+
+Two provider-agnostic checks that assert a cloud's bare-metal hosts establish a
+hardware root of trust. They are modelled on the two attestation subsystems a
+GPU cloud control plane (e.g. NVIDIA's NICo / infra-controller) actually runs:
+
+- ``NonceAttestationCheck`` (SEC22-01): each host passes a *fresh* nonce-based
+  device attestation. This mirrors NICo's **SPDM device attestation**, where the
+  verifier issues a random nonce, the device's root of trust (GPU/CPU/BMC ERoT)
+  returns signed evidence over that nonce, and a verifier (NRAS) checks it. The
+  host passes when the nonce challenge is satisfied (``nonce_verified`` -- proves
+  liveness, not a replay) and the returned evidence signature verifies
+  (``attestation_signature_valid``).
+- ``FirmwareAttestationCheck`` (CNP09-02): all firmware is cryptographically
+  signed and its measurements are attested during boot. This mirrors NICo's
+  **Measured Boot**, where firmware/bootloader/kernel measurements are extended
+  into TPM PCRs during boot and verified against a golden bundle. The host passes
+  when secure boot is enabled (``secure_boot_enabled`` -- firmware signatures
+  enforced, PCR 7) and the boot measurements were attested against the expected
+  golden values (``boot_measurements_attested``).
+
+Both only inspect the provider-neutral JSON a step script emits (one record per
+host), so any provider that maps its attestation surface into the documented
+fields can reuse them. A host that does not support/expose attestation
+(``attestation_supported`` false) fails -- the requirement is that the hardware
+*passes* attestation.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any, ClassVar
+
+import pytest
+
+from isvtest.core.validation import BaseValidation
+
+
+def _machine_label(machine: dict[str, Any]) -> str:
+    """Human-facing identifier for a machine record."""
+    return machine.get("machine_id") or "unknown"
+
+
+class _AttestationCheck(BaseValidation):
+    """Shared machinery for the per-machine attestation checks.
+
+    Subclasses implement ``_evaluate(machine) -> (passed, message)`` and set the
+    ``subject`` / ``subtest_prefix`` wording. Each keeps its own ``description``
+    and ``labels`` so it maps to a single test ID and can be toggled
+    independently in a suite. A machine that does not support attestation fails
+    uniformly (handled here) before the subclass gate runs.
+
+    ``_evaluate`` is abstract so this base helper stays abstract and is excluded
+    from validation discovery (it is not a runnable check on its own).
+    """
+
+    timeout: ClassVar[int] = 120
+    subject: ClassVar[str] = "Attestation"
+    subtest_prefix: ClassVar[str] = "attestation"
+
+    @abstractmethod
+    def _evaluate(self, machine: dict[str, Any]) -> tuple[bool, str]:
+        """Return ``(passed, message)`` for one machine (attestation supported)."""
+        raise NotImplementedError
+
+    def _evaluate_machine(self, machine: dict[str, Any]) -> tuple[bool, str]:
+        """Gate on attestation support, then defer to the subclass evaluation."""
+        label = _machine_label(machine)
+        if not machine.get("attestation_supported"):
+            return False, f"{label}: hardware does not support/expose attestation"
+        return self._evaluate(machine)
+
+    def run(self) -> None:
+        """Validate that every machine passes the subclass attestation gate."""
+        step_output = self.config.get("step_output", {})
+
+        if step_output.get("skipped"):
+            pytest.skip(step_output.get("skip_reason") or "Attestation validation skipped")
+
+        if not step_output.get("success"):
+            self.set_failed(f"Attestation step failed: {step_output.get('error', 'Unknown error')}")
+            return
+
+        machines = step_output.get("machines")
+        if not isinstance(machines, list):
+            self.set_failed("Attestation step output is missing the 'machines' list")
+            return
+
+        if not machines:
+            self.set_failed("No machines found in step output")
+            return
+
+        failed: dict[str, str] = {}
+        for machine in machines:
+            label = _machine_label(machine)
+            passed, message = self._evaluate_machine(machine)
+            self.report_subtest(f"{self.subtest_prefix}_{label}", passed=passed, message=message)
+            if not passed:
+                failed[label] = message
+
+        total = len(machines)
+        if failed:
+            # Keep the summary concise: name a few offenders and a count. The
+            # full per-machine reason is preserved in the subtests.
+            sample = ", ".join(list(failed)[:3])
+            more = len(failed) - min(len(failed), 3)
+            summary = f"{sample} (+{more} more)" if more else sample
+            self.set_failed(f"{self.subject} failed for {len(failed)}/{total} machine(s): {summary}")
+            return
+
+        self.set_passed(f"{self.subject} verified on {total} machine(s)")
+
+
+class NonceAttestationCheck(_AttestationCheck):
+    """Validate hardware passes a fresh nonce-based attestation (SEC22-01).
+
+    Mirrors SPDM device attestation: a verifier issues a random challenge nonce
+    and the host's device root of trust returns signed evidence. The host passes
+    only when the nonce challenge is satisfied (``nonce_verified`` -- proving
+    freshness, not a replay) and the returned evidence signature verifies
+    (``attestation_signature_valid``). A host that cannot attest fails.
+
+    Config:
+        step_output: Step output containing per-machine attestation records.
+
+    Step output (provider-neutral contract):
+        success: bool
+        platform: str
+        machines_checked: int
+        machines: list[dict]:
+            machine_id: str
+            attestation_supported: bool -- host participates in device attestation
+            nonce_verified: bool -- the challenge nonce was satisfied (fresh)
+            attestation_signature_valid: bool -- returned evidence verified
+    """
+
+    description: ClassVar[str] = "Check hardware passes a fresh nonce-based attestation"
+    labels: ClassVar[tuple[str, ...]] = ("bare_metal", "security", "attestation")
+    subject: ClassVar[str] = "Nonce attestation"
+    subtest_prefix: ClassVar[str] = "nonce"
+
+    def _evaluate(self, machine: dict[str, Any]) -> tuple[bool, str]:
+        """Pass when the nonce challenge was satisfied and the evidence verified."""
+        label = _machine_label(machine)
+        if not machine.get("nonce_verified"):
+            return False, f"{label}: nonce-based attestation not satisfied (stale, failed, or in progress)"
+        if not machine.get("attestation_signature_valid"):
+            return False, f"{label}: attestation evidence signature did not verify"
+        return True, f"{label}: passed fresh nonce-based attestation"
+
+
+class FirmwareAttestationCheck(_AttestationCheck):
+    """Validate all firmware is signed and attested during boot (CNP09-02).
+
+    Mirrors Measured Boot: firmware/bootloader/kernel measurements are extended
+    into TPM PCRs during boot and verified against a golden bundle. The host
+    passes when secure boot is enabled (``secure_boot_enabled`` -- firmware
+    signatures are enforced, recorded in PCR 7) and the boot measurements were
+    attested against the expected golden values (``boot_measurements_attested``).
+    The recorded measured-boot state is surfaced for diagnostics. A host that
+    cannot attest fails.
+
+    Config:
+        step_output: Step output containing per-machine attestation records
+            (see ``NonceAttestationCheck`` for the shared schema; this check
+            additionally reads ``secure_boot_enabled``,
+            ``boot_measurements_attested``, and the optional
+            ``measured_boot_state`` diagnostic).
+    """
+
+    description: ClassVar[str] = "Check all firmware is signed and attested during boot"
+    labels: ClassVar[tuple[str, ...]] = ("bare_metal", "security", "attestation", "firmware")
+    subject: ClassVar[str] = "Firmware attestation"
+    subtest_prefix: ClassVar[str] = "firmware"
+
+    def _evaluate(self, machine: dict[str, Any]) -> tuple[bool, str]:
+        """Pass when secure boot is enabled and boot measurements were attested."""
+        label = _machine_label(machine)
+        if not machine.get("secure_boot_enabled"):
+            return False, f"{label}: secure boot is not enabled"
+        if not machine.get("boot_measurements_attested"):
+            state = machine.get("measured_boot_state") or "unknown"
+            return False, f"{label}: boot measurements not attested against golden values (state: {state})"
+        return True, f"{label}: secure boot enabled and boot measurements attested"

--- a/isvtest/tests/test_attestation.py
+++ b/isvtest/tests/test_attestation.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the hardware/firmware attestation validations (SEC22-01 / CNP09-02)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from isvtest.validations.attestation import (
+    FirmwareAttestationCheck,
+    NonceAttestationCheck,
+)
+
+
+def _machine(
+    *,
+    machine_id: str = "m-001",
+    attestation_supported: bool = True,
+    nonce_verified: bool = True,
+    attestation_signature_valid: bool = True,
+    secure_boot_enabled: bool = True,
+    boot_measurements_attested: bool = True,
+    measured_boot_state: str = "measured",
+) -> dict[str, Any]:
+    """Build a provider-neutral per-machine attestation record."""
+    return {
+        "machine_id": machine_id,
+        "attestation_supported": attestation_supported,
+        "nonce_verified": nonce_verified,
+        "attestation_signature_valid": attestation_signature_valid,
+        "secure_boot_enabled": secure_boot_enabled,
+        "boot_measurements_attested": boot_measurements_attested,
+        "measured_boot_state": measured_boot_state,
+    }
+
+
+def _output(
+    *,
+    success: bool = True,
+    machines: list[dict[str, Any]] | None = None,
+    error: str = "",
+) -> dict[str, Any]:
+    """Build an attestation step output."""
+    if machines is None:
+        machines = [_machine()]
+    return {
+        "success": success,
+        "platform": "nico",
+        "machines_checked": len(machines),
+        "machines": machines,
+        "error": error,
+    }
+
+
+# ===========================================================================
+# NonceAttestationCheck (SEC22-01)
+# ===========================================================================
+
+
+class TestNonceAttestationCheck:
+    """Tests for NonceAttestationCheck validation."""
+
+    def test_fresh_attestation_passes(self) -> None:
+        """A host that satisfied the nonce challenge and verified passes."""
+        check = NonceAttestationCheck(config={"step_output": _output()})
+        check.run()
+        assert check._passed is True, check._error
+        sub = next(r for r in check._subtest_results if r["name"] == "nonce_m-001")
+        assert sub["passed"] is True
+
+    def test_unverified_nonce_fails(self) -> None:
+        """A stale/unsatisfied nonce challenge fails."""
+        check = NonceAttestationCheck(config={"step_output": _output(machines=[_machine(nonce_verified=False)])})
+        check.run()
+        assert check._passed is False
+        assert "1/1 machine(s)" in check._error
+        sub = next(r for r in check._subtest_results if r["name"].startswith("nonce_"))
+        assert "nonce-based attestation not satisfied" in sub["message"]
+
+    def test_invalid_signature_fails(self) -> None:
+        """Attestation evidence whose signature does not verify fails."""
+        check = NonceAttestationCheck(
+            config={"step_output": _output(machines=[_machine(attestation_signature_valid=False)])}
+        )
+        check.run()
+        assert check._passed is False
+        sub = next(r for r in check._subtest_results if r["name"].startswith("nonce_"))
+        assert "signature did not verify" in sub["message"]
+
+    def test_unsupported_attestation_fails(self) -> None:
+        """Hardware that cannot attest fails the requirement."""
+        check = NonceAttestationCheck(config={"step_output": _output(machines=[_machine(attestation_supported=False)])})
+        check.run()
+        assert check._passed is False
+        sub = next(r for r in check._subtest_results if r["name"].startswith("nonce_"))
+        assert "does not support" in sub["message"]
+
+    def test_step_failure(self) -> None:
+        """A failed step is reported with its error detail."""
+        check = NonceAttestationCheck(config={"step_output": _output(success=False, error="API timeout")})
+        check.run()
+        assert check._passed is False
+        assert "API timeout" in check._error
+
+    def test_skipped_step_skips_validation(self) -> None:
+        """A provider-level skip should become a pytest runtime skip."""
+        check = NonceAttestationCheck(
+            config={"step_output": {"success": True, "skipped": True, "skip_reason": "admin CLI unavailable"}}
+        )
+        with pytest.raises(pytest.skip.Exception, match="admin CLI unavailable"):
+            check.run()
+
+    def test_missing_machines_list(self) -> None:
+        """A non-list machines field fails."""
+        output = _output()
+        output["machines"] = None
+        check = NonceAttestationCheck(config={"step_output": output})
+        check.run()
+        assert check._passed is False
+        assert "machines" in check._error
+
+    def test_no_machines_fails(self) -> None:
+        """An empty machine list fails -- nothing was validated."""
+        check = NonceAttestationCheck(config={"step_output": _output(machines=[])})
+        check.run()
+        assert check._passed is False
+        assert "No machines" in check._error
+
+    def test_reports_all_machines_and_summary(self) -> None:
+        """One failing host fails the check while the clean host still passes."""
+        good = _machine(machine_id="m-good")
+        bad = _machine(machine_id="m-bad", nonce_verified=False)
+        check = NonceAttestationCheck(config={"step_output": _output(machines=[good, bad])})
+        check.run()
+        assert check._passed is False
+        assert "1/2 machine(s)" in check._error
+        names = {r["name"]: r["passed"] for r in check._subtest_results}
+        assert names["nonce_m-good"] is True
+        assert names["nonce_m-bad"] is False
+
+
+# ===========================================================================
+# FirmwareAttestationCheck (CNP09-02)
+# ===========================================================================
+
+
+class TestFirmwareAttestationCheck:
+    """Tests for FirmwareAttestationCheck validation."""
+
+    def test_measured_fleet_passes(self) -> None:
+        """A fleet with secure boot and attested boot measurements passes."""
+        check = FirmwareAttestationCheck(config={"step_output": _output()})
+        check.run()
+        assert check._passed is True, check._error
+        sub = next(r for r in check._subtest_results if r["name"] == "firmware_m-001")
+        assert sub["passed"] is True
+        assert "boot measurements attested" in sub["message"]
+
+    def test_secure_boot_disabled_fails(self) -> None:
+        """A host without secure boot fails."""
+        machine = _machine(secure_boot_enabled=False)
+        check = FirmwareAttestationCheck(config={"step_output": _output(machines=[machine])})
+        check.run()
+        assert check._passed is False
+        sub = next(r for r in check._subtest_results if r["name"].startswith("firmware_"))
+        assert "secure boot is not enabled" in sub["message"]
+
+    def test_unattested_measurements_fail_and_surface_state(self) -> None:
+        """A host whose boot measurements were not attested fails and surfaces its state."""
+        machine = _machine(boot_measurements_attested=False, measured_boot_state="pending_bundle")
+        check = FirmwareAttestationCheck(config={"step_output": _output(machines=[machine])})
+        check.run()
+        assert check._passed is False
+        sub = next(r for r in check._subtest_results if r["name"].startswith("firmware_"))
+        assert "not attested against golden values" in sub["message"]
+        assert "pending_bundle" in sub["message"]
+
+    def test_unsupported_attestation_fails(self) -> None:
+        """Hardware that cannot attest fails the requirement."""
+        machine = _machine(attestation_supported=False)
+        check = FirmwareAttestationCheck(config={"step_output": _output(machines=[machine])})
+        check.run()
+        assert check._passed is False
+        sub = next(r for r in check._subtest_results if r["name"].startswith("firmware_"))
+        assert "does not support" in sub["message"]
+
+    def test_step_failure(self) -> None:
+        """A failed step fails the check with its error detail."""
+        check = FirmwareAttestationCheck(config={"step_output": _output(success=False, error="API down")})
+        check.run()
+        assert check._passed is False
+        assert "API down" in check._error


### PR DESCRIPTION
## Summary

Adds the M6 attestation checks for bare-metal hosts and wires them into the NICo provider through the existing step-based validation flow.

- `NonceAttestationCheck` (SEC22-01) verifies nonce-backed SPDM attestation status per host.
- `FirmwareAttestationCheck` (CNP09-02) verifies measured-boot state per host against NICo's golden-bundle flow.
- NICo now provides a `query_attestation` step that enumerates tenant machines through REST, then reads SPDM and measured-boot status from `nico-admin-cli` / Forge control-plane APIs when operator credentials are configured.

The checks remain unreleased (`released_tests.json` untouched), so they only run with `ISVTEST_INCLUDE_UNRELEASED=1`.

Closes #315
Closes #259

## What changes

- `isvtest` adds provider-neutral attestation validations and registers them for discovery.
- The bare-metal suite binds `NonceAttestationCheck` and `FirmwareAttestationCheck` to `query_attestation`.
- The NICo provider wires `query_attestation.py` as an operator-mode adapter over `nico-admin-cli`.
- Missing admin CLI / operator setup is reported as a runtime skip instead of failing the attestation checks.
- Tests cover SPDM pass/fail/missing states, measured-boot pass/pending states, skipped admin-cli setup, and validation behavior.

## Verification

- `uv run pytest isvctl/tests/test_nico_provider.py isvtest/tests/test_attestation.py -q`
- `uvx --from ruff==0.15.12 ruff check isvctl/configs/providers/nico/scripts/attestation/query_attestation.py isvctl/tests/test_nico_provider.py isvtest/src/isvtest/validations/attestation.py isvtest/tests/test_attestation.py`
- Pre-commit hooks passed during the latest DCO-signed commit.

## Notes

NICo attestation is exposed on the Forge control-plane/admin surface, not the tenant REST API. Running these checks live therefore requires `nico-admin-cli` plus operator client certs and a `carbide-api` build with SPDM read RBAC (`ListAttestationMachines` / `GetAttestationMachine`). Older deployed builds will skip if the CLI is not configured, or fail the step if the control-plane RPCs return authorization errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bare-metal attestation validation covering SPDM and measured-boot, with nonce and firmware/secure-boot checks
  * Integrated a provider attestation query step into bare-metal validation flows

* **Documentation**
  * Documented the new Query Attestation step and expected machine-level outputs

* **Tests**
  * Added unit and integration tests for attestation mapping, error/skip handling, and validation behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->