### PR TITLE
test: group provider-specific isvctl tests by provider

### DIFF
--- a/isvctl/tests/providers/__init__.py
+++ b/isvctl/tests/providers/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Provider-specific isvctl tests."""

--- a/isvctl/tests/providers/aws/__init__.py
+++ b/isvctl/tests/providers/aws/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""AWS provider tests."""

--- a/isvctl/tests/providers/aws/test_aws_bare_metal_launch_instance.py
+++ b/isvctl/tests/providers/aws/test_aws_bare_metal_launch_instance.py
@@ -26,7 +26,7 @@ from typing import Any
 
 import pytest
 
-ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+ISVCTL_ROOT = Path(__file__).resolve().parents[3]
 AWS_BM_LAUNCH_SCRIPT = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "bare_metal" / "launch_instance.py"
 
 

--- a/isvctl/tests/providers/aws/test_aws_bare_metal_reinstall_instance.py
+++ b/isvctl/tests/providers/aws/test_aws_bare_metal_reinstall_instance.py
@@ -27,7 +27,7 @@ from typing import Any
 import pytest
 from botocore.exceptions import ClientError, WaiterError
 
-ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+ISVCTL_ROOT = Path(__file__).resolve().parents[3]
 AWS_BM_REINSTALL_SCRIPT = (
     ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "bare_metal" / "reinstall_instance.py"
 )

--- a/isvctl/tests/providers/aws/test_aws_capacity_atomic_allocation.py
+++ b/isvctl/tests/providers/aws/test_aws_capacity_atomic_allocation.py
@@ -15,7 +15,7 @@ from typing import Any
 import pytest
 from botocore.exceptions import ClientError
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(__file__).resolve().parents[4]
 SCRIPT = (
     ROOT / "isvctl" / "configs" / "providers" / "aws" / "scripts" / "capacity" / "topology_block_atomic_allocation.py"
 )

--- a/isvctl/tests/providers/aws/test_aws_control_plane_scripts.py
+++ b/isvctl/tests/providers/aws/test_aws_control_plane_scripts.py
@@ -26,7 +26,7 @@ from typing import Any
 
 import pytest
 
-ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+ISVCTL_ROOT = Path(__file__).resolve().parents[3]
 AWS_CONTROL_PLANE_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "control-plane"
 
 

--- a/isvctl/tests/providers/aws/test_aws_delete_retry.py
+++ b/isvctl/tests/providers/aws/test_aws_delete_retry.py
@@ -30,7 +30,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from botocore.exceptions import BotoCoreError, ClientError, EndpointConnectionError
 
-_COMMON_DIR = Path(__file__).resolve().parents[1] / "configs" / "providers" / "aws" / "scripts"
+_COMMON_DIR = Path(__file__).resolve().parents[3] / "configs" / "providers" / "aws" / "scripts"
 if str(_COMMON_DIR) not in sys.path:
     sys.path.insert(0, str(_COMMON_DIR))
 

--- a/isvctl/tests/providers/aws/test_aws_eks_autoscaler_config.py
+++ b/isvctl/tests/providers/aws/test_aws_eks_autoscaler_config.py
@@ -17,7 +17,7 @@
 
 from pathlib import Path
 
-AWS_EKS_DIR = Path(__file__).resolve().parents[1] / "configs" / "providers" / "aws" / "scripts" / "eks"
+AWS_EKS_DIR = Path(__file__).resolve().parents[3] / "configs" / "providers" / "aws" / "scripts" / "eks"
 
 
 def test_eks_terraform_installs_upstream_cluster_autoscaler_with_irsa() -> None:

--- a/isvctl/tests/providers/aws/test_aws_eks_node_pool_scripts.py
+++ b/isvctl/tests/providers/aws/test_aws_eks_node_pool_scripts.py
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Contract tests for AWS EKS shared-VPC cluster helper scripts."""
-
-from __future__ import annotations
+"""Contract tests for AWS EKS node-pool helper scripts."""
 
 import os
 import subprocess
@@ -23,14 +21,14 @@ from pathlib import Path
 
 import pytest
 
-AWS_EKS_DIR = Path(__file__).resolve().parents[1] / "configs" / "providers" / "aws" / "scripts" / "eks"
+AWS_EKS_DIR = Path(__file__).resolve().parents[3] / "configs" / "providers" / "aws" / "scripts" / "eks"
 
 
-@pytest.mark.parametrize("script_name", ["create_shared_vpc_cluster.sh", "destroy_shared_vpc_cluster.sh"])
-@pytest.mark.parametrize("state_file", ["../terraform.tfstate", "/tmp/shared-vpc-cluster.tfstate"])
-def test_shared_vpc_cluster_scripts_reject_state_file_paths(script_name: str, state_file: str) -> None:
-    """Shared-cluster state overrides must stay local to terraform-shared-vpc-cluster/."""
-    env = {**os.environ, "SHARED_VPC_CLUSTER_STATE_FILE": state_file}
+@pytest.mark.parametrize("script_name", ["create_node_pool.sh", "destroy_node_pool.sh"])
+@pytest.mark.parametrize("state_file", ["../terraform.tfstate", "/tmp/node-pool.tfstate"])
+def test_node_pool_scripts_reject_state_file_paths(script_name: str, state_file: str) -> None:
+    """Node-pool state overrides must stay local to terraform-node-pool/."""
+    env = {**os.environ, "NODE_POOL_STATE_FILE": state_file}
 
     completed = subprocess.run(
         ["bash", str(AWS_EKS_DIR / script_name)],
@@ -41,4 +39,4 @@ def test_shared_vpc_cluster_scripts_reject_state_file_paths(script_name: str, st
     )
 
     assert completed.returncode == 1
-    assert "SHARED_VPC_CLUSTER_STATE_FILE must be a local .tfstate filename" in completed.stderr
+    assert "NODE_POOL_STATE_FILE must be a local .tfstate filename" in completed.stderr

--- a/isvctl/tests/providers/aws/test_aws_eks_shared_vpc_cluster_scripts.py
+++ b/isvctl/tests/providers/aws/test_aws_eks_shared_vpc_cluster_scripts.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Contract tests for AWS EKS node-pool helper scripts."""
+"""Contract tests for AWS EKS shared-VPC cluster helper scripts."""
+
+from __future__ import annotations
 
 import os
 import subprocess
@@ -21,14 +23,14 @@ from pathlib import Path
 
 import pytest
 
-AWS_EKS_DIR = Path(__file__).resolve().parents[1] / "configs" / "providers" / "aws" / "scripts" / "eks"
+AWS_EKS_DIR = Path(__file__).resolve().parents[3] / "configs" / "providers" / "aws" / "scripts" / "eks"
 
 
-@pytest.mark.parametrize("script_name", ["create_node_pool.sh", "destroy_node_pool.sh"])
-@pytest.mark.parametrize("state_file", ["../terraform.tfstate", "/tmp/node-pool.tfstate"])
-def test_node_pool_scripts_reject_state_file_paths(script_name: str, state_file: str) -> None:
-    """Node-pool state overrides must stay local to terraform-node-pool/."""
-    env = {**os.environ, "NODE_POOL_STATE_FILE": state_file}
+@pytest.mark.parametrize("script_name", ["create_shared_vpc_cluster.sh", "destroy_shared_vpc_cluster.sh"])
+@pytest.mark.parametrize("state_file", ["../terraform.tfstate", "/tmp/shared-vpc-cluster.tfstate"])
+def test_shared_vpc_cluster_scripts_reject_state_file_paths(script_name: str, state_file: str) -> None:
+    """Shared-cluster state overrides must stay local to terraform-shared-vpc-cluster/."""
+    env = {**os.environ, "SHARED_VPC_CLUSTER_STATE_FILE": state_file}
 
     completed = subprocess.run(
         ["bash", str(AWS_EKS_DIR / script_name)],
@@ -39,4 +41,4 @@ def test_node_pool_scripts_reject_state_file_paths(script_name: str, state_file:
     )
 
     assert completed.returncode == 1
-    assert "NODE_POOL_STATE_FILE must be a local .tfstate filename" in completed.stderr
+    assert "SHARED_VPC_CLUSTER_STATE_FILE must be a local .tfstate filename" in completed.stderr

--- a/isvctl/tests/providers/aws/test_aws_network_scripts.py
+++ b/isvctl/tests/providers/aws/test_aws_network_scripts.py
@@ -30,7 +30,7 @@ from typing import Any
 import pytest
 from botocore.exceptions import ClientError
 
-ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+ISVCTL_ROOT = Path(__file__).resolve().parents[3]
 AWS_NETWORK_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "network"
 MY_ISV_NETWORK_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "my-isv" / "scripts" / "network"
 STABLE_EGRESS_TEST_NAMES = {"create_instance", "probe_egress_ip", "egress_ip_stable"}

--- a/isvctl/tests/providers/aws/test_aws_observability_scripts.py
+++ b/isvctl/tests/providers/aws/test_aws_observability_scripts.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from botocore.exceptions import ClientError
 
-ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+ISVCTL_ROOT = Path(__file__).resolve().parents[3]
 AWS_OBSERVABILITY_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "observability"
 
 

--- a/isvctl/tests/providers/aws/test_aws_security_scripts.py
+++ b/isvctl/tests/providers/aws/test_aws_security_scripts.py
@@ -31,7 +31,7 @@ from urllib.error import HTTPError
 import pytest
 from botocore.exceptions import ClientError, WaiterError
 
-ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+ISVCTL_ROOT = Path(__file__).resolve().parents[3]
 AWS_SECURITY_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "security"
 
 

--- a/isvctl/tests/providers/aws/test_aws_serial_console_scripts.py
+++ b/isvctl/tests/providers/aws/test_aws_serial_console_scripts.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 
-ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+ISVCTL_ROOT = Path(__file__).resolve().parents[3]
 AWS_COMMON_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "common"
 MY_ISV_BM_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "my-isv" / "scripts" / "bare_metal"
 

--- a/isvctl/tests/providers/aws/test_aws_ssh_utils.py
+++ b/isvctl/tests/providers/aws/test_aws_ssh_utils.py
@@ -25,7 +25,7 @@ from typing import Any
 
 import pytest
 
-ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+ISVCTL_ROOT = Path(__file__).resolve().parents[3]
 AWS_COMMON_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "common"
 
 

--- a/isvctl/tests/providers/aws/test_aws_verified_reuse.py
+++ b/isvctl/tests/providers/aws/test_aws_verified_reuse.py
@@ -31,7 +31,7 @@ from unittest.mock import MagicMock
 import pytest
 from botocore.exceptions import ClientError
 
-_COMMON_DIR = Path(__file__).resolve().parents[1] / "configs" / "providers" / "aws" / "scripts"
+_COMMON_DIR = Path(__file__).resolve().parents[3] / "configs" / "providers" / "aws" / "scripts"
 if str(_COMMON_DIR) not in sys.path:
     sys.path.insert(0, str(_COMMON_DIR))
 

--- a/isvctl/tests/providers/aws/test_aws_vm_console_rbac.py
+++ b/isvctl/tests/providers/aws/test_aws_vm_console_rbac.py
@@ -23,7 +23,7 @@ from typing import Any
 
 from botocore.exceptions import ClientError
 
-from .conftest import load_vm_script
+from ...conftest import load_vm_script
 
 
 class FakeSts:

--- a/isvctl/tests/providers/aws/test_aws_vm_reboot_instance.py
+++ b/isvctl/tests/providers/aws/test_aws_vm_reboot_instance.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import pytest
 
-from .conftest import load_vm_script
+from ...conftest import load_vm_script
 
 
 def test_get_uptime_via_ssh_uses_shared_ssh_helper(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/isvctl/tests/providers/aws/test_aws_vm_virtual_device_hardening.py
+++ b/isvctl/tests/providers/aws/test_aws_vm_virtual_device_hardening.py
@@ -23,7 +23,7 @@ from types import ModuleType
 
 import pytest
 
-from .conftest import load_vm_script
+from ...conftest import load_vm_script
 
 
 def _guest_probe_with_services(module: ModuleType, monkeypatch: pytest.MonkeyPatch, services: str) -> dict:

--- a/isvctl/tests/providers/aws/test_capacity_reservation.py
+++ b/isvctl/tests/providers/aws/test_capacity_reservation.py
@@ -30,7 +30,7 @@ from isvctl.config.schema import RunConfig
 from isvctl.orchestrator.context import Context
 from isvctl.orchestrator.step_executor import StepExecutor
 
-ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+ISVCTL_ROOT = Path(__file__).resolve().parents[3]
 AWS_SECURITY_CONFIG = ISVCTL_ROOT / "configs" / "providers" / "aws" / "config" / "security.yaml"
 AWS_CAPACITY_SCRIPT = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "capacity" / "reservation_grouping.py"
 

--- a/isvctl/tests/providers/nico/__init__.py
+++ b/isvctl/tests/providers/nico/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""NICo provider tests."""

--- a/isvctl/tests/providers/nico/test_nico_provider.py
+++ b/isvctl/tests/providers/nico/test_nico_provider.py
@@ -40,7 +40,7 @@ from isvtest.validations.sanitization import (
 
 from isvctl.config.merger import merge_yaml_files
 
-ISVCTL_ROOT = Path(__file__).resolve().parents[1]
+ISVCTL_ROOT = Path(__file__).resolve().parents[3]
 NICO_COMMON = ISVCTL_ROOT / "configs" / "providers" / "nico" / "scripts" / "common"
 NICO_CONFIG = ISVCTL_ROOT / "configs" / "providers" / "nico" / "config"
 NICO_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "nico" / "scripts"


### PR DESCRIPTION
## Summary

- Moves AWS-specific isvctl tests under `isvctl/tests/providers/aws/` and the NICo provider test under `isvctl/tests/providers/nico/`.
- Adds provider test package markers so provider-owned test coverage can be targeted by directory.
- Keeps moved test imports working by adjusting path assumptions after the layout change.

## Verification

- [x] `make test`
- [x] `make lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized AWS and NICo provider test packages with proper headers and documentation.
  * Updated test configuration file resolution paths across multiple test modules for consistent directory reference handling.
  * Updated test import references to use correct module paths.

* **Chores**
  * Added standardized licensing headers to provider test package files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->