### PR TITLE
docs: correct LICENSE copyright notices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
                                  Apache License
                            Version 2.0, January 2004
@@ -176,7 +177,18 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2021 NVIDIA Corporation
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Applies the two OSRB-requested corrections to the top-level `LICENSE` file so it matches the canonical Apache 2.0 format:

1. **Top of file** — adds the required NVIDIA copyright line as the first line, followed by a blank line, before the Apache License text:
   ```
   Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
   ```
2. **Bottom of file** — replaces the stale `Copyright 2021 NVIDIA Corporation` line with the canonical Apache 2.0 `APPENDIX: How to apply the Apache License to your work` boilerplate and the standard `Copyright [yyyy] [name of copyright owner]` placeholder.

This matches the reference diff shared in the OSRB feedback and the official Apache 2.0 LICENSE layout (real copyright at the top, placeholder in the appendix).

## Testing

- N/A — documentation-only change to the `LICENSE` text. Verified the rendered file content manually.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69f39314-93ea-4ff0-85cc-036c20e27d2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69f39314-93ea-4ff0-85cc-036c20e27d2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright year and copyright holder information in license documentation
  * Expanded Apache License appendix with complete boilerplate text

<!-- end of auto-generated comment: release notes by coderabbit.ai -->