### PR TITLE
fix(isvtest): parse CUDA UMD Version from nvidia-smi output

### DIFF
--- a/isvtest/src/isvtest/core/nvidia.py
+++ b/isvtest/src/isvtest/core/nvidia.py
@@ -141,9 +141,11 @@ def parse_cuda_version(output: str) -> str | None:
         CUDA version string (e.g., "12.4") or None if not found
 
     Note: This is the maximum CUDA version supported by the driver,
-    not necessarily the installed CUDA toolkit version.
+    not necessarily the installed CUDA toolkit version. Newer drivers
+    report ``CUDA UMD Version`` instead of the deprecated ``CUDA Version``
+    header; both are accepted.
     """
-    match = re.search(r"CUDA Version:\s+(\d+\.\d+)", output)
+    match = re.search(r"CUDA(?: UMD)? Version:\s+(\d+\.\d+)", output)
     if match:
         return match.group(1)
     return None

--- a/isvtest/src/isvtest/validations/host.py
+++ b/isvtest/src/isvtest/validations/host.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     import paramiko
 
 from isvtest.core.ngc import get_ngc_api_key
+from isvtest.core.nvidia import parse_cuda_version
 from isvtest.core.ssh import (
     get_failed_subtests,
     get_ssh_client,
@@ -966,10 +967,11 @@ class HostSoftwareCheck(BaseValidation):
                 self.report_subtest("nvidia_driver", False, "NVIDIA driver not found")
                 failures.append("NVIDIA driver not installed")
 
-            # CUDA version
-            exit_code, stdout, _ = run_ssh_command(ssh, "nvidia-smi | grep 'CUDA Version' | awk '{print $9}'")
-            if exit_code == 0 and stdout.strip():
-                self.report_subtest("cuda_version", True, f"CUDA: {stdout.strip()}")
+            # CUDA version (driver-reported max; legacy or UMD header)
+            exit_code, stdout, _ = run_ssh_command(ssh, "nvidia-smi")
+            cuda_version = parse_cuda_version(stdout) if exit_code == 0 else None
+            if cuda_version:
+                self.report_subtest("cuda_version", True, f"CUDA: {cuda_version}")
 
             # NVIDIA kernel module version (should match userspace driver)
             exit_code, stdout, _ = run_ssh_command(
@@ -1044,7 +1046,7 @@ class GpuCheck(BaseValidation):
             ssh = get_ssh_client(host, user, key_path, timeout=60)
 
             # Test nvidia-smi
-            exit_code, stdout, stderr = run_ssh_command(ssh, "nvidia-smi")
+            exit_code, smi_stdout, stderr = run_ssh_command(ssh, "nvidia-smi")
             if exit_code != 0:
                 self.set_failed(f"nvidia-smi failed: {stderr}")
                 ssh.close()
@@ -1077,10 +1079,10 @@ class GpuCheck(BaseValidation):
             if exit_code == 0:
                 self.report_subtest("gpu_memory", True, stdout.strip())
 
-            # Get CUDA version
-            exit_code, stdout, _ = run_ssh_command(ssh, "nvidia-smi | grep 'CUDA Version' | awk '{print $9}'")
-            if exit_code == 0 and stdout.strip():
-                self.report_subtest("cuda", True, f"v{stdout.strip()}")
+            # Get CUDA version from nvidia-smi header (legacy or UMD)
+            cuda_version = parse_cuda_version(smi_stdout)
+            if cuda_version:
+                self.report_subtest("cuda", True, f"v{cuda_version}")
 
             ssh.close()
 

--- a/isvtest/tests/test_nvidia.py
+++ b/isvtest/tests/test_nvidia.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for NVIDIA parsing helpers."""
+
+from isvtest.core.nvidia import parse_cuda_version
+
+
+class TestParseCudaVersion:
+    """Tests for parse_cuda_version()."""
+
+    def test_legacy_cuda_version_header(self) -> None:
+        header = "| NVIDIA-SMI 550.54.15    Driver Version: 550.54.15    CUDA Version: 12.4     |"
+        assert parse_cuda_version(header) == "12.4"
+
+    def test_cuda_umd_version_header(self) -> None:
+        header = "| NVIDIA-SMI 610.47    KMD Version: 610.47    CUDA UMD Version: 13.3     |"
+        assert parse_cuda_version(header) == "13.3"
+
+    def test_prefers_first_match_when_both_present(self) -> None:
+        output = "CUDA Version: 12.4\nCUDA UMD Version: 13.3"
+        assert parse_cuda_version(output) == "12.4"
+
+    def test_returns_none_when_missing(self) -> None:
+        assert parse_cuda_version("Driver Version: 550.54.15") is None

--- a/isvtest/tests/test_validation.py
+++ b/isvtest/tests/test_validation.py
@@ -1869,8 +1869,12 @@ class TestHostSoftwareCheckBiosBaselines:
                 return (0, "2\n", "")
             if "--query-gpu=driver_version" in cmd:
                 return (0, "550.54.15\n", "")
-            if "grep 'CUDA Version'" in cmd:
-                return (0, "12.4\n", "")
+            if cmd.strip() == "nvidia-smi":
+                return (
+                    0,
+                    "| NVIDIA-SMI 550.54.15    Driver Version: 550.54.15    CUDA Version: 12.4     |\n",
+                    "",
+                )
             if "/sys/module/nvidia/version" in cmd:
                 return (0, "550.54.15\n", "")
             if "--query-gpu=persistence_mode" in cmd:
@@ -2028,8 +2032,12 @@ class TestHostSoftwareCheckTpmBaselines:
                 return (0, f"{tpm_output}\n", "")
             if "--query-gpu=driver_version" in cmd:
                 return (0, "550.54.15\n", "")
-            if "grep 'CUDA Version'" in cmd:
-                return (0, "12.4\n", "")
+            if cmd.strip() == "nvidia-smi":
+                return (
+                    0,
+                    "| NVIDIA-SMI 550.54.15    Driver Version: 550.54.15    CUDA Version: 12.4     |\n",
+                    "",
+                )
             if "/sys/module/nvidia/version" in cmd:
                 return (0, "550.54.15\n", "")
             if "--query-gpu=persistence_mode" in cmd:


### PR DESCRIPTION
## Summary
- Extend `parse_cuda_version()` to accept both legacy `CUDA Version:` and newer `CUDA UMD Version:` nvidia-smi headers.
- Update `HostSoftwareCheck` and `GpuCheck` to use the shared parser instead of grepping for the legacy header.
- Add unit tests for legacy, UMD, and missing-header cases.

## Test plan
- [x] `uv run python -m pytest isvtest/tests/test_nvidia.py isvtest/tests/test_validation.py::TestHostSoftwareCheckBiosBaselines isvtest/tests/test_validation.py::TestHostSoftwareCheckTpmBaselines -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting CUDA version from newer NVIDIA-SMI output formats alongside legacy formats.

* **Tests**
  * New unit tests for CUDA version parsing covering legacy and modern output formats, version preference handling, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->