### PR TITLE
fix: sync validation labels with test plan

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,14 +29,14 @@ repos:
     hooks:
       - id: check-md-links
         name: check markdown relative links
-        entry: python3 scripts/check_md_links.py
+        entry: uv run python scripts/check_md_links.py
         language: system
         pass_filenames: false
         types: [markdown]
 
       - id: check-spdx-headers
         name: check SPDX license headers
-        entry: python3 scripts/add_spdx_headers.py --check
+        entry: uv run python scripts/add_spdx_headers.py --check
         language: system
         pass_filenames: false
         types_or: [python, shell, yaml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
 
       - id: validate-suites
         name: check tests suites (test_id + labels)
-        entry: python3 scripts/validate_suite_wiring.py --check
+        entry: uv run python scripts/validate_suite_wiring.py --check
         language: system
         pass_filenames: false
         files: ^isvctl/configs/suites/.*\.yaml$

--- a/docs/test-plan.adoc
+++ b/docs/test-plan.adoc
@@ -18,7 +18,7 @@ Run `make plan` to regenerate.
 | [[BOOT01-01]]BOOT01-01
 | BOOT01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/37[#37]
-| min_req
+| image_registry, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/37[#37] +
@@ -33,7 +33,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/38[#38]
 | [[BOOT01-02]]BOOT01-02
 | BOOT01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/39[#39]
-|
+| image_registry
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/39[#39]
@@ -61,7 +61,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/40[#40]
 | [[BOOT03-02]]BOOT03-02
 | BOOT03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/104[#104]
-| min_req
+| image_registry, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/104[#104]
@@ -75,7 +75,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/104[#104]
 | [[BOOT01-03]]BOOT01-03
 | BOOT01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/41[#41]
-| min_req
+| image_registry, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/41[#41]
@@ -89,7 +89,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/41[#41]
 | [[BOOT01-04]]BOOT01-04
 | BOOT01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/43[#43]
-| min_req
+| image_registry, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/43[#43]
@@ -103,7 +103,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/43[#43]
 | [[BOOT01-05]]BOOT01-05
 | BOOT01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/44[#44]
-| min_req
+| image_registry, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/44[#44]
@@ -176,7 +176,7 @@ a|
 | [[AUTH-XX-02]]AUTH-XX-02
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/247[#247]
-|
+| vm
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/247[#247]
@@ -207,7 +207,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/248[#248]
 | [[IAM-XX-01]]IAM-XX-01
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/21[#21]
-| min_req
+| iam, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/21[#21]
@@ -235,7 +235,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/23[#23]
 | [[IAM-XX-03]]IAM-XX-03
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/341[#341]
-|
+| iam
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/341[#341]
@@ -252,7 +252,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/341[#341]
 | [[CP-XX-01]]CP-XX-01
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/131[#131]
-|
+| network, ssh
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/131[#131]
@@ -266,7 +266,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/131[#131]
 | [[CP-XX-02]]CP-XX-02
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/132[#132]
-|
+| network
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/132[#132]
@@ -347,7 +347,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/261[#261]
 | [[CP-XX-05]]CP-XX-05
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/28[#28]
-|
+| control_plane, iam
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/28[#28]
@@ -361,7 +361,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/28[#28]
 | [[CP-XX-06]]CP-XX-06
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/29[#29]
-| min_req
+| control_plane, iam, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/29[#29]
@@ -375,7 +375,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/29[#29]
 | [[CP-XX-07]]CP-XX-07
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/30[#30]
-|
+| control_plane, iam
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/30[#30]
@@ -389,7 +389,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/30[#30]
 | [[CP-XX-08]]CP-XX-08
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/31[#31]
-|
+| control_plane, iam
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/31[#31]
@@ -403,7 +403,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/31[#31]
 | [[CP-XX-09]]CP-XX-09
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/32[#32]
-|
+| control_plane, iam
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/32[#32] +
@@ -418,7 +418,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/33[#33]
 | [[CP-XX-10]]CP-XX-10
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/34[#34]
-|
+| control_plane
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/34[#34]
@@ -449,7 +449,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/35[#35]
 | [[HWING-XX-01]]HWING-XX-01
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/133[#133]
-|
+| bare_metal, ingestion
 |
 | P1 (check w/ ISVs)
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/133[#133]
@@ -480,7 +480,7 @@ a|
 | [[SEC22-01]]SEC22-01
 | SEC22
 | https://github.com/NVIDIA/ai-cloud-validation/issues/315[#315]
-|
+| attestation, bare_metal, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/315[#315]
@@ -551,7 +551,7 @@ a|
 | [[CNP09-02]]CNP09-02
 | CNP09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/259[#259]
-| min_req
+| attestation, bare_metal, firmware, min_req, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/259[#259]
@@ -625,7 +625,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/53[#53]
 | [[SEC21-01]]SEC21-01
 | SEC21
 | https://github.com/NVIDIA/ai-cloud-validation/issues/54[#54]
-| min_req
+| bare_metal, min_req, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/54[#54] +
@@ -640,7 +640,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/47[#47]
 | [[SEC21-02]]SEC21-02
 | SEC21
 | https://github.com/NVIDIA/ai-cloud-validation/issues/134[#134]
-| min_req
+| bare_metal, disk, min_req, sanitization, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/134[#134]
@@ -654,7 +654,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/134[#134]
 | [[CNP01-04]]CNP01-04
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/105[#105]
-| min_req
+| bare_metal, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/105[#105]
@@ -698,7 +698,7 @@ a|
 | [[BMAAS-XX-03]]BMAAS-XX-03
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/48[#48]
-|
+| bare_metal, ssh
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/48[#48] +
@@ -713,7 +713,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/56[#56]
 | [[CNP01-05]]CNP01-05
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/50[#50]
-| min_req
+| bare_metal, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/50[#50] +
@@ -728,7 +728,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/57[#57]
 | [[CNP01-06]]CNP01-06
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/135[#135]
-| min_req
+| bare_metal, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/135[#135]
@@ -757,7 +757,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/69[#69]
 | [[CNP01-07]]CNP01-07
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/106[#106]
-| min_req
+| bare_metal, min_req
 | MinAPI
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/106[#106]
@@ -771,7 +771,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/106[#106]
 | [[BOOT02-01]]BOOT02-01
 | BOOT02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/107[#107]
-| min_req
+| bare_metal, min_req, ssh
 | MinAPI
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/107[#107] +
@@ -786,7 +786,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/113[#113]
 | [[CNP01-08]]CNP01-08
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/108[#108]
-| min_req
+| bare_metal, min_req
 | MinAPI
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/108[#108]
@@ -800,7 +800,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/108[#108]
 | [[CNP05-01]]CNP05-01
 | CNP05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/112[#112]
-| min_req
+| bare_metal, min_req
 | MinAPI
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/112[#112] +
@@ -817,7 +817,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/181[#181]
 | [[BMAAS-XX-05]]BMAAS-XX-05
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/136[#136]
-|
+| bare_metal, dpu
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/136[#136]
@@ -831,7 +831,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/136[#136]
 | [[BMAAS-XX-06]]BMAAS-XX-06
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/60[#60]
-|
+| bare_metal, gpu, network, ssh
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/60[#60]
@@ -847,7 +847,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/60[#60]
 | [[BMAAS-XX-07]]BMAAS-XX-07
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/250[#250]
-|
+| bare_metal
 | REVIEW
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/250[#250]
@@ -861,7 +861,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/250[#250]
 | [[CNP06-01]]CNP06-01
 | CNP06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/109[#109]
-| min_req
+| bare_metal, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/109[#109] +
@@ -876,7 +876,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/114[#114]
 | [[BMAAS-XX-08]]BMAAS-XX-08
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/61[#61]
-|
+| bare_metal, gpu, ssh
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/61[#61]
@@ -890,7 +890,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/61[#61]
 | [[BMAAS-XX-09]]BMAAS-XX-09
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/63[#63]
-| min_req
+| bare_metal, gpu, min_req, ssh, workload
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/63[#63] +
@@ -905,7 +905,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/68[#68]
 | [[BMAAS-XX-10]]BMAAS-XX-10
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/64[#64]
-| min_req
+| bare_metal, gpu, min_req, slow, ssh, workload
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/64[#64] +
@@ -920,7 +920,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/82[#82]
 | [[BMAAS-XX-11]]BMAAS-XX-11
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/65[#65]
-| min_req
+| bare_metal, gpu, min_req, ssh, workload
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/65[#65]
@@ -934,7 +934,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/65[#65]
 | [[BMAAS-XX-12]]BMAAS-XX-12
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/66[#66]
-| min_req
+| bare_metal, gpu, min_req, ssh, workload
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/66[#66]
@@ -948,7 +948,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/66[#66]
 | [[CNP06-02]]CNP06-02
 | CNP06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/258[#258]
-| min_req
+| bare_metal, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/258[#258]
@@ -964,7 +964,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/258[#258]
 | [[CNP08-01]]CNP08-01
 | CNP08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/197[#197]
-| min_req
+| bare_metal, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/197[#197] +
@@ -997,7 +997,7 @@ a|
 | [[CNP01-09]]CNP01-09
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/42[#42]
-| min_req
+| min_req, vm
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/42[#42]
@@ -1025,7 +1025,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/51[#51]
 | [[CNP01-11]]CNP01-11
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/45[#45]
-| min_req
+| min_req, vm
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/45[#45]
@@ -1069,7 +1069,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/47[#47]
 | [[VMAAS-XX-01]]VMAAS-XX-01
 |
 |
-|
+| ssh, vm
 |
 | P0
 a|
@@ -1083,7 +1083,7 @@ a|
 | [[CNP01-13]]CNP01-13
 | CNP01
 |
-|
+| vm
 |
 | P0
 a|
@@ -1111,7 +1111,7 @@ a|
 | [[CNP01-14]]CNP01-14
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/110[#110]
-| min_req
+| min_req, vm
 | MinAPI
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/110[#110]
@@ -1125,7 +1125,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/110[#110]
 | [[CNP01-15]]CNP01-15
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/111[#111]
-| min_req
+| min_req, vm
 | MinAPI
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/111[#111]
@@ -1139,7 +1139,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/111[#111]
 | [[CNP05-02]]CNP05-02
 | CNP05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/112[#112]
-| min_req
+| min_req, vm
 | MinAPI
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/112[#112]
@@ -1153,7 +1153,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/112[#112]
 | [[BOOT02-02]]BOOT02-02
 | BOOT02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/113[#113]
-| min_req
+| min_req, ssh, vm
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/113[#113]
@@ -1199,7 +1199,7 @@ a|
 | [[VMAAS-XX-05]]VMAAS-XX-05
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/55[#55]
-|
+| ssh, vm
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/55[#55]
@@ -1213,7 +1213,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/55[#55]
 | [[VMAAS-XX-06]]VMAAS-XX-06
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/59[#59]
-|
+| gpu, ssh, vm
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/59[#59]
@@ -1227,7 +1227,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/59[#59]
 | [[VMAAS-XX-07]]VMAAS-XX-07
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/62[#62]
-|
+| gpu, ssh, vm
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/62[#62]
@@ -1255,7 +1255,7 @@ a|
 | [[VMAAS-XX-09]]VMAAS-XX-09
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/67[#67]
-|
+| gpu, ssh, vm
 | Does this include GPU Passthrough
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/67[#67]
@@ -1299,7 +1299,7 @@ a|
 | [[VMAAS-XX-12]]VMAAS-XX-12
 |
 |
-|
+| gpu, slow, ssh, vm, workload
 |
 | P0
 a|
@@ -1345,7 +1345,7 @@ a|
 | [[CNP06-03]]CNP06-03
 | CNP06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/114[#114]
-| min_req
+| min_req, vm
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/114[#114]
@@ -1361,7 +1361,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/114[#114]
 | [[CNP08-03]]CNP08-03
 | CNP08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/198[#198]
-| min_req
+| min_req, vm
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/198[#198]
@@ -1391,7 +1391,7 @@ a|
 | [[CNP01-16]]CNP01-16
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/256[#256]
-| min_req
+| iam, min_req, security, vm
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/256[#256]
@@ -1405,7 +1405,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/256[#256]
 | [[CNP01-17]]CNP01-17
 | CNP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/257[#257]
-| min_req
+| min_req, security, vm
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/257[#257]
@@ -1422,7 +1422,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/257[#257]
 | [[SDN01-01]]SDN01-01
 | SDN01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/11[#11]
-| min_req
+| min_req, network
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/11[#11]
@@ -1436,7 +1436,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/11[#11]
 | [[SDN01-02]]SDN01-02
 | SDN01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/12[#12]
-| min_req
+| min_req, network
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/12[#12]
@@ -1450,7 +1450,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/12[#12]
 | [[SDN01-03]]SDN01-03
 | SDN01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/13[#13]
-| min_req
+| min_req, network
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/13[#13]
@@ -1464,7 +1464,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/13[#13]
 | [[SDN01-04]]SDN01-04
 | SDN01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/14[#14]
-| min_req
+| min_req, network
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/14[#14]
@@ -1492,7 +1492,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/16[#16]
 | [[SDN04-02]]SDN04-02
 | SDN04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/17[#17]
-| min_req
+| min_req, network, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/17[#17] +
@@ -1521,7 +1521,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/18[#18]
 | [[NET03-01]]NET03-01
 | NET03, SDN01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/115[#115]
-| min_req
+| min_req, network
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/115[#115]
@@ -1535,7 +1535,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/115[#115]
 | [[SDN-XX-01]]SDN-XX-01
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/116[#116]
-| min_req
+| min_req, network
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/116[#116]
@@ -1549,7 +1549,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/116[#116]
 | [[SDN05-01]]SDN05-01
 | SDN05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/117[#117]
-| min_req
+| min_req, network
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/117[#117]
@@ -1563,7 +1563,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/117[#117]
 | [[SDN06-01]]SDN06-01
 | SDN06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/118[#118]
-| min_req
+| min_req, network
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/118[#118]
@@ -1577,7 +1577,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/118[#118]
 | [[SDN07-01]]SDN07-01
 | SDN07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/119[#119]
-| min_req
+| min_req, network
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/119[#119]
@@ -1591,7 +1591,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/119[#119]
 | [[SDN02-01]]SDN02-01
 | SDN02, SDN03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/199[#199]
-| min_req
+| min_req, network, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/199[#199] +
@@ -1607,7 +1607,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/178[#178]
 | [[SDN02-02]]SDN02-02
 | SDN02, SDN03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/200[#200]
-| min_req
+| min_req, network, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/200[#200]
@@ -1621,7 +1621,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/200[#200]
 | [[SDN02-03]]SDN02-03
 | SDN02, SDN03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/201[#201]
-| min_req
+| min_req, network, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/201[#201]
@@ -1635,7 +1635,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/201[#201]
 | [[SDN02-04]]SDN02-04
 | SDN02, SDN03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/202[#202]
-| min_req
+| min_req, network, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/202[#202]
@@ -1903,7 +1903,7 @@ a|
 | [[SDN02-05]]SDN02-05
 | SDN02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/281[#281]
-| min_req
+| min_req, network, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/281[#281]
@@ -1917,7 +1917,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/281[#281]
 | [[SDN02-06]]SDN02-06
 | SDN02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/282[#282]
-| min_req
+| min_req, network, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/282[#282]
@@ -1931,7 +1931,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/282[#282]
 | [[SDN02-07]]SDN02-07
 | SDN02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/283[#283]
-| min_req
+| min_req, network, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/283[#283]
@@ -1945,7 +1945,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/283[#283]
 | [[SDN02-08]]SDN02-08
 | SDN02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/284[#284]
-| min_req
+| min_req, network, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/284[#284]
@@ -1959,7 +1959,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/284[#284]
 | [[SDN02-09]]SDN02-09
 | SDN02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/285[#285]
-| min_req
+| min_req, network, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/285[#285]
@@ -1975,7 +1975,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/285[#285]
 | [[SDN08-01]]SDN08-01
 | SDN08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/289[#289]
-| min_req
+| min_req, network
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/289[#289]
@@ -1991,7 +1991,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/289[#289]
 | [[SDN02-10]]SDN02-10
 | SDN02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/286[#286]
-| min_req
+| min_req, network, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/286[#286]
@@ -2007,7 +2007,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/286[#286]
 | [[SDN09-01]]SDN09-01
 | SDN09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/290[#290]
-| min_req
+| min_req, network
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/290[#290]
@@ -2021,7 +2021,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/290[#290]
 | [[SDN09-02]]SDN09-02
 | SDN09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/291[#291]
-| min_req
+| min_req, network
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/291[#291]
@@ -2035,7 +2035,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/291[#291]
 | [[SDN09-03]]SDN09-03
 | SDN09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/292[#292]
-| min_req
+| min_req, network, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/292[#292]
@@ -2567,7 +2567,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/265[#265]
 | [[DMS05-01]]DMS05-01
 | DMS05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/266[#266]
-| min_req
+| min_req, network
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/266[#266]
@@ -2641,7 +2641,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/361[#361]
 | [[SEC04-01]]SEC04-01
 | SEC04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/296[#296]
-| min_req
+| iam, min_req, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/296[#296]
@@ -2789,7 +2789,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/340[#340]
 | [[DATASVC-XX-01]]DATASVC-XX-01
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/262[#262]
-| min_req
+| control_plane, min_req
 |
 | P2
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/262[#262]
@@ -2965,7 +2965,7 @@ a|
 | [[SLURM-XX-02]]SLURM-XX-02
 |
 |
-|
+| slurm
 |
 | P0
 a|
@@ -2979,7 +2979,7 @@ a|
 | [[SLURM-XX-03]]SLURM-XX-03
 |
 |
-|
+| slurm
 |
 | P0
 a|
@@ -2993,7 +2993,7 @@ a|
 | [[SLURM-XX-04]]SLURM-XX-04
 |
 |
-|
+| slurm
 |
 | P0
 a|
@@ -3007,7 +3007,7 @@ a|
 | [[SLURM-XX-05]]SLURM-XX-05
 |
 |
-|
+| slurm
 |
 | P0
 a|
@@ -3021,7 +3021,7 @@ a|
 | [[SLURM-XX-06]]SLURM-XX-06
 |
 |
-|
+| slurm
 |
 | P0
 a|
@@ -3035,7 +3035,7 @@ a|
 | [[SLURM-XX-07]]SLURM-XX-07
 |
 |
-|
+| gpu, slow, slurm, workload
 |
 | P0
 a|
@@ -3049,7 +3049,7 @@ a|
 | [[SLURM-XX-08]]SLURM-XX-08
 |
 |
-|
+| gpu, slow, slurm, workload
 |
 | P0
 a|
@@ -3063,7 +3063,7 @@ a|
 | [[SLURM-XX-09]]SLURM-XX-09
 |
 |
-|
+| slow, slurm, workload
 |
 | P0
 a|
@@ -3094,7 +3094,7 @@ a|
 | [[K8S05-01]]K8S05-01
 | K8S05
 |
-| min_req
+| kubernetes, min_req
 |
 | P0
 a|
@@ -3182,7 +3182,7 @@ a|
 | [[K8S-XX-03]]K8S-XX-03
 |
 |
-|
+| gpu, kubernetes, slow, workload
 |
 | P0
 a|
@@ -3196,7 +3196,7 @@ a|
 | [[K8S-XX-04]]K8S-XX-04
 |
 |
-|
+| gpu, kubernetes, slow, workload
 |
 | P0
 a|
@@ -3212,7 +3212,7 @@ a|
 | [[K8S-XX-05]]K8S-XX-05
 |
 |
-| min_req
+| gpu, kubernetes, min_req, slow, workload
 |
 | P0
 a|
@@ -3260,7 +3260,7 @@ a|
 | [[K8S01-01]]K8S01-01
 | K8S01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/233[#233]
-| min_req
+| kubernetes, l2, min_req, slow
 | k8s01
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/233[#233]
@@ -3324,7 +3324,7 @@ a|
 | [[K8S22-01]]K8S22-01
 | K8S22
 | https://github.com/NVIDIA/ai-cloud-validation/issues/219[#219]
-| min_req
+| kubernetes, min_req
 | K8s20
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/219[#219]
@@ -3368,7 +3368,7 @@ a|
 | [[K8S23-04]]K8S23-04
 | K8S23
 | https://github.com/NVIDIA/ai-cloud-validation/issues/273[#273]
-| min_req
+| kubernetes, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/273[#273]
@@ -3382,7 +3382,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/273[#273]
 | [[K8S23-05]]K8S23-05
 | K8S23
 | https://github.com/NVIDIA/ai-cloud-validation/issues/274[#274]
-| min_req
+| kubernetes, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/274[#274]
@@ -3396,7 +3396,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/274[#274]
 | [[K8S23-06]]K8S23-06
 | K8S23
 | https://github.com/NVIDIA/ai-cloud-validation/issues/275[#275]
-| min_req
+| kubernetes, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/275[#275]
@@ -3410,7 +3410,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/275[#275]
 | [[K8S23-07]]K8S23-07
 | K8S23
 | https://github.com/NVIDIA/ai-cloud-validation/issues/276[#276]
-| min_req
+| kubernetes, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/276[#276]
@@ -3426,7 +3426,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/276[#276]
 | [[K8S25-01]]K8S25-01
 | K8S25
 |
-| min_req
+| kubernetes, min_req
 | K8S23
 | P0
 a|
@@ -3548,7 +3548,7 @@ a|
 | [[K8S15-01]]K8S15-01
 | K8S15
 | https://github.com/NVIDIA/ai-cloud-validation/issues/271[#271]
-| min_req
+| kubernetes, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/271[#271]
@@ -3580,7 +3580,7 @@ a|
 | [[SEC09-01]]SEC09-01
 | SEC09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/301[#301]
-| min_req
+| min_req, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/301[#301]
@@ -3594,7 +3594,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/301[#301]
 | [[SEC09-02]]SEC09-02
 | SEC09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/302[#302]
-| min_req
+| min_req, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/302[#302]
@@ -3610,7 +3610,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/302[#302]
 | [[K8S-XX-08]]K8S-XX-08
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/267[#267]
-| min_req
+| kubernetes, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/267[#267]
@@ -3642,7 +3642,7 @@ a|
 | [[K8S06-01]]K8S06-01
 | K8S06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/269[#269]
-| min_req
+| kubernetes, min_req, slow
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/269[#269] +
@@ -3657,7 +3657,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/221[#221]
 | [[K8S06-02]]K8S06-02
 | K8S06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/270[#270]
-| min_req
+| kubernetes, min_req, slow
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/270[#270] +
@@ -3672,7 +3672,7 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/222[#222]
 | [[K8S06-03]]K8S06-03
 | K8S06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/223[#223]
-| min_req
+| kubernetes, min_req, slow
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/223[#223]
@@ -3702,7 +3702,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/224[#224]
 | [[K8S07-01]]K8S07-01
 | K8S07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/225[#225]
-| min_req
+| kubernetes, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/225[#225]
@@ -3718,7 +3718,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/225[#225]
 | [[K8S18-01]]K8S18-01
 | K8S18
 | https://github.com/NVIDIA/ai-cloud-validation/issues/226[#226]
-| min_req
+| kubernetes, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/226[#226]
@@ -3734,7 +3734,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/226[#226]
 | [[K8S20-01]]K8S20-01
 | K8S20
 | https://github.com/NVIDIA/ai-cloud-validation/issues/227[#227]
-| min_req
+| kubernetes, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/227[#227]
@@ -3766,7 +3766,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/268[#268]
 | [[K8S26-01]]K8S26-01
 | K8S26
 | https://github.com/NVIDIA/ai-cloud-validation/issues/277[#277]
-| min_req
+| kubernetes, min_req
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/277[#277]
@@ -4083,7 +4083,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/353[#353]
 | [[OBS-XX-17]]OBS-XX-17
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/354[#354]
-| min_req
+| min_req, observability, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/354[#354]
@@ -4097,7 +4097,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/354[#354]
 | [[OBS-XX-18]]OBS-XX-18
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/355[#355]
-| min_req
+| bare_metal, min_req, observability
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/355[#355]
@@ -4111,7 +4111,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/355[#355]
 | [[OBS-XX-19]]OBS-XX-19
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/356[#356]
-| min_req
+| min_req, network, observability
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/356[#356]
@@ -4172,7 +4172,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/121[#121]
 | [[TELEM-XX-04]]TELEM-XX-04
 |
 | https://github.com/NVIDIA/ai-cloud-validation/issues/362[#362]
-| min_req
+| gpu, min_req, observability, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/362[#362]
@@ -4250,7 +4250,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/366[#366]
 | [[SEC12-01]]SEC12-01
 | SEC12
 | https://github.com/NVIDIA/ai-cloud-validation/issues/306[#306]
-| min_req
+| min_req, network, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/306[#306]
@@ -4264,7 +4264,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/306[#306]
 | [[SEC12-02]]SEC12-02
 | SEC12
 | https://github.com/NVIDIA/ai-cloud-validation/issues/307[#307]
-| min_req
+| min_req, network, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/307[#307]
@@ -4278,7 +4278,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/307[#307]
 | [[CNP10-01]]CNP10-01
 | CNP10
 | https://github.com/NVIDIA/ai-cloud-validation/issues/260[#260]
-| min_req
+| min_req, network, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/260[#260]
@@ -4292,7 +4292,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/260[#260]
 | [[SEC12-03]]SEC12-03
 | SEC12
 | https://github.com/NVIDIA/ai-cloud-validation/issues/308[#308]
-| min_req
+| min_req, network, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/308[#308]
@@ -4324,7 +4324,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/309[#309]
 | [[SEC14-01]]SEC14-01
 | SEC14
 | https://github.com/NVIDIA/ai-cloud-validation/issues/311[#311]
-| min_req
+| min_req, network, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/311[#311]
@@ -4338,7 +4338,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/311[#311]
 | [[SEC13-02]]SEC13-02
 | SEC13
 | https://github.com/NVIDIA/ai-cloud-validation/issues/310[#310]
-| min_req
+| min_req, network, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/310[#310]
@@ -4354,7 +4354,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/310[#310]
 | [[SDN04-04]]SDN04-04
 | SDN04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/287[#287]
-| min_req
+| bare_metal, infiniband, min_req, network, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/287[#287]
@@ -4368,7 +4368,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/287[#287]
 | [[SDN04-05]]SDN04-05
 | SDN04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/288[#288]
-| min_req
+| bare_metal, infiniband, min_req, network, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/288[#288]
@@ -4384,7 +4384,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/288[#288]
 | [[SEC11-01]]SEC11-01
 | SEC11
 | https://github.com/NVIDIA/ai-cloud-validation/issues/305[#305]
-| min_req
+| iam, min_req, network, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/305[#305]
@@ -4401,7 +4401,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/305[#305]
 | [[SEC01-01]]SEC01-01
 | SEC01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/293[#293]
-| min_req
+| iam, min_req, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/293[#293]
@@ -4417,7 +4417,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/293[#293]
 | [[SEC02-01]]SEC02-01
 | SEC02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/294[#294]
-| min_req
+| iam, min_req, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/294[#294]
@@ -4433,7 +4433,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/294[#294]
 | [[SEC03-01]]SEC03-01
 | SEC03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/295[#295]
-| min_req
+| iam, min_req, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/295[#295]
@@ -4449,7 +4449,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/295[#295]
 | [[SEC07-01]]SEC07-01
 | SEC07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/298[#298]
-| min_req
+| iam, min_req, security
 | INFO
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/298[#298]
@@ -4466,7 +4466,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/298[#298]
 | [[SEC04-02]]SEC04-02
 | SEC04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/297[#297]
-| min_req
+| iam, min_req, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/297[#297]
@@ -4483,7 +4483,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/297[#297]
 | [[SEC08-01]]SEC08-01
 | SEC08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/299[#299]
-| min_req
+| min_req, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/299[#299]
@@ -4497,7 +4497,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/299[#299]
 | [[SEC08-02]]SEC08-02
 | SEC08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/300[#300]
-| min_req
+| min_req, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/300[#300]
@@ -4514,7 +4514,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/300[#300]
 | [[SEC21-04]]SEC21-04
 | SEC21
 | https://github.com/NVIDIA/ai-cloud-validation/issues/312[#312]
-| min_req
+| bare_metal, min_req, sanitization, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/312[#312]
@@ -4528,7 +4528,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/312[#312]
 | [[SEC21-05]]SEC21-05
 | SEC21
 | https://github.com/NVIDIA/ai-cloud-validation/issues/313[#313]
-| min_req
+| bare_metal, gpu, min_req, sanitization, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/313[#313]
@@ -4542,7 +4542,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/313[#313]
 | [[SEC21-06]]SEC21-06
 | SEC21, SEC22
 | https://github.com/NVIDIA/ai-cloud-validation/issues/314[#314]
-| min_req
+| bare_metal, firmware, min_req, sanitization, security
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/314[#314]
@@ -4574,7 +4574,7 @@ a|
 | [[SEC09-03]]SEC09-03
 | SEC09, SEC10
 | https://github.com/NVIDIA/ai-cloud-validation/issues/303[#303]
-| min_req
+| min_req, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/303[#303]
@@ -4588,7 +4588,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/303[#303]
 | [[SEC09-04]]SEC09-04
 | SEC09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/304[#304]
-| min_req
+| min_req, security, slow, workload
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/304[#304]
@@ -4606,7 +4606,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/304[#304]
 | [[NET01-01]]NET01-01
 | NET01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/278[#278]
-| min_req
+| min_req, network
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/278[#278]
@@ -4623,7 +4623,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/278[#278]
 | [[NET02-02]]NET02-02
 | NET02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/279[#279]
-| min_req
+| min_req, network
 |
 | P0
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/279[#279]
@@ -4718,7 +4718,7 @@ a|
 | [[CAP01-01]]CAP01-01
 | CAP01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/251[#251]
-| min_req
+| bare_metal, governance, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/251[#251]
@@ -4735,7 +4735,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/251[#251]
 | [[CAP04-01]]CAP04-01
 | CAP04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/252[#252]
-| min_req
+| bare_metal, capacity, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/252[#252]
@@ -4749,7 +4749,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/252[#252]
 | [[CAP04-02]]CAP04-02
 | CAP04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/253[#253]
-| min_req
+| bare_metal, capacity, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/253[#253]
@@ -4766,7 +4766,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/253[#253]
 | [[CAP05-01]]CAP05-01
 | CAP05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/254[#254]
-| min_req
+| bare_metal, health, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/254[#254]
@@ -4780,7 +4780,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/254[#254]
 | [[CAP05-02]]CAP05-02
 | CAP05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/255[#255]
-| min_req
+| bare_metal, health, min_req
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/255[#255]

--- a/docs/test-plan.adoc
+++ b/docs/test-plan.adoc
@@ -4735,7 +4735,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/251[#251]
 | [[CAP04-01]]CAP04-01
 | CAP04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/252[#252]
-| bare_metal, capacity, min_req
+| bare_metal, capacity, min_req, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/252[#252]
@@ -4749,7 +4749,7 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/252[#252]
 | [[CAP04-02]]CAP04-02
 | CAP04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/253[#253]
-| bare_metal, capacity, min_req
+| bare_metal, capacity, min_req, security
 |
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/253[#253]

--- a/docs/test-plan.yaml
+++ b/docs/test-plan.yaml
@@ -25,6 +25,7 @@ domains:
             tests:
               - summary: CRUD an custom OS image (iso file) (Upload an ISO file if supported, or remote URL if supported).
                 labels:
+                  - image_registry
                   - min_req
                 priority: P0
                 dependencies:
@@ -48,6 +49,8 @@ domains:
                 test_id: BOOT01-02
                 status: approved
                 notes: ""
+                labels:
+                  - image_registry
               - summary: CRUD a custom VM image
                 labels:
                   - min_req
@@ -63,6 +66,7 @@ domains:
                 notes: ""
               - summary: CRUD (get, list, create, delete) custom OS images for fast boot (raw, qcow2, img, etc) for BM/VM
                 labels:
+                  - image_registry
                   - min_req
                 priority: P0
                 milestone: M3
@@ -74,6 +78,7 @@ domains:
                 notes: ""
               - summary: Check that an OS image can be installed on a BMaaS system
                 labels:
+                  - image_registry
                   - min_req
                 priority: P0
                 dependencies:
@@ -87,6 +92,7 @@ domains:
                 notes: ""
               - summary: Check that an OS install configuration can be installed on a BMaaS system
                 labels:
+                  - image_registry
                   - min_req
                 priority: P0
                 dependencies:
@@ -100,6 +106,7 @@ domains:
                 notes: ""
               - summary: Check that a VM image can be installed onto a VMaaS system
                 labels:
+                  - image_registry
                   - min_req
                 priority: P0
                 dependencies:
@@ -155,6 +162,8 @@ domains:
                 notes: ""
                 github_issues:
                   - "#247"
+                labels:
+                  - vm
               - summary: Access other components via a specified key as possible (SOL, Network devices)
                 milestone: M5
                 req_id: ""
@@ -171,6 +180,7 @@ domains:
             tests:
               - summary: Create user and log in as that user
                 labels:
+                  - iam
                   - min_req
                 priority: P0
                 dependencies:
@@ -204,6 +214,8 @@ domains:
                 notes: ""
                 github_issues:
                   - "#341"
+                labels:
+                  - iam
       - name: DDI
         capabilities:
           - description: core network services for name resolution, IP allocation, and address lifecycle management
@@ -220,6 +232,9 @@ domains:
                 test_id: CP-XX-01
                 status: approved
                 notes: ""
+                labels:
+                  - network
+                  - ssh
               - summary: "Check that IP addresses are managed sensibly as VPCs are configured (Move to SDN section?)"
                 priority: P0
                 dependencies:
@@ -231,6 +246,8 @@ domains:
                 test_id: CP-XX-02
                 status: approved
                 notes: ""
+                labels:
+                  - network
       - name: "Network Underlay & Mgmt"
         capabilities:
           - description: Brings up the physical network fabric for Day 0, base configuration, and network OS installation. Manages switch OS versions, compliance, and safe upgrades over time. Provides base network that overlays and tenants are built upon.
@@ -298,8 +315,13 @@ domains:
                 test_id: CP-XX-05
                 status: approved
                 notes: ""
+                labels:
+                  - control_plane
+                  - iam
               - summary: Access keys can expire or be disabled
                 labels:
+                  - control_plane
+                  - iam
                   - min_req
                 priority: P0
                 dependencies:
@@ -322,6 +344,9 @@ domains:
                 test_id: CP-XX-07
                 status: approved
                 notes: ""
+                labels:
+                  - control_plane
+                  - iam
               - summary: Retrieve list of tenants
                 priority: P0
                 dependencies:
@@ -333,6 +358,9 @@ domains:
                 test_id: CP-XX-08
                 status: approved
                 notes: ""
+                labels:
+                  - control_plane
+                  - iam
               - summary: Retrieve info about individual tenant
                 priority: P0
                 dependencies:
@@ -345,6 +373,9 @@ domains:
                 test_id: CP-XX-09
                 status: approved
                 notes: ""
+                labels:
+                  - control_plane
+                  - iam
               - summary: Delete Tenant
                 priority: P0
                 dependencies:
@@ -356,6 +387,8 @@ domains:
                 test_id: CP-XX-10
                 status: approved
                 notes: ""
+                labels:
+                  - control_plane
               - summary: Add user to tenant
                 labels:
                   - min_req
@@ -384,6 +417,9 @@ domains:
                 test_id: HWING-XX-01
                 status: approved
                 notes: ""
+                labels:
+                  - bare_metal
+                  - ingestion
               - summary: Make sure that a device can be removed from the system
                 priority: P1
                 dependencies:
@@ -408,6 +444,10 @@ domains:
                 notes: ""
                 github_issues:
                   - "#315"
+                labels:
+                  - attestation
+                  - bare_metal
+                  - security
               - summary: Check that OS is approved
                 priority: P1
                 dependencies:
@@ -455,7 +495,11 @@ domains:
                 notes: ""
               - summary: Verify all firmware is cryptographically signed and attested during boot
                 labels:
+                  - attestation
+                  - bare_metal
+                  - firmware
                   - min_req
+                  - security
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -515,7 +559,9 @@ domains:
                 notes: ""
               - summary: Confirm sanitization on delete - Tenant View
                 labels:
+                  - bare_metal
                   - min_req
+                  - security
                 priority: P0
                 dependencies:
                   - LimitedEnv
@@ -529,7 +575,11 @@ domains:
                 notes: ""
               - summary: Confirm sanitization on delete - Low Level
                 labels:
+                  - bare_metal
+                  - disk
                   - min_req
+                  - sanitization
+                  - security
                 priority: P0
                 dependencies:
                   - MiniCloud
@@ -542,6 +592,7 @@ domains:
                 notes: ""
               - summary: Topology-based placement
                 labels:
+                  - bare_metal
                   - min_req
                 priority: P0
                 dependencies:
@@ -580,8 +631,12 @@ domains:
                 test_id: BMAAS-XX-03
                 status: approved
                 notes: ""
+                labels:
+                  - bare_metal
+                  - ssh
               - summary: A running node can be rebooted in case of issue (Bare Metal)
                 labels:
+                  - bare_metal
                   - min_req
                 priority: P0
                 milestone: M1
@@ -594,6 +649,7 @@ domains:
                 notes: ""
               - summary: A running node can be power-cycled in case of issue
                 labels:
+                  - bare_metal
                   - min_req
                 priority: P0
                 dependencies:
@@ -619,6 +675,7 @@ domains:
                 notes: ""
               - summary: A running node can be powered off (Without being destroyed)
                 labels:
+                  - bare_metal
                   - min_req
                 notes: MinAPI
                 priority: P0
@@ -632,7 +689,9 @@ domains:
                 status: approved
               - summary: Support for cloud-init and instance metadata discovery via link-local addresses (e.g. 169.254.169.254) or virtual devices (Bare Metal)
                 labels:
+                  - bare_metal
                   - min_req
+                  - ssh
                 notes: MinAPI
                 priority: P0
                 milestone: M3
@@ -644,6 +703,7 @@ domains:
                 status: approved
               - summary: A powered off node can be powered back on
                 labels:
+                  - bare_metal
                   - min_req
                 notes: MinAPI
                 priority: P0
@@ -657,6 +717,7 @@ domains:
                 status: approved
               - summary: Support for user-defined tags/labels and cloud-init metadata on instances. (Bare Metal)
                 labels:
+                  - bare_metal
                   - min_req
                 notes: MinAPI
                 dependencies:
@@ -683,6 +744,9 @@ domains:
                 test_id: BMAAS-XX-05
                 status: approved
                 notes: ""
+                labels:
+                  - bare_metal
+                  - dpu
               - summary: Nodes can communicate across ethernet, infiniband, and NVLink (Bare Metal)
                 priority: P0
                 dependencies:
@@ -694,6 +758,11 @@ domains:
                 test_id: BMAAS-XX-06
                 status: approved
                 notes: ""
+                labels:
+                  - bare_metal
+                  - gpu
+                  - network
+                  - ssh
           - description: "Observability & Debug"
             example: AWS EC2/Forge
             tests:
@@ -706,8 +775,11 @@ domains:
                 status: approved
                 github_issues:
                   - "#250"
+                labels:
+                  - bare_metal
               - summary: Serial console access is required (read-only sufficient, interactive preferred) (Bare Metal)
                 labels:
+                  - bare_metal
                   - min_req
                 priority: P0
                 dependencies:
@@ -731,9 +803,17 @@ domains:
                 test_id: BMAAS-XX-08
                 status: approved
                 notes: ""
+                labels:
+                  - bare_metal
+                  - gpu
+                  - ssh
               - summary: GPU Stress workload (Bare Metal)
                 labels:
+                  - bare_metal
+                  - gpu
                   - min_req
+                  - ssh
+                  - workload
                 priority: P0
                 dependencies:
                   - LimitedEnv
@@ -747,7 +827,12 @@ domains:
                 notes: ""
               - summary: Nim Inference jobs (Bare Metal)
                 labels:
+                  - bare_metal
+                  - gpu
                   - min_req
+                  - slow
+                  - ssh
+                  - workload
                 notes: ""
                 priority: P0
                 dependencies:
@@ -761,7 +846,11 @@ domains:
                 status: approved
               - summary: NCCL tests
                 labels:
+                  - bare_metal
+                  - gpu
                   - min_req
+                  - ssh
+                  - workload
                 priority: P0
                 dependencies:
                   - LimitedEnv
@@ -774,7 +863,11 @@ domains:
                 notes: ""
               - summary: Training workload test
                 labels:
+                  - bare_metal
+                  - gpu
                   - min_req
+                  - ssh
+                  - workload
                 notes: ""
                 priority: P0
                 dependencies:
@@ -787,6 +880,7 @@ domains:
                 status: approved
               - summary: Verify that serial console output is logged and queryable for at least 1 month of history
                 labels:
+                  - bare_metal
                   - min_req
                 priority: P0
                 milestone: M5
@@ -800,6 +894,7 @@ domains:
             tests:
               - summary: Verify that a BM node's ID does not change after a reboot
                 labels:
+                  - bare_metal
                   - min_req
                 priority: P0
                 milestone: M5
@@ -828,6 +923,7 @@ domains:
               - summary: Create a VM node
                 labels:
                   - min_req
+                  - vm
                 priority: P0
                 dependencies:
                   - LimitedEnv
@@ -854,6 +950,7 @@ domains:
               - summary: Get a list of all VM nodes in a VPC
                 labels:
                   - min_req
+                  - vm
                 priority: P0
                 dependencies:
                   - LimitedEnv
@@ -901,6 +998,9 @@ domains:
                 test_id: VMAAS-XX-01
                 status: approved
                 notes: ""
+                labels:
+                  - ssh
+                  - vm
               - summary: A running node can be rebooted in case of issue (VM)
                 priority: P0
                 dependencies:
@@ -910,6 +1010,8 @@ domains:
                 test_id: CNP01-13
                 status: approved
                 notes: ""
+                labels:
+                  - vm
               - summary: "DEPRECATED: A node can be reinstalled from its configured stock operating system"
                 priority: P0
                 dependencies:
@@ -922,6 +1024,7 @@ domains:
               - summary: A running VM can be stopped (Without being destroyed)
                 labels:
                   - min_req
+                  - vm
                 notes: MinAPI
                 priority: P0
                 dependencies:
@@ -935,6 +1038,7 @@ domains:
               - summary: A powered off VM can be started
                 labels:
                   - min_req
+                  - vm
                 notes: MinAPI
                 priority: P0
                 dependencies:
@@ -948,6 +1052,7 @@ domains:
               - summary: Support for user-defined tags/labels and cloud-init metadata on instances. (VM)
                 labels:
                   - min_req
+                  - vm
                 notes: MinAPI
                 priority: P0
                 dependencies:
@@ -961,6 +1066,8 @@ domains:
               - summary: Support for cloud-init and instance metadata discovery via link-local addresses (e.g. 169.254.169.254) or virtual devices (VM)
                 labels:
                   - min_req
+                  - ssh
+                  - vm
                 priority: P0
                 milestone: M3
                 github_issues:
@@ -996,6 +1103,9 @@ domains:
                 test_id: VMAAS-XX-05
                 status: approved
                 notes: ""
+                labels:
+                  - ssh
+                  - vm
               - summary: Check that the GPU is visible and accessible from the VM
                 priority: P0
                 dependencies:
@@ -1007,6 +1117,10 @@ domains:
                 test_id: VMAAS-XX-06
                 status: approved
                 notes: ""
+                labels:
+                  - gpu
+                  - ssh
+                  - vm
               - summary: Check that the correct Linux Kernel, libvirt, sbios, and NVIDIA drivers are installed
                 priority: P0
                 dependencies:
@@ -1018,6 +1132,10 @@ domains:
                 test_id: VMAAS-XX-07
                 status: approved
                 notes: ""
+                labels:
+                  - gpu
+                  - ssh
+                  - vm
               - summary: Check that vEGM is configured correctly
                 priority: P0
                 dependencies:
@@ -1038,6 +1156,10 @@ domains:
                 req_id: ""
                 test_id: VMAAS-XX-09
                 status: approved
+                labels:
+                  - gpu
+                  - ssh
+                  - vm
               - summary: "TODO: More things from the \"NVIDIA Grace I/O Virtualization Guide\""
                 priority: P1
                 dependencies:
@@ -1067,6 +1189,12 @@ domains:
                 test_id: VMAAS-XX-12
                 status: approved
                 notes: ""
+                labels:
+                  - gpu
+                  - slow
+                  - ssh
+                  - vm
+                  - workload
               - summary: Run NCCL tests
                 priority: P0
                 milestone: M5
@@ -1091,6 +1219,7 @@ domains:
               - summary: Serial console access is required (read-only sufficient, interactive preferred) (VM)
                 labels:
                   - min_req
+                  - vm
                 priority: P0
                 milestone: M3
                 github_issues:
@@ -1104,6 +1233,7 @@ domains:
               - summary: Verify that a VM's ID does not change after a stop/start cycle
                 labels:
                   - min_req
+                  - vm
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -1126,7 +1256,10 @@ domains:
             tests:
               - summary: Verify console access is restricted via RBAC
                 labels:
+                  - iam
                   - min_req
+                  - security
+                  - vm
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -1138,6 +1271,8 @@ domains:
               - summary: Verify USB, clipboard, and unnecessary virtual devices are disabled
                 labels:
                   - min_req
+                  - security
+                  - vm
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -1153,6 +1288,7 @@ domains:
               - summary: Create a VPC
                 labels:
                   - min_req
+                  - network
                 priority: P0
                 dependencies:
                   - LimitedEnv
@@ -1166,6 +1302,7 @@ domains:
               - summary: Retrieve a VPC
                 labels:
                   - min_req
+                  - network
                 priority: P0
                 dependencies:
                   - LimitedEnv
@@ -1179,6 +1316,7 @@ domains:
               - summary: Update a VPC
                 labels:
                   - min_req
+                  - network
                 priority: P0
                 dependencies:
                   - LimitedEnv
@@ -1192,6 +1330,7 @@ domains:
               - summary: Delete a VPC
                 labels:
                   - min_req
+                  - network
                 priority: P0
                 dependencies:
                   - LimitedEnv
@@ -1216,6 +1355,8 @@ domains:
               - summary: Verify that nodes in two VPCs cannot communicate over the N/S (TAN) network
                 labels:
                   - min_req
+                  - network
+                  - security
                 priority: P0
                 dependencies:
                   - LimitedEnv
@@ -1243,6 +1384,7 @@ domains:
               - summary: Support non-conflicting Bring-Your-Own-IP (including 7.0.0.0/8)
                 labels:
                   - min_req
+                  - network
                 priority: P0
                 milestone: M3
                 github_issues:
@@ -1254,6 +1396,7 @@ domains:
               - summary: Support Stable Private IP allocations, where if a VM crashes and restarts the same IP address remains pinned until the node is deleted
                 labels:
                   - min_req
+                  - network
                 priority: P0
                 milestone: M3
                 github_issues:
@@ -1265,6 +1408,7 @@ domains:
               - summary: "Atomically switch a floating private IP between nodes via API within <10 seconds without requiring an instance reboot."
                 labels:
                   - min_req
+                  - network
                 priority: P0
                 milestone: M3
                 github_issues:
@@ -1276,6 +1420,7 @@ domains:
               - summary: "Localized DNS: Support for custom, localized DNS settings to enable internal domain resolution to private endpoints (e.g. storage endpoints)"
                 labels:
                   - min_req
+                  - network
                 priority: P0
                 milestone: M3
                 github_issues:
@@ -1287,6 +1432,7 @@ domains:
               - summary: "Support for VPC peering with full bandwidth and no \"hairpin\" routing."
                 labels:
                   - min_req
+                  - network
                 priority: P0
                 milestone: M3
                 github_issues:
@@ -1298,6 +1444,8 @@ domains:
               - summary: Create a Security Group
                 labels:
                   - min_req
+                  - network
+                  - security
                 notes: ""
                 req_id: SDN02, SDN03
                 test_id: SDN02-01
@@ -1310,6 +1458,8 @@ domains:
               - summary: Retrieve a Security Group/list Security Groups
                 labels:
                   - min_req
+                  - network
+                  - security
                 notes: ""
                 req_id: SDN02, SDN03
                 test_id: SDN02-02
@@ -1320,6 +1470,8 @@ domains:
               - summary: Update a Security Group
                 labels:
                   - min_req
+                  - network
+                  - security
                 notes: ""
                 req_id: SDN02, SDN03
                 test_id: SDN02-03
@@ -1330,6 +1482,8 @@ domains:
               - summary: Delete a Security Group
                 labels:
                   - min_req
+                  - network
+                  - security
                 notes: ""
                 req_id: SDN02, SDN03
                 test_id: SDN02-04
@@ -1487,6 +1641,8 @@ domains:
               - summary: Verify security group rules can be scoped at workload level
                 labels:
                   - min_req
+                  - network
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -1498,6 +1654,8 @@ domains:
               - summary: Verify security group rules can be scoped at node level
                 labels:
                   - min_req
+                  - network
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -1509,6 +1667,8 @@ domains:
               - summary: Verify security group rules can be scoped at subnet/tenant level
                 labels:
                   - min_req
+                  - network
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -1520,6 +1680,8 @@ domains:
               - summary: Measure and verify policy propagation timing is within acceptable bounds
                 labels:
                   - min_req
+                  - network
+                  - security
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -1531,6 +1693,8 @@ domains:
               - summary: Verify security group rules can be scoped at K8s API service level
                 labels:
                   - min_req
+                  - network
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -1544,6 +1708,7 @@ domains:
               - summary: Verify that storage hosts can route to each other with all-to-all L3 communication
                 labels:
                   - min_req
+                  - network
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -1557,6 +1722,8 @@ domains:
               - summary: Verify customizable port security policies can be applied to virtual interfaces
                 labels:
                   - min_req
+                  - network
+                  - security
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -1570,6 +1737,7 @@ domains:
               - summary: Verify logging is available for network hardware faults
                 labels:
                   - min_req
+                  - network
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -1581,6 +1749,7 @@ domains:
               - summary: Verify logging captures latency/performance fluctuations
                 labels:
                   - min_req
+                  - network
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -1592,6 +1761,8 @@ domains:
               - summary: Verify a detailed audit trail exists for all configuration changes to network filtering rules
                 labels:
                   - min_req
+                  - network
+                  - security
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -1981,6 +2152,7 @@ domains:
               - summary: Verify stable egress IP for allowlisting access to NVIDIA services
                 labels:
                   - min_req
+                  - network
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -2039,7 +2211,9 @@ domains:
             tests:
               - summary: Verify least-privilege access policies (resource-based, user-based, network-based)
                 labels:
+                  - iam
                   - min_req
+                  - security
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -2160,6 +2334,7 @@ domains:
             tests:
               - summary: Verify S3-compatible API access with authenticated endpoints
                 labels:
+                  - control_plane
                   - min_req
                 priority: P2
                 milestone: M5
@@ -2305,6 +2480,8 @@ domains:
                 req_id: ""
                 test_id: SLURM-XX-02
                 status: done
+                labels:
+                  - slurm
               - summary: SlurmPartition cpu and gpu
                 notes: ""
                 priority: P0
@@ -2314,6 +2491,8 @@ domains:
                 req_id: ""
                 test_id: SLURM-XX-03
                 status: done
+                labels:
+                  - slurm
               - summary: SlurmJobSubmission
                 notes: ""
                 priority: P0
@@ -2323,6 +2502,8 @@ domains:
                 req_id: ""
                 test_id: SLURM-XX-04
                 status: done
+                labels:
+                  - slurm
               - summary: SlurmGpuAllocation 1gpu and 2gpu
                 notes: ""
                 priority: P0
@@ -2332,6 +2513,8 @@ domains:
                 req_id: ""
                 test_id: SLURM-XX-05
                 status: done
+                labels:
+                  - slurm
               - summary: SlurmNodeJobExecution cpu and gpu
                 notes: ""
                 priority: P0
@@ -2341,6 +2524,8 @@ domains:
                 req_id: ""
                 test_id: SLURM-XX-06
                 status: done
+                labels:
+                  - slurm
               - summary: SlurmGpuStressWorkload
                 notes: ""
                 priority: P0
@@ -2350,6 +2535,11 @@ domains:
                 req_id: ""
                 test_id: SLURM-XX-07
                 status: done
+                labels:
+                  - gpu
+                  - slow
+                  - slurm
+                  - workload
               - summary: SlurmNcclMultiNodeWorkload
                 notes: ""
                 priority: P0
@@ -2359,6 +2549,11 @@ domains:
                 req_id: ""
                 test_id: SLURM-XX-08
                 status: done
+                labels:
+                  - gpu
+                  - slow
+                  - slurm
+                  - workload
               - summary: SlurmSbatchWorkload gpu and cpu
                 notes: ""
                 priority: P0
@@ -2368,6 +2563,10 @@ domains:
                 req_id: ""
                 test_id: SLURM-XX-09
                 status: done
+                labels:
+                  - slow
+                  - slurm
+                  - workload
               - summary: SlurmSbatchWorkload-inline
                 notes: ""
                 priority: P0
@@ -2384,6 +2583,7 @@ domains:
             tests:
               - summary: Create a K8s Instance using the software platform (CLI, Terraform)
                 labels:
+                  - kubernetes
                   - min_req
                 notes: ""
                 priority: P0
@@ -2450,6 +2650,11 @@ domains:
                 req_id: ""
                 test_id: K8S-XX-03
                 status: done
+                labels:
+                  - gpu
+                  - kubernetes
+                  - slow
+                  - workload
               - summary: K8s Nim Helm
                 notes: ""
                 priority: P0
@@ -2459,11 +2664,20 @@ domains:
                 req_id: ""
                 test_id: K8S-XX-04
                 status: done
+                labels:
+                  - gpu
+                  - kubernetes
+                  - slow
+                  - workload
           - description: Topology based placement
             tests:
               - summary: K8s Nccl
                 labels:
+                  - gpu
+                  - kubernetes
                   - min_req
+                  - slow
+                  - workload
                 priority: P0
                 req_id: ""
                 test_id: K8S-XX-05
@@ -2493,7 +2707,10 @@ domains:
             tests:
               - summary: "get versions, topology, core APIs by: (a) pass CNCF k8s conformance: https://github.com/cncf/k8s-conformance (b) add AI conformance: [https://github.com/cncf/k8s-ai-conformance](https://github.com/cncf/k8s-ai-conformance)"
                 labels:
+                  - kubernetes
+                  - l2
                   - min_req
+                  - slow
                 notes: k8s01
                 req_id: K8S01
                 test_id: K8S01-01
@@ -2536,6 +2753,7 @@ domains:
             tests:
               - summary: Apply a NetworkPolicy; verify pod connectivity is restricted as expected; verify IPv4 and IPv6 addresses are assigned on dual-stack nodes
                 labels:
+                  - kubernetes
                   - min_req
                 notes: K8s20
                 req_id: K8S22
@@ -2564,6 +2782,7 @@ domains:
                 priority: ""
               - summary: Verify CSI supports block, shared filesystem, and NFS storage
                 labels:
+                  - kubernetes
                   - min_req
                 priority: P0
                 milestone: M5
@@ -2575,6 +2794,7 @@ domains:
                 status: pending
               - summary: Verify CSI supports both static and dynamic provisioning via PVs and PVCs
                 labels:
+                  - kubernetes
                   - min_req
                 priority: P0
                 milestone: M5
@@ -2586,6 +2806,7 @@ domains:
                 status: pending
               - summary: Verify CSI credentials are tenant cluster scoped (no cross-cluster access)
                 labels:
+                  - kubernetes
                   - min_req
                 priority: P0
                 milestone: M5
@@ -2597,6 +2818,7 @@ domains:
                 status: pending
               - summary: Verify APIs to query storage usage against overall cluster quota with per-PVC/Volume breakdown
                 labels:
+                  - kubernetes
                   - min_req
                 priority: P0
                 milestone: M5
@@ -2610,6 +2832,7 @@ domains:
             tests:
               - summary: "TODO: Compatibility with the mainline NVIDIA GPU Operator"
                 labels:
+                  - kubernetes
                   - min_req
                 notes: K8S23
                 req_id: K8S25
@@ -2699,6 +2922,7 @@ domains:
             tests:
               - summary: Verify the K8s API endpoint has network access controls (firewall/private link)
                 labels:
+                  - kubernetes
                   - min_req
                 priority: P0
                 milestone: M5
@@ -2725,6 +2949,7 @@ domains:
               - summary: Verify certificates are rotated on a 60-day cycle
                 labels:
                   - min_req
+                  - security
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -2736,6 +2961,7 @@ domains:
               - summary: Verify support for both provider-managed and customer-managed keys
                 labels:
                   - min_req
+                  - security
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -2748,6 +2974,7 @@ domains:
             tests:
               - summary: Verify Cluster Autoscaler integration (upstream)
                 labels:
+                  - kubernetes
                   - min_req
                 priority: P1
                 milestone: M5
@@ -2773,7 +3000,9 @@ domains:
             tests:
               - summary: Create a K8s node pool via API/CLI specifying node type (CPU or GPU instance type)
                 labels:
+                  - kubernetes
                   - min_req
+                  - slow
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -2785,7 +3014,9 @@ domains:
                 status: pending
               - summary: Update a K8s node pool (e.g., scale to a target count)
                 labels:
+                  - kubernetes
                   - min_req
+                  - slow
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -2797,7 +3028,9 @@ domains:
                 status: pending
               - summary: Delete a K8s node pool
                 labels:
+                  - kubernetes
                   - min_req
+                  - slow
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -2821,6 +3054,7 @@ domains:
             tests:
               - summary: Verify API Server metrics are available in a Prometheus-scrapable format for SLO measurement
                 labels:
+                  - kubernetes
                   - min_req
                 priority: P1
                 milestone: M5
@@ -2834,6 +3068,7 @@ domains:
             tests:
               - summary: Verify the cluster exposes a cluster-specific OIDC Issuer endpoint for workload identity federation
                 labels:
+                  - kubernetes
                   - min_req
                 priority: P0
                 milestone: M5
@@ -2847,6 +3082,7 @@ domains:
             tests:
               - summary: Verify ability to view or export Kubernetes control plane logs (apiserver, kcm)
                 labels:
+                  - kubernetes
                   - min_req
                 priority: P1
                 milestone: M5
@@ -2875,6 +3111,7 @@ domains:
                 req_id: K8S26
                 test_id: K8S26-01
                 labels:
+                  - kubernetes
                   - min_req
                 priority: P0
                 milestone: M5
@@ -3114,6 +3351,8 @@ domains:
               - summary: Verify BMC SEL logs are available
                 labels:
                   - min_req
+                  - observability
+                  - security
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -3124,7 +3363,9 @@ domains:
                 status: pending
               - summary: Verify host syslogs are available
                 labels:
+                  - bare_metal
                   - min_req
+                  - observability
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -3136,6 +3377,8 @@ domains:
               - summary: Verify VPC Flow logs (all ingress/egress traffic) are available
                 labels:
                   - min_req
+                  - network
+                  - observability
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -3186,7 +3429,10 @@ domains:
             tests:
               - summary: Verify BMC/Redfish telemetry is accessible via API for GPU metrics not available from the host OS
                 labels:
+                  - gpu
                   - min_req
+                  - observability
+                  - security
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -3252,6 +3498,8 @@ domains:
               - summary: Verify BMC management is on a dedicated, restricted network (physically separate or VLAN/VRF-isolated)
                 labels:
                   - min_req
+                  - network
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -3263,6 +3511,8 @@ domains:
               - summary: Verify BMC interfaces are not reachable from tenant networks
                 labels:
                   - min_req
+                  - network
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -3274,6 +3524,8 @@ domains:
               - summary: Verify IPMI is disabled; Redfish over TLS is used with AAA
                 labels:
                   - min_req
+                  - network
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -3285,6 +3537,8 @@ domains:
               - summary: Verify BMC is only accessible via a hardened bastion (jumphost) server; direct public/corporate network access is blocked
                 labels:
                   - min_req
+                  - network
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -3311,6 +3565,8 @@ domains:
               - summary: Verify no public internet access to API endpoints by default
                 labels:
                   - min_req
+                  - network
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -3322,6 +3578,8 @@ domains:
               - summary: Verify insecure protocols (HTTP, SSLv3, TLSv1) are disabled
                 labels:
                   - min_req
+                  - network
+                  - security
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -3334,7 +3592,11 @@ domains:
             tests:
               - summary: Verify IB tenant isolation — compute dedicated to NVIDIA is isolated from other customers
                 labels:
+                  - bare_metal
+                  - infiniband
                   - min_req
+                  - network
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -3345,7 +3607,11 @@ domains:
                 status: pending
               - summary: "Verify IB keys are configured: P_Key, Management Key, Aggregation Management Key, VendorSpecific Key, CongestionControl Key, Node2Node Key, Manager2Node Key"
                 labels:
+                  - bare_metal
+                  - infiniband
                   - min_req
+                  - network
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -3360,7 +3626,10 @@ domains:
                 req_id: SEC11
                 test_id: SEC11-01
                 labels:
+                  - iam
                   - min_req
+                  - network
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -3373,7 +3642,9 @@ domains:
             tests:
               - summary: Verify user authentication via OIDC for platform services
                 labels:
+                  - iam
                   - min_req
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -3386,7 +3657,9 @@ domains:
             tests:
               - summary: Verify workloads and nodes receive short-lived credentials/tokens
                 labels:
+                  - iam
                   - min_req
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -3399,7 +3672,9 @@ domains:
             tests:
               - summary: Verify out-of-cluster service accounts can authenticate with long-lived credentials
                 labels:
+                  - iam
                   - min_req
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -3412,7 +3687,9 @@ domains:
             tests:
               - summary: Verify all administrative interfaces (UI, CLI, API) are protected by Multi-Factor Authentication
                 labels:
+                  - iam
                   - min_req
+                  - security
                 priority: P0
                 milestone: M5
                 notes: INFO
@@ -3427,7 +3704,9 @@ domains:
             tests:
               - summary: Assign a minimal role to a user; verify they cannot perform actions outside that role on Compute, Storage, and Network APIs
                 labels:
+                  - iam
                   - min_req
+                  - security
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -3443,6 +3722,7 @@ domains:
               - summary: Perform a management API call; verify an audit log entry is generated with correct metadata
                 labels:
                   - min_req
+                  - security
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -3454,6 +3734,7 @@ domains:
               - summary: Verify audit logs are retained for at least 30 days
                 labels:
                   - min_req
+                  - security
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -3468,7 +3749,10 @@ domains:
             tests:
               - summary: Verify memory sanitization between tenants
                 labels:
+                  - bare_metal
                   - min_req
+                  - sanitization
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -3479,7 +3763,11 @@ domains:
                 status: pending
               - summary: Verify SRAM/GPU memory is sanitized between tenants
                 labels:
+                  - bare_metal
+                  - gpu
                   - min_req
+                  - sanitization
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -3490,7 +3778,11 @@ domains:
                 status: pending
               - summary: Verify TPM and BIOS are reset during tenant transitions or hardware replacement
                 labels:
+                  - bare_metal
+                  - firmware
                   - min_req
+                  - sanitization
+                  - security
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -3516,6 +3808,7 @@ domains:
               - summary: Verify a centralized KMS is used for all encryption keys and secrets
                 labels:
                   - min_req
+                  - security
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -3527,6 +3820,9 @@ domains:
               - summary: Verify support for Customer Managed Keys (BYOK)
                 labels:
                   - min_req
+                  - security
+                  - slow
+                  - workload
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -3544,6 +3840,7 @@ domains:
               - summary: Query the API for a compute node and verify it returns backend switch IDs (leaf, spine, core)
                 labels:
                   - min_req
+                  - network
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -3559,6 +3856,7 @@ domains:
               - summary: Query the NVLink domain ID for a compute node supporting NVLink
                 labels:
                   - min_req
+                  - network
                 priority: P0
                 milestone: M5
                 notes: ""
@@ -3634,6 +3932,8 @@ domains:
             tests:
               - summary: Query and verify governance API returns Delivered, Healthy, Reserved, and Active metrics for nodes/GPUs
                 labels:
+                  - bare_metal
+                  - governance
                   - min_req
                 priority: P1
                 milestone: M5
@@ -3649,6 +3949,8 @@ domains:
             tests:
               - summary: Verify a set of resources can be logically grouped and pinned to an account
                 labels:
+                  - bare_metal
+                  - capacity
                   - min_req
                 priority: P1
                 milestone: M5
@@ -3660,6 +3962,8 @@ domains:
                 status: pending
               - summary: Verify atomic allocation of a topology block as a single unit
                 labels:
+                  - bare_metal
+                  - capacity
                   - min_req
                 priority: P1
                 milestone: M5
@@ -3675,6 +3979,8 @@ domains:
             tests:
               - summary: Verify per-host health API returns real-time GPU state, thermal status, memory health
                 labels:
+                  - bare_metal
+                  - health
                   - min_req
                 priority: P1
                 milestone: M5
@@ -3686,6 +3992,8 @@ domains:
                 status: pending
               - summary: Verify primitive-level health aggregation (cluster, nodegroup, or reservation level)
                 labels:
+                  - bare_metal
+                  - health
                   - min_req
                 priority: P1
                 milestone: M5

--- a/docs/test-plan.yaml
+++ b/docs/test-plan.yaml
@@ -3952,6 +3952,7 @@ domains:
                   - bare_metal
                   - capacity
                   - min_req
+                  - security
                 priority: P1
                 milestone: M5
                 notes: ""
@@ -3965,6 +3966,7 @@ domains:
                   - bare_metal
                   - capacity
                   - min_req
+                  - security
                 priority: P1
                 milestone: M5
                 notes: ""

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -70,7 +70,7 @@ tests:
       checks:
         InstanceTagCheck:
           test_id: "CNP05-01"
-          labels: ["bare_metal"]
+          labels: ["bare_metal", "min_req"]
           required_keys: ["Name", "CreatedBy"]
 
     topology_placement:
@@ -81,24 +81,24 @@ tests:
           labels: ["bare_metal"]
         TopologyPlacementCheck:
           test_id: "CNP01-04"
-          labels: ["bare_metal"]
+          labels: ["bare_metal", "min_req"]
 
     serial_console:
       step: serial_console
       checks:
         SerialConsoleCheck:
           test_id: "CNP06-01"
-          labels: ["bare_metal"]
+          labels: ["bare_metal", "min_req"]
         SerialConsoleRetentionCheck:
           test_id: "CNP06-02"
-          labels: ["bare_metal"]
+          labels: ["bare_metal", "min_req"]
 
     cloud_init:
       step: launch_instance
       checks:
         CloudInitCheck:
           test_id: "BOOT02-01"
-          labels: ["bare_metal", "ssh"]
+          labels: ["bare_metal", "min_req", "ssh"]
 
     instance_info:
       step: describe_instance
@@ -163,7 +163,7 @@ tests:
       checks:
         GpuStressCheck:
           test_id: "BMAAS-XX-09"
-          labels: ["bare_metal", "ssh", "gpu", "workload"]
+          labels: ["bare_metal", "gpu", "min_req", "ssh", "workload"]
           runtime: 30
           memory_gb: 16
 
@@ -173,7 +173,7 @@ tests:
       checks:
         NcclCheck:
           test_id: "BMAAS-XX-11"
-          labels: ["bare_metal", "ssh", "gpu", "workload"]
+          labels: ["bare_metal", "gpu", "min_req", "ssh", "workload"]
 
     # DDP training workload - validates full training stack
     training:
@@ -181,7 +181,7 @@ tests:
       checks:
         TrainingCheck:
           test_id: "BMAAS-XX-12"
-          labels: ["bare_metal", "ssh", "gpu", "workload"]
+          labels: ["bare_metal", "gpu", "min_req", "ssh", "workload"]
           steps: 50
 
     # Network / interconnect checks
@@ -197,14 +197,14 @@ tests:
       checks:
         InfiniBandCheck:
           test_id: "BMAAS-XX-06"
-          labels: ["bare_metal", "ssh", "network"]
+          labels: ["bare_metal", "gpu", "network", "ssh"]
 
     ethernet:
       step: describe_instance
       checks:
         EthernetCheck:
           test_id: "BMAAS-XX-06"
-          labels: ["bare_metal", "ssh", "network"]
+          labels: ["bare_metal", "gpu", "network", "ssh"]
           ping_target: "8.8.8.8"
 
     driver_info:
@@ -234,17 +234,17 @@ tests:
       checks:
         InstanceStopCheck:
           test_id: "CNP01-07"
-          labels: ["bare_metal"]
+          labels: ["bare_metal", "min_req"]
 
     start_checks:
       step: start_instance
       checks:
         InstanceStartCheck:
           test_id: "CNP01-08"
-          labels: ["bare_metal"]
+          labels: ["bare_metal", "min_req"]
         StableIdentifierCheck:
           test_id: "CNP08-01"
-          labels: ["bare_metal"]
+          labels: ["bare_metal", "min_req"]
           reference_id: "{{steps.launch_instance.instance_id}}"
 
     # SSH/GPU checks bound to start_instance / reboot_instance use the IP
@@ -282,12 +282,12 @@ tests:
       checks:
         InstanceRebootCheck:
           test_id: "CNP01-05"
-          labels: ["bare_metal"]
+          labels: ["bare_metal", "min_req"]
           max_uptime: 600
         # StableIdentifierCheck -> CNP08-01 (declared in the "start_checks" section)
         StableIdentifierCheck:
           test_id: "CNP08-01"
-          labels: ["bare_metal"]
+          labels: ["bare_metal", "min_req"]
           reference_id: "{{steps.launch_instance.instance_id}}"
 
     reboot_state:
@@ -330,12 +330,12 @@ tests:
       checks:
         InstancePowerCycleCheck:
           test_id: "CNP01-06"
-          labels: ["bare_metal"]
+          labels: ["bare_metal", "min_req"]
           max_recovery_time: 900
         # StableIdentifierCheck -> CNP08-01 (declared in the "start_checks" section)
         StableIdentifierCheck:
           test_id: "CNP08-01"
-          labels: ["bare_metal"]
+          labels: ["bare_metal", "min_req"]
           reference_id: "{{steps.launch_instance.instance_id}}"
 
     power_cycle_state:
@@ -377,7 +377,7 @@ tests:
           expected_state: "running"
         StableIdentifierCheck:
           test_id: "CNP08-01"
-          labels: ["bare_metal"]
+          labels: ["bare_metal", "min_req"]
           reference_id: "{{steps.launch_instance.instance_id}}"
 
     reinstall_ssh:
@@ -405,21 +405,21 @@ tests:
       checks:
         NimHealthCheck:
           test_id: "BMAAS-XX-10"
-          labels: ["bare_metal", "ssh", "gpu"]
+          labels: ["bare_metal", "gpu", "min_req", "slow", "ssh", "workload"]
 
     nim_models:
       step: deploy_nim
       checks:
         NimModelCheck:
           test_id: "BMAAS-XX-10"
-          labels: ["bare_metal", "ssh", "gpu"]
+          labels: ["bare_metal", "gpu", "min_req", "slow", "ssh", "workload"]
 
     nim_inference:
       step: deploy_nim
       checks:
         NimInferenceCheck:
           test_id: "BMAAS-XX-10"
-          labels: ["bare_metal", "ssh", "gpu", "workload", "slow"]
+          labels: ["bare_metal", "gpu", "min_req", "slow", "ssh", "workload"]
           prompt: "What is CUDA?"
           max_tokens: 50
 
@@ -442,7 +442,7 @@ tests:
       checks:
         StepSuccessCheck:
           test_id: "SEC21-01"
-          labels: ["bare_metal", "security"]
+          labels: ["bare_metal", "min_req", "security"]
 
     # Hardware ingestion: expected-machine manifest vs discovered machines.
     # Only runs for providers that implement the verify_ingestion step.
@@ -475,7 +475,7 @@ tests:
       checks:
         GovernanceMetricsCheck:
           test_id: "CAP01-01"
-          labels: ["bare_metal", "governance"]
+          labels: ["bare_metal", "governance", "min_req"]
           min_delivered_nodes: 1
 
     # Per-host health API (CAP05-01). Asserts the API returns a report per host
@@ -489,7 +489,7 @@ tests:
       checks:
         HostHealthCheck:
           test_id: "CAP05-01"
-          labels: ["bare_metal", "health"]
+          labels: ["bare_metal", "health", "min_req"]
           require_report: true
 
     # Primitive-level health aggregation at the nodegroup/reservation level
@@ -500,7 +500,7 @@ tests:
       checks:
         HealthAggregationCheck:
           test_id: "CAP05-02"
-          labels: ["bare_metal", "health"]
+          labels: ["bare_metal", "health", "min_req"]
           min_groups: 1
 
     # InfiniBand tenant isolation (SDN04-04). Verifies each tenant's IB
@@ -513,7 +513,7 @@ tests:
       checks:
         IbTenantIsolationCheck:
           test_id: "SDN04-04"
-          labels: ["bare_metal", "security", "network", "infiniband"]
+          labels: ["bare_metal", "infiniband", "min_req", "network", "security"]
           min_partitions: 1
 
     # InfiniBand security keys (SDN04-05). The full requirement covers the
@@ -529,7 +529,7 @@ tests:
       checks:
         IbKeysConfiguredCheck:
           test_id: "SDN04-05"
-          labels: ["bare_metal", "security", "network", "infiniband"]
+          labels: ["bare_metal", "infiniband", "min_req", "network", "security"]
           required_keys: ["p_key", "management_key"]
 
     # Tenant-transition data sanitization (SEC21 / SEC22). Each check asserts
@@ -545,21 +545,21 @@ tests:
       checks:
         MemorySanitizationCheck:
           test_id: "SEC21-04"
-          labels: ["bare_metal", "security", "sanitization"]
+          labels: ["bare_metal", "min_req", "sanitization", "security"]
 
     gpu_memory_sanitization:
       step: query_sanitization
       checks:
         GpuMemorySanitizationCheck:
           test_id: "SEC21-05"
-          labels: ["bare_metal", "security", "sanitization", "gpu"]
+          labels: ["bare_metal", "gpu", "min_req", "sanitization", "security"]
 
     firmware_reset:
       step: query_sanitization
       checks:
         FirmwareResetCheck:
           test_id: "SEC21-06"
-          labels: ["bare_metal", "security", "sanitization", "firmware"]
+          labels: ["bare_metal", "firmware", "min_req", "sanitization", "security"]
 
     # SEC21-02: confirm storage is sanitized on delete. Gates on the same
     # sanitizing lifecycle stage as the memory check, because that stage also
@@ -570,7 +570,7 @@ tests:
       checks:
         DiskSanitizationCheck:
           test_id: "SEC21-02"
-          labels: ["bare_metal", "security", "sanitization", "disk"]
+          labels: ["bare_metal", "disk", "min_req", "sanitization", "security"]
 
     # Hardware/firmware attestation (SEC22 / CNP09). Each check asserts a host
     # establishes a hardware root of trust. Only runs for providers that
@@ -591,7 +591,7 @@ tests:
       checks:
         FirmwareAttestationCheck:
           test_id: "CNP09-02"
-          labels: ["bare_metal", "security", "attestation", "firmware"]
+          labels: ["attestation", "bare_metal", "firmware", "min_req", "security"]
 
   exclude:
     labels: []

--- a/isvctl/configs/suites/control-plane.yaml
+++ b/isvctl/configs/suites/control-plane.yaml
@@ -67,7 +67,7 @@ tests:
         # "s3_object_lifecycle" section, which declares the same test_id.
         FieldValueCheck:
           test_id: "DATASVC-XX-01"
-          labels: ["control_plane"]
+          labels: ["control_plane", "min_req"]
           field: "success"
           expected: true
 
@@ -90,11 +90,11 @@ tests:
           step: test_access_key
         AccessKeyDisabledCheck:
           test_id: "CP-XX-06"
-          labels: ["control_plane", "iam"]
+          labels: ["control_plane", "iam", "min_req"]
           step: disable_access_key
         AccessKeyRejectedCheck:
           test_id: "CP-XX-06"
-          labels: ["control_plane", "iam"]
+          labels: ["control_plane", "iam", "min_req"]
           step: verify_key_rejected
 
     tenant_lifecycle:
@@ -122,7 +122,7 @@ tests:
           fields: ["bucket_name", "object_key", "operations"]
         CrudOperationsCheck:
           test_id: "DATASVC-XX-01"
-          labels: ["control_plane"]
+          labels: ["control_plane", "min_req"]
           operations: ["put", "get", "delete"]
 
     teardown_checks:

--- a/isvctl/configs/suites/iam.yaml
+++ b/isvctl/configs/suites/iam.yaml
@@ -53,7 +53,7 @@ tests:
       checks:
         FieldExistsCheck:
           test_id: "IAM-XX-01"
-          labels: ["iam"]
+          labels: ["iam", "min_req"]
           fields: ["username", "access_key_id"]
         StepSuccessCheck:
           test_id: "N/A"

--- a/isvctl/configs/suites/image-registry.yaml
+++ b/isvctl/configs/suites/image-registry.yaml
@@ -59,7 +59,7 @@ tests:
           labels: ["image_registry"]
         FieldExistsCheck:
           test_id: "BOOT01-01"
-          labels: ["image_registry"]
+          labels: ["image_registry", "min_req"]
           fields: ["image_id", "storage_bucket", "disk_ids"]
 
     # --- Image CRUD ---
@@ -75,7 +75,7 @@ tests:
           fields: ["image_id", "operations"]
         CrudOperationsCheck:
           test_id: "BOOT03-02"
-          labels: ["image_registry"]
+          labels: ["image_registry", "min_req"]
           operations: ["get", "list", "create", "delete"]
 
     # --- VM Launch from Image ---
@@ -84,7 +84,7 @@ tests:
       checks:
         StepSuccessCheck:
           test_id: "BOOT01-05"
-          labels: ["image_registry"]
+          labels: ["image_registry", "min_req"]
         FieldExistsCheck:
           test_id: "N/A"
           labels: ["image_registry"]
@@ -123,7 +123,7 @@ tests:
       checks:
         StepSuccessCheck:
           test_id: "BOOT01-03"
-          labels: ["image_registry"]
+          labels: ["image_registry", "min_req"]
         FieldExistsCheck:
           test_id: "N/A"
           labels: ["image_registry"]
@@ -139,7 +139,7 @@ tests:
       checks:
         StepSuccessCheck:
           test_id: "BOOT01-04"
-          labels: ["image_registry"]
+          labels: ["image_registry", "min_req"]
         FieldExistsCheck:
           test_id: "N/A"
           labels: ["image_registry"]

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -79,7 +79,7 @@ tests:
           # Create (CPU pool): pool reaches desired replica count with its
           # specified CPU instance type.
           test_id: "K8S06-01"
-          labels: ["kubernetes", "slow"]
+          labels: ["kubernetes", "min_req", "slow"]
           step: create_test_node_pool
           label_selector: "{{ steps.create_test_node_pool.label_selector }}"
           expected_replicas: "{{ steps.create_test_node_pool.expected_replicas | default(1, true) }}"
@@ -93,7 +93,7 @@ tests:
           # Create (GPU pool): a separate pool reaches its own node count with
           # its specified GPU instance type, coexisting with the CPU pool.
           test_id: "K8S06-01"
-          labels: ["kubernetes", "slow"]
+          labels: ["kubernetes", "min_req", "slow"]
           step: create_test_gpu_node_pool
           label_selector: "{{ steps.create_test_gpu_node_pool.label_selector }}"
           expected_replicas: "{{ steps.create_test_gpu_node_pool.expected_replicas | default(1, true) }}"
@@ -106,7 +106,7 @@ tests:
       - K8sNodePoolCheck:
           # Update (scale): same pool converges to the new count.
           test_id: "K8S06-02"
-          labels: ["kubernetes", "slow"]
+          labels: ["kubernetes", "min_req", "slow"]
           step: update_test_node_pool
           label_selector: "{{ steps.update_test_node_pool.label_selector }}"
           expected_replicas: "{{ steps.update_test_node_pool.expected_replicas | default(2, true) }}"
@@ -121,7 +121,7 @@ tests:
           # delete step. Selector comes from its create step; the label/taint/
           # instance-type assertions are omitted (no nodes to check).
           test_id: "K8S06-03"
-          labels: ["kubernetes", "slow"]
+          labels: ["kubernetes", "min_req", "slow"]
           step: delete_test_node_pool
           label_selector: "{{ steps.create_test_delete_node_pool.label_selector }}"
           expected_replicas: 0
@@ -135,7 +135,7 @@ tests:
       checks:
         K8sMultiClusterSameVpcCheck:
           test_id: "K8S26-01"
-          labels: ["kubernetes"]
+          labels: ["kubernetes", "min_req"]
           step: create_test_shared_vpc_cluster
 
     kubernetes:
@@ -150,7 +150,7 @@ tests:
           names: []
         K8sNodeReadyCheck:
           test_id: "K8S05-01"
-          labels: ["kubernetes"]
+          labels: ["kubernetes", "min_req"]
           require_all_ready: true
         K8sNvidiaSmiCheck:
           test_id: "N/A"
@@ -179,11 +179,11 @@ tests:
           expected_total: "{{ steps.setup.kubernetes.total_gpus | default(16, true) }}"
         K8sGpuOperatorNamespaceCheck:
           test_id: "K8S25-01"
-          labels: ["kubernetes"]
+          labels: ["kubernetes", "min_req"]
           namespace: "{{ steps.setup.kubernetes.gpu_operator_namespace | default('nvidia-gpu-operator') }}"
         K8sGpuOperatorPodsCheck:
           test_id: "K8S25-01"
-          labels: ["kubernetes"]
+          labels: ["kubernetes", "min_req"]
           namespace: "{{ steps.setup.kubernetes.gpu_operator_namespace | default('nvidia-gpu-operator') }}"
         K8sGpuLabelsCheck:
           test_id: "N/A"
@@ -209,11 +209,11 @@ tests:
             "nvidia.com/mig.strategy": "single"
         K8sDualStackNodeCheck:
           test_id: "K8S22-01"
-          labels: ["kubernetes"]
+          labels: ["kubernetes", "min_req"]
           require_dual_stack: "auto" # true | false | "auto"
         K8sClusterAutoscalerCheck:
           test_id: "K8S-XX-08"
-          labels: ["kubernetes"]
+          labels: ["kubernetes", "min_req"]
           require_autoscaler: false
           namespace: "{{ steps.setup.kubernetes.cluster_autoscaler_namespace | default('kube-system', true) }}"
           deployment_names:
@@ -224,7 +224,7 @@ tests:
             - "k8s-app=cluster-autoscaler"
         K8sNetworkPolicyCheck:
           test_id: "K8S22-01"
-          labels: ["kubernetes"]
+          labels: ["kubernetes", "min_req"]
           image: "registry.k8s.io/e2e-test-images/agnhost:2.47"
           probe_port: 8080
           probe_timeout_s: 10
@@ -236,7 +236,7 @@ tests:
       checks:
         K8sCsiStorageTypesCheck:
           test_id: "K8S23-04"
-          labels: ["kubernetes"]
+          labels: ["kubernetes", "min_req"]
           # StorageClass names by type; omit (or leave empty) to skip that type.
           # Env overrides: K8S_CSI_BLOCK_SC, K8S_CSI_SHARED_FS_SC, K8S_CSI_NFS_SC.
           block_storage_class: "{{ steps.setup.csi.block_storage_class | default('', true) }}"
@@ -247,7 +247,7 @@ tests:
           namespace_prefix: "isvtest-csi-types"
         K8sCsiStorageQuotaApiCheck:
           test_id: "K8S23-07"
-          labels: ["kubernetes"]
+          labels: ["kubernetes", "min_req"]
           # Uses the block StorageClass by default; skips entirely when unset.
           # per_sc_quota must exceed pvc_request so the usage PVC fits, and
           # over_quota_request must exceed per_sc_quota so admission rejects it.
@@ -261,7 +261,7 @@ tests:
           namespace_prefix: "isvtest-csi-quota"
         K8sCsiTenantScopedCredentialsCheck:
           test_id: "K8S23-06"
-          labels: ["kubernetes"]
+          labels: ["kubernetes", "min_req"]
           # Pure read-only check: verifies CSI credentials are tenant-scoped
           # by construction (Secret namespaces, labels/annotations, RBAC,
           # and node-plugin volume topology). Skipped entirely when no
@@ -273,7 +273,7 @@ tests:
             - "shared-across-clusters=true"
         K8sCsiProvisioningModesCheck:
           test_id: "K8S23-05"
-          labels: ["kubernetes"]
+          labels: ["kubernetes", "min_req"]
           # Exercises dynamic and static CSI provisioning end-to-end with a
           # BusyBox mount + canary-file write/read. Skipped entirely when
           # dynamic_storage_class is unset. The static subtest is skipped
@@ -294,13 +294,13 @@ tests:
       checks:
         K8sOidcIssuerCheck:
           test_id: "K8S18-01"
-          labels: ["kubernetes"]
+          labels: ["kubernetes", "min_req"]
 
     k8s_conformance:
       checks:
         K8sCncfConformanceCheck:
           test_id: "K8S01-01"
-          labels: ["kubernetes", "l2", "slow"]
+          labels: ["kubernetes", "l2", "min_req", "slow"]
           # Valid `mode` values (see docs/guides/configuration.md#kubernetes-conformance-modes):
           #   - "certified-conformance": full [Conformance] suite, serial. Required
           #     for CNCF certification; expect multi-hour runtime.
@@ -318,12 +318,12 @@ tests:
       checks:
         K8sNcclWorkload:
           test_id: "K8S-XX-05"
-          labels: ["kubernetes", "gpu", "workload", "slow"]
+          labels: ["gpu", "kubernetes", "min_req", "slow", "workload"]
           min_bus_bw_gbps: 100
           timeout: 600
         K8sNcclMultiNodeWorkload:
           test_id: "K8S-XX-05"
-          labels: ["kubernetes", "gpu", "workload", "slow"]
+          labels: ["gpu", "kubernetes", "min_req", "slow", "workload"]
           nodes: "{{ steps.setup.kubernetes.gpu_node_count | default(2, true) }}"
           min_bus_bw_gbps: 100
           quick_mode: false
@@ -362,10 +362,10 @@ tests:
       checks:
         K8sApiServerMetricsCheck:
           test_id: "K8S07-01"
-          labels: ["kubernetes"]
+          labels: ["kubernetes", "min_req"]
         K8sControlPlaneLogsCheck:
           test_id: "K8S20-01"
-          labels: ["kubernetes"]
+          labels: ["kubernetes", "min_req"]
           # mode=auto resolves each component independently: kubectl when a
           # control-plane pod exists in `namespace`, else `commands[component]`.
           # This covers hybrid clusters (some components as static pods, others
@@ -397,7 +397,7 @@ tests:
       checks:
         K8sApiNetworkAclCheck:
           test_id: "K8S15-01"
-          labels: ["kubernetes"]
+          labels: ["kubernetes", "min_req"]
           # Probe-based, provider-agnostic: verifies the reviewed cluster's
           # Kubernetes API endpoint refuses connections from a source that
           # should be blocked. By default the validation uses the configured

--- a/isvctl/configs/suites/network.yaml
+++ b/isvctl/configs/suites/network.yaml
@@ -62,22 +62,22 @@ tests:
         # bind to the same vpc_crud step and assert their slice of its output.
         VpcCrudCheck-create:
           test_id: "SDN01-01"
-          labels: ["network"]
+          labels: ["min_req", "network"]
           step: vpc_crud
           operations: ["create_vpc"]
         VpcCrudCheck-read:
           test_id: "SDN01-02"
-          labels: ["network"]
+          labels: ["min_req", "network"]
           step: vpc_crud
           operations: ["read_vpc"]
         VpcCrudCheck-update:
           test_id: "SDN01-03"
-          labels: ["network"]
+          labels: ["min_req", "network"]
           step: vpc_crud
           operations: ["update_tags", "update_dns"]
         VpcCrudCheck-delete:
           test_id: "SDN01-04"
-          labels: ["network"]
+          labels: ["min_req", "network"]
           step: vpc_crud
           operations: ["delete_vpc"]
         # no test id for subnet count / multi-AZ layout (SDN04-01 covers exclusive-subnet isolation, not subnet topology).
@@ -90,26 +90,26 @@ tests:
         VpcIsolationCheck:
           # SDN04-03 (E/W isolation) is exercised by the same check but is not separately attributable under a single test_id.
           test_id: "SDN04-02"
-          labels: ["network", "security"]
+          labels: ["min_req", "network", "security"]
           step: vpc_isolation
         SgCrudCheck-create:
           test_id: "SDN02-01"
-          labels: ["network", "security"]
+          labels: ["min_req", "network", "security"]
           step: sg_crud
           operations: ["create_vpc", "create_sg"]
         SgCrudCheck-read:
           test_id: "SDN02-02"
-          labels: ["network", "security"]
+          labels: ["min_req", "network", "security"]
           step: sg_crud
           operations: ["read_sg"]
         SgCrudCheck-update:
           test_id: "SDN02-03"
-          labels: ["network", "security"]
+          labels: ["min_req", "network", "security"]
           step: sg_crud
           operations: ["update_sg_add_rule", "update_sg_modify_rule", "update_sg_remove_rule"]
         SgCrudCheck-delete:
           test_id: "SDN02-04"
-          labels: ["network", "security"]
+          labels: ["min_req", "network", "security"]
           step: sg_crud
           operations: ["delete_sg", "verify_deleted"]
         # SG/NACL enforcement + connectivity/traffic behavior have no dedicated
@@ -139,30 +139,30 @@ tests:
       checks:
         SgWorkloadScopingCheck:
           test_id: "SDN02-05"
-          labels: ["network", "security"]
+          labels: ["min_req", "network", "security"]
           step: sg_workload_scoping
         SgNodeScopingCheck:
           test_id: "SDN02-06"
-          labels: ["network", "security"]
+          labels: ["min_req", "network", "security"]
           step: sg_node_scoping
         SgSubnetScopingCheck:
           test_id: "SDN02-07"
-          labels: ["network", "security"]
+          labels: ["min_req", "network", "security"]
           step: sg_subnet_scoping
         SgServiceScopingCheck:
           test_id: "SDN02-09"
-          labels: ["network", "security"]
+          labels: ["min_req", "network", "security"]
           step: sg_service_scoping
         SgPortSecurityPolicyCheck:
           test_id: "SDN02-10"
-          labels: ["network", "security"]
+          labels: ["min_req", "network", "security"]
           step: sg_port_security_policy
 
     sdn_policy:
       checks:
         SgPolicyPropagationTimingCheck:
           test_id: "SDN02-08"
-          labels: ["network", "security"]
+          labels: ["min_req", "network", "security"]
           step: sg_policy_propagation
           max_propagation_seconds: 10
 
@@ -170,47 +170,47 @@ tests:
       checks:
         SdnHardwareFaultLoggingCheck:
           test_id: "SDN09-01"
-          labels: ["network"]
+          labels: ["min_req", "network"]
           step: sdn_hardware_fault_logging
         SdnLatencyPerfLoggingCheck:
           test_id: "SDN09-02"
-          labels: ["network"]
+          labels: ["min_req", "network"]
           step: sdn_latency_perf_logging
         SdnFilterAuditTrailCheck:
           test_id: "SDN09-03"
-          labels: ["network", "security"]
+          labels: ["min_req", "network", "security"]
           step: sdn_filter_audit_trail
 
     sdn:
       checks:
         ByoipCheck:
           test_id: "NET03-01"
-          labels: ["network"]
+          labels: ["min_req", "network"]
           step: byoip_test
         StablePrivateIpCheck:
           test_id: "SDN-XX-01"
-          labels: ["network"]
+          labels: ["min_req", "network"]
           step: stable_ip_test
         StableEgressIpCheck:
           test_id: "DMS05-01"
-          labels: ["network"]
+          labels: ["min_req", "network"]
           step: stable_egress_ip_test
         FloatingIpCheck:
           test_id: "SDN05-01"
-          labels: ["network"]
+          labels: ["min_req", "network"]
           step: floating_ip_test
           max_switch_seconds: 10
         LocalizedDnsCheck:
           test_id: "SDN06-01"
-          labels: ["network"]
+          labels: ["min_req", "network"]
           step: dns_test
         VpcPeeringCheck:
           test_id: "SDN07-01"
-          labels: ["network"]
+          labels: ["min_req", "network"]
           step: peering_test
         StorageL3RoutingCheck:
           test_id: "SDN08-01"
-          labels: ["network"]
+          labels: ["min_req", "network"]
           step: storage_l3_routing
 
     # Read-only metadata/API checks for provider-reported backend fabric
@@ -219,11 +219,11 @@ tests:
       checks:
         BackendSwitchFabricCheck:
           test_id: "NET01-01"
-          labels: ["network"]
+          labels: ["min_req", "network"]
           step: backend_switch_fabric
         NvlinkDomainCheck:
           test_id: "NET02-02"
-          labels: ["network"]
+          labels: ["min_req", "network"]
           step: nvlink_domain
 
     teardown_checks:

--- a/isvctl/configs/suites/observability.yaml
+++ b/isvctl/configs/suites/observability.yaml
@@ -34,28 +34,28 @@ tests:
       checks:
         VpcFlowLogsCheck:
           test_id: "OBS-XX-19"
-          labels: ["observability", "network"]
+          labels: ["min_req", "network", "observability"]
           step: vpc_flow_logs
 
     host_logs:
       checks:
         HostSyslogCheck:
           test_id: "OBS-XX-18"
-          labels: ["observability", "bare_metal"]
+          labels: ["bare_metal", "min_req", "observability"]
           step: host_syslogs
 
     bmc_logs:
       checks:
         BmcSelLogsCheck:
           test_id: "OBS-XX-17"
-          labels: ["observability", "security"]
+          labels: ["min_req", "observability", "security"]
           step: bmc_sel_logs
 
     bmc_telemetry:
       checks:
         BmcGpuTelemetryCheck:
           test_id: "TELEM-XX-04"
-          labels: ["observability", "security", "gpu"]
+          labels: ["gpu", "min_req", "observability", "security"]
           step: bmc_gpu_telemetry
 
   exclude:

--- a/isvctl/configs/suites/security.yaml
+++ b/isvctl/configs/suites/security.yaml
@@ -54,133 +54,133 @@ tests:
       checks:
         BmcManagementNetworkCheck:
           test_id: "SEC12-01"
-          labels: ["security", "network"]
+          labels: ["min_req", "network", "security"]
           step: bmc_management_network
 
     bmc_isolation:
       checks:
         BmcTenantIsolationCheck:
           test_id: "SEC12-02"
-          labels: ["security", "network"]
+          labels: ["min_req", "network", "security"]
           step: bmc_tenant_isolation
 
     bmc_protocol_security:
       checks:
         BmcProtocolSecurityCheck:
           test_id: "CNP10-01"
-          labels: ["security", "network"]
+          labels: ["min_req", "network", "security"]
           step: bmc_protocol_security
 
     bmc_bastion_access:
       checks:
         BmcBastionAccessCheck:
           test_id: "SEC12-03"
-          labels: ["security", "network"]
+          labels: ["min_req", "network", "security"]
           step: bmc_bastion_access
 
     api_security:
       checks:
         ApiEndpointIsolationCheck:
           test_id: "SEC14-01"
-          labels: ["security", "network"]
+          labels: ["min_req", "network", "security"]
           step: api_endpoint_isolation
 
     insecure_protocols:
       checks:
         InsecureProtocolsCheck:
           test_id: "SEC13-02"
-          labels: ["security", "network"]
+          labels: ["min_req", "network", "security"]
           step: insecure_protocols_test
 
     mfa_enforcement:
       checks:
         MfaEnforcedCheck:
           test_id: "SEC07-01"
-          labels: ["security", "iam"]
+          labels: ["iam", "min_req", "security"]
           step: mfa_enforcement
 
     cert_rotation:
       checks:
         CertRotationCycleCheck:
           test_id: "SEC09-01"
-          labels: ["security"]
+          labels: ["min_req", "security"]
           step: cert_rotation_test
 
     kms_encryption_options:
       checks:
         KmsEncryptionOptionCheck:
           test_id: "SEC09-02"
-          labels: ["security"]
+          labels: ["min_req", "security"]
           step: kms_encryption_options_test
 
     centralized_kms:
       checks:
         CentralizedKmsCheck:
           test_id: "SEC09-03"
-          labels: ["security"]
+          labels: ["min_req", "security"]
           step: centralized_kms_test
 
     customer_managed_key:
       checks:
         CustomerManagedKeyCheck:
           test_id: "SEC09-04"
-          labels: ["security", "workload", "slow"]
+          labels: ["min_req", "security", "slow", "workload"]
           step: customer_managed_key_test
 
     service_account_auth:
       checks:
         ServiceAccountCredentialCheck:
           test_id: "SEC03-01"
-          labels: ["security", "iam"]
+          labels: ["iam", "min_req", "security"]
           step: sa_credential_test
 
     user_auth_oidc:
       checks:
         OidcUserAuthCheck:
           test_id: "SEC01-01"
-          labels: ["security", "iam"]
+          labels: ["iam", "min_req", "security"]
           step: oidc_user_auth_test
 
     short_lived_credentials:
       checks:
         ShortLivedCredentialsCheck:
           test_id: "SEC02-01"
-          labels: ["security", "iam"]
+          labels: ["iam", "min_req", "security"]
           step: short_lived_credentials_test
 
     least_privilege_policy:
       checks:
         LeastPrivilegePolicyCheck:
           test_id: "SEC04-01"
-          labels: ["security", "iam"]
+          labels: ["iam", "min_req", "security"]
           step: least_privilege_test
 
     minimal_role_enforcement:
       checks:
         MinimalRoleEnforcementCheck:
           test_id: "SEC04-02"
-          labels: ["security", "iam"]
+          labels: ["iam", "min_req", "security"]
           step: least_privilege_test
 
     audit_log_entry:
       checks:
         AuditLogEntryCheck:
           test_id: "SEC08-01"
-          labels: ["security"]
+          labels: ["min_req", "security"]
           step: audit_logging_test
 
     audit_log_retention:
       checks:
         AuditLogRetentionCheck:
           test_id: "SEC08-02"
-          labels: ["security"]
+          labels: ["min_req", "security"]
           step: audit_logging_test
 
     tenant_isolation:
       checks:
         TenantIsolationCheck:
           test_id: "SEC11-01"
-          labels: ["security", "network", "iam"]
+          labels: ["iam", "min_req", "network", "security"]
           step: tenant_isolation_test
 
     # Verify capacity is logically grouped and pinned to one tenant/account
@@ -189,7 +189,7 @@ tests:
       checks:
         CapacityReservationGroupingCheck:
           test_id: "CAP04-01"
-          labels: ["capacity", "bare_metal"]
+          labels: ["bare_metal", "capacity", "min_req"]
           step: capacity_reservation_grouping
           min_resources: "{{min_resources}}"
 
@@ -200,7 +200,7 @@ tests:
       checks:
         CapacityTopologyBlockAtomicAllocationCheck:
           test_id: "CAP04-02"
-          labels: ["capacity", "bare_metal"]
+          labels: ["bare_metal", "capacity", "min_req"]
           min_resources: 2
 
     teardown_checks:

--- a/isvctl/configs/suites/security.yaml
+++ b/isvctl/configs/suites/security.yaml
@@ -189,7 +189,7 @@ tests:
       checks:
         CapacityReservationGroupingCheck:
           test_id: "CAP04-01"
-          labels: ["bare_metal", "capacity", "min_req"]
+          labels: ["bare_metal", "capacity", "min_req", "security"]
           step: capacity_reservation_grouping
           min_resources: "{{min_resources}}"
 
@@ -200,7 +200,7 @@ tests:
       checks:
         CapacityTopologyBlockAtomicAllocationCheck:
           test_id: "CAP04-02"
-          labels: ["bare_metal", "capacity", "min_req"]
+          labels: ["bare_metal", "capacity", "min_req", "security"]
           min_resources: 2
 
     teardown_checks:

--- a/isvctl/configs/suites/vm.yaml
+++ b/isvctl/configs/suites/vm.yaml
@@ -74,14 +74,14 @@ tests:
       checks:
         InstanceCreatedCheck:
           test_id: "CNP01-09"
-          labels: ["vm"]
+          labels: ["min_req", "vm"]
 
     list_instances:
       step: list_instances
       checks:
         InstanceListCheck:
           test_id: "CNP01-11"
-          labels: ["vm"]
+          labels: ["min_req", "vm"]
           min_count: 1
 
     tag_checks:
@@ -89,7 +89,7 @@ tests:
       checks:
         InstanceTagCheck:
           test_id: "CNP05-02"
-          labels: ["vm"]
+          labels: ["min_req", "vm"]
           required_keys: ["Name", "CreatedBy"]
 
     serial_console:
@@ -97,28 +97,28 @@ tests:
       checks:
         SerialConsoleCheck:
           test_id: "CNP06-03"
-          labels: ["vm"]
+          labels: ["min_req", "vm"]
 
     console_rbac:
       step: console_rbac
       checks:
         ConsoleRbacCheck:
           test_id: "CNP01-16"
-          labels: ["vm", "security", "iam"]
+          labels: ["iam", "min_req", "security", "vm"]
 
     virtual_device_hardening:
       step: virtual_device_hardening
       checks:
         VirtualDeviceHardeningCheck:
           test_id: "CNP01-17"
-          labels: ["vm", "security"]
+          labels: ["min_req", "security", "vm"]
 
     cloud_init:
       step: launch_instance
       checks:
         CloudInitCheck:
           test_id: "BOOT02-02"
-          labels: ["vm", "ssh"]
+          labels: ["min_req", "ssh", "vm"]
 
     # ─── Host-level validations anchored to describe_instance ────────
     # describe_instance runs AFTER reboot, so these checks prove the
@@ -155,14 +155,14 @@ tests:
       checks:
         VcpuPinningCheck:
           test_id: "VMAAS-XX-09"
-          labels: ["vm", "ssh"]
+          labels: ["gpu", "ssh", "vm"]
         PciBusCheck:
           test_id: "VMAAS-XX-09"
           labels: ["vm", "ssh", "gpu"]
           expected_gpus: 1
         HostSoftwareCheck:
           test_id: "VMAAS-XX-07"
-          labels: ["vm", "ssh"]
+          labels: ["gpu", "ssh", "vm"]
 
     driver_info:
       step: describe_instance
@@ -191,17 +191,17 @@ tests:
       checks:
         InstanceStopCheck:
           test_id: "CNP01-14"
-          labels: ["vm"]
+          labels: ["min_req", "vm"]
 
     start_checks:
       step: start_instance
       checks:
         InstanceStartCheck:
           test_id: "CNP01-15"
-          labels: ["vm"]
+          labels: ["min_req", "vm"]
         StableIdentifierCheck:
           test_id: "CNP08-03"
-          labels: ["vm"]
+          labels: ["min_req", "vm"]
           reference_id: "{{steps.launch_instance.instance_id}}"
 
     start_ssh:
@@ -235,7 +235,7 @@ tests:
         # StableIdentifierCheck -> CNP08-03 (declared in the "start_checks" section)
         StableIdentifierCheck:
           test_id: "CNP08-03"
-          labels: ["vm"]
+          labels: ["min_req", "vm"]
           reference_id: "{{steps.launch_instance.instance_id}}"
 
     reboot_state:
@@ -273,14 +273,14 @@ tests:
       checks:
         NimHealthCheck:
           test_id: "VMAAS-XX-12"
-          labels: ["vm", "ssh", "gpu"]
+          labels: ["gpu", "slow", "ssh", "vm", "workload"]
 
     nim_models:
       step: deploy_nim
       checks:
         NimModelCheck:
           test_id: "VMAAS-XX-12"
-          labels: ["vm", "ssh", "gpu"]
+          labels: ["gpu", "slow", "ssh", "vm", "workload"]
 
     nim_inference:
       step: deploy_nim

--- a/isvctl/tests/test_capacity_config.py
+++ b/isvctl/tests/test_capacity_config.py
@@ -23,7 +23,7 @@ def test_security_suite_defines_capacity_validations() -> None:
     assert grouping["checks"] == {
         "CapacityReservationGroupingCheck": {
             "test_id": "CAP04-01",
-            "labels": ["capacity", "bare_metal"],
+            "labels": ["bare_metal", "capacity", "min_req", "security"],
             "step": "capacity_reservation_grouping",
             "min_resources": "{{min_resources}}",
         }
@@ -35,7 +35,7 @@ def test_security_suite_defines_capacity_validations() -> None:
     assert topology["checks"] == {
         "CapacityTopologyBlockAtomicAllocationCheck": {
             "test_id": "CAP04-02",
-            "labels": ["capacity", "bare_metal"],
+            "labels": ["bare_metal", "capacity", "min_req", "security"],
             "min_resources": 2,
         }
     }

--- a/scripts/test_plan_coverage.py
+++ b/scripts/test_plan_coverage.py
@@ -160,7 +160,7 @@ def _normalize_labels(value: Any) -> list[str]:
         value = [value]
     if not isinstance(value, list):
         return []
-    return sorted({label for label in value if isinstance(label, str) and label})
+    return sorted({label.strip() for label in value if isinstance(label, str) and label.strip()})
 
 
 def config_test_label_instances(suites_dir: Path = SUITES_DIR) -> list[tuple[str, str, str, list[str]]]:
@@ -340,7 +340,11 @@ def run_guardrails(
     entries: list[dict[str, Any]],
     plan_entries: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, list[str]]:
-    """Return integrity and consistency errors for ``entries`` against ``plan_ids``."""
+    """Return guardrail errors for ``entries`` against ``plan_ids``.
+
+    Always returns ``integrity`` and ``consistency`` keys; includes ``label_sync``
+    when ``plan_entries`` is provided.
+    """
     class_map = class_test_id_map(entries)
     checks = {
         "integrity": integrity_errors(plan_ids, class_map),

--- a/scripts/test_plan_coverage.py
+++ b/scripts/test_plan_coverage.py
@@ -195,19 +195,24 @@ def label_sync_errors(
     for _source, _name, tid, labels in instances:
         config_labels_by_id[tid].update(labels)
 
+    required_by_id = {
+        tid: plan_labels.get(tid, set()) | config_labels for tid, config_labels in config_labels_by_id.items()
+    }
+
     errors: list[str] = []
-    for tid, config_labels in sorted(config_labels_by_id.items()):
+    for tid in sorted(required_by_id):
         if tid not in plan_entries:
             continue
-        required = plan_labels.get(tid, set()) | config_labels
         actual = plan_labels.get(tid, set())
-        if actual != required:
-            errors.append(f"docs/test-plan.yaml:{tid} labels are {sorted(actual)}, expected union {sorted(required)}")
+        if actual != required_by_id[tid]:
+            errors.append(
+                f"docs/test-plan.yaml:{tid} labels are {sorted(actual)}, expected union {sorted(required_by_id[tid])}"
+            )
 
     for source, name, tid, labels in instances:
         if tid not in plan_entries:
             continue
-        required = plan_labels.get(tid, set()) | config_labels_by_id.get(tid, set())
+        required = required_by_id.get(tid, set())
         actual = set(labels)
         if actual != required:
             errors.append(f"{source}: {name} ({tid}) labels are {sorted(actual)}, expected union {sorted(required)}")

--- a/scripts/test_plan_coverage.py
+++ b/scripts/test_plan_coverage.py
@@ -150,12 +150,68 @@ def config_label_map(suites_dir: Path = SUITES_DIR) -> dict[str, list[str]]:
     out: dict[str, set[str]] = defaultdict(set)
     for path in sorted(suites_dir.glob("*.yaml")):
         for name, params in iter_config_checks(path):
-            labels = params.get("labels")
-            if isinstance(labels, str):
-                labels = [labels]
-            if isinstance(labels, list):
-                out[name].update(label for label in labels if isinstance(label, str) and label)
+            out[name].update(_normalize_labels(params.get("labels")))
     return {name: sorted(labels) for name, labels in out.items()}
+
+
+def _normalize_labels(value: Any) -> list[str]:
+    """Return sorted, non-empty label strings from YAML metadata."""
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, list):
+        return []
+    return sorted({label for label in value if isinstance(label, str) and label})
+
+
+def config_test_label_instances(suites_dir: Path = SUITES_DIR) -> list[tuple[str, str, str, list[str]]]:
+    """Return ``(source, check_name, test_id, labels)`` for each mapped suite check."""
+    instances: list[tuple[str, str, str, list[str]]] = []
+    for path in sorted(suites_dir.glob("*.yaml")):
+        try:
+            source = path.relative_to(REPO_ROOT).as_posix()
+        except ValueError:
+            source = path.as_posix()
+        for name, params in iter_config_checks(path):
+            tid = params.get("test_id")
+            if isinstance(tid, str) and tid and tid != UNMAPPED:
+                instances.append((source, name, tid, _normalize_labels(params.get("labels"))))
+    return instances
+
+
+def label_sync_errors(
+    plan_entries: dict[str, dict[str, Any]],
+    instances: list[tuple[str, str, str, list[str]]] | None = None,
+) -> list[str]:
+    """Errors where plan and suite labels for a test_id are not the same union.
+
+    ``docs/test-plan.yaml`` and suite check wiring both carry labels. For every
+    mapped ``test_id``, the plan item and every suite check mapped to it must all
+    carry the union of labels from both sides.
+    """
+    instances = config_test_label_instances() if instances is None else instances
+    plan_labels = {tid: set(_normalize_labels(entry.get("labels"))) for tid, entry in plan_entries.items()}
+
+    config_labels_by_id: dict[str, set[str]] = defaultdict(set)
+    for _source, _name, tid, labels in instances:
+        config_labels_by_id[tid].update(labels)
+
+    errors: list[str] = []
+    for tid, config_labels in sorted(config_labels_by_id.items()):
+        if tid not in plan_entries:
+            continue
+        required = plan_labels.get(tid, set()) | config_labels
+        actual = plan_labels.get(tid, set())
+        if actual != required:
+            errors.append(f"docs/test-plan.yaml:{tid} labels are {sorted(actual)}, expected union {sorted(required)}")
+
+    for source, name, tid, labels in instances:
+        if tid not in plan_entries:
+            continue
+        required = plan_labels.get(tid, set()) | config_labels_by_id.get(tid, set())
+        actual = set(labels)
+        if actual != required:
+            errors.append(f"{source}: {name} ({tid}) labels are {sorted(actual)}, expected union {sorted(required)}")
+    return sorted(errors)
 
 
 def _variant_base(name: str) -> str:
@@ -277,13 +333,17 @@ def consistency_errors(entries: list[dict[str, Any]]) -> list[str]:
 def run_guardrails(
     plan_ids: set[str],
     entries: list[dict[str, Any]],
+    plan_entries: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, list[str]]:
     """Return integrity and consistency errors for ``entries`` against ``plan_ids``."""
     class_map = class_test_id_map(entries)
-    return {
+    checks = {
         "integrity": integrity_errors(plan_ids, class_map),
         "consistency": consistency_errors(entries),
     }
+    if plan_entries is not None:
+        checks["label_sync"] = label_sync_errors(plan_entries)
+    return checks
 
 
 def build_coverage(
@@ -405,7 +465,7 @@ def main(argv: list[str] | None = None) -> int:
     else:
         entries = entries_from_config_maps(seed_entries=catalog_entries())
 
-    checks = run_guardrails(plan_ids, entries)
+    checks = run_guardrails(plan_ids, entries, plan_entries)
     class_map = class_test_id_map(entries)
     all_errors = [f"[{kind}] {msg}" for kind, msgs in checks.items() for msg in msgs]
 
@@ -413,7 +473,7 @@ def main(argv: list[str] | None = None) -> int:
         if all_errors:
             sys.stderr.write("test-plan coverage check failed:\n  " + "\n  ".join(all_errors) + "\n")
             return 1
-        print(f"OK: {len(class_map)} mapped classes pass integrity and consistency.")
+        print(f"OK: {len(class_map)} mapped classes pass integrity, consistency, and label sync.")
         return 0
 
     if all_errors:

--- a/scripts/tests/test_test_plan_coverage.py
+++ b/scripts/tests/test_test_plan_coverage.py
@@ -106,6 +106,25 @@ def test_consistency_passes_when_yaml_label_supplies_domain() -> None:
     assert test_plan_coverage.consistency_errors(merged) == []
 
 
+def test_label_sync_errors_require_plan_and_suite_union() -> None:
+    """Plan and suite wiring must both carry the union of labels for a test_id."""
+    plan = {"SEC01-01": {"labels": ["min_req"]}}
+    instances = [("suite.yaml", "SecurityCheck", "SEC01-01", ["security"])]
+
+    errors = test_plan_coverage.label_sync_errors(plan, instances)
+
+    assert any("docs/test-plan.yaml:SEC01-01" in error and "security" in error for error in errors)
+    assert any("suite.yaml: SecurityCheck" in error and "min_req" in error for error in errors)
+
+
+def test_label_sync_errors_empty_when_plan_and_suite_match() -> None:
+    """No drift when every mapped check and plan entry has the same label union."""
+    plan = {"SEC01-01": {"labels": ["min_req", "security"]}}
+    instances = [("suite.yaml", "SecurityCheck", "SEC01-01", ["min_req", "security"])]
+
+    assert test_plan_coverage.label_sync_errors(plan, instances) == []
+
+
 def test_load_plan_rejects_duplicate_test_ids(tmp_path: Path) -> None:
     """A test_id repeated in the plan is fatal, not a silent last-write-wins."""
     plan = tmp_path / "plan.yaml"
@@ -128,21 +147,24 @@ def test_repo_metadata_passes_all_guardrails() -> None:
     mapping's domain is inconsistent with the check's labels. There is no
     completeness check: a check with no test_id is allowed.
     """
-    plan_ids = set(test_plan_coverage.load_plan())
-    checks = test_plan_coverage.run_guardrails(plan_ids, test_plan_coverage.entries_from_config_maps())
+    plan_entries = test_plan_coverage.load_plan()
+    plan_ids = set(plan_entries)
+    checks = test_plan_coverage.run_guardrails(plan_ids, test_plan_coverage.entries_from_config_maps(), plan_entries)
     all_errors = [msg for msgs in checks.values() for msg in msgs]
     assert not all_errors, "\n  ".join(["test-plan coverage guardrails failed:", *all_errors])
 
 
 def test_guardrail_fast_path_matches_catalog_path() -> None:
     """YAML-only guardrail seed must agree with the catalog-backed report path."""
-    plan_ids = set(test_plan_coverage.load_plan())
+    plan_entries = test_plan_coverage.load_plan()
+    plan_ids = set(plan_entries)
     test_id_map = test_plan_coverage.config_test_id_map()
     label_map = test_plan_coverage.config_label_map()
 
     fast = test_plan_coverage.run_guardrails(
         plan_ids,
         test_plan_coverage.entries_from_config_maps(test_id_map, label_map),
+        plan_entries,
     )
     slow = test_plan_coverage.run_guardrails(
         plan_ids,
@@ -151,5 +173,6 @@ def test_guardrail_fast_path_matches_catalog_path() -> None:
             label_map,
             test_plan_coverage.catalog_entries(),
         ),
+        plan_entries,
     )
     assert fast == slow

--- a/scripts/tests/test_validate_suite_wiring.py
+++ b/scripts/tests/test_validate_suite_wiring.py
@@ -58,6 +58,28 @@ tests:
     assert any("BadCheck" in err and "missing labels" in err for err in errors)
 
 
+def test_wiring_errors_require_canonical_suite_label(tmp_path: Path) -> None:
+    """Checks in known suite files must include that suite's label."""
+    suite = tmp_path / "k8s.yaml"
+    suite.write_text(
+        """\
+tests:
+  validations:
+    example:
+      checks:
+        MissingSuiteLabel:
+          test_id: "K8S01-01"
+          labels: ["gpu"]
+        GoodCheck:
+          test_id: "K8S01-02"
+          labels: ["gpu", "kubernetes"]
+"""
+    )
+    errors = validate_suite_wiring.wiring_errors(tmp_path)
+    assert any("MissingSuiteLabel" in err and "missing suite label 'kubernetes'" in err for err in errors)
+    assert not any("GoodCheck" in err for err in errors)
+
+
 def test_wiring_errors_reports_yaml_parse_failures(tmp_path: Path) -> None:
     """Malformed suite YAML surfaces as a validation error instead of being skipped."""
     suite = tmp_path / "broken.yaml"

--- a/scripts/validate_suite_wiring.py
+++ b/scripts/validate_suite_wiring.py
@@ -22,6 +22,8 @@ validation metadata on this branch. Each wired check must declare:
 * ``test_id`` - a plan id from ``docs/test-plan.yaml``, or ``"N/A"`` when the
   check is generic plumbing with no plan item.
 * ``labels`` - a non-empty list used for pytest selection and catalog reporting.
+  Each canonical suite check must include its suite label, for example checks in
+  ``bare_metal.yaml`` must include ``bare_metal``.
 
 Usage:
     python3 scripts/validate_suite_wiring.py
@@ -43,6 +45,18 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SUITES_DIR = REPO_ROOT / "isvctl" / "configs" / "suites"
 _NEXT_CATEGORY_LINE = re.compile(r"^    \S")
+SUITE_REQUIRED_LABELS: dict[str, str] = {
+    "bare_metal": "bare_metal",
+    "control-plane": "control_plane",
+    "iam": "iam",
+    "image-registry": "image_registry",
+    "k8s": "kubernetes",
+    "network": "network",
+    "observability": "observability",
+    "security": "security",
+    "slurm": "slurm",
+    "vm": "vm",
+}
 
 
 def _check_line_patterns(check_name: str) -> tuple[re.Pattern[str], ...]:
@@ -86,6 +100,11 @@ def _normalize_test_id(value: Any) -> str | None:
     if isinstance(value, str) and value.strip():
         return value.strip()
     return None
+
+
+def required_suite_label(config_path: Path) -> str | None:
+    """Return the label every check in a known canonical suite must carry."""
+    return SUITE_REQUIRED_LABELS.get(config_path.stem)
 
 
 def iter_suite_checks(config_path: Path) -> Iterator[tuple[str, str, dict[str, Any]]]:
@@ -150,10 +169,13 @@ def wiring_errors(suites_dir: Path = SUITES_DIR) -> list[str]:
             location = _format_location(path, category, name, line_number)
             test_id = _normalize_test_id(params.get("test_id"))
             labels = _normalize_labels(params.get("labels"))
+            required_label = required_suite_label(path)
             if test_id is None:
                 errors.append(f'{location}: missing test_id (use a plan id or "N/A")')
             if not labels:
                 errors.append(f"{location}: missing labels (non-empty list required)")
+            elif required_label and required_label not in labels:
+                errors.append(f"{location}: missing suite label {required_label!r}")
     return errors
 
 
@@ -177,7 +199,7 @@ def main(argv: list[str] | None = None) -> int:
         print(message)
         return 0
 
-    ok = f"OK: all wired checks in {SUITES_DIR.relative_to(REPO_ROOT)} declare test_id and labels."
+    ok = f"OK: all wired checks in {SUITES_DIR.relative_to(REPO_ROOT)} declare test_id, labels, and suite labels."
     print(ok)
     return 0
 


### PR DESCRIPTION
## Summary
- Sync labels between suite validation wiring and docs/test-plan.yaml so both sides carry the same union of metadata.
- Add guardrails for label drift and require each canonical suite check to include its suite label.
- Regenerate docs/test-plan.adoc from the updated test plan.

## Test plan
- uv run pytest scripts/tests/test_test_plan_coverage.py scripts/tests/test_validate_suite_wiring.py
- uv run python scripts/test_plan_coverage.py --check
- uv run python scripts/validate_suite_wiring.py --check
- pre-commit hooks during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added label synchronization guardrails to ensure test documentation and suite wiring labels remain consistent.
  * Enforced that canonical suite checks include the expected suite label.
* **Documentation**
  * Expanded test-plan coverage metadata with richer dependency/capability labels, consistently adding `min_req` and capability tags.
* **Chores**
  * Updated local pre-commit hooks to run Python scripts via `uv`.
* **Tests**
  * Added unit tests for label synchronization and for suite wiring label enforcement.
* **Refactor**
  * Improved label normalization to produce consistent, comparable label sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->