### PR TITLE
fix: preserve configured skipped steps

### DIFF
--- a/isvctl/src/isvctl/config/schema.py
+++ b/isvctl/src/isvctl/config/schema.py
@@ -410,10 +410,7 @@ class RunConfig(BaseModel):
         platform_cmds = self.commands.get(platform)
         if platform_cmds is None:
             raise KeyError(f"Platform '{platform}' not configured in commands")
-        # Check platform-level skip first
-        if platform_cmds.skip:
-            return []
-        return [step for step in platform_cmds.steps if not step.skip]
+        return platform_cmds.steps
 
     def get_phases(self, platform: str) -> list[str]:
         """Get the ordered phases list for a given platform.

--- a/isvctl/src/isvctl/orchestrator/loop.py
+++ b/isvctl/src/isvctl/orchestrator/loop.py
@@ -292,6 +292,15 @@ def _phase_enum_for_name(phase_name: str) -> Phase:
     return Phase.TEST
 
 
+def _requested_config_phases(config_phases: list[str], requested_phases: list[Phase]) -> list[str]:
+    """Return configured phase names selected by the requested phase filter."""
+    if Phase.ALL in requested_phases:
+        return config_phases
+
+    requested_phase_names = {phase.value for phase in requested_phases}
+    return [phase for phase in config_phases if phase in requested_phase_names]
+
+
 def _has_explicit_pytest_selection(extra_pytest_args: list[str] | None) -> bool:
     """Return whether pytest args explicitly select tests or markers."""
     if not extra_pytest_args:
@@ -429,6 +438,22 @@ class Orchestrator:
         """
         logger.info(f"Running in steps mode for platform: {platform}")
 
+        config_phases = self.config.get_phases(platform)
+        if self.config.commands[platform].skip:
+            skipped_phases = _requested_config_phases(config_phases, requested_phases)
+            return OrchestratorResult(
+                success=True,
+                phases=[
+                    PhaseResult(
+                        phase=_phase_enum_for_name(phase_name),
+                        success=True,
+                        message=f"SKIPPED: platform '{platform}' is skipped by configuration",
+                    )
+                    for phase_name in skipped_phases
+                ],
+                inventory={},
+            )
+
         steps = self.config.get_steps(platform)
         if not steps:
             return OrchestratorResult(
@@ -448,7 +473,6 @@ class Orchestrator:
 
         steps = _apply_step_validation_gates(steps, released_tests)
 
-        config_phases = self.config.get_phases(platform)
         logger.info(f"Configured phases: {config_phases}")
 
         for step in steps:
@@ -703,7 +727,15 @@ class Orchestrator:
         display_name = phase_name or phase.value
 
         # Build step messages
-        step_messages = [f"{s.name}: {'passed' if s.success else 'failed'}" for s in step_results.steps]
+        step_messages = []
+        for step in step_results.steps:
+            if step.error == "Step skipped":
+                status = "skipped"
+            elif step.success:
+                status = "passed"
+            else:
+                status = "failed"
+            step_messages.append(f"{step.name}: {status}")
 
         # Check if any validations failed
         validation_failures = [v for v in validation_results if not v.get("passed", False)]

--- a/isvctl/tests/test_orchestrator_loop.py
+++ b/isvctl/tests/test_orchestrator_loop.py
@@ -271,9 +271,32 @@ EOF
 
         result = orchestrator.run(phases=[Phase.SETUP])
 
-        # When platform is skipped, no steps are returned which results in "No steps defined"
-        assert not result.success
-        assert "No steps defined" in result.phases[0].message
+        assert result.success
+        assert len(result.phases) == 1
+        assert result.phases[0].phase == Phase.SETUP
+        assert result.phases[0].success
+        assert "SKIPPED" in result.phases[0].message
+        assert "platform 'kubernetes' is skipped" in result.phases[0].message
+
+    def test_run_platform_skip_marks_requested_phases_skipped(self) -> None:
+        """Platform-level skip marks each requested configured phase as skipped."""
+        config = RunConfig(
+            commands={
+                "kubernetes": PlatformCommands(
+                    skip=True,
+                    phases=["setup", "teardown"],
+                )
+            },
+            tests=ValidationConfig(platform="kubernetes"),
+        )
+        orchestrator = Orchestrator(config)
+
+        result = orchestrator.run(phases=[Phase.SETUP, Phase.TEARDOWN])
+
+        assert result.success
+        assert [phase.phase for phase in result.phases] == [Phase.SETUP, Phase.TEARDOWN]
+        assert all(phase.success for phase in result.phases)
+        assert all(phase.message.startswith("SKIPPED:") for phase in result.phases)
 
     def test_run_test_phase_requires_steps(self) -> None:
         """Test that test phase with no steps fails gracefully."""
@@ -419,6 +442,13 @@ EOF
         )
         orchestrator = Orchestrator(config)
         result = orchestrator.run(teardown_on_failure=True)
+
+        setup_phases = [p for p in result.phases if p.phase == Phase.SETUP]
+        assert len(setup_phases) == 1
+        assert setup_phases[0].success
+        assert "setup_cluster: skipped" in setup_phases[0].message
+        assert setup_phases[0].details
+        assert setup_phases[0].details["steps"][0]["error"] == "Step skipped"
 
         teardown_phases = [p for p in result.phases if p.phase == Phase.TEARDOWN]
         assert len(teardown_phases) == 1

--- a/isvctl/tests/test_schema.py
+++ b/isvctl/tests/test_schema.py
@@ -180,12 +180,14 @@ class TestRunConfigModel:
         assert len(k8s_steps) == 2
         assert k8s_steps[0].command == "./k8s-setup.sh"
 
-        # Skipped steps are filtered out
+        # Skipped steps are returned so the executor can record skipped placeholders.
         slurm_steps = config.get_steps("slurm")
-        assert len(slurm_steps) == 0
+        assert len(slurm_steps) == 1
+        assert slurm_steps[0].name == "skipped_step"
+        assert slurm_steps[0].skip is True
 
-    def test_platform_level_skip(self) -> None:
-        """Test platform-level skip skips all phases."""
+    def test_platform_level_skip_preserves_configured_steps(self) -> None:
+        """Test platform-level skip does not hide configured steps."""
         config = RunConfig(
             commands={
                 "kubernetes": PlatformCommands(
@@ -195,7 +197,12 @@ class TestRunConfigModel:
                     ]
                 ),
                 # Platform-level skip - simpler than skipping each step
-                "slurm": PlatformCommands(skip=True),
+                "slurm": PlatformCommands(
+                    skip=True,
+                    steps=[
+                        StepConfig(name="setup_slurm", command="./slurm-setup.sh", phase="setup"),
+                    ],
+                ),
             }
         )
 
@@ -203,9 +210,10 @@ class TestRunConfigModel:
         k8s_steps = config.get_steps("kubernetes")
         assert len(k8s_steps) == 2
 
-        # Slurm should be skipped at platform level (returns empty list)
+        # Platform-level skip is handled by the orchestrator, not by dropping steps here.
         slurm_steps = config.get_steps("slurm")
-        assert len(slurm_steps) == 0
+        assert len(slurm_steps) == 1
+        assert slurm_steps[0].name == "setup_slurm"
 
     def test_get_phases(self) -> None:
         """Test getting phases for a platform."""


### PR DESCRIPTION
## Summary
- return configured steps from `RunConfig.get_steps()`, including `skip: true` entries
- treat platform-level `skip: true` as successful skipped phase results instead of a missing-steps failure
- make skipped step placeholders visible in phase summaries and update the skip tests

## Why
`skip: true` was being filtered before the orchestrator/executor could record an intentional skip. That made step-level skips disappear, and platform-level skips failed with `No steps defined for platform` even though the config asked for a skip.

## Testing
- `uv run pytest isvctl/tests/test_schema.py isvctl/tests/test_orchestrator_loop.py -q`
- `uvx pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed platform-level skipping to complete successfully with skipped phases reported, rather than failing.
  * Skipped steps now explicitly appear as "skipped" in status summaries for better visibility.
  * Improved consistency in how skip semantics are handled across platforms and individual steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->