### PR TITLE
feat(isvctl): add interactive `isvctl configure` to persist env vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,24 @@ forwarded env vars → optional isvreporter upload.
 | `KUBECTL` | Optional kubectl-compatible CLI prefix (POSIX `shlex` in Python, word-split in shell; overrides `K8S_PROVIDER` detection) | isvtest `get_kubectl_command`, isvctl k8s scripts |
 | `ISVCTL_DEMO_MODE` | `"1"` makes `my-isv` scripts return dummy success | scripts |
 | `AWS_SKIP_TEARDOWN` | Skip teardown phase (run later with `--phase teardown`) | AWS configs |
+| `ISVCTL_CONFIG` / `ISVCTL_SECRETS` | Override the `config.yml` / `secrets.yml` paths (default `${XDG_CONFIG_HOME:-~/.config}/isvctl/`) | isvctl `configure`, `test`, `doctor` |
+
+### Persisted user config
+
+`isvctl configure` persists env vars so users don't re-`export` them per shell.
+On disk they are grouped into provider-namespaced sections (`nico.api_base` ⇆
+`NICO_API_BASE`); non-secret values go in `config.yml` (`0644`), secrets in
+`secrets.yml` (`0600`). The variable catalog and the section/prefix mapping live
+in `isvctl/config/env_catalog.py` (shared with `doctor`); the section⇆env-name
+translation is a serialization detail in `config/user.py` (the public API stays
+keyed by env var name). Both files carry a top-level `version:` (the on-disk
+schema version, `SCHEMA_VERSION` in `config/user.py`); a missing version reads as
+the initial `1`, and a version newer than the build understands is rejected with
+a clear "upgrade isvctl" error rather than mis-parsed. Secret-vs-non-secret
+routing reuses `redaction.is_secret_env_var`. The "Flags" group is non-persistable.
+`test run`, `test validate`, and `doctor` apply both files (unless
+`--no-user-config`) via `cli/common.apply_user_config`, and an already-exported
+var always wins (process env > files > defaults).
 
 ## Cursor Cloud specific instructions
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ export AWS_REGION=...
 export AWS_SESSION_TOKEN=...  # only required for temporary/SSO credentials
 ```
 
+Prefer not to re-`export` every shell? Persist the values once:
+
+```bash
+uv run isvctl configure   # interactive; secrets saved to a 0600 file
+```
+
 Execution:
 
 ```bash
@@ -110,6 +116,11 @@ See [Contributing](CONTRIBUTING.md) for development setup and guidelines.
 | `ISV_CLIENT_ID` | Required for ISV Lab Service uploads |
 | `ISV_CLIENT_SECRET` | Required for ISV Lab Service uploads |
 | `NGC_API_KEY` | Required for NIM model benchmarks |
+
+Instead of exporting these every session, run `isvctl configure` to persist them
+(non-secrets in `config.yml`, secrets in a `0600` `secrets.yml` under
+`${XDG_CONFIG_HOME:-~/.config}/isvctl/`). An exported variable always overrides
+the saved value. See the [isvctl README](isvctl/README.md#configuration).
 
 ## Security
 

--- a/isvctl/README.md
+++ b/isvctl/README.md
@@ -7,6 +7,7 @@ Unified controller for ISV Lab cluster lifecycle orchestration.
 ```bash
 # From workspace root
 uv sync
+uv run isvctl configure                 # persist env vars once (interactive)
 uv run isvctl doctor
 uv run isvctl test run -f isvctl/configs/suites/k8s.yaml
 
@@ -23,6 +24,50 @@ uv run isvctl docs tests -l kubernetes                   # filter by label
 uv run isvctl docs tests -f isvctl/configs/suites/k8s.yaml      # show config test instances
 uv run isvctl docs tests -i StepSuccessCheck             # detailed info for a test
 ```
+
+## Configuration
+
+`isvctl configure` persists the env vars an `isvctl test run` needs so you don't
+re-`export` them in every shell (handy for providers like NICo that need several).
+
+```bash
+uv run isvctl configure                 # walk every variable
+uv run isvctl configure --provider nico # only NICo's variables
+uv run isvctl configure show            # show what's saved (secrets masked)
+uv run isvctl configure path            # print the file paths
+```
+
+Values are split across two files under `${XDG_CONFIG_HOME:-~/.config}/isvctl/`,
+organized into provider-namespaced sections:
+
+- `config.yml` (`0644`) — non-secret values.
+- `secrets.yml` (`0600`) — secret values (API keys, client secrets, tokens).
+
+```yaml
+# config.yml
+nico:
+  api_base: https://nico.example.com
+  organization: example-org
+  site_id: 00000000-0000-0000-0000-000000000000
+```
+
+```yaml
+# secrets.yml (0600)
+nico:
+  client_secret: ...
+```
+
+Each key maps to an env var by section prefix — `nico.api_base` ⇆ `NICO_API_BASE`,
+`aws.region` ⇆ `AWS_REGION`, `ngc.api_key` ⇆ `NGC_API_KEY` — so what gets exported
+is unambiguous. `ISVCTL_CONFIG` and `ISVCTL_SECRETS` override the individual paths.
+Precedence is **process env > files > defaults**: a variable already exported in
+your shell is never overridden, so CI and one-off `FOO=bar isvctl ...` overrides
+keep working. Pass `--no-user-config` to `test run`/`test validate`/`doctor` to
+ignore the files. Per-run flags (`KUBECTL`, `ISVCTL_DEMO_MODE`, …) are deliberately
+not persisted — pass them on the command line or export them each time.
+
+Keep `~/.config/isvctl/` out of any repository — `secrets.yml` holds plaintext
+credentials. Run `isvctl doctor` (optionally `--provider <name>`) to verify.
 
 ## Documentation
 

--- a/isvctl/README.md
+++ b/isvctl/README.md
@@ -34,6 +34,11 @@ re-`export` them in every shell (handy for providers like NICo that need several
 uv run isvctl configure                 # walk every variable
 uv run isvctl configure --provider nico # only NICo's variables
 uv run isvctl configure show            # show what's saved (secrets masked)
+uv run isvctl configure set NICO_API_BASE https://nico.example.com
+uv run isvctl configure set nico.organization=ncx nico.oidc_scope=example
+uv run isvctl configure unset nico.api_base
+uv run isvctl configure unset nico     # remove one section after confirmation
+uv run isvctl configure unset --all     # remove all saved config after confirmation
 uv run isvctl configure path            # print the file paths
 ```
 
@@ -62,9 +67,16 @@ Each key maps to an env var by section prefix — `nico.api_base` ⇆ `NICO_API_
 is unambiguous. `ISVCTL_CONFIG` and `ISVCTL_SECRETS` override the individual paths.
 Precedence is **process env > files > defaults**: a variable already exported in
 your shell is never overridden, so CI and one-off `FOO=bar isvctl ...` overrides
-keep working. Pass `--no-user-config` to `test run`/`test validate`/`doctor` to
-ignore the files. Per-run flags (`KUBECTL`, `ISVCTL_DEMO_MODE`, …) are deliberately
-not persisted — pass them on the command line or export them each time.
+keep working. Use `isvctl configure set <name> [value]`,
+`isvctl configure set <name>=<value> [<name>=<value> ...]`, and
+`isvctl configure unset <name>` for precise edits; both env var names
+(`NICO_API_BASE`) and section keys (`nico.api_base`) are accepted. Multiple
+values must use `key=value` assignment form. Use `isvctl configure unset <section>`
+(`nico`, `aws`, `ngc`, `isv_lab_service`) to remove all saved values for a section
+from both files after confirmation. Omitting the value prompts interactively, with hidden input for secrets. Pass
+`--no-user-config` to `test run`/`test validate`/`doctor` to ignore the files.
+Per-run flags (`KUBECTL`, `ISVCTL_DEMO_MODE`, …) are deliberately not persisted —
+pass them on the command line or export them each time.
 
 Keep `~/.config/isvctl/` out of any repository — `secrets.yml` holds plaintext
 credentials. Run `isvctl doctor` (optionally `--provider <name>`) to verify.

--- a/isvctl/src/isvctl/cli/common.py
+++ b/isvctl/src/isvctl/cli/common.py
@@ -15,10 +15,15 @@
 
 """Shared constants and helpers for CLI subcommands."""
 
+import logging
 from pathlib import Path
 
 import typer
 from rich.console import Console
+
+from isvctl.config.user import apply_user_env, load_user_env
+
+logger = logging.getLogger(__name__)
 
 OUTPUT_DIR_NAME = "_output"
 
@@ -45,6 +50,25 @@ def print_progress(message: str) -> None:
 def print_step(message: str) -> None:
     """Write a progress step with the '==>' marker to stderr."""
     typer.echo(typer.style("==>", fg=typer.colors.GREEN) + f" {message}", err=True)
+
+
+def apply_user_config(no_user_config: bool) -> None:
+    """Apply persisted user config (config.yml / secrets.yml) to the environment.
+
+    No-op when ``--no-user-config`` is set. Loaded values never override env
+    vars already exported in the process (precedence: process env > files).
+    Exits with a clear error if the user config is malformed, before any work
+    begins.
+    """
+    if no_user_config:
+        return
+    try:
+        applied = apply_user_env(load_user_env())
+    except (ValueError, OSError) as e:
+        print_error(f"Failed to load user config: {e}")
+        raise typer.Exit(code=1) from e
+    if applied:
+        logger.debug("Applied user config env vars: %s", ", ".join(applied))
 
 
 def get_output_dir(root: Path | None = None) -> Path:

--- a/isvctl/src/isvctl/cli/config.py
+++ b/isvctl/src/isvctl/cli/config.py
@@ -26,11 +26,20 @@ from typing import Annotated
 import typer
 
 from isvctl.cli.common import print_error, print_step
-from isvctl.config.env_catalog import EnvVar, env_to_section_key, vars_for_provider
+from isvctl.config.env_catalog import (
+    ENV_VARS,
+    SECTIONS,
+    EnvVar,
+    env_to_section_key,
+    section_key_to_env,
+    vars_for_provider,
+)
 from isvctl.config.user import (
+    clear_user_config,
     get_config_path,
     get_secrets_path,
     load_user_env,
+    unset_user_config,
     write_user_config,
 )
 from isvctl.redaction import is_secret_env_var
@@ -43,6 +52,14 @@ app = typer.Typer(
 )
 
 _SECRET_PLACEHOLDER = "(set)"
+_NON_PERSISTABLE_NAMES = frozenset(var.name for var in ENV_VARS if not var.persistable)
+_SECTION_NAMES = frozenset(section.name for section in SECTIONS)
+_SECTION_ENV_NAMES = {
+    section.name: tuple(
+        var.name for var in ENV_VARS if var.persistable and env_to_section_key(var.name)[0] == section.name
+    )
+    for section in SECTIONS
+}
 
 
 def _resolve_vars(provider: str | None) -> list[EnvVar]:
@@ -70,6 +87,96 @@ def _load_current() -> dict[str, str]:
         raise typer.Exit(code=1) from exc
 
 
+def _resolve_config_key(key: str) -> str:
+    """Resolve an env var name or ``section.key`` alias to a persistable env name."""
+    if "." in key:
+        section, section_key = key.split(".", 1)
+        env_name = section_key_to_env(section, section_key)
+        if env_name is not None:
+            return env_name
+    else:
+        if key in _NON_PERSISTABLE_NAMES:
+            raise ValueError(
+                f"'{key}' is a per-run flag and is not persisted; pass it on the command line or export it"
+            )
+        try:
+            env_to_section_key(key)
+        except KeyError:
+            pass
+        else:
+            return key
+    raise ValueError(f"unknown config key '{key}' (use an env var name or section.key)")
+
+
+def _resolve_config_key_or_exit(key: str) -> str:
+    """Resolve a CLI key, exiting with a usage error on bad input."""
+    try:
+        return _resolve_config_key(key)
+    except ValueError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=2) from exc
+
+
+def _parse_assignment(raw: str) -> tuple[str, str]:
+    """Parse one ``key=value`` token into an env var name and value."""
+    key, value = raw.split("=", 1)
+    return _resolve_config_key_or_exit(key), value
+
+
+def _parse_set_args(args: list[str]) -> tuple[dict[str, str], str | None]:
+    """Parse ``configure set`` args into explicit values and optional prompt key."""
+    if not args:
+        print_error("provide a key or key=value assignment")
+        raise typer.Exit(code=2)
+
+    if len(args) == 1:
+        if "=" in args[0]:
+            return dict([_parse_assignment(args[0])]), None
+        return {}, _resolve_config_key_or_exit(args[0])
+
+    if len(args) == 2:
+        if "=" not in args[0]:
+            return {_resolve_config_key_or_exit(args[0]): args[1]}, None
+        if "=" not in args[1]:
+            print_error("cannot combine key=value with a separate value")
+            raise typer.Exit(code=2)
+        return dict(_parse_assignment(arg) for arg in args), None
+
+    if all("=" in arg for arg in args):
+        return dict(_parse_assignment(arg) for arg in args), None
+
+    print_error("multiple values must use key=value assignments")
+    raise typer.Exit(code=2)
+
+
+def _unset_section(section: str) -> None:
+    """Remove all persisted values for one config section after confirmation."""
+    current = _load_current()
+    env_names = tuple(name for name in _SECTION_ENV_NAMES[section] if name in current)
+    if not env_names:
+        typer.echo(f"No saved values for {section}.")
+        return
+
+    typer.echo(f"{section}:")
+    for env_name in env_names:
+        _, section_key = env_to_section_key(env_name)
+        suffix = " (secret)" if is_secret_env_var(env_name) else ""
+        typer.echo(f"  {section_key}{suffix}")
+
+    confirmed = typer.confirm(f"Remove {len(env_names)} saved value(s) from section '{section}'?", default=False)
+    if not confirmed:
+        typer.echo("Aborted.")
+        raise typer.Exit(code=1)
+
+    try:
+        unset_user_config(env_names, existing=current)
+    except (ValueError, OSError) as exc:
+        print_error(f"Failed to update user config: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    print_step(f"Unset {len(env_names)} var(s) from {section}.")
+
+
 @app.callback(invoke_without_command=True)
 def configure(
     ctx: typer.Context,
@@ -93,6 +200,9 @@ def configure(
         isvctl configure --provider nico
         isvctl configure show
         isvctl configure path
+        isvctl configure set NICO_API_BASE https://nico.example.com
+        isvctl configure unset nico.api_base
+        isvctl configure unset nico
     """
     if ctx.invoked_subcommand is not None:
         return
@@ -174,6 +284,101 @@ def show(
             last_section = section
         display = _SECRET_PLACEHOLDER if is_secret_env_var(var.name) else current[var.name]
         typer.echo(f"  {key.ljust(width)} = {display}")
+
+
+@app.command("set")
+def set_value(
+    args: Annotated[
+        list[str],
+        typer.Argument(
+            help=("Env var name or section.key, optionally as key=value. Use key=value for multiple values."),
+        ),
+    ],
+) -> None:
+    """Set one or more persisted configuration values."""
+    values, prompt_env_name = _parse_set_args(args)
+    current = _load_current()
+
+    if prompt_env_name is not None:
+        section, section_key = env_to_section_key(prompt_env_name)
+        prompt = f"{prompt_env_name} ({section}.{section_key})"
+        values[prompt_env_name] = typer.prompt(
+            prompt,
+            hide_input=is_secret_env_var(prompt_env_name),
+            show_default=False,
+        )
+
+    try:
+        result = write_user_config(values, existing=current)
+    except (ValueError, OSError) as exc:
+        print_error(f"Failed to write user config: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    config_count = sum(1 for name in values if not is_secret_env_var(name))
+    secret_count = len(values) - config_count
+    if config_count:
+        print_step(f"Set {config_count} var(s) in {result.config_path}")
+    if secret_count:
+        print_step(f"Set {secret_count} secret(s) in {result.secrets_path} (mode 0600)")
+
+
+@app.command("unset")
+def unset_value(
+    key: Annotated[
+        str | None,
+        typer.Argument(help="Env var name, section.key, or section name to remove."),
+    ] = None,
+    all_values: Annotated[
+        bool,
+        typer.Option("--all", help="Remove all saved isvctl configuration after confirmation."),
+    ] = False,
+) -> None:
+    """Remove one persisted value, one section, or all values with ``--all``."""
+    if all_values and key is not None:
+        print_error("pass either a key or --all, not both")
+        raise typer.Exit(code=2)
+    if not all_values and key is None:
+        print_error("provide a key or pass --all")
+        raise typer.Exit(code=2)
+
+    if all_values:
+        config_path = get_config_path()
+        secrets_path = get_secrets_path()
+        if not config_path.exists() and not secrets_path.exists():
+            typer.echo("No configuration found.")
+            return
+        typer.echo(f"config.yml:  {config_path}")
+        typer.echo(f"secrets.yml: {secrets_path}")
+        confirmed = typer.confirm("Remove all saved isvctl configuration?", default=False)
+        if not confirmed:
+            typer.echo("Aborted.")
+            raise typer.Exit(code=1)
+        try:
+            clear_user_config()
+        except OSError as exc:
+            print_error(f"Failed to remove user config: {exc}")
+            raise typer.Exit(code=1) from exc
+        print_step("Removed all saved isvctl configuration.")
+        return
+
+    if key in _SECTION_NAMES:
+        _unset_section(key)
+        return
+
+    env_name = _resolve_config_key_or_exit(key)
+    current = _load_current()
+    if env_name not in current:
+        typer.echo(f"{env_name} is not saved.")
+        return
+
+    try:
+        result = unset_user_config([env_name], existing=current)
+    except (ValueError, OSError) as exc:
+        print_error(f"Failed to update user config: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    target = result.secrets_path if is_secret_env_var(env_name) else result.config_path
+    print_step(f"Unset {env_name} from {target}")
 
 
 @app.command("path")

--- a/isvctl/src/isvctl/cli/config.py
+++ b/isvctl/src/isvctl/cli/config.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Interactive ``isvctl configure`` command.
+
+Persists the env vars an ``isvctl test run`` needs so users do not re-export
+them in every shell. Non-secret values are written to ``config.yml`` and
+secrets to a ``0600`` ``secrets.yml``. The variable catalog and provider
+grouping come from ``isvctl.config.env_catalog`` (shared with ``doctor``).
+"""
+
+from typing import Annotated
+
+import typer
+
+from isvctl.cli.common import print_error, print_step
+from isvctl.config.env_catalog import EnvVar, env_to_section_key, vars_for_provider
+from isvctl.config.user import (
+    get_config_path,
+    get_secrets_path,
+    load_user_env,
+    write_user_config,
+)
+from isvctl.redaction import is_secret_env_var
+
+app = typer.Typer(
+    name="configure",
+    help="Persist env vars for `isvctl test run` (interactive).",
+    invoke_without_command=True,
+    no_args_is_help=False,
+)
+
+_SECRET_PLACEHOLDER = "(set)"
+
+
+def _resolve_vars(provider: str | None) -> list[EnvVar]:
+    """Resolve persistable catalog vars for a provider, exiting on a bad name.
+
+    Per-run flags (the "Flags" group) are excluded — they are not persisted.
+    """
+    try:
+        return [var for var in vars_for_provider(provider) if var.persistable]
+    except ValueError as exc:
+        print_error(str(exc))
+        raise typer.Exit(code=2) from exc
+
+
+def _load_current() -> dict[str, str]:
+    """Load persisted config, exiting cleanly on a malformed file.
+
+    ``configure`` is the command users reach for to *fix* a broken file, so a
+    bad config.yml/secrets.yml must surface as a clear error, not a traceback.
+    """
+    try:
+        return load_user_env()
+    except (ValueError, OSError) as exc:
+        print_error(f"Failed to read user config: {exc}")
+        raise typer.Exit(code=1) from exc
+
+
+@app.callback(invoke_without_command=True)
+def configure(
+    ctx: typer.Context,
+    provider: Annotated[
+        str | None,
+        typer.Option(
+            "--provider",
+            help="Only prompt for this provider's vars (e.g. 'nico', 'aws').",
+        ),
+    ] = None,
+) -> None:
+    """Interactively set isvctl configuration.
+
+    Walks every variable isvctl knows about (or just one provider's, with
+    ``--provider``), pre-filling current values. Press Enter to keep a value;
+    secrets are entered hidden. Non-secrets are saved to config.yml, secrets to
+    a 0600 secrets.yml.
+
+    Examples:
+        isvctl configure
+        isvctl configure --provider nico
+        isvctl configure show
+        isvctl configure path
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+
+    variables = _resolve_vars(provider)
+    current = _load_current()
+
+    typer.echo("Configuring isvctl. Press Enter to keep the current value.\n")
+
+    answers: dict[str, str] = {}
+    last_group: str | None = None
+    for var in variables:
+        if var.group != last_group:
+            typer.echo(typer.style(var.group, bold=True))
+            last_group = var.group
+
+        secret = is_secret_env_var(var.name)
+        existing = current.get(var.name)
+        prompt_text = f"  {var.name} ({var.hint})"
+
+        if secret:
+            if existing:
+                prompt_text += f" [{_SECRET_PLACEHOLDER}]"
+            value = typer.prompt(prompt_text, default="", hide_input=True, show_default=False)
+        else:
+            value = typer.prompt(prompt_text, default=existing or "", show_default=bool(existing))
+
+        if value:
+            answers[var.name] = value
+
+    if not answers:
+        typer.echo("\nNothing to save.")
+        return
+
+    try:
+        result = write_user_config(answers, existing=current)
+    except (ValueError, OSError) as exc:
+        print_error(f"Failed to write user config: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    config_count = sum(1 for name in answers if not is_secret_env_var(name))
+    secret_count = len(answers) - config_count
+    typer.echo("")
+    if config_count:
+        print_step(f"Wrote {config_count} var(s) to {result.config_path}")
+    if secret_count:
+        print_step(f"Wrote {secret_count} secret(s) to {result.secrets_path} (mode 0600)")
+
+    verify = "isvctl doctor" + (f" --provider {provider}" if provider else "")
+    typer.echo(f"\nVerify with: {verify}")
+
+
+@app.command("show")
+def show(
+    provider: Annotated[
+        str | None,
+        typer.Option("--provider", help="Only show this provider's vars."),
+    ] = None,
+) -> None:
+    """Show persisted configuration (secret values are never printed)."""
+    variables = _resolve_vars(provider)
+    current = _load_current()
+    configured = [var for var in variables if var.name in current]
+
+    typer.echo(f"config.yml:  {get_config_path()}")
+    typer.echo(f"secrets.yml: {get_secrets_path()}")
+
+    if not configured:
+        typer.echo("\nNo configuration found. Run `isvctl configure`.")
+        return
+
+    typer.echo("")
+    pairs = [(env_to_section_key(var.name), var) for var in configured]
+    width = max(len(key) for (_, key), _ in pairs)
+    last_section: str | None = None
+    for (section, key), var in pairs:
+        if section != last_section:
+            typer.echo(typer.style(f"{section}:", bold=True))
+            last_section = section
+        display = _SECRET_PLACEHOLDER if is_secret_env_var(var.name) else current[var.name]
+        typer.echo(f"  {key.ljust(width)} = {display}")
+
+
+@app.command("path")
+def path() -> None:
+    """Print the config and secrets file paths."""
+    typer.echo(str(get_config_path()))
+    typer.echo(str(get_secrets_path()))

--- a/isvctl/src/isvctl/cli/doctor.py
+++ b/isvctl/src/isvctl/cli/doctor.py
@@ -27,6 +27,7 @@ import typer
 from isvreporter.version import get_version
 
 from isvctl.cli import setup_logging
+from isvctl.cli.common import apply_user_config
 from isvctl.doctor.checks import check_configs, check_env, check_tools
 from isvctl.doctor.report import render_json, render_rich
 from isvctl.doctor.result import CategoryReport, Status, worst
@@ -97,8 +98,19 @@ def doctor(
             help="Treat warnings as failures for exit-code purposes.",
         ),
     ] = False,
+    no_user_config: Annotated[
+        bool,
+        typer.Option(
+            "--no-user-config",
+            help="Do not apply persisted user config (config.yml / secrets.yml).",
+        ),
+    ] = False,
 ) -> None:
     """Diagnose the local environment for `isvctl test run`.
+
+    Persisted user config (from `isvctl configure`) is applied first, so the
+    env category reflects what an actual run would see. Use `--no-user-config`
+    to check only the live process environment.
 
     Examples:
         isvctl doctor
@@ -113,6 +125,7 @@ def doctor(
         return
 
     setup_logging(verbose)
+    apply_user_config(no_user_config)
 
     providers = _parse_csv(provider)
     requested = _parse_csv(check) or list(_CATEGORY_NAMES)

--- a/isvctl/src/isvctl/cli/test.py
+++ b/isvctl/src/isvctl/cli/test.py
@@ -32,6 +32,7 @@ from isvtest.catalog import build_catalog, get_catalog_version
 from isvctl.cli import setup_logging
 from isvctl.cli.common import (
     OUTPUT_DIR_NAME,
+    apply_user_config,
     get_output_dir,
     print_error,
     print_progress,
@@ -138,6 +139,13 @@ def run(
             help="Enable verbose logging",
         ),
     ] = False,
+    no_user_config: Annotated[
+        bool,
+        typer.Option(
+            "--no-user-config",
+            help="Do not apply persisted user config (config.yml / secrets.yml).",
+        ),
+    ] = False,
     junitxml: Annotated[
         Path,
         typer.Option(
@@ -198,6 +206,7 @@ def run(
         isvctl test run -f config.yaml -- -v -s -k "test_name"
     """
     setup_logging(verbose)
+    apply_user_config(no_user_config)
 
     # Validate at least one config file is provided
     if not config_files:
@@ -470,12 +479,21 @@ def validate(
             help="Set values on the command line",
         ),
     ] = None,
+    no_user_config: Annotated[
+        bool,
+        typer.Option(
+            "--no-user-config",
+            help="Do not apply persisted user config (config.yml / secrets.yml).",
+        ),
+    ] = False,
 ) -> None:
     """Validate merged configuration without running.
 
     Useful for checking configuration syntax and schema compliance
     before executing a test run.
     """
+    apply_user_config(no_user_config)
+
     # Validate at least one config file is provided
     if not config_files:
         print_error("At least one --config/-f config file is required.")

--- a/isvctl/src/isvctl/config/env_catalog.py
+++ b/isvctl/src/isvctl/config/env_catalog.py
@@ -1,0 +1,287 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Catalog of environment variables isvctl knows about.
+
+Single source of truth for which env vars matter, how strictly each is needed,
+and which provider group it belongs to. Both `isvctl doctor` (which validates
+presence) and `isvctl configure` (which persists values) consume this table so
+they never drift.
+"""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class Requirement(StrEnum):
+    """How strictly an env var is needed."""
+
+    REQUIRED = "required"  # missing → FAIL
+    RECOMMENDED = "recommended"  # missing → WARN
+    OPTIONAL = "optional"  # missing → SKIP (informational only)
+
+
+@dataclass(frozen=True)
+class EnvVar:
+    """One environment variable in the catalog."""
+
+    name: str
+    group: str
+    requirement: Requirement
+    hint: str
+    # Per-run toggles (the "Flags" group) are intentionally NOT persistable:
+    # they belong on the command line or in an explicit export each time, not in
+    # config.yml. `doctor` still reports them; `configure` skips them and the
+    # loader rejects them.
+    persistable: bool = True
+
+
+# Variable table — single source of truth for which env vars isvctl knows
+# about and how it classifies them. Keep grouped for stable rendering order.
+ENV_VARS: tuple[EnvVar, ...] = (
+    # ISV Lab Service
+    EnvVar(
+        "ISV_SERVICE_ENDPOINT",
+        "ISV Lab Service",
+        Requirement.RECOMMENDED,
+        "needed to upload results to ISV Lab Service",
+    ),
+    EnvVar(
+        "ISV_SSA_ISSUER",
+        "ISV Lab Service",
+        Requirement.RECOMMENDED,
+        "needed for SSA auth against ISV Lab Service",
+    ),
+    EnvVar(
+        "ISV_CLIENT_ID",
+        "ISV Lab Service",
+        Requirement.RECOMMENDED,
+        "needed to authenticate result uploads",
+    ),
+    EnvVar(
+        "ISV_CLIENT_SECRET",
+        "ISV Lab Service",
+        Requirement.RECOMMENDED,
+        "needed to authenticate result uploads",
+    ),
+    # NGC
+    EnvVar(
+        "NGC_API_KEY",
+        "NGC",
+        Requirement.RECOMMENDED,
+        "needed for NIM workloads and the NGC container registry",
+    ),
+    EnvVar(
+        "NGC_NIM_API_KEY",
+        "NGC",
+        Requirement.OPTIONAL,
+        "alternative to NGC_API_KEY for NIM workloads",
+    ),
+    # AWS — informational only. Static keys are just one of several credential
+    # sources boto3 accepts; `--provider aws` runs `_check_aws_provider` which
+    # validates the whole chain instead of demanding these specific vars.
+    EnvVar(
+        "AWS_ACCESS_KEY_ID",
+        "AWS",
+        Requirement.OPTIONAL,
+        "one way to supply AWS credentials (see also AWS_PROFILE / SSO)",
+    ),
+    EnvVar(
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS",
+        Requirement.OPTIONAL,
+        "one way to supply AWS credentials (see also AWS_PROFILE / SSO)",
+    ),
+    EnvVar(
+        "AWS_REGION",
+        "AWS",
+        Requirement.OPTIONAL,
+        "AWS region; may also come from AWS_DEFAULT_REGION or ~/.aws/config",
+    ),
+    # Flags — informational only, and never persisted (per-run toggles).
+    EnvVar(
+        "KUBECTL",
+        "Flags",
+        Requirement.OPTIONAL,
+        "override the kubectl command (POSIX shlex split)",
+        persistable=False,
+    ),
+    EnvVar(
+        "ISVCTL_DEMO_MODE",
+        "Flags",
+        Requirement.OPTIONAL,
+        "set to '1' to use my-isv demo stubs",
+        persistable=False,
+    ),
+    EnvVar(
+        "ISVTEST_INCLUDE_UNRELEASED",
+        "Flags",
+        Requirement.OPTIONAL,
+        "include unreleased validations",
+        persistable=False,
+    ),
+    EnvVar(
+        "AWS_SKIP_TEARDOWN",
+        "Flags",
+        Requirement.OPTIONAL,
+        "skip AWS teardown phase",
+        persistable=False,
+    ),
+    # NICo — optional by default; --provider nico runs strict provider-specific
+    # checks for the same variables.
+    EnvVar(
+        "NICO_API_BASE",
+        "NICo",
+        Requirement.OPTIONAL,
+        "NICo API base URL",
+    ),
+    EnvVar(
+        "NICO_ORGANIZATION",
+        "NICo",
+        Requirement.OPTIONAL,
+        "NICo organization name used in the API path",
+    ),
+    EnvVar(
+        "NICO_SITE_ID",
+        "NICo",
+        Requirement.OPTIONAL,
+        "Forge site UUID for NICo hardware checks",
+    ),
+    EnvVar(
+        "NICO_BEARER_TOKEN",
+        "NICo",
+        Requirement.OPTIONAL,
+        "local NICo bearer token for API authentication",
+    ),
+    EnvVar(
+        "NICO_SSA_ISSUER",
+        "NICo",
+        Requirement.OPTIONAL,
+        "SSA issuer URL for NICo client_credentials auth",
+    ),
+    EnvVar(
+        "NICO_CLIENT_ID",
+        "NICo",
+        Requirement.OPTIONAL,
+        "OIDC client ID for NICo client_credentials auth",
+    ),
+    EnvVar(
+        "NICO_CLIENT_SECRET",
+        "NICo",
+        Requirement.OPTIONAL,
+        "OIDC client secret for NICo client_credentials auth",
+    ),
+    EnvVar(
+        "NICO_OIDC_SCOPE",
+        "NICo",
+        Requirement.OPTIONAL,
+        "optional OIDC scope for NICo client_credentials auth",
+    ),
+)
+
+
+# Maps a provider name (as passed to `--provider`) to its catalog group, so
+# `isvctl configure --provider nico` and `isvctl doctor --provider nico` scope
+# to the same variables.
+PROVIDER_GROUPS: dict[str, str] = {
+    "aws": "AWS",
+    "nico": "NICo",
+}
+
+
+@dataclass(frozen=True)
+class Section:
+    """A provider-namespaced section in the persisted config files.
+
+    `name` is the YAML key (e.g. ``nico``); `group` is the catalog group it
+    holds; `env_prefix` is the common prefix shared by every env var in that
+    group, used to translate between ``nico.api_base`` and ``NICO_API_BASE``.
+    """
+
+    name: str
+    group: str
+    env_prefix: str
+
+
+# On-disk config.yml / secrets.yml are organized into these provider-namespaced
+# sections instead of a flat env map. Each persistable catalog group maps to one
+# section; the "Flags" group has none (flags are never persisted).
+SECTIONS: tuple[Section, ...] = (
+    Section("isv_lab_service", "ISV Lab Service", "ISV_"),
+    Section("ngc", "NGC", "NGC_"),
+    Section("aws", "AWS", "AWS_"),
+    Section("nico", "NICo", "NICO_"),
+)
+
+_GROUP_TO_SECTION: dict[str, Section] = {s.group: s for s in SECTIONS}
+_SECTION_BY_NAME: dict[str, Section] = {s.name: s for s in SECTIONS}
+
+
+def _build_section_maps() -> tuple[dict[str, tuple[str, str]], dict[tuple[str, str], str]]:
+    """Build the env-name <-> (section, key) translation tables from the catalog.
+
+    Validates the catalog invariant that every persistable var belongs to a
+    section whose prefix it carries — so a drifting catalog fails loudly here.
+    """
+    env_to_sk: dict[str, tuple[str, str]] = {}
+    sk_to_env: dict[tuple[str, str], str] = {}
+    for var in ENV_VARS:
+        section = _GROUP_TO_SECTION.get(var.group)
+        if section is None:
+            if var.persistable:
+                raise ValueError(f"persistable var {var.name!r} has no section for group {var.group!r}")
+            continue
+        if not var.name.startswith(section.env_prefix):
+            raise ValueError(f"{var.name!r} does not start with section prefix {section.env_prefix!r}")
+        key = var.name[len(section.env_prefix) :].lower()
+        env_to_sk[var.name] = (section.name, key)
+        sk_to_env[(section.name, key)] = var.name
+    return env_to_sk, sk_to_env
+
+
+_ENV_TO_SECTION_KEY, _SECTION_KEY_TO_ENV = _build_section_maps()
+
+
+def is_known_section(name: str) -> bool:
+    """Return True if `name` is a valid top-level section key."""
+    return name in _SECTION_BY_NAME
+
+
+def env_to_section_key(name: str) -> tuple[str, str]:
+    """Translate an env var name to its ``(section, key)`` pair."""
+    return _ENV_TO_SECTION_KEY[name]
+
+
+def section_key_to_env(section: str, key: str) -> str | None:
+    """Translate a ``(section, key)`` pair to its env var name, or None."""
+    return _SECTION_KEY_TO_ENV.get((section, key))
+
+
+def vars_for_provider(provider: str | None) -> list[EnvVar]:
+    """Return catalog vars for a provider group, or all vars when None.
+
+    Args:
+        provider: A provider name from `PROVIDER_GROUPS`, or None for every var.
+
+    Raises:
+        ValueError: If `provider` is not a known provider name.
+    """
+    if provider is None:
+        return list(ENV_VARS)
+    group = PROVIDER_GROUPS.get(provider)
+    if group is None:
+        valid = ", ".join(sorted(PROVIDER_GROUPS))
+        raise ValueError(f"unknown provider '{provider}'. Valid: {valid}")
+    return [var for var in ENV_VARS if var.group == group]

--- a/isvctl/src/isvctl/config/user.py
+++ b/isvctl/src/isvctl/config/user.py
@@ -203,6 +203,7 @@ def _read_env_file(path: Path, *, secret_file: bool) -> dict[str, str]:
             env_name = section_key_to_env(section_name, key)
             if env_name is None:
                 raise ValueError(f"{path}: unknown key '{section_name}.{key}'")
+            _check_persistable(env_name, f"{path}: '{section_name}.{key}' maps to ")
             if not isinstance(value, str):
                 raise ValueError(f"{path}: '{section_name}.{key}' value must be a string (quote it in YAML)")
             if secret_file and not is_secret_env_var(env_name):

--- a/isvctl/src/isvctl/config/user.py
+++ b/isvctl/src/isvctl/config/user.py
@@ -1,0 +1,324 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""User-level persisted configuration for isvctl.
+
+Lets users persist the env vars an `isvctl test run` needs once, instead of
+re-exporting them in every shell. On disk the values are organized into
+provider-namespaced sections (``nico``, ``aws``, ``ngc``, ``isv_lab_service``)
+with short keys, e.g. ``nico.api_base`` rather than ``NICO_API_BASE``. They are
+split across two files so secrets stay isolated and permission-locked:
+
+- ``config.yml``  (0644) - non-secret values, safe to read aloud or share.
+- ``secrets.yml`` (0600) - secret values.
+
+Both live under ``${XDG_CONFIG_HOME:-~/.config}/isvctl/``. ``ISVCTL_CONFIG`` and
+``ISVCTL_SECRETS`` override the individual paths (used by tests and advanced
+users). The public API is keyed by env var name; the section/key translation
+is purely a serialization detail handled here. Loaded values only *fill* env
+vars not already present in the process environment, so an explicit ``export``
+always wins.
+
+Both files carry a top-level ``version:`` recording the on-disk schema. A file
+written by a newer isvctl is rejected with a clear error rather than silently
+mis-parsed; a file predating versioning (no ``version:``) is read as version 1.
+"""
+
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from isvctl.config.env_catalog import (
+    ENV_VARS,
+    SECTIONS,
+    env_to_section_key,
+    is_known_section,
+    section_key_to_env,
+)
+from isvctl.redaction import is_secret_env_var
+
+# Only persistable vars may live in the files. Per-run toggles (the "Flags"
+# group) are known to the catalog but rejected here — they belong on the CLI or
+# an explicit export each time.
+_PERSISTABLE_NAMES: frozenset[str] = frozenset(var.name for var in ENV_VARS if var.persistable)
+_NON_PERSISTABLE_NAMES: frozenset[str] = frozenset(var.name for var in ENV_VARS if not var.persistable)
+
+
+def _check_persistable(name: str, where: str) -> None:
+    """Raise a clear error if ``name`` is unknown or a non-persistable flag."""
+    if name in _NON_PERSISTABLE_NAMES:
+        raise ValueError(
+            f"{where}'{name}' is a per-run flag and is not persisted; pass it on the command line or export it"
+        )
+    if name not in _PERSISTABLE_NAMES:
+        raise ValueError(f"{where}unknown env var '{name}' (not in the isvctl catalog)")
+
+
+_FILE_HEADER = (
+    "# Managed by `isvctl configure`. Values are grouped into provider sections\n"
+    "# (e.g. `nico.api_base`). `version` is the on-disk schema version - leave it\n"
+    "# as-is. Edit by hand or re-run `isvctl configure`.\n"
+)
+
+# On-disk schema version for config.yml / secrets.yml. Bump only on a breaking
+# change to the file layout (section/key renames, a different secret split, ...).
+# A file with no `version:` predates versioning and is read as this initial 1.
+SCHEMA_VERSION = 1
+_VERSION_KEY = "version"
+
+_DIR_MODE = 0o700
+_CONFIG_MODE = 0o644
+_SECRETS_MODE = 0o600
+
+
+@dataclass(frozen=True)
+class WriteResult:
+    """Outcome of persisting user config to disk (the files each value landed in)."""
+
+    config_path: Path
+    secrets_path: Path
+
+
+def _base_dir() -> Path:
+    """Return the isvctl config directory, honoring XDG_CONFIG_HOME."""
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "isvctl"
+
+
+def get_config_path() -> Path:
+    """Path to the non-secret config file (``ISVCTL_CONFIG`` overrides)."""
+    override = os.environ.get("ISVCTL_CONFIG")
+    return Path(override) if override else _base_dir() / "config.yml"
+
+
+def get_secrets_path() -> Path:
+    """Path to the secret config file (``ISVCTL_SECRETS`` overrides)."""
+    override = os.environ.get("ISVCTL_SECRETS")
+    return Path(override) if override else _base_dir() / "secrets.yml"
+
+
+def _check_schema_version(path: Path, version: object) -> None:
+    """Validate the on-disk schema ``version`` of a single config file.
+
+    A missing version (``None``) is treated as the initial schema - the files
+    written before versioning - and accepted. A version newer than this build
+    understands is rejected rather than silently mis-parsed against a layout it
+    was not written for.
+
+    Raises:
+        ValueError: If ``version`` is not a positive integer, or is newer than
+            ``SCHEMA_VERSION``.
+    """
+    if version is None:
+        return
+    # bool is an int subclass; `version: true` must not slip through.
+    if isinstance(version, bool) or not isinstance(version, int):
+        raise ValueError(f"{path}: '{_VERSION_KEY}' must be an integer")
+    if version < 1:
+        raise ValueError(f"{path}: invalid schema version {version}")
+    if version > SCHEMA_VERSION:
+        raise ValueError(
+            f"{path}: schema version {version} was written by a newer isvctl "
+            f"(this build supports up to {SCHEMA_VERSION}); upgrade isvctl"
+        )
+
+
+def _read_env_file(path: Path, *, secret_file: bool) -> dict[str, str]:
+    """Read and validate one section-organized config file.
+
+    Translates ``section.key`` entries back to env var names.
+
+    Args:
+        path: File to read. A missing file yields ``{}``.
+        secret_file: True for ``secrets.yml`` (must hold only secret values),
+            False for ``config.yml`` (must hold only non-secret values).
+
+    Returns:
+        A flat ``{ENV_NAME: value}`` mapping.
+
+    Raises:
+        ValueError: On malformed structure, unknown sections/keys, values in
+            the wrong file, or non-string values.
+    """
+    if not path.exists():
+        return {}
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{path}: invalid YAML: {exc}") from exc
+
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: expected a mapping of sections at the top level")
+
+    # Pop the schema version before the section loop so it is not mistaken for
+    # an (unknown) section.
+    _check_schema_version(path, raw.pop(_VERSION_KEY, None))
+
+    result: dict[str, str] = {}
+    for section_name, body in raw.items():
+        if not is_known_section(section_name):
+            raise ValueError(f"{path}: unknown section '{section_name}'")
+        if body is None:
+            continue
+        if not isinstance(body, dict):
+            raise ValueError(f"{path}: section '{section_name}' must be a mapping of key: value")
+        for key, value in body.items():
+            env_name = section_key_to_env(section_name, key)
+            if env_name is None:
+                raise ValueError(f"{path}: unknown key '{section_name}.{key}'")
+            if not isinstance(value, str):
+                raise ValueError(f"{path}: '{section_name}.{key}' value must be a string (quote it in YAML)")
+            if secret_file and not is_secret_env_var(env_name):
+                raise ValueError(f"{path}: '{section_name}.{key}' is not a secret; it belongs in config.yml")
+            if not secret_file and is_secret_env_var(env_name):
+                raise ValueError(f"{path}: '{section_name}.{key}' is a secret; it belongs in secrets.yml")
+            result[env_name] = value
+    return result
+
+
+def load_user_env(config_path: Path | None = None, secrets_path: Path | None = None) -> dict[str, str]:
+    """Load and merge persisted env vars from both files.
+
+    Returns:
+        A ``{name: value}`` mapping. Secret values override nothing — the two
+        files hold disjoint keys by construction.
+    """
+    config = _read_env_file(config_path or get_config_path(), secret_file=False)
+    secrets = _read_env_file(secrets_path or get_secrets_path(), secret_file=True)
+    return {**config, **secrets}
+
+
+def apply_user_env(env: dict[str, str]) -> list[str]:
+    """Apply loaded env vars to ``os.environ`` without clobbering exports.
+
+    A var already present in the process environment (even set-but-empty) is
+    left untouched, preserving the precedence: process env > files.
+
+    Returns:
+        The names actually applied (for debug logging — never the values).
+    """
+    applied: list[str] = []
+    for name, value in env.items():
+        if name not in os.environ:
+            os.environ[name] = value
+            applied.append(name)
+    return applied
+
+
+def _to_sections(env: dict[str, str]) -> dict[str, dict[str, str]]:
+    """Group a flat ``{ENV_NAME: value}`` map into ordered ``section: {key: value}``."""
+    grouped: dict[str, dict[str, str]] = {}
+    for name, value in env.items():
+        section, key = env_to_section_key(name)
+        grouped.setdefault(section, {})[key] = value
+    # Stable output: sections in catalog order, keys sorted within each.
+    ordered: dict[str, dict[str, str]] = {}
+    for section in SECTIONS:
+        if section.name in grouped:
+            ordered[section.name] = dict(sorted(grouped[section.name].items()))
+    return ordered
+
+
+def _write_env_file(path: Path, env: dict[str, str], mode: int) -> None:
+    """Write a section-organized config file with the given mode (0700 dir).
+
+    The parent directory is tightened to 0700 only when we create it. A
+    pre-existing directory is left as-is — it may be one the user pointed us at
+    via ``ISVCTL_CONFIG``/``ISVCTL_SECRETS`` (``$HOME``, ``/tmp``, a shared
+    dir), and silently re-permissioning it would break unrelated files. The
+    per-file ``mode`` (0600 for secrets) protects the file regardless.
+    """
+    parent = path.parent
+    parent_existed = parent.exists()
+    parent.mkdir(parents=True, exist_ok=True)
+    if not parent_existed:
+        os.chmod(parent, _DIR_MODE)
+
+    # `version` first, then the provider sections; sort_keys=False keeps order.
+    data: dict[str, object] = {_VERSION_KEY: SCHEMA_VERSION, **_to_sections(env)}
+    body = _FILE_HEADER + yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+    # Create with the target mode up front so a secrets file is never briefly
+    # world-readable between creation and chmod. O_NOFOLLOW refuses to write
+    # through a symlink planted at `path`, so secrets can't be redirected to an
+    # arbitrary target; fchmod then enforces the mode on the opened fd (O_CREAT
+    # only honors `mode` for a freshly created file, and operating on the fd
+    # avoids re-resolving the path).
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, mode)
+    try:
+        os.write(fd, body.encode("utf-8"))
+        os.fchmod(fd, mode)
+    finally:
+        os.close(fd)
+
+
+def write_user_config(
+    values: dict[str, str],
+    config_path: Path | None = None,
+    secrets_path: Path | None = None,
+    *,
+    existing: dict[str, str] | None = None,
+) -> WriteResult:
+    """Persist env vars, routing each to config.yml or secrets.yml.
+
+    New values are merged over whatever the files already hold, so a
+    provider-scoped run never wipes other providers' values. A file is
+    (re)written only when it actually gains a value, so configuring non-secrets
+    never rewrites secrets.yml (and vice versa).
+
+    Args:
+        existing: Already-loaded current values (as returned by
+            ``load_user_env``) for the same paths, supplied to avoid re-reading
+            both files. Defaults to reading them from disk.
+
+    Raises:
+        ValueError: If a value is not a string or names an unknown env var.
+    """
+    config_path = config_path or get_config_path()
+    secrets_path = secrets_path or get_secrets_path()
+
+    new_config: dict[str, str] = {}
+    new_secrets: dict[str, str] = {}
+    for name, value in values.items():
+        _check_persistable(name, "")
+        if not isinstance(value, str):
+            raise ValueError(f"'{name}' value must be a string")
+        if is_secret_env_var(name):
+            new_secrets[name] = value
+        else:
+            new_config[name] = value
+
+    if existing is None:
+        existing = load_user_env(config_path, secrets_path)
+    current_config = {k: v for k, v in existing.items() if not is_secret_env_var(k)}
+    current_secrets = {k: v for k, v in existing.items() if is_secret_env_var(k)}
+
+    if new_config:
+        _write_env_file(config_path, {**current_config, **new_config}, _CONFIG_MODE)
+    if new_secrets:
+        _write_env_file(secrets_path, {**current_secrets, **new_secrets}, _SECRETS_MODE)
+
+    return WriteResult(config_path=config_path, secrets_path=secrets_path)
+
+
+def file_mode(path: Path) -> int:
+    """Return the file's permission bits (e.g. 0o600), for diagnostics."""
+    return stat.S_IMODE(path.stat().st_mode)

--- a/isvctl/src/isvctl/config/user.py
+++ b/isvctl/src/isvctl/config/user.py
@@ -38,6 +38,7 @@ mis-parsed; a file predating versioning (no ``version:``) is read as version 1.
 
 import os
 import stat
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -270,6 +271,17 @@ def _write_env_file(path: Path, env: dict[str, str], mode: int) -> None:
         os.close(fd)
 
 
+def _write_or_remove_env_file(path: Path, env: dict[str, str], mode: int) -> None:
+    """Write ``env`` to ``path``, or remove the file when no values remain."""
+    if env:
+        _write_env_file(path, env, mode)
+        return
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+
+
 def write_user_config(
     values: dict[str, str],
     config_path: Path | None = None,
@@ -316,6 +328,58 @@ def write_user_config(
     if new_secrets:
         _write_env_file(secrets_path, {**current_secrets, **new_secrets}, _SECRETS_MODE)
 
+    return WriteResult(config_path=config_path, secrets_path=secrets_path)
+
+
+def unset_user_config(
+    names: Iterable[str],
+    config_path: Path | None = None,
+    secrets_path: Path | None = None,
+    *,
+    existing: dict[str, str] | None = None,
+) -> WriteResult:
+    """Remove persisted env vars by name while preserving unrelated values.
+
+    Args:
+        names: Env var names to remove from config.yml/secrets.yml.
+        existing: Already-loaded current values for the same paths, supplied to
+            avoid re-reading both files. Defaults to reading them from disk.
+
+    Raises:
+        ValueError: If any name is unknown or non-persistable.
+    """
+    config_path = config_path or get_config_path()
+    secrets_path = secrets_path or get_secrets_path()
+
+    remove_names = set(names)
+    for name in remove_names:
+        _check_persistable(name, "")
+
+    if existing is None:
+        existing = load_user_env(config_path, secrets_path)
+
+    current_config = {k: v for k, v in existing.items() if not is_secret_env_var(k)}
+    current_secrets = {k: v for k, v in existing.items() if is_secret_env_var(k)}
+    remaining_config = {k: v for k, v in current_config.items() if k not in remove_names}
+    remaining_secrets = {k: v for k, v in current_secrets.items() if k not in remove_names}
+
+    if remaining_config != current_config:
+        _write_or_remove_env_file(config_path, remaining_config, _CONFIG_MODE)
+    if remaining_secrets != current_secrets:
+        _write_or_remove_env_file(secrets_path, remaining_secrets, _SECRETS_MODE)
+
+    return WriteResult(config_path=config_path, secrets_path=secrets_path)
+
+
+def clear_user_config(config_path: Path | None = None, secrets_path: Path | None = None) -> WriteResult:
+    """Remove both persisted config files, if present."""
+    config_path = config_path or get_config_path()
+    secrets_path = secrets_path or get_secrets_path()
+    for path in (config_path, secrets_path):
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            continue
     return WriteResult(config_path=config_path, secrets_path=secrets_path)
 
 

--- a/isvctl/src/isvctl/config/user.py
+++ b/isvctl/src/isvctl/config/user.py
@@ -38,6 +38,7 @@ mis-parsed; a file predating versioning (no ``version:``) is read as version 1.
 
 import os
 import stat
+import tempfile
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -112,6 +113,22 @@ def get_secrets_path() -> Path:
     """Path to the secret config file (``ISVCTL_SECRETS`` overrides)."""
     override = os.environ.get("ISVCTL_SECRETS")
     return Path(override) if override else _base_dir() / "secrets.yml"
+
+
+def _check_distinct_paths(config_path: Path, secrets_path: Path) -> None:
+    """Raise if config.yml and secrets.yml resolve to the same file."""
+    config_resolved = config_path.resolve()
+    secrets_resolved = secrets_path.resolve()
+    if config_resolved == secrets_resolved:
+        raise ValueError(f"config and secrets paths must be different (both resolve to {config_resolved})")
+
+
+def _user_config_paths(config_path: Path | None, secrets_path: Path | None) -> tuple[Path, Path]:
+    """Return validated config/secrets paths for a read or write operation."""
+    resolved_config_path = config_path or get_config_path()
+    resolved_secrets_path = secrets_path or get_secrets_path()
+    _check_distinct_paths(resolved_config_path, resolved_secrets_path)
+    return resolved_config_path, resolved_secrets_path
 
 
 def _check_schema_version(path: Path, version: object) -> None:
@@ -203,8 +220,9 @@ def load_user_env(config_path: Path | None = None, secrets_path: Path | None = N
         A ``{name: value}`` mapping. Secret values override nothing — the two
         files hold disjoint keys by construction.
     """
-    config = _read_env_file(config_path or get_config_path(), secret_file=False)
-    secrets = _read_env_file(secrets_path or get_secrets_path(), secret_file=True)
+    config_path, secrets_path = _user_config_paths(config_path, secrets_path)
+    config = _read_env_file(config_path, secret_file=False)
+    secrets = _read_env_file(secrets_path, secret_file=True)
     return {**config, **secrets}
 
 
@@ -239,6 +257,16 @@ def _to_sections(env: dict[str, str]) -> dict[str, dict[str, str]]:
     return ordered
 
 
+def _write_all(fd: int, data: bytes) -> None:
+    """Write all bytes to ``fd`` or raise on short/failed writes."""
+    remaining = memoryview(data)
+    while remaining:
+        written = os.write(fd, remaining)
+        if written == 0:
+            raise OSError("short write")
+        remaining = remaining[written:]
+
+
 def _write_env_file(path: Path, env: dict[str, str], mode: int) -> None:
     """Write a section-organized config file with the given mode (0700 dir).
 
@@ -253,22 +281,29 @@ def _write_env_file(path: Path, env: dict[str, str], mode: int) -> None:
     parent.mkdir(parents=True, exist_ok=True)
     if not parent_existed:
         os.chmod(parent, _DIR_MODE)
+    if path.is_symlink():
+        raise OSError(f"refusing to write through symlink: {path}")
 
     # `version` first, then the provider sections; sort_keys=False keeps order.
     data: dict[str, object] = {_VERSION_KEY: SCHEMA_VERSION, **_to_sections(env)}
     body = _FILE_HEADER + yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
-    # Create with the target mode up front so a secrets file is never briefly
-    # world-readable between creation and chmod. O_NOFOLLOW refuses to write
-    # through a symlink planted at `path`, so secrets can't be redirected to an
-    # arbitrary target; fchmod then enforces the mode on the opened fd (O_CREAT
-    # only honors `mode` for a freshly created file, and operating on the fd
-    # avoids re-resolving the path).
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, mode)
+    tmp_name: str | None = None
     try:
-        os.write(fd, body.encode("utf-8"))
-        os.fchmod(fd, mode)
-    finally:
-        os.close(fd)
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=parent)
+        try:
+            _write_all(fd, body.encode("utf-8"))
+            os.fchmod(fd, mode)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        os.replace(tmp_name, path)
+    except BaseException:
+        if tmp_name is not None:
+            try:
+                Path(tmp_name).unlink()
+            except FileNotFoundError:
+                pass
+        raise
 
 
 def _write_or_remove_env_file(path: Path, env: dict[str, str], mode: int) -> None:
@@ -304,8 +339,7 @@ def write_user_config(
     Raises:
         ValueError: If a value is not a string or names an unknown env var.
     """
-    config_path = config_path or get_config_path()
-    secrets_path = secrets_path or get_secrets_path()
+    config_path, secrets_path = _user_config_paths(config_path, secrets_path)
 
     new_config: dict[str, str] = {}
     new_secrets: dict[str, str] = {}
@@ -348,8 +382,7 @@ def unset_user_config(
     Raises:
         ValueError: If any name is unknown or non-persistable.
     """
-    config_path = config_path or get_config_path()
-    secrets_path = secrets_path or get_secrets_path()
+    config_path, secrets_path = _user_config_paths(config_path, secrets_path)
 
     remove_names = set(names)
     for name in remove_names:
@@ -373,8 +406,7 @@ def unset_user_config(
 
 def clear_user_config(config_path: Path | None = None, secrets_path: Path | None = None) -> WriteResult:
     """Remove both persisted config files, if present."""
-    config_path = config_path or get_config_path()
-    secrets_path = secrets_path or get_secrets_path()
+    config_path, secrets_path = _user_config_paths(config_path, secrets_path)
     for path in (config_path, secrets_path):
         try:
             path.unlink()

--- a/isvctl/src/isvctl/doctor/checks/env.py
+++ b/isvctl/src/isvctl/doctor/checks/env.py
@@ -23,175 +23,19 @@ import base64
 import json
 import os
 from collections.abc import Callable
-from dataclasses import dataclass
-from enum import StrEnum
 from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
+from isvctl.config.env_catalog import ENV_VARS, Requirement
 from isvctl.doctor.result import CategoryReport, CheckResult, Status
 from isvctl.redaction import redact_text
 
 _NICO_TOKEN_TIMEOUT_SECONDS = 30
 
-
-class Requirement(StrEnum):
-    """How strictly an env var is needed."""
-
-    REQUIRED = "required"  # missing → FAIL
-    RECOMMENDED = "recommended"  # missing → WARN
-    OPTIONAL = "optional"  # missing → SKIP (informational only)
-
-
-@dataclass(frozen=True)
-class _Var:
-    """One environment variable to check."""
-
-    name: str
-    group: str
-    requirement: Requirement
-    hint: str
-
-
-# Variable table — single source of truth for which env vars `doctor` knows
-# about and how it classifies them. Keep grouped for stable rendering order.
-_VARS: tuple[_Var, ...] = (
-    # ISV Lab Service
-    _Var(
-        "ISV_SERVICE_ENDPOINT",
-        "ISV Lab Service",
-        Requirement.RECOMMENDED,
-        "needed to upload results to ISV Lab Service",
-    ),
-    _Var(
-        "ISV_SSA_ISSUER",
-        "ISV Lab Service",
-        Requirement.RECOMMENDED,
-        "needed for SSA auth against ISV Lab Service",
-    ),
-    _Var(
-        "ISV_CLIENT_ID",
-        "ISV Lab Service",
-        Requirement.RECOMMENDED,
-        "needed to authenticate result uploads",
-    ),
-    _Var(
-        "ISV_CLIENT_SECRET",
-        "ISV Lab Service",
-        Requirement.RECOMMENDED,
-        "needed to authenticate result uploads",
-    ),
-    # NGC
-    _Var(
-        "NGC_API_KEY",
-        "NGC",
-        Requirement.RECOMMENDED,
-        "needed for NIM workloads and the NGC container registry",
-    ),
-    _Var(
-        "NGC_NIM_API_KEY",
-        "NGC",
-        Requirement.OPTIONAL,
-        "alternative to NGC_API_KEY for NIM workloads",
-    ),
-    # AWS — informational only. Static keys are just one of several credential
-    # sources boto3 accepts; `--provider aws` runs `_check_aws_provider` which
-    # validates the whole chain instead of demanding these specific vars.
-    _Var(
-        "AWS_ACCESS_KEY_ID",
-        "AWS",
-        Requirement.OPTIONAL,
-        "one way to supply AWS credentials (see also AWS_PROFILE / SSO)",
-    ),
-    _Var(
-        "AWS_SECRET_ACCESS_KEY",
-        "AWS",
-        Requirement.OPTIONAL,
-        "one way to supply AWS credentials (see also AWS_PROFILE / SSO)",
-    ),
-    _Var(
-        "AWS_REGION",
-        "AWS",
-        Requirement.OPTIONAL,
-        "AWS region; may also come from AWS_DEFAULT_REGION or ~/.aws/config",
-    ),
-    # Flags — informational only.
-    _Var(
-        "KUBECTL",
-        "Flags",
-        Requirement.OPTIONAL,
-        "override the kubectl command (POSIX shlex split)",
-    ),
-    _Var(
-        "ISVCTL_DEMO_MODE",
-        "Flags",
-        Requirement.OPTIONAL,
-        "set to '1' to use my-isv demo stubs",
-    ),
-    _Var(
-        "ISVTEST_INCLUDE_UNRELEASED",
-        "Flags",
-        Requirement.OPTIONAL,
-        "include unreleased validations",
-    ),
-    _Var(
-        "AWS_SKIP_TEARDOWN",
-        "Flags",
-        Requirement.OPTIONAL,
-        "skip AWS teardown phase",
-    ),
-    # NICo — optional by default; --provider nico runs strict provider-specific
-    # checks for the same variables.
-    _Var(
-        "NICO_API_BASE",
-        "NICo",
-        Requirement.OPTIONAL,
-        "NICo API base URL",
-    ),
-    _Var(
-        "NICO_ORGANIZATION",
-        "NICo",
-        Requirement.OPTIONAL,
-        "NICo organization name used in the API path",
-    ),
-    _Var(
-        "NICO_SITE_ID",
-        "NICo",
-        Requirement.OPTIONAL,
-        "Forge site UUID for NICo hardware checks",
-    ),
-    _Var(
-        "NICO_BEARER_TOKEN",
-        "NICo",
-        Requirement.OPTIONAL,
-        "local NICo bearer token for API authentication",
-    ),
-    _Var(
-        "NICO_SSA_ISSUER",
-        "NICo",
-        Requirement.OPTIONAL,
-        "SSA issuer URL for NICo client_credentials auth",
-    ),
-    _Var(
-        "NICO_CLIENT_ID",
-        "NICo",
-        Requirement.OPTIONAL,
-        "OIDC client ID for NICo client_credentials auth",
-    ),
-    _Var(
-        "NICO_CLIENT_SECRET",
-        "NICo",
-        Requirement.OPTIONAL,
-        "OIDC client secret for NICo client_credentials auth",
-    ),
-    _Var(
-        "NICO_OIDC_SCOPE",
-        "NICo",
-        Requirement.OPTIONAL,
-        "optional OIDC scope for NICo client_credentials auth",
-    ),
-)
+# The variable catalog lives in `isvctl.config.env_catalog` so `doctor` and
+# `isvctl configure` share one source of truth.
 
 
 def _status_for(requirement: Requirement, present: bool) -> Status:
@@ -492,7 +336,7 @@ def check_env(providers: list[str] | None = None) -> CategoryReport:
     provider_strict_vars = {
         name for prov in providers or [] for name in _PROVIDER_STRICT_ENV_VARS.get(prov, frozenset())
     }
-    for var in _VARS:
+    for var in ENV_VARS:
         if var.name in provider_strict_vars:
             continue
         # "set" means exported, even if empty — distinguishing set-but-empty

--- a/isvctl/src/isvctl/main.py
+++ b/isvctl/src/isvctl/main.py
@@ -22,6 +22,7 @@ from isvreporter.main import app as report_app
 from isvreporter.version import get_version
 
 from isvctl.cli import catalog, clean, deploy, docs, doctor, provider, test
+from isvctl.cli import config as configure_cli
 
 app = typer.Typer(
     name="isvctl",
@@ -50,6 +51,7 @@ def main(
 # Register subcommands
 app.add_typer(catalog.app, name="catalog")
 app.add_typer(clean.app, name="clean")
+app.add_typer(configure_cli.app, name="configure")
 app.add_typer(deploy.app, name="deploy")
 app.add_typer(docs.app, name="docs")
 app.add_typer(doctor.app, name="doctor")

--- a/isvctl/src/isvctl/redaction.py
+++ b/isvctl/src/isvctl/redaction.py
@@ -198,17 +198,24 @@ SENSITIVE_ENV_SUFFIXES: tuple[str, ...] = (
 )
 
 
+def is_secret_env_var(name: str) -> bool:
+    """Return True if an environment variable name holds a secret value.
+
+    A variable is secret if it appears in the explicit deny-list or its name
+    ends with a sensitive suffix. This is the single rule used both to filter
+    secrets out of the Jinja2 context and to route values written by
+    `isvctl configure` into the permission-locked secrets file.
+    """
+    return name in SENSITIVE_ENV_VARS or any(name.upper().endswith(s) for s in SENSITIVE_ENV_SUFFIXES)
+
+
 def filter_env(env: dict[str, str]) -> dict[str, str]:
     """Return a copy of env with known-sensitive variables removed.
 
     Variables are excluded if they appear in the explicit deny-list or
     their name ends with a sensitive suffix.
     """
-    return {
-        k: v
-        for k, v in env.items()
-        if k not in SENSITIVE_ENV_VARS and not any(k.upper().endswith(s) for s in SENSITIVE_ENV_SUFFIXES)
-    }
+    return {k: v for k, v in env.items() if not is_secret_env_var(k)}
 
 
 # ---------------------------------------------------------------------------

--- a/isvctl/tests/conftest.py
+++ b/isvctl/tests/conftest.py
@@ -21,10 +21,26 @@ import importlib.util
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 ISVCTL_ROOT = Path(__file__).resolve().parents[1]
 AWS_VM_SCRIPTS = ISVCTL_ROOT / "configs" / "providers" / "aws" / "scripts" / "vm"
 
 _LOADED_MODULES: dict[str, ModuleType] = {}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_user_config(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Point isvctl user config at an empty temp dir for every test.
+
+    Several CLI commands (`configure`, `doctor`, `test`) now load
+    config.yml / secrets.yml. Without this, tests would read the developer's
+    real ~/.config/isvctl and become environment-dependent. Tests that need a
+    populated config override XDG_CONFIG_HOME themselves.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path_factory.mktemp("xdg-config")))
+    monkeypatch.delenv("ISVCTL_CONFIG", raising=False)
+    monkeypatch.delenv("ISVCTL_SECRETS", raising=False)
 
 
 def load_vm_script(script_name: str) -> ModuleType:

--- a/isvctl/tests/test_cli_configure.py
+++ b/isvctl/tests/test_cli_configure.py
@@ -162,3 +162,239 @@ def test_show_never_lists_flags(isolated_env: Path) -> None:
     assert result.exit_code == 0
     assert "KUBECTL" not in result.stdout
     assert "api_base" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# set / unset
+# ---------------------------------------------------------------------------
+
+
+def test_set_writes_nonsecret_from_env_name(isolated_env: Path) -> None:
+    result = runner.invoke(app, ["set", "NICO_API_BASE", "https://nico.example.com"])
+    assert result.exit_code == 0, result.stdout
+
+    config_data = yaml.safe_load(get_config_path().read_text())
+    assert config_data["nico"]["api_base"] == "https://nico.example.com"
+    assert not get_secrets_path().exists()
+
+
+def test_set_accepts_section_key_alias(isolated_env: Path) -> None:
+    result = runner.invoke(app, ["set", "nico.api_base", "https://nico.example.com"])
+    assert result.exit_code == 0, result.stdout
+
+    config_data = yaml.safe_load(get_config_path().read_text())
+    assert config_data["nico"]["api_base"] == "https://nico.example.com"
+
+
+def test_set_accepts_section_key_assignment(isolated_env: Path) -> None:
+    result = runner.invoke(app, ["set", "nico.api_base=https://nico.example.com"])
+    assert result.exit_code == 0, result.stdout
+
+    config_data = yaml.safe_load(get_config_path().read_text())
+    assert config_data["nico"]["api_base"] == "https://nico.example.com"
+
+
+def test_set_accepts_env_name_assignment(isolated_env: Path) -> None:
+    result = runner.invoke(app, ["set", "NICO_API_BASE=https://nico.example.com"])
+    assert result.exit_code == 0, result.stdout
+
+    config_data = yaml.safe_load(get_config_path().read_text())
+    assert config_data["nico"]["api_base"] == "https://nico.example.com"
+
+
+def test_set_accepts_multiple_assignments(isolated_env: Path) -> None:
+    result = runner.invoke(app, ["set", "nico.organization=ncx", "nico.oidc_scope=example"])
+    assert result.exit_code == 0, result.stdout
+
+    config_data = yaml.safe_load(get_config_path().read_text())
+    assert config_data["nico"]["organization"] == "ncx"
+    assert config_data["nico"]["oidc_scope"] == "example"
+
+
+def test_set_split_form_accepts_value_containing_equals(isolated_env: Path) -> None:
+    result = runner.invoke(app, ["set", "nico.oidc_scope", "audience=example"])
+    assert result.exit_code == 0, result.stdout
+
+    config_data = yaml.safe_load(get_config_path().read_text())
+    assert config_data["nico"]["oidc_scope"] == "audience=example"
+
+
+def test_set_rejects_assignment_with_extra_value(isolated_env: Path) -> None:
+    result = runner.invoke(app, ["set", "nico.organization=ncx", "ignored"])
+    assert result.exit_code == 2
+    assert "cannot combine key=value with a separate value" in (result.stderr or result.output)
+
+
+def test_set_rejects_multiple_split_pairs(isolated_env: Path) -> None:
+    result = runner.invoke(app, ["set", "nico.organization", "ncx", "nico.oidc_scope", "example"])
+    assert result.exit_code == 2
+    assert "multiple values must use key=value" in (result.stderr or result.output)
+
+
+def test_set_prompts_for_secret_without_echoing_value(isolated_env: Path) -> None:
+    result = runner.invoke(app, ["set", "NICO_CLIENT_SECRET"], input="super-secret-value\n")
+    assert result.exit_code == 0, result.stdout
+
+    secrets_data = yaml.safe_load(get_secrets_path().read_text())
+    assert secrets_data["nico"]["client_secret"] == "super-secret-value"
+    assert "super-secret-value" not in result.output
+
+
+def test_set_rejects_unknown_key(isolated_env: Path) -> None:
+    result = runner.invoke(app, ["set", "nico.not_real", "value"])
+    assert result.exit_code == 2
+    assert "unknown config key" in (result.stderr or result.output)
+
+
+def test_set_rejects_per_run_flag_before_loading_config(isolated_env: Path) -> None:
+    get_config_path().parent.mkdir(parents=True)
+    get_config_path().write_text("nico:\n  client_secret: leaked\n")
+
+    result = runner.invoke(app, ["set", "KUBECTL", "kubectl"])
+    assert result.exit_code == 2
+    assert "per-run flag" in (result.stderr or result.output)
+    assert "Failed to read user config" not in result.output
+
+
+def test_unset_removes_one_saved_key(isolated_env: Path) -> None:
+    get_config_path().parent.mkdir(parents=True)
+    get_config_path().write_text("nico:\n  api_base: https://nico.example.com\n  organization: example-org\n")
+
+    result = runner.invoke(app, ["unset", "NICO_API_BASE"])
+    assert result.exit_code == 0, result.stdout
+
+    config_data = yaml.safe_load(get_config_path().read_text())
+    assert config_data["nico"] == {"organization": "example-org"}
+
+
+def test_unset_accepts_section_key_alias(isolated_env: Path) -> None:
+    get_config_path().parent.mkdir(parents=True)
+    get_config_path().write_text("nico:\n  api_base: https://nico.example.com\n")
+
+    result = runner.invoke(app, ["unset", "nico.api_base"])
+    assert result.exit_code == 0, result.stdout
+
+    assert not get_config_path().exists()
+
+
+def test_unset_section_removes_saved_values_after_confirmation(isolated_env: Path) -> None:
+    get_config_path().parent.mkdir(parents=True)
+    get_config_path().write_text(
+        "aws:\n"
+        "  region: us-west-2\n"
+        "isv_lab_service:\n"
+        "  service_endpoint: https://service.example.com\n"
+        "nico:\n"
+        "  api_base: https://nico.example.com\n"
+        "  organization: example-org\n"
+    )
+    get_secrets_path().write_text(
+        "isv_lab_service:\n  client_secret: service-secret-value\nnico:\n  client_secret: super-secret-value\n"
+    )
+
+    result = runner.invoke(app, ["unset", "nico"], input="y\n")
+    assert result.exit_code == 0, result.stdout
+    assert "api_base" in result.output
+    assert "client_secret" in result.output
+    assert "super-secret-value" not in result.output
+    assert "service-secret-value" not in result.output
+
+    config_data = yaml.safe_load(get_config_path().read_text())
+    secrets_data = yaml.safe_load(get_secrets_path().read_text())
+    assert "nico" not in config_data
+    assert "nico" not in secrets_data
+    assert config_data["aws"]["region"] == "us-west-2"
+    assert config_data["isv_lab_service"]["service_endpoint"] == "https://service.example.com"
+    assert secrets_data["isv_lab_service"]["client_secret"] == "service-secret-value"
+
+
+def test_unset_section_requires_confirmation(isolated_env: Path) -> None:
+    get_config_path().parent.mkdir(parents=True)
+    get_config_path().write_text("nico:\n  api_base: https://nico.example.com\n")
+    get_secrets_path().write_text("nico:\n  client_secret: super-secret-value\n")
+
+    result = runner.invoke(app, ["unset", "nico"], input="n\n")
+    assert result.exit_code == 1
+    assert "Aborted." in result.output
+    assert "super-secret-value" not in result.output
+
+    config_data = yaml.safe_load(get_config_path().read_text())
+    secrets_data = yaml.safe_load(get_secrets_path().read_text())
+    assert config_data["nico"]["api_base"] == "https://nico.example.com"
+    assert secrets_data["nico"]["client_secret"] == "super-secret-value"
+
+
+def test_unset_section_with_no_saved_values(isolated_env: Path) -> None:
+    get_config_path().parent.mkdir(parents=True)
+    get_config_path().write_text("aws:\n  region: us-west-2\n")
+
+    result = runner.invoke(app, ["unset", "nico"])
+    assert result.exit_code == 0, result.stdout
+    assert "No saved values for nico." in result.output
+
+    config_data = yaml.safe_load(get_config_path().read_text())
+    assert config_data["aws"]["region"] == "us-west-2"
+
+
+def test_unset_section_rejects_malformed_config_without_deleting(isolated_env: Path) -> None:
+    get_config_path().parent.mkdir(parents=True)
+    config_body = "nico:\n  client_secret: leaked\n"
+    secrets_body = "nico:\n  client_secret: super-secret-value\n"
+    get_config_path().write_text(config_body)
+    get_secrets_path().write_text(secrets_body)
+
+    result = runner.invoke(app, ["unset", "nico"], input="y\n")
+    assert result.exit_code == 1
+    assert "Failed to read user config" in (result.stderr or result.output)
+    assert "leaked" not in result.output
+    assert "super-secret-value" not in result.output
+    assert get_config_path().read_text() == config_body
+    assert get_secrets_path().read_text() == secrets_body
+
+
+def test_unset_without_key_requires_all_flag(isolated_env: Path) -> None:
+    result = runner.invoke(app, ["unset"])
+    assert result.exit_code == 2
+    assert "provide a key or pass --all" in (result.stderr or result.output)
+
+
+def test_unset_rejects_per_run_flag_before_loading_config(isolated_env: Path) -> None:
+    get_config_path().parent.mkdir(parents=True)
+    get_config_path().write_text("nico:\n  client_secret: leaked\n")
+
+    result = runner.invoke(app, ["unset", "KUBECTL"])
+    assert result.exit_code == 2
+    assert "per-run flag" in (result.stderr or result.output)
+    assert "Failed to read user config" not in result.output
+
+
+def test_unset_all_requires_confirmation(isolated_env: Path) -> None:
+    write_values = ["set", "NICO_API_BASE", "https://nico.example.com"]
+    assert runner.invoke(app, write_values).exit_code == 0
+
+    result = runner.invoke(app, ["unset", "--all"], input="n\n")
+    assert result.exit_code == 1
+    assert get_config_path().exists()
+
+
+def test_unset_all_removes_config_after_confirmation(isolated_env: Path) -> None:
+    assert runner.invoke(app, ["set", "NICO_API_BASE", "https://nico.example.com"]).exit_code == 0
+    assert runner.invoke(app, ["set", "NICO_CLIENT_SECRET"], input="super-secret-value\n").exit_code == 0
+
+    result = runner.invoke(app, ["unset", "--all"], input="y\n")
+    assert result.exit_code == 0, result.stdout
+
+    assert not get_config_path().exists()
+    assert not get_secrets_path().exists()
+
+
+def test_unset_all_can_clear_malformed_config(isolated_env: Path) -> None:
+    get_config_path().parent.mkdir(parents=True)
+    get_config_path().write_text("nico:\n  client_secret: leaked\n")
+    get_secrets_path().write_text("nico:\n  client_secret: super-secret-value\n")
+
+    result = runner.invoke(app, ["unset", "--all"], input="y\n")
+    assert result.exit_code == 0, result.stdout
+
+    assert not get_config_path().exists()
+    assert not get_secrets_path().exists()

--- a/isvctl/tests/test_cli_configure.py
+++ b/isvctl/tests/test_cli_configure.py
@@ -34,6 +34,7 @@ _PERSISTABLE_PROMPTS = sum(1 for var in vars_for_provider(None) if var.persistab
 
 @pytest.fixture
 def isolated_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point configure commands at an isolated user config directory."""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     monkeypatch.delenv("ISVCTL_CONFIG", raising=False)
     monkeypatch.delenv("ISVCTL_SECRETS", raising=False)
@@ -46,6 +47,7 @@ def isolated_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
 
 
 def test_path_prints_both_files(isolated_env: Path) -> None:
+    """The path command prints both persisted config file locations."""
     result = runner.invoke(app, ["path"])
     assert result.exit_code == 0
     assert str(get_config_path()) in result.stdout
@@ -53,12 +55,14 @@ def test_path_prints_both_files(isolated_env: Path) -> None:
 
 
 def test_show_with_no_files(isolated_env: Path) -> None:
+    """The show command reports when no persisted config exists."""
     result = runner.invoke(app, ["show"])
     assert result.exit_code == 0
     assert "No configuration found" in result.stdout
 
 
 def test_malformed_file_errors_cleanly_not_traceback(isolated_env: Path) -> None:
+    """Malformed persisted config fails cleanly without a traceback."""
     # A bad persisted file must surface a clean error (exit 1), not a traceback —
     # `configure`/`show` are how users fix a broken file.
     config = get_config_path()
@@ -73,6 +77,7 @@ def test_malformed_file_errors_cleanly_not_traceback(isolated_env: Path) -> None
 
 
 def test_show_prints_nonsecret_and_masks_secret(isolated_env: Path) -> None:
+    """The show command prints non-secrets and masks secrets."""
     config = get_config_path()
     secrets = get_secrets_path()
     config.parent.mkdir(parents=True)
@@ -92,6 +97,7 @@ def test_show_prints_nonsecret_and_masks_secret(isolated_env: Path) -> None:
 
 
 def test_wizard_writes_both_files(isolated_env: Path) -> None:
+    """The wizard writes non-secret and secret answers to separate files."""
     # Answer only the two NICo vars we care about; Enter (blank) skips the rest.
     nico_vars = vars_for_provider("nico")
     answers = []
@@ -112,6 +118,7 @@ def test_wizard_writes_both_files(isolated_env: Path) -> None:
 
 
 def test_wizard_secrets_file_is_0600(isolated_env: Path) -> None:
+    """The wizard writes secrets.yml with owner-only permissions."""
     nico_vars = vars_for_provider("nico")
     answers = ["shhh" if var.name == "NICO_CLIENT_SECRET" else "" for var in nico_vars]
     result = runner.invoke(app, ["--provider", "nico"], input="\n".join(answers) + "\n")
@@ -120,6 +127,7 @@ def test_wizard_secrets_file_is_0600(isolated_env: Path) -> None:
 
 
 def test_wizard_blank_keeps_existing(isolated_env: Path) -> None:
+    """Blank wizard answers preserve existing saved values."""
     get_config_path().parent.mkdir(parents=True)
     get_config_path().write_text("nico:\n  api_base: https://keep.example.com\n")
 
@@ -133,6 +141,7 @@ def test_wizard_blank_keeps_existing(isolated_env: Path) -> None:
 
 
 def test_wizard_only_prompts_provider_group(isolated_env: Path) -> None:
+    """A provider-scoped wizard prompts only that provider group."""
     nico_vars = vars_for_provider("nico")
     result = runner.invoke(app, ["--provider", "nico"], input="\n" * len(nico_vars))
     assert result.exit_code == 0, result.stdout
@@ -141,12 +150,14 @@ def test_wizard_only_prompts_provider_group(isolated_env: Path) -> None:
 
 
 def test_unknown_provider_errors(isolated_env: Path) -> None:
+    """An unknown provider name is rejected before prompting."""
     result = runner.invoke(app, ["--provider", "gcp"], input="\n")
     assert result.exit_code == 2
     assert "unknown provider" in (result.stderr or result.output)
 
 
 def test_wizard_never_prompts_flags(isolated_env: Path) -> None:
+    """The bare wizard never prompts for non-persistable flags."""
     # Bare wizard walks every persistable var; flags must not appear.
     result = runner.invoke(app, [], input="\n" * _PERSISTABLE_PROMPTS)
     assert result.exit_code == 0, result.stdout
@@ -155,6 +166,7 @@ def test_wizard_never_prompts_flags(isolated_env: Path) -> None:
 
 
 def test_show_never_lists_flags(isolated_env: Path) -> None:
+    """The show command never lists non-persistable flags."""
     # Even if a flag somehow lands in a file, show resolves only persistable vars.
     get_config_path().parent.mkdir(parents=True)
     get_config_path().write_text("nico:\n  api_base: https://x\n")
@@ -170,6 +182,7 @@ def test_show_never_lists_flags(isolated_env: Path) -> None:
 
 
 def test_set_writes_nonsecret_from_env_name(isolated_env: Path) -> None:
+    """The set command accepts an env var name for non-secret values."""
     result = runner.invoke(app, ["set", "NICO_API_BASE", "https://nico.example.com"])
     assert result.exit_code == 0, result.stdout
 
@@ -179,6 +192,7 @@ def test_set_writes_nonsecret_from_env_name(isolated_env: Path) -> None:
 
 
 def test_set_accepts_section_key_alias(isolated_env: Path) -> None:
+    """The set command accepts section.key aliases."""
     result = runner.invoke(app, ["set", "nico.api_base", "https://nico.example.com"])
     assert result.exit_code == 0, result.stdout
 
@@ -187,6 +201,7 @@ def test_set_accepts_section_key_alias(isolated_env: Path) -> None:
 
 
 def test_set_accepts_section_key_assignment(isolated_env: Path) -> None:
+    """The set command accepts section.key=value assignments."""
     result = runner.invoke(app, ["set", "nico.api_base=https://nico.example.com"])
     assert result.exit_code == 0, result.stdout
 
@@ -195,6 +210,7 @@ def test_set_accepts_section_key_assignment(isolated_env: Path) -> None:
 
 
 def test_set_accepts_env_name_assignment(isolated_env: Path) -> None:
+    """The set command accepts ENV_NAME=value assignments."""
     result = runner.invoke(app, ["set", "NICO_API_BASE=https://nico.example.com"])
     assert result.exit_code == 0, result.stdout
 
@@ -203,6 +219,7 @@ def test_set_accepts_env_name_assignment(isolated_env: Path) -> None:
 
 
 def test_set_accepts_multiple_assignments(isolated_env: Path) -> None:
+    """The set command accepts multiple key=value assignments."""
     result = runner.invoke(app, ["set", "nico.organization=ncx", "nico.oidc_scope=example"])
     assert result.exit_code == 0, result.stdout
 
@@ -212,6 +229,7 @@ def test_set_accepts_multiple_assignments(isolated_env: Path) -> None:
 
 
 def test_set_split_form_accepts_value_containing_equals(isolated_env: Path) -> None:
+    """The split set form preserves equals signs inside the value."""
     result = runner.invoke(app, ["set", "nico.oidc_scope", "audience=example"])
     assert result.exit_code == 0, result.stdout
 
@@ -220,18 +238,21 @@ def test_set_split_form_accepts_value_containing_equals(isolated_env: Path) -> N
 
 
 def test_set_rejects_assignment_with_extra_value(isolated_env: Path) -> None:
+    """The set command rejects key=value combined with a separate value."""
     result = runner.invoke(app, ["set", "nico.organization=ncx", "ignored"])
     assert result.exit_code == 2
     assert "cannot combine key=value with a separate value" in (result.stderr or result.output)
 
 
 def test_set_rejects_multiple_split_pairs(isolated_env: Path) -> None:
+    """The set command rejects multiple split key/value pairs."""
     result = runner.invoke(app, ["set", "nico.organization", "ncx", "nico.oidc_scope", "example"])
     assert result.exit_code == 2
     assert "multiple values must use key=value" in (result.stderr or result.output)
 
 
 def test_set_prompts_for_secret_without_echoing_value(isolated_env: Path) -> None:
+    """The set command prompts for secret values without echoing them."""
     result = runner.invoke(app, ["set", "NICO_CLIENT_SECRET"], input="super-secret-value\n")
     assert result.exit_code == 0, result.stdout
 
@@ -241,12 +262,14 @@ def test_set_prompts_for_secret_without_echoing_value(isolated_env: Path) -> Non
 
 
 def test_set_rejects_unknown_key(isolated_env: Path) -> None:
+    """The set command rejects unknown section.key names."""
     result = runner.invoke(app, ["set", "nico.not_real", "value"])
     assert result.exit_code == 2
     assert "unknown config key" in (result.stderr or result.output)
 
 
 def test_set_rejects_per_run_flag_before_loading_config(isolated_env: Path) -> None:
+    """The set command rejects flags before reading existing config."""
     get_config_path().parent.mkdir(parents=True)
     get_config_path().write_text("nico:\n  client_secret: leaked\n")
 
@@ -257,6 +280,7 @@ def test_set_rejects_per_run_flag_before_loading_config(isolated_env: Path) -> N
 
 
 def test_unset_removes_one_saved_key(isolated_env: Path) -> None:
+    """The unset command removes one saved env var value."""
     get_config_path().parent.mkdir(parents=True)
     get_config_path().write_text("nico:\n  api_base: https://nico.example.com\n  organization: example-org\n")
 
@@ -268,6 +292,7 @@ def test_unset_removes_one_saved_key(isolated_env: Path) -> None:
 
 
 def test_unset_accepts_section_key_alias(isolated_env: Path) -> None:
+    """The unset command accepts section.key aliases."""
     get_config_path().parent.mkdir(parents=True)
     get_config_path().write_text("nico:\n  api_base: https://nico.example.com\n")
 
@@ -278,6 +303,7 @@ def test_unset_accepts_section_key_alias(isolated_env: Path) -> None:
 
 
 def test_unset_section_removes_saved_values_after_confirmation(isolated_env: Path) -> None:
+    """The unset command removes a whole section after confirmation."""
     get_config_path().parent.mkdir(parents=True)
     get_config_path().write_text(
         "aws:\n"
@@ -309,6 +335,7 @@ def test_unset_section_removes_saved_values_after_confirmation(isolated_env: Pat
 
 
 def test_unset_section_requires_confirmation(isolated_env: Path) -> None:
+    """The unset command preserves a section when confirmation is denied."""
     get_config_path().parent.mkdir(parents=True)
     get_config_path().write_text("nico:\n  api_base: https://nico.example.com\n")
     get_secrets_path().write_text("nico:\n  client_secret: super-secret-value\n")
@@ -325,6 +352,7 @@ def test_unset_section_requires_confirmation(isolated_env: Path) -> None:
 
 
 def test_unset_section_with_no_saved_values(isolated_env: Path) -> None:
+    """The unset command is a no-op for a section with no saved values."""
     get_config_path().parent.mkdir(parents=True)
     get_config_path().write_text("aws:\n  region: us-west-2\n")
 
@@ -337,6 +365,7 @@ def test_unset_section_with_no_saved_values(isolated_env: Path) -> None:
 
 
 def test_unset_section_rejects_malformed_config_without_deleting(isolated_env: Path) -> None:
+    """The unset command leaves files intact when section removal cannot load config."""
     get_config_path().parent.mkdir(parents=True)
     config_body = "nico:\n  client_secret: leaked\n"
     secrets_body = "nico:\n  client_secret: super-secret-value\n"
@@ -353,12 +382,14 @@ def test_unset_section_rejects_malformed_config_without_deleting(isolated_env: P
 
 
 def test_unset_without_key_requires_all_flag(isolated_env: Path) -> None:
+    """The unset command requires a key unless --all is passed."""
     result = runner.invoke(app, ["unset"])
     assert result.exit_code == 2
     assert "provide a key or pass --all" in (result.stderr or result.output)
 
 
 def test_unset_rejects_per_run_flag_before_loading_config(isolated_env: Path) -> None:
+    """The unset command rejects flags before reading existing config."""
     get_config_path().parent.mkdir(parents=True)
     get_config_path().write_text("nico:\n  client_secret: leaked\n")
 
@@ -369,6 +400,7 @@ def test_unset_rejects_per_run_flag_before_loading_config(isolated_env: Path) ->
 
 
 def test_unset_all_requires_confirmation(isolated_env: Path) -> None:
+    """The unset --all command preserves files when confirmation is denied."""
     write_values = ["set", "NICO_API_BASE", "https://nico.example.com"]
     assert runner.invoke(app, write_values).exit_code == 0
 
@@ -378,6 +410,7 @@ def test_unset_all_requires_confirmation(isolated_env: Path) -> None:
 
 
 def test_unset_all_removes_config_after_confirmation(isolated_env: Path) -> None:
+    """The unset --all command removes all persisted files after confirmation."""
     assert runner.invoke(app, ["set", "NICO_API_BASE", "https://nico.example.com"]).exit_code == 0
     assert runner.invoke(app, ["set", "NICO_CLIENT_SECRET"], input="super-secret-value\n").exit_code == 0
 
@@ -389,6 +422,7 @@ def test_unset_all_removes_config_after_confirmation(isolated_env: Path) -> None
 
 
 def test_unset_all_can_clear_malformed_config(isolated_env: Path) -> None:
+    """The unset --all command can remove malformed persisted files."""
     get_config_path().parent.mkdir(parents=True)
     get_config_path().write_text("nico:\n  client_secret: leaked\n")
     get_secrets_path().write_text("nico:\n  client_secret: super-secret-value\n")

--- a/isvctl/tests/test_cli_configure.py
+++ b/isvctl/tests/test_cli_configure.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the interactive `isvctl configure` command."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from isvctl.cli.config import app
+from isvctl.config.env_catalog import vars_for_provider
+from isvctl.config.user import file_mode, get_config_path, get_secrets_path
+
+runner = CliRunner()
+
+# Enough blank answers to walk every interactive prompt (one per persistable
+# var). Derived from the catalog so it can't fall behind as vars are added.
+_PERSISTABLE_PROMPTS = sum(1 for var in vars_for_provider(None) if var.persistable)
+
+
+@pytest.fixture
+def isolated_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("ISVCTL_CONFIG", raising=False)
+    monkeypatch.delenv("ISVCTL_SECRETS", raising=False)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# path / show
+# ---------------------------------------------------------------------------
+
+
+def test_path_prints_both_files(isolated_env: Path) -> None:
+    result = runner.invoke(app, ["path"])
+    assert result.exit_code == 0
+    assert str(get_config_path()) in result.stdout
+    assert str(get_secrets_path()) in result.stdout
+
+
+def test_show_with_no_files(isolated_env: Path) -> None:
+    result = runner.invoke(app, ["show"])
+    assert result.exit_code == 0
+    assert "No configuration found" in result.stdout
+
+
+def test_malformed_file_errors_cleanly_not_traceback(isolated_env: Path) -> None:
+    # A bad persisted file must surface a clean error (exit 1), not a traceback —
+    # `configure`/`show` are how users fix a broken file.
+    config = get_config_path()
+    config.parent.mkdir(parents=True)
+    config.write_text("nico:\n  client_secret: leaked\n")  # secret in config.yml
+
+    for argv in (["show"], []):
+        result = runner.invoke(app, argv, input="\n" * _PERSISTABLE_PROMPTS)
+        assert result.exit_code == 1, result.output
+        assert "Failed to read user config" in (result.stderr or result.output)
+        assert "Traceback" not in result.output
+
+
+def test_show_prints_nonsecret_and_masks_secret(isolated_env: Path) -> None:
+    config = get_config_path()
+    secrets = get_secrets_path()
+    config.parent.mkdir(parents=True)
+    config.write_text("nico:\n  api_base: https://nico.example.com\n")
+    secrets.write_text("nico:\n  client_secret: super-secret-value\n")
+
+    result = runner.invoke(app, ["show"])
+    assert result.exit_code == 0
+    assert "https://nico.example.com" in result.stdout
+    assert "super-secret-value" not in result.stdout
+    assert "(set)" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# wizard
+# ---------------------------------------------------------------------------
+
+
+def test_wizard_writes_both_files(isolated_env: Path) -> None:
+    # Answer only the two NICo vars we care about; Enter (blank) skips the rest.
+    nico_vars = vars_for_provider("nico")
+    answers = []
+    for var in nico_vars:
+        if var.name == "NICO_API_BASE":
+            answers.append("https://nico.example.com")
+        elif var.name == "NICO_CLIENT_SECRET":
+            answers.append("shhh")
+        else:
+            answers.append("")
+    result = runner.invoke(app, ["--provider", "nico"], input="\n".join(answers) + "\n")
+    assert result.exit_code == 0, result.stdout
+
+    config_data = yaml.safe_load(get_config_path().read_text())
+    secrets_data = yaml.safe_load(get_secrets_path().read_text())
+    assert config_data["nico"]["api_base"] == "https://nico.example.com"
+    assert secrets_data["nico"]["client_secret"] == "shhh"
+
+
+def test_wizard_secrets_file_is_0600(isolated_env: Path) -> None:
+    nico_vars = vars_for_provider("nico")
+    answers = ["shhh" if var.name == "NICO_CLIENT_SECRET" else "" for var in nico_vars]
+    result = runner.invoke(app, ["--provider", "nico"], input="\n".join(answers) + "\n")
+    assert result.exit_code == 0, result.stdout
+    assert file_mode(get_secrets_path()) == 0o600
+
+
+def test_wizard_blank_keeps_existing(isolated_env: Path) -> None:
+    get_config_path().parent.mkdir(parents=True)
+    get_config_path().write_text("nico:\n  api_base: https://keep.example.com\n")
+
+    nico_vars = vars_for_provider("nico")
+    # All blank → keep everything as-is.
+    result = runner.invoke(app, ["--provider", "nico"], input="\n" * len(nico_vars))
+    assert result.exit_code == 0, result.stdout
+
+    config_data = yaml.safe_load(get_config_path().read_text())
+    assert config_data["nico"]["api_base"] == "https://keep.example.com"
+
+
+def test_wizard_only_prompts_provider_group(isolated_env: Path) -> None:
+    nico_vars = vars_for_provider("nico")
+    result = runner.invoke(app, ["--provider", "nico"], input="\n" * len(nico_vars))
+    assert result.exit_code == 0, result.stdout
+    assert "NICO_API_BASE" in result.stdout
+    assert "AWS_REGION" not in result.stdout
+
+
+def test_unknown_provider_errors(isolated_env: Path) -> None:
+    result = runner.invoke(app, ["--provider", "gcp"], input="\n")
+    assert result.exit_code == 2
+    assert "unknown provider" in (result.stderr or result.output)
+
+
+def test_wizard_never_prompts_flags(isolated_env: Path) -> None:
+    # Bare wizard walks every persistable var; flags must not appear.
+    result = runner.invoke(app, [], input="\n" * _PERSISTABLE_PROMPTS)
+    assert result.exit_code == 0, result.stdout
+    for flag in ("KUBECTL", "ISVCTL_DEMO_MODE", "ISVTEST_INCLUDE_UNRELEASED", "AWS_SKIP_TEARDOWN", "Flags"):
+        assert flag not in result.stdout
+
+
+def test_show_never_lists_flags(isolated_env: Path) -> None:
+    # Even if a flag somehow lands in a file, show resolves only persistable vars.
+    get_config_path().parent.mkdir(parents=True)
+    get_config_path().write_text("nico:\n  api_base: https://x\n")
+    result = runner.invoke(app, ["show"])
+    assert result.exit_code == 0
+    assert "KUBECTL" not in result.stdout
+    assert "api_base" in result.stdout

--- a/isvctl/tests/test_cli_test_user_config.py
+++ b/isvctl/tests/test_cli_test_user_config.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for applying persisted user config during `isvctl test`."""
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from isvctl.cli.test import app
+from isvctl.config.user import get_config_path
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def isolated_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[Path]:
+    """Point user config at a temp dir and clear NICO_API_BASE before/after each test."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("ISVCTL_CONFIG", raising=False)
+    monkeypatch.delenv("ISVCTL_SECRETS", raising=False)
+    monkeypatch.delenv("NICO_API_BASE", raising=False)
+    yield tmp_path
+    # apply_user_env writes os.environ directly; undo any leak for other tests.
+    os.environ.pop("NICO_API_BASE", None)
+
+
+_RUN_CONFIG = """
+commands:
+  kubernetes:
+    phases: [test]
+    steps:
+      - name: test_step
+        command: echo
+        args: ['{"success": true}']
+        phase: test
+tests:
+  platform: kubernetes
+  validations: {}
+"""
+
+
+def _write_user_config(value: str) -> None:
+    """Write a config.yml persisting ``nico.api_base`` to ``value``."""
+    config = get_config_path()
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text(f"nico:\n  api_base: {value}\n")
+
+
+def _write_run_config(tmp_path: Path) -> Path:
+    """Write a minimal valid run config and return its path."""
+    cfg = tmp_path / "run.yaml"
+    cfg.write_text(_RUN_CONFIG, encoding="utf-8")
+    return cfg
+
+
+def test_run_applies_user_config(isolated_env: Path, tmp_path: Path) -> None:
+    """`test run` applies a persisted var that isn't already exported."""
+    _write_user_config("https://from-file.example.com")
+    cfg = _write_run_config(tmp_path)
+    result = runner.invoke(app, ["run", "-f", str(cfg), "--no-upload", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert os.environ.get("NICO_API_BASE") == "https://from-file.example.com"
+
+
+def test_process_env_wins_over_file(isolated_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An exported var takes precedence over the persisted file value."""
+    monkeypatch.setenv("NICO_API_BASE", "https://from-shell.example.com")
+    _write_user_config("https://from-file.example.com")
+    cfg = _write_run_config(tmp_path)
+    result = runner.invoke(app, ["run", "-f", str(cfg), "--no-upload", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert os.environ["NICO_API_BASE"] == "https://from-shell.example.com"
+
+
+def test_no_user_config_skips_loading(isolated_env: Path, tmp_path: Path) -> None:
+    """`--no-user-config` leaves the persisted file unapplied."""
+    _write_user_config("https://from-file.example.com")
+    cfg = _write_run_config(tmp_path)
+    result = runner.invoke(app, ["run", "-f", str(cfg), "--no-upload", "--dry-run", "--no-user-config"])
+    assert result.exit_code == 0, result.output
+    assert os.environ.get("NICO_API_BASE") is None
+
+
+def test_invalid_user_config_exits_before_running(isolated_env: Path, tmp_path: Path) -> None:
+    """A malformed user config fails the run with a clean error before work begins."""
+    config = get_config_path()
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text("nico:\n  client_secret: leaked\n")  # secret in config.yml
+    cfg = _write_run_config(tmp_path)
+    result = runner.invoke(app, ["run", "-f", str(cfg), "--no-upload", "--dry-run"])
+    assert result.exit_code == 1
+    assert "Failed to load user config" in (result.stderr or result.output)
+
+
+def test_validate_applies_user_config(isolated_env: Path, tmp_path: Path) -> None:
+    """`test validate` also applies persisted user config."""
+    _write_user_config("https://from-file.example.com")
+    cfg = _write_run_config(tmp_path)
+    result = runner.invoke(app, ["validate", "-f", str(cfg)])
+    assert result.exit_code == 0, result.output
+    assert os.environ.get("NICO_API_BASE") == "https://from-file.example.com"

--- a/isvctl/tests/test_doctor_cli.py
+++ b/isvctl/tests/test_doctor_cli.py
@@ -26,6 +26,7 @@ import pytest
 from typer.testing import CliRunner
 
 from isvctl.cli.doctor import app
+from isvctl.config.env_catalog import EnvVar
 from isvctl.doctor.checks import env as env_checks
 from isvctl.doctor.checks import tools as tools_checks
 from isvctl.doctor.result import Status, worst
@@ -71,14 +72,14 @@ def all_tools_present(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture
 def all_env_set(monkeypatch: pytest.MonkeyPatch) -> None:
     """Set every env var the doctor knows about so the env category is all-OK."""
-    for var in env_checks._VARS:
+    for var in env_checks.ENV_VARS:
         monkeypatch.setenv(var.name, "x")
 
 
 @pytest.fixture
 def all_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure no known env var is set (independent of the host environment)."""
-    for var in env_checks._VARS:
+    for var in env_checks.ENV_VARS:
         monkeypatch.delenv(var.name, raising=False)
 
 
@@ -364,9 +365,9 @@ def test_doctor_required_env_var_reports_required(monkeypatch: pytest.MonkeyPatc
     monkeypatch.delenv(name, raising=False)
     monkeypatch.setattr(
         env_checks,
-        "_VARS",
+        "ENV_VARS",
         (
-            env_checks._Var(
+            EnvVar(
                 name=name,
                 group="Test",
                 requirement=env_checks.Requirement.REQUIRED,
@@ -379,6 +380,41 @@ def test_doctor_required_env_var_reports_required(monkeypatch: pytest.MonkeyPatc
 
     assert report.results[0].status == Status.FAIL
     assert report.results[0].message == "unset (required)"
+
+
+# ---------------------------------------------------------------------------
+# Persisted user config integration
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_applies_persisted_user_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """doctor should see vars persisted by `isvctl configure`, not just exports."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("NICO_API_BASE", raising=False)
+    cfg_dir = tmp_path / "isvctl"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "config.yml").write_text("nico:\n  api_base: https://nico.example.com\n")
+
+    result = runner.invoke(app, ["--check", "env", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    env_results = {r["name"]: r for cat in payload["categories"] for r in cat["results"]}
+    assert env_results["NICO_API_BASE"]["status"] == "OK"
+
+
+def test_doctor_no_user_config_ignores_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """--no-user-config should ignore persisted config files."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("NICO_API_BASE", raising=False)
+    cfg_dir = tmp_path / "isvctl"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "config.yml").write_text("nico:\n  api_base: https://nico.example.com\n")
+
+    result = runner.invoke(app, ["--check", "env", "--json", "--no-user-config"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    env_results = {r["name"]: r for cat in payload["categories"] for r in cat["results"]}
+    assert env_results["NICO_API_BASE"]["status"] != "OK"
 
 
 # ---------------------------------------------------------------------------

--- a/isvctl/tests/test_env_catalog.py
+++ b/isvctl/tests/test_env_catalog.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the shared environment-variable catalog."""
+
+import pytest
+
+from isvctl.config.env_catalog import (
+    ENV_VARS,
+    PROVIDER_GROUPS,
+    EnvVar,
+    Requirement,
+    vars_for_provider,
+)
+
+
+def test_catalog_is_non_empty_and_well_formed() -> None:
+    assert ENV_VARS
+    for var in ENV_VARS:
+        assert isinstance(var, EnvVar)
+        assert var.name
+        assert var.group
+        assert isinstance(var.requirement, Requirement)
+        assert var.hint
+
+
+def test_var_names_are_unique() -> None:
+    names = [var.name for var in ENV_VARS]
+    assert len(names) == len(set(names))
+
+
+def test_provider_groups() -> None:
+    assert PROVIDER_GROUPS["nico"] == "NICo"
+    assert PROVIDER_GROUPS["aws"] == "AWS"
+
+
+def test_vars_for_provider_none_returns_all() -> None:
+    assert vars_for_provider(None) == list(ENV_VARS)
+
+
+def test_vars_for_provider_nico_scopes_to_group() -> None:
+    nico_vars = vars_for_provider("nico")
+    assert nico_vars
+    assert all(var.group == "NICo" for var in nico_vars)
+    names = {var.name for var in nico_vars}
+    assert "NICO_API_BASE" in names
+    assert "NICO_CLIENT_SECRET" in names
+    assert "AWS_REGION" not in names
+
+
+def test_vars_for_provider_unknown_raises() -> None:
+    with pytest.raises(ValueError, match="unknown provider"):
+        vars_for_provider("gcp")
+
+
+def test_flags_group_is_not_persistable() -> None:
+    flags = [var for var in ENV_VARS if var.group == "Flags"]
+    assert flags
+    assert all(not var.persistable for var in flags)
+    # Specific per-run toggles that must never be persisted.
+    names = {var.name for var in flags}
+    assert {"KUBECTL", "ISVCTL_DEMO_MODE", "ISVTEST_INCLUDE_UNRELEASED", "AWS_SKIP_TEARDOWN"} <= names
+
+
+def test_non_flag_vars_are_persistable() -> None:
+    for var in ENV_VARS:
+        if var.group != "Flags":
+            assert var.persistable, var.name

--- a/isvctl/tests/test_redaction.py
+++ b/isvctl/tests/test_redaction.py
@@ -24,6 +24,7 @@ import xml.etree.ElementTree as ET
 from isvctl.redaction import (
     REDACTED,
     filter_env,
+    is_secret_env_var,
     is_sensitive_key,
     mask_sensitive_args,
     redact_dict,
@@ -260,6 +261,35 @@ class TestFilterEnv:
         }
         result = filter_env(env)
         assert result == env
+
+
+# ---------------------------------------------------------------------------
+# is_secret_env_var
+# ---------------------------------------------------------------------------
+
+
+class TestIsSecretEnvVar:
+    """Tests for environment-variable secret classification."""
+
+    def test_explicit_deny_list(self) -> None:
+        assert is_secret_env_var("NICO_CLIENT_SECRET")
+        assert is_secret_env_var("NICO_BEARER_TOKEN")
+        assert is_secret_env_var("NGC_API_KEY")
+        assert is_secret_env_var("ISV_CLIENT_SECRET")
+        assert is_secret_env_var("AWS_SECRET_ACCESS_KEY")
+
+    def test_suffix_matches(self) -> None:
+        assert is_secret_env_var("MY_CUSTOM_SECRET")
+        assert is_secret_env_var("DB_PASSWORD")
+        assert is_secret_env_var("CUSTOM_API_KEY")
+
+    def test_non_secret_vars(self) -> None:
+        assert not is_secret_env_var("NICO_API_BASE")
+        assert not is_secret_env_var("NICO_ORGANIZATION")
+        assert not is_secret_env_var("NICO_SITE_ID")
+        assert not is_secret_env_var("NICO_CLIENT_ID")
+        assert not is_secret_env_var("KUBECTL")
+        assert not is_secret_env_var("AWS_REGION")
 
 
 # ---------------------------------------------------------------------------

--- a/isvctl/tests/test_user_config.py
+++ b/isvctl/tests/test_user_config.py
@@ -62,6 +62,23 @@ def test_path_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     assert get_secrets_path() == Path("/tmp/s.yml")
 
 
+@pytest.mark.parametrize("operation", ["load", "write", "unset", "clear"])
+def test_user_config_operations_reject_identical_paths(isolated_env: Path, operation: str) -> None:
+    """User config helpers reject config and secrets paths resolving to one file."""
+    same_path = isolated_env / "same.yml"
+    paths = {"config_path": same_path, "secrets_path": same_path}
+
+    with pytest.raises(ValueError, match="must be different"):
+        if operation == "load":
+            load_user_env(**paths)
+        elif operation == "write":
+            write_user_config({"NICO_API_BASE": "https://x"}, **paths)
+        elif operation == "unset":
+            unset_user_config(["NICO_API_BASE"], **paths)
+        else:
+            clear_user_config(**paths)
+
+
 # ---------------------------------------------------------------------------
 # Loading
 # ---------------------------------------------------------------------------
@@ -326,6 +343,22 @@ def test_writing_secret_only_leaves_existing_config_untouched(isolated_env: Path
     write_user_config({"NICO_CLIENT_SECRET": "shhh"})
     assert get_config_path().read_bytes() == before  # config.yml byte-identical
     assert get_secrets_path().exists()
+
+
+def test_failed_write_leaves_existing_file_intact(isolated_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A low-level write failure leaves the previous config.yml bytes intact."""
+    write_user_config({"NICO_API_BASE": "https://before.example.com"})
+    before = get_config_path().read_bytes()
+
+    def fail_write(fd: int, data: bytes) -> int:
+        raise OSError("no space left")
+
+    monkeypatch.setattr(os, "write", fail_write)
+
+    with pytest.raises(OSError, match="no space left"):
+        write_user_config({"NICO_API_BASE": "https://after.example.com"})
+
+    assert get_config_path().read_bytes() == before
 
 
 def test_refuses_to_write_through_a_symlink(isolated_env: Path) -> None:

--- a/isvctl/tests/test_user_config.py
+++ b/isvctl/tests/test_user_config.py
@@ -155,6 +155,17 @@ def test_non_string_value_raises(isolated_env: Path) -> None:
         load_user_env()
 
 
+def test_load_rejects_non_persistable_catalog_var(isolated_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A resolved non-persistable catalog var is rejected on load."""
+    config = get_config_path()
+    config.parent.mkdir(parents=True)
+    config.write_text("nico:\n  api_base: kubectl\n")
+    monkeypatch.setattr("isvctl.config.user.section_key_to_env", lambda _section, _key: "KUBECTL")
+
+    with pytest.raises(ValueError, match="per-run flag"):
+        load_user_env()
+
+
 # ---------------------------------------------------------------------------
 # apply_user_env
 # ---------------------------------------------------------------------------

--- a/isvctl/tests/test_user_config.py
+++ b/isvctl/tests/test_user_config.py
@@ -24,10 +24,12 @@ import yaml
 from isvctl.config.user import (
     SCHEMA_VERSION,
     apply_user_env,
+    clear_user_config,
     file_mode,
     get_config_path,
     get_secrets_path,
     load_user_env,
+    unset_user_config,
     write_user_config,
 )
 
@@ -213,6 +215,50 @@ def test_write_roundtrips_through_load(isolated_env: Path) -> None:
     """A written value reads back identically through load_user_env."""
     write_user_config({"NICO_SITE_ID": "00000000-0000-0000-0000-000000000000"})
     assert load_user_env() == {"NICO_SITE_ID": "00000000-0000-0000-0000-000000000000"}
+
+
+def test_unset_removes_value_and_preserves_other_files(isolated_env: Path) -> None:
+    """unset_user_config removes selected values without touching unrelated files."""
+    write_user_config(
+        {
+            "NICO_API_BASE": "https://nico.example.com",
+            "AWS_REGION": "us-west-2",
+            "NICO_CLIENT_SECRET": "shhh",
+        }
+    )
+    secrets_before = get_secrets_path().read_bytes()
+
+    unset_user_config(["NICO_API_BASE"])
+
+    assert load_user_env() == {"AWS_REGION": "us-west-2", "NICO_CLIENT_SECRET": "shhh"}
+    assert get_secrets_path().read_bytes() == secrets_before
+
+
+def test_unset_deletes_file_when_last_value_is_removed(isolated_env: Path) -> None:
+    """Removing the last value in a file deletes that empty config file."""
+    write_user_config({"NICO_API_BASE": "https://nico.example.com"})
+
+    unset_user_config(["NICO_API_BASE"])
+
+    assert not get_config_path().exists()
+    assert load_user_env() == {}
+
+
+def test_unset_rejects_unknown_name(isolated_env: Path) -> None:
+    """unset_user_config validates names against the same catalog as writes."""
+    with pytest.raises(ValueError, match="unknown env var"):
+        unset_user_config(["NOT_A_REAL_ENV"])
+
+
+def test_clear_user_config_removes_both_files(isolated_env: Path) -> None:
+    """clear_user_config removes all persisted values and both backing files."""
+    write_user_config({"NICO_API_BASE": "https://nico.example.com", "NICO_CLIENT_SECRET": "shhh"})
+
+    clear_user_config()
+
+    assert not get_config_path().exists()
+    assert not get_secrets_path().exists()
+    assert load_user_env() == {}
 
 
 # ---------------------------------------------------------------------------

--- a/isvctl/tests/test_user_config.py
+++ b/isvctl/tests/test_user_config.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for user-level persisted config (config.yml / secrets.yml)."""
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from isvctl.config.user import (
+    SCHEMA_VERSION,
+    apply_user_env,
+    file_mode,
+    get_config_path,
+    get_secrets_path,
+    load_user_env,
+    write_user_config,
+)
+
+
+@pytest.fixture
+def isolated_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point config + secrets at a temp dir and clear path overrides."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("ISVCTL_CONFIG", raising=False)
+    monkeypatch.delenv("ISVCTL_SECRETS", raising=False)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+def test_default_paths_honor_xdg(isolated_env: Path) -> None:
+    """Default config/secrets paths live under XDG_CONFIG_HOME/isvctl."""
+    assert get_config_path() == isolated_env / "isvctl" / "config.yml"
+    assert get_secrets_path() == isolated_env / "isvctl" / "secrets.yml"
+
+
+def test_path_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ISVCTL_CONFIG/ISVCTL_SECRETS override the individual file paths."""
+    monkeypatch.setenv("ISVCTL_CONFIG", "/tmp/c.yml")
+    monkeypatch.setenv("ISVCTL_SECRETS", "/tmp/s.yml")
+    assert get_config_path() == Path("/tmp/c.yml")
+    assert get_secrets_path() == Path("/tmp/s.yml")
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+
+def test_missing_files_return_empty(isolated_env: Path) -> None:
+    """Loading with no files present yields an empty mapping."""
+    assert load_user_env() == {}
+
+
+def test_merges_both_files(isolated_env: Path) -> None:
+    """load_user_env merges values from config.yml and secrets.yml."""
+    config = get_config_path()
+    secrets = get_secrets_path()
+    config.parent.mkdir(parents=True)
+    config.write_text("nico:\n  api_base: https://nico.example.com\n")
+    secrets.write_text("nico:\n  client_secret: shhh\n")
+
+    env = load_user_env()
+    assert env == {
+        "NICO_API_BASE": "https://nico.example.com",
+        "NICO_CLIENT_SECRET": "shhh",
+    }
+
+
+def test_secret_in_config_file_raises(isolated_env: Path) -> None:
+    """A secret stored in config.yml is rejected on load."""
+    config = get_config_path()
+    config.parent.mkdir(parents=True)
+    config.write_text("nico:\n  client_secret: shhh\n")
+    with pytest.raises(ValueError, match="belongs in secrets"):
+        load_user_env()
+
+
+def test_non_secret_in_secrets_file_raises(isolated_env: Path) -> None:
+    """A non-secret stored in secrets.yml is rejected on load."""
+    secrets = get_secrets_path()
+    secrets.parent.mkdir(parents=True)
+    secrets.write_text("nico:\n  api_base: https://x\n")
+    with pytest.raises(ValueError, match="belongs in config"):
+        load_user_env()
+
+
+def test_unknown_section_raises(isolated_env: Path) -> None:
+    """An unrecognized top-level section is rejected on load."""
+    config = get_config_path()
+    config.parent.mkdir(parents=True)
+    config.write_text("bogus:\n  x: 1\n")
+    with pytest.raises(ValueError, match="unknown section"):
+        load_user_env()
+
+
+def test_unknown_key_raises(isolated_env: Path) -> None:
+    """An unrecognized key within a known section is rejected on load."""
+    config = get_config_path()
+    config.parent.mkdir(parents=True)
+    config.write_text("nico:\n  totally_made_up: 1\n")
+    with pytest.raises(ValueError, match="unknown key"):
+        load_user_env()
+
+
+def test_write_rejects_flag_var(isolated_env: Path) -> None:
+    """Persisting a per-run flag var is rejected."""
+    with pytest.raises(ValueError, match="per-run flag"):
+        write_user_config({"AWS_SKIP_TEARDOWN": "1"})
+
+
+def test_non_string_value_raises(isolated_env: Path) -> None:
+    """A non-string value in a config file is rejected on load."""
+    config = get_config_path()
+    config.parent.mkdir(parents=True)
+    config.write_text("nico:\n  site_id: 12345\n")
+    with pytest.raises(ValueError, match="must be a string"):
+        load_user_env()
+
+
+# ---------------------------------------------------------------------------
+# apply_user_env
+# ---------------------------------------------------------------------------
+
+
+def test_apply_sets_absent_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    """apply_user_env sets a var that isn't already in the environment."""
+    monkeypatch.delenv("NICO_API_BASE", raising=False)
+    applied = apply_user_env({"NICO_API_BASE": "https://x"})
+    assert applied == ["NICO_API_BASE"]
+    assert os.environ["NICO_API_BASE"] == "https://x"
+
+
+def test_apply_never_overwrites_exported_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """apply_user_env never clobbers an already-exported var."""
+    monkeypatch.setenv("NICO_API_BASE", "from-shell")
+    applied = apply_user_env({"NICO_API_BASE": "from-file"})
+    assert applied == []
+    assert os.environ["NICO_API_BASE"] == "from-shell"
+
+
+def test_apply_preserves_set_but_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A set-but-empty exported var counts as present and is preserved."""
+    monkeypatch.setenv("NICO_API_BASE", "")
+    applied = apply_user_env({"NICO_API_BASE": "from-file"})
+    assert applied == []
+    assert os.environ["NICO_API_BASE"] == ""
+
+
+# ---------------------------------------------------------------------------
+# write_user_config
+# ---------------------------------------------------------------------------
+
+
+def test_write_routes_by_secret_ness(isolated_env: Path) -> None:
+    """Secrets land in secrets.yml and non-secrets in config.yml."""
+    result = write_user_config(
+        {
+            "NICO_API_BASE": "https://nico.example.com",
+            "NICO_CLIENT_SECRET": "shhh",
+        }
+    )
+    assert result.config_path.exists() and result.secrets_path.exists()
+
+    config_data = yaml.safe_load(get_config_path().read_text())
+    secrets_data = yaml.safe_load(get_secrets_path().read_text())
+    assert config_data == {"version": SCHEMA_VERSION, "nico": {"api_base": "https://nico.example.com"}}
+    assert secrets_data == {"version": SCHEMA_VERSION, "nico": {"client_secret": "shhh"}}
+
+
+def test_secrets_file_is_0600(isolated_env: Path) -> None:
+    """secrets.yml is written with 0600 permissions."""
+    write_user_config({"NICO_CLIENT_SECRET": "shhh"})
+    assert file_mode(get_secrets_path()) == 0o600
+
+
+def test_config_file_is_0644(isolated_env: Path) -> None:
+    """config.yml is written with 0644 permissions."""
+    write_user_config({"NICO_API_BASE": "https://x"})
+    assert file_mode(get_config_path()) == 0o644
+
+
+def test_write_merges_with_existing(isolated_env: Path) -> None:
+    """A second write merges over existing values without wiping others."""
+    write_user_config({"NICO_API_BASE": "https://x", "AWS_REGION": "us-west-2"})
+    # A provider-scoped second write must not wipe AWS_REGION.
+    write_user_config({"NICO_API_BASE": "https://y"})
+
+    env = load_user_env()
+    assert env["NICO_API_BASE"] == "https://y"
+    assert env["AWS_REGION"] == "us-west-2"
+
+
+def test_write_roundtrips_through_load(isolated_env: Path) -> None:
+    """A written value reads back identically through load_user_env."""
+    write_user_config({"NICO_SITE_ID": "00000000-0000-0000-0000-000000000000"})
+    assert load_user_env() == {"NICO_SITE_ID": "00000000-0000-0000-0000-000000000000"}
+
+
+# ---------------------------------------------------------------------------
+# Schema version
+# ---------------------------------------------------------------------------
+
+
+def test_write_stamps_version_into_both_files(isolated_env: Path) -> None:
+    """Both files are stamped with the current schema version on write."""
+    write_user_config({"NICO_API_BASE": "https://x", "NICO_CLIENT_SECRET": "shhh"})
+    config_data = yaml.safe_load(get_config_path().read_text())
+    secrets_data = yaml.safe_load(get_secrets_path().read_text())
+    assert config_data["version"] == SCHEMA_VERSION
+    assert secrets_data["version"] == SCHEMA_VERSION
+
+
+def test_version_is_first_line(isolated_env: Path) -> None:
+    """The version key is rendered above the provider sections."""
+    # Stable, human-friendly ordering: the version sits above the sections.
+    write_user_config({"NICO_API_BASE": "https://x"})
+    lines = [ln for ln in get_config_path().read_text().splitlines() if not ln.startswith("#")]
+    assert lines[0] == f"version: {SCHEMA_VERSION}"
+
+
+def test_versioned_file_roundtrips(isolated_env: Path) -> None:
+    """A versioned file written by isvctl reads back identically."""
+    write_user_config({"NICO_API_BASE": "https://x", "NICO_CLIENT_SECRET": "shhh"})
+    assert load_user_env() == {"NICO_API_BASE": "https://x", "NICO_CLIENT_SECRET": "shhh"}
+
+
+def test_missing_version_reads_as_initial_schema(isolated_env: Path) -> None:
+    """A file without a version key loads as the initial schema."""
+    # Files written before versioning have no `version:` and must still load.
+    config = get_config_path()
+    config.parent.mkdir(parents=True)
+    config.write_text("nico:\n  api_base: https://x\n")
+    assert load_user_env() == {"NICO_API_BASE": "https://x"}
+
+
+# ---------------------------------------------------------------------------
+# Directory permissions
+# ---------------------------------------------------------------------------
+
+
+def test_creates_default_dir_as_0700(isolated_env: Path) -> None:
+    """A config dir created by isvctl is locked down to 0700."""
+    # The directory we create gets locked down to owner-only.
+    write_user_config({"NICO_API_BASE": "https://x"})
+    assert file_mode(get_config_path().parent) == 0o700
+
+
+def test_writing_non_secret_does_not_touch_secrets_file(isolated_env: Path) -> None:
+    """A non-secret-only write does not create secrets.yml."""
+    # A non-secret-only write must not create or rewrite secrets.yml.
+    write_user_config({"NICO_API_BASE": "https://x"})
+    assert get_config_path().exists()
+    assert not get_secrets_path().exists()
+
+
+def test_writing_secret_only_leaves_existing_config_untouched(isolated_env: Path) -> None:
+    """Adding a secret leaves an unchanged config.yml byte-identical."""
+    # Adding a secret must not rewrite an unrelated, unchanged config.yml.
+    write_user_config({"NICO_API_BASE": "https://x"})
+    before = get_config_path().read_bytes()
+    write_user_config({"NICO_CLIENT_SECRET": "shhh"})
+    assert get_config_path().read_bytes() == before  # config.yml byte-identical
+    assert get_secrets_path().exists()
+
+
+def test_refuses_to_write_through_a_symlink(isolated_env: Path) -> None:
+    """Writing refuses to follow a symlink planted at the target path."""
+    # O_NOFOLLOW must stop secrets being redirected through a planted symlink.
+    secrets = get_secrets_path()
+    secrets.parent.mkdir(parents=True)
+    target = isolated_env / "victim"
+    secrets.symlink_to(target)
+    with pytest.raises(OSError):
+        write_user_config({"NICO_CLIENT_SECRET": "shhh"})
+    assert not target.exists()  # nothing written through the link
+
+
+def test_does_not_re_permission_existing_override_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A pre-existing override directory keeps its permissions on write."""
+    # A pre-existing directory the user points us at via ISVCTL_CONFIG/SECRETS
+    # must NOT be silently re-chmod'd to 0700 (it could be $HOME or a shared dir).
+    shared = tmp_path / "shared"
+    shared.mkdir(mode=0o755)
+    shared.chmod(0o755)  # mkdir mode is subject to umask; force it.
+    monkeypatch.setenv("ISVCTL_CONFIG", str(shared / "config.yml"))
+    monkeypatch.setenv("ISVCTL_SECRETS", str(shared / "secrets.yml"))
+
+    write_user_config({"NICO_API_BASE": "https://x", "NICO_CLIENT_SECRET": "shhh"})
+
+    assert file_mode(shared) == 0o755  # directory perms untouched
+    assert file_mode(shared / "secrets.yml") == 0o600  # file still locked down
+
+
+def test_explicit_current_version_loads(isolated_env: Path) -> None:
+    """A file stamped with the current schema version loads normally."""
+    config = get_config_path()
+    config.parent.mkdir(parents=True)
+    config.write_text(f"version: {SCHEMA_VERSION}\nnico:\n  api_base: https://x\n")
+    assert load_user_env() == {"NICO_API_BASE": "https://x"}
+
+
+def test_newer_version_raises(isolated_env: Path) -> None:
+    """A config.yml from a newer schema version is rejected."""
+    config = get_config_path()
+    config.parent.mkdir(parents=True)
+    config.write_text(f"version: {SCHEMA_VERSION + 1}\nnico:\n  api_base: https://x\n")
+    with pytest.raises(ValueError, match="newer isvctl"):
+        load_user_env()
+
+
+def test_newer_version_in_secrets_raises(isolated_env: Path) -> None:
+    """A secrets.yml from a newer schema version is rejected."""
+    secrets = get_secrets_path()
+    secrets.parent.mkdir(parents=True)
+    secrets.write_text(f"version: {SCHEMA_VERSION + 1}\nnico:\n  client_secret: shhh\n")
+    with pytest.raises(ValueError, match="newer isvctl"):
+        load_user_env()
+
+
+@pytest.mark.parametrize("bad", ['"1"', "true", "1.0", "[]"])
+def test_non_integer_version_raises(isolated_env: Path, bad: str) -> None:
+    """A non-integer version value is rejected on load."""
+    config = get_config_path()
+    config.parent.mkdir(parents=True)
+    config.write_text(f"version: {bad}\nnico:\n  api_base: https://x\n")
+    with pytest.raises(ValueError, match="must be an integer"):
+        load_user_env()
+
+
+def test_zero_version_raises(isolated_env: Path) -> None:
+    """A version below the initial schema (0) is rejected on load."""
+    config = get_config_path()
+    config.parent.mkdir(parents=True)
+    config.write_text("version: 0\nnico:\n  api_base: https://x\n")
+    with pytest.raises(ValueError, match="invalid schema version"):
+        load_user_env()


### PR DESCRIPTION
## Summary
Add an interactive `isvctl configure` command that persists the env vars an `isvctl test run` needs, so users don't re-`export` them in every shell (handy for providers like NICo that need several).

## Changes
- Values are split across two files under `${XDG_CONFIG_HOME:-~/.config}/isvctl/`, organized into provider-namespaced sections (`nico.api_base` ⇆ `NICO_API_BASE`): `config.yml` (`0644`) for non-secrets and `secrets.yml` (`0600`) for secrets. Secret-vs-non-secret routing reuses `redaction.is_secret_env_var`.
- Add `configure show` (secrets masked) and `configure path` subcommands.
- Extract the env-var catalog into `config/env_catalog.py`, shared by `doctor` and `configure` so they never drift; each file carries a top-level `version:` schema marker.
- `test run`, `test validate`, and `doctor` apply both files (unless `--no-user-config`). Precedence is **process env > files > defaults** — an exported var always wins, so CI and one-off `FOO=bar isvctl ...` overrides keep working.
- Hardening: tighten the config dir to `0700` only when we create it (never re-permission a pre-existing `ISVCTL_CONFIG`/`ISVCTL_SECRETS` override dir); write with `O_NOFOLLOW` + `fchmod` so a planted symlink can't redirect a secret write; only (re)write a file that actually gains a value; surface a malformed config/secrets file as a clean error instead of a traceback.

## Example

   ```console
   $ isvctl configure --provider nico
   Configuring isvctl. Press Enter to keep the current value.

   NICo
     NICO_API_BASE (NICo API base URL): https://nico.example.com
     NICO_ORGANIZATION (NICo organization name used in the API path): example-org
     NICO_SITE_ID (Forge site UUID for NICo hardware checks): 00000000-0000-0000-0000-000000000000
     NICO_BEARER_TOKEN (local NICo bearer token for API authentication):      # secret, entered hidden — left blank
     NICO_SSA_ISSUER (SSA issuer URL for NICo client_credentials auth):
     NICO_CLIENT_ID (OIDC client ID for NICo client_credentials auth): my-client-id
     NICO_CLIENT_SECRET (OIDC client secret for NICo client_credentials auth):  # secret, entered hidden
     NICO_OIDC_SCOPE (optional OIDC scope for NICo client_credentials auth):

   ==> Wrote 4 var(s) to ~/.config/isvctl/config.yml
   ==> Wrote 1 secret(s) to ~/.config/isvctl/secrets.yml (mode 0600)

   Verify with: isvctl doctor --provider nico
   ```
   Resulting files:

   ```yaml
   # ~/.config/isvctl/config.yml   (0644)
   # Managed by `isvctl configure`. Values are grouped into provider sections
   # (e.g. `nico.api_base`). `version` is the on-disk schema version - leave it
   # as-is. Edit by hand or re-run `isvctl configure`.
   version: 1
   nico:
     api_base: https://nico.example.com
     client_id: my-client-id
     organization: example-org
     site_id: 00000000-0000-0000-0000-000000000000
   ```

   ```yaml
   # ~/.config/isvctl/secrets.yml   (0600)
   # Managed by `isvctl configure`. Values are grouped into provider sections
   # (e.g. `nico.api_base`). `version` is the on-disk schema version - leave it
   # as-is. Edit by hand or re-run `isvctl configure`.
   version: 1
   nico:
     client_secret: s3cr3t-value
   ```

   `isvctl configure show` reads them back with secrets masked:

   ```console
   $ isvctl configure show --provider nico
   config.yml:  ~/.config/isvctl/config.yml
   secrets.yml: ~/.config/isvctl/secrets.yml

   nico:
     api_base      = https://nico.example.com
     organization  = example-org
     site_id       = 00000000-0000-0000-0000-000000000000
     client_id     = my-client-id
     client_secret = (set)
   ```

   Targeted edits can set one value, set several values at once, or remove saved values/sections:

   ```console
   $ isvctl configure set NICO_API_BASE https://nico.example.com
   $ isvctl configure set nico.organization=ncx nico.oidc_scope=example
   $ isvctl configure unset nico.api_base
   $ isvctl configure unset nico     # remove one section after confirmation
   $ isvctl configure unset --all    # remove all saved config after confirmation
   ```

## Test plan

- [x] `make test`
- [x] `make lint`
- [x] `uv run pytest isvctl/tests/` (1070 passed)
- [x] `uv run pytest isvctl/tests/test_user_config.py isvctl/tests/test_cli_configure.py isvctl/tests/test_cli_test_user_config.py isvctl/tests/test_doctor_cli.py isvctl/tests/test_env_catalog.py isvctl/tests/test_redaction.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `isvctl configure` wizard and commands: `show`, `set`, `unset`, and `path` to persist provider settings.
  * Persisted settings are split into non-secrets (`config.yml`) and secrets (`secrets.yml`) with secure handling.
  * Added `--no-user-config` to `test run`, `test validate`, and `doctor`, plus `ISVCTL_CONFIG` / `ISVCTL_SECRETS` path overrides.
* **Documentation**
  * Updated README, `isvctl/README.md`, and `AGENTS.md` with the new workflow, precedence, and verification guidance.
* **Bug Fixes**
  * Improved validation/error handling for malformed saved configuration and hardened safety behavior.
* **Tests**
  * Added/expanded integration and unit tests for configuration persistence, redaction, and `--no-user-config` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
