### PR TITLE
feat(k8s): add K8S21 CRD webhook validation

### DIFF
--- a/docs/test-plan.adoc
+++ b/docs/test-plan.adoc
@@ -3292,7 +3292,7 @@ a|
 | [[K8S21-01]]K8S21-01
 | K8S21
 | https://github.com/NVIDIA/ai-cloud-validation/issues/218[#218]
-| min_req
+| kubernetes, min_req
 | k8s19
 | P1
 a| https://github.com/NVIDIA/ai-cloud-validation/issues/218[#218]

--- a/docs/test-plan.yaml
+++ b/docs/test-plan.yaml
@@ -2731,6 +2731,7 @@ domains:
             tests:
               - summary: create a CRD, create webhook, and test validation/mutation requirement
                 labels:
+                  - kubernetes
                   - min_req
                 notes: k8s19
                 req_id: K8S21

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -235,7 +235,7 @@ tests:
           test_id: "K8S21-01"
           labels: ["kubernetes", "min_req"]
           image: "registry.k8s.io/e2e-test-images/agnhost:2.47"
-          namespace_prefix: "isvtest-k8s21"
+          namespace_prefix: "isvtest-crd-webhook"
           wait_timeout: 180
           poll_interval: 2
 

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -231,6 +231,13 @@ tests:
           settle_timeout_s: 30
           namespace_prefix: "isvtest-netpol"
           test_egress: true
+        K8sCrdWebhookCheck:
+          test_id: "K8S21-01"
+          labels: ["kubernetes", "min_req"]
+          image: "registry.k8s.io/e2e-test-images/agnhost:2.47"
+          namespace_prefix: "isvtest-k8s21"
+          wait_timeout: 180
+          poll_interval: 2
 
     k8s_storage:
       checks:

--- a/isvtest/src/isvtest/validations/k8s_crd_webhook.py
+++ b/isvtest/src/isvtest/validations/k8s_crd_webhook.py
@@ -1,0 +1,597 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Kubernetes CRD and admission webhook validation (K8S21-01)."""
+
+from __future__ import annotations
+
+import base64
+import datetime as dt
+import shlex
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar
+
+import yaml
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from isvtest.core.k8s import KubectlParseError, get_kubectl_base_shell, get_kubectl_command, parse_kubectl_json
+from isvtest.core.validation import BaseValidation
+
+_MANIFEST_PATH = Path(__file__).parent / "manifests" / "k8s" / "crd_webhook.yaml"
+_ROLE_ANNOTATION = "isvtest.nvidia.com/k8s21-role"
+_LABEL_KEY = "isvtest-k8s21"
+_DEFAULT_IMAGE = "registry.k8s.io/e2e-test-images/agnhost:2.47"
+_SERVICE_PORT = 443
+_CONTAINER_PORT = 8444
+_API_VERSION = "v1"
+_KIND = "K8s21Widget"
+_PLURAL = "k8s21widgets"
+_SINGULAR = "k8s21widget"
+
+
+@dataclass(frozen=True)
+class _CertBundle:
+    """PEM certificate material encoded for Kubernetes Secret and webhook fields."""
+
+    ca_bundle: str
+    tls_crt: str
+    tls_key: str
+
+
+@dataclass(frozen=True)
+class _RuntimeNames:
+    """Names generated for one ephemeral K8S21 validation run."""
+
+    suffix: str
+    namespace: str
+    secret: str
+    service: str
+    deployment: str
+    crd_name: str
+    crd_group: str
+    deny_crd_name: str
+    deny_crd_group: str
+    crd_validator: str
+    cr_mutator: str
+    cr_validator: str
+    resource: str
+
+
+class K8sCrdWebhookCheck(BaseValidation):
+    """Verify Kubernetes CRDs plus validating and mutating admission webhooks.
+
+    The check deploys the upstream ``agnhost webhook`` server in an ephemeral
+    namespace, registers admission webhooks, and then verifies:
+
+    * CRD creation is denied when the CRD has the disallowed label.
+    * A valid namespaced custom resource definition can be established.
+    * A custom resource is mutated with ``data.mutation-stage-1=yes``.
+    * A custom resource with disallowed data is rejected.
+
+    Config keys:
+        image: agnhost image containing the ``webhook`` subcommand.
+        namespace_prefix: Prefix for the ephemeral namespace.
+        wait_timeout: Timeout for waits and admission propagation retries.
+        poll_interval: Delay between admission propagation retry attempts.
+    """
+
+    description: ClassVar[str] = "Create a CRD and verify validating and mutating admission webhooks."
+    timeout: ClassVar[int] = 300
+
+    def run(self) -> None:
+        """Create webhook resources, verify admission behavior, and clean up."""
+        wait_timeout = self._parse_positive_int("wait_timeout", default=180)
+        poll_interval = self._parse_positive_int("poll_interval", default=2)
+        if wait_timeout is None or poll_interval is None:
+            return
+
+        self._wait_timeout = wait_timeout
+        self._poll_interval = poll_interval
+        self._image = str(self.config.get("image") or _DEFAULT_IMAGE)
+        self._kubectl_parts = get_kubectl_command()
+        self._kubectl_base = get_kubectl_base_shell()
+        self._names = _make_names(str(self.config.get("namespace_prefix", "isvtest-k8s21")))
+        service_dns_names = _service_dns_names(self._names.service, self._names.namespace)
+        self._certs = _generate_cert_bundle(service_dns_names)
+
+        try:
+            if not self._create_namespace():
+                return
+            if not self._apply_or_fail(self._render_roles({"secret", "service", "deployment"}), "webhook server"):
+                return
+            if not self._wait_for_webhook_deployment():
+                return
+            if not self._apply_or_fail(self._render_roles({"crd-validator"}), "CRD validating webhook"):
+                return
+            if not self._expect_apply_rejected(
+                self._render_crd(disallowed=True),
+                "the crd contains unwanted label",
+                "CRD validating webhook did not reject the disallowed CRD",
+                f"{self._kubectl_base} delete crd {shlex.quote(self._names.deny_crd_name)} --ignore-not-found=true",
+            ):
+                return
+            if not self._apply_or_fail(self._render_crd(disallowed=False), "custom resource definition"):
+                return
+            if not self._wait_for_crd():
+                return
+            if not self._apply_or_fail(
+                self._render_roles({"cr-mutator", "cr-validator"}),
+                "custom resource webhooks",
+            ):
+                return
+            if not self._verify_custom_resource_mutation():
+                return
+            if not self._expect_apply_rejected(
+                self._render_custom_resource("rejected", {"webhook-e2e-test": "webhook-disallow"}),
+                "the custom resource contains unwanted data",
+                "Custom resource validating webhook did not reject disallowed data",
+                self._delete_custom_resource_command("rejected"),
+            ):
+                return
+
+            self.set_passed("CRD admission and custom resource webhook mutation/validation verified")
+        finally:
+            self._cleanup()
+
+    def _create_namespace(self) -> bool:
+        """Create and label the ephemeral namespace used by namespaced webhook resources."""
+        namespace = shlex.quote(self._names.namespace)
+        result = self.run_command(f"{self._kubectl_base} create namespace {namespace}")
+        if result.exit_code != 0:
+            self.set_failed(f"Failed to create namespace {self._names.namespace}: {_command_detail(result)}")
+            return False
+
+        label = shlex.quote(f"{_LABEL_KEY}={self._names.suffix}")
+        label_result = self.run_command(f"{self._kubectl_base} label namespace {namespace} {label} --overwrite")
+        if label_result.exit_code != 0:
+            self.set_failed(f"Failed to label namespace {self._names.namespace}: {_command_detail(label_result)}")
+            return False
+        return True
+
+    def _wait_for_webhook_deployment(self) -> bool:
+        """Wait for the agnhost webhook Deployment to become Available."""
+        cmd = (
+            f"{self._kubectl_base} wait --for=condition=Available "
+            f"--timeout={self._wait_timeout}s deployment/{shlex.quote(self._names.deployment)} "
+            f"-n {shlex.quote(self._names.namespace)}"
+        )
+        result = self.run_command(cmd, timeout=self._wait_timeout + 30)
+        if result.exit_code != 0:
+            self.set_failed(f"Webhook deployment did not become Available: {_command_detail(result)}")
+            return False
+        return True
+
+    def _wait_for_crd(self) -> bool:
+        """Wait for the custom resource definition to become Established."""
+        cmd = (
+            f"{self._kubectl_base} wait --for=condition=Established "
+            f"--timeout={self._wait_timeout}s crd/{shlex.quote(self._names.crd_name)}"
+        )
+        result = self.run_command(cmd, timeout=self._wait_timeout + 30)
+        if result.exit_code != 0:
+            self.set_failed(f"CustomResourceDefinition did not become Established: {_command_detail(result)}")
+            return False
+        return True
+
+    def _verify_custom_resource_mutation(self) -> bool:
+        """Create a custom resource and verify the mutating webhook added stage-1 data."""
+        manifest = self._render_custom_resource("mutated", {"mutation-start": "yes"})
+        last_detail = ""
+        attempts = self._attempts()
+        deadline = time.monotonic() + self._wait_timeout
+        for attempt in range(attempts):
+            proc = self._run_apply(manifest, timeout=self._apply_timeout(deadline))
+            if proc.returncode != 0:
+                last_detail = _process_detail(proc)
+            else:
+                result = self.run_command(
+                    f"{self._kubectl_base} get {shlex.quote(self._names.resource)} mutated "
+                    f"-n {shlex.quote(self._names.namespace)} -o json"
+                )
+                if result.exit_code != 0:
+                    last_detail = _command_detail(result)
+                else:
+                    try:
+                        payload = parse_kubectl_json(result, "mutated custom resource")
+                    except KubectlParseError as exc:
+                        last_detail = str(exc)
+                    else:
+                        data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+                        if data.get("mutation-stage-1") == "yes":
+                            return True
+                        last_detail = f"observed data={data!r}"
+                self._cleanup_command(self._delete_custom_resource_command("mutated"), "mutated custom resource")
+
+            if attempt < attempts - 1:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                time.sleep(min(float(self._poll_interval), remaining))
+
+        self.set_failed(f"Custom resource mutation did not add data.mutation-stage-1=yes: {last_detail}")
+        return False
+
+    def _expect_apply_rejected(
+        self,
+        manifest: str,
+        expected: str,
+        failure_message: str,
+        cleanup_cmd: str,
+    ) -> bool:
+        """Run ``kubectl apply`` until the admission webhook rejects with ``expected``."""
+        last_detail = ""
+        attempts = self._attempts()
+        deadline = time.monotonic() + self._wait_timeout
+        for attempt in range(attempts):
+            proc = self._run_apply(manifest, timeout=self._apply_timeout(deadline))
+            detail = _process_detail(proc)
+            if proc.returncode != 0:
+                if expected in detail:
+                    return True
+                last_detail = detail
+            else:
+                last_detail = "kubectl apply unexpectedly succeeded"
+                self._cleanup_command(cleanup_cmd, "unexpectedly admitted resource")
+
+            if attempt < attempts - 1:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                time.sleep(min(float(self._poll_interval), remaining))
+
+        self.set_failed(f"{failure_message}: {last_detail}")
+        return False
+
+    def _attempts(self) -> int:
+        """Return the number of admission propagation attempts to make."""
+        return max(1, (self._wait_timeout + self._poll_interval - 1) // self._poll_interval)
+
+    def _apply_timeout(self, deadline: float) -> float:
+        """Return a per-apply timeout bounded by the remaining retry budget."""
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return 0.1
+        return min(float(self.timeout), max(0.1, remaining))
+
+    def _apply_or_fail(self, manifest: str, label: str) -> bool:
+        """Apply a manifest and mark the validation failed on kubectl errors."""
+        proc = self._run_apply(manifest)
+        if proc.returncode != 0:
+            self.set_failed(f"kubectl apply failed for {label}: {_process_detail(proc)}")
+            return False
+        return True
+
+    def _run_apply(self, manifest: str, timeout: float | None = None) -> subprocess.CompletedProcess[str]:
+        """Run ``kubectl apply -f -`` for a rendered manifest string."""
+        try:
+            return subprocess.run(
+                self._kubectl_parts + ["apply", "-f", "-"],
+                input=manifest,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout if timeout is None else timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+            stderr = exc.stderr if isinstance(exc.stderr, str) else "kubectl apply timed out"
+            return subprocess.CompletedProcess(self._kubectl_parts + ["apply", "-f", "-"], 124, stdout, stderr)
+        except Exception as exc:
+            return subprocess.CompletedProcess(
+                self._kubectl_parts + ["apply", "-f", "-"],
+                1,
+                "",
+                f"kubectl apply raised: {exc}",
+            )
+
+    def _render_roles(self, roles: set[str]) -> str:
+        """Render all manifest documents whose role annotation is in ``roles``."""
+        docs = [self._mutate_doc(doc) for doc in _load_template_docs() if _doc_role(doc) in roles]
+        return yaml.safe_dump_all(docs, sort_keys=False)
+
+    def _render_crd(self, *, disallowed: bool) -> str:
+        """Render the CRD document, optionally with the disallowed webhook label."""
+        crd = next(doc for doc in _load_template_docs() if _doc_role(doc) == "crd")
+        return yaml.safe_dump(self._mutate_crd_doc(crd, disallowed=disallowed), sort_keys=False)
+
+    def _render_custom_resource(self, name: str, data: dict[str, str]) -> str:
+        """Render a namespaced custom resource instance for the generated CRD."""
+        doc: dict[str, Any] = {
+            "apiVersion": f"{self._names.crd_group}/{_API_VERSION}",
+            "kind": _KIND,
+            "metadata": {
+                "name": name,
+                "namespace": self._names.namespace,
+                "labels": {_LABEL_KEY: self._names.suffix},
+            },
+            "data": data,
+        }
+        return yaml.safe_dump(doc, sort_keys=False)
+
+    def _mutate_doc(self, doc: dict[str, Any]) -> dict[str, Any]:
+        """Patch a template document with runtime values."""
+        role = _doc_role(doc)
+        if role == "secret":
+            return self._mutate_secret_doc(doc)
+        if role == "service":
+            return self._mutate_service_doc(doc)
+        if role == "deployment":
+            return self._mutate_deployment_doc(doc)
+        if role == "crd":
+            return self._mutate_crd_doc(doc, disallowed=False)
+        if role == "crd-validator":
+            return self._mutate_webhook_doc(doc, self._names.crd_validator)
+        if role == "cr-mutator":
+            return self._mutate_custom_resource_webhook_doc(doc, self._names.cr_mutator)
+        if role == "cr-validator":
+            return self._mutate_custom_resource_webhook_doc(doc, self._names.cr_validator)
+        msg = f"Unsupported K8S21 manifest role: {role}"
+        raise ValueError(msg)
+
+    def _mutate_secret_doc(self, doc: dict[str, Any]) -> dict[str, Any]:
+        """Patch the TLS Secret document."""
+        metadata = _metadata(doc)
+        metadata["name"] = self._names.secret
+        metadata["namespace"] = self._names.namespace
+        metadata.setdefault("labels", {})[_LABEL_KEY] = self._names.suffix
+        doc["data"] = {"tls.crt": self._certs.tls_crt, "tls.key": self._certs.tls_key}
+        return doc
+
+    def _mutate_service_doc(self, doc: dict[str, Any]) -> dict[str, Any]:
+        """Patch the webhook Service document."""
+        metadata = _metadata(doc)
+        metadata["name"] = self._names.service
+        metadata["namespace"] = self._names.namespace
+        metadata.setdefault("labels", {})[_LABEL_KEY] = self._names.suffix
+        doc["spec"]["selector"] = {"app": self._names.deployment}
+        doc["spec"]["ports"][0]["port"] = _SERVICE_PORT
+        doc["spec"]["ports"][0]["targetPort"] = "https"
+        return doc
+
+    def _mutate_deployment_doc(self, doc: dict[str, Any]) -> dict[str, Any]:
+        """Patch the agnhost webhook Deployment document."""
+        metadata = _metadata(doc)
+        metadata["name"] = self._names.deployment
+        metadata["namespace"] = self._names.namespace
+        metadata.setdefault("labels", {})[_LABEL_KEY] = self._names.suffix
+        selector_labels = {"app": self._names.deployment}
+        doc["spec"]["selector"]["matchLabels"] = selector_labels
+        doc["spec"]["template"]["metadata"]["labels"] = {**selector_labels, _LABEL_KEY: self._names.suffix}
+        container = doc["spec"]["template"]["spec"]["containers"][0]
+        container["image"] = self._image
+        container["args"] = [
+            "webhook",
+            "--tls-cert-file=/webhook.local.config/certificates/tls.crt",
+            "--tls-private-key-file=/webhook.local.config/certificates/tls.key",
+            f"--port={_CONTAINER_PORT}",
+        ]
+        doc["spec"]["template"]["spec"]["volumes"][0]["secret"]["secretName"] = self._names.secret
+        return doc
+
+    def _mutate_crd_doc(self, doc: dict[str, Any], *, disallowed: bool) -> dict[str, Any]:
+        """Patch the CustomResourceDefinition document."""
+        metadata = _metadata(doc)
+        group = self._names.deny_crd_group if disallowed else self._names.crd_group
+        crd_name = self._names.deny_crd_name if disallowed else self._names.crd_name
+        metadata["name"] = crd_name
+        labels = metadata.setdefault("labels", {})
+        labels[_LABEL_KEY] = self._names.suffix
+        if disallowed:
+            labels["webhook-e2e-test"] = "webhook-disallow"
+        else:
+            labels.pop("webhook-e2e-test", None)
+        doc["spec"]["group"] = group
+        doc["spec"]["names"]["plural"] = _PLURAL
+        doc["spec"]["names"]["singular"] = _SINGULAR
+        doc["spec"]["names"]["kind"] = _KIND
+        doc["spec"]["names"]["listKind"] = f"{_KIND}List"
+        return doc
+
+    def _mutate_webhook_doc(self, doc: dict[str, Any], name: str) -> dict[str, Any]:
+        """Patch common webhook configuration fields."""
+        _metadata(doc)["name"] = name
+        for webhook in doc["webhooks"]:
+            webhook["clientConfig"]["caBundle"] = self._certs.ca_bundle
+            service = webhook["clientConfig"]["service"]
+            service["namespace"] = self._names.namespace
+            service["name"] = self._names.service
+            service["port"] = _SERVICE_PORT
+            if "objectSelector" in webhook:
+                webhook["objectSelector"]["matchLabels"] = {_LABEL_KEY: self._names.suffix}
+            if "namespaceSelector" in webhook:
+                webhook["namespaceSelector"]["matchLabels"] = {_LABEL_KEY: self._names.suffix}
+        return doc
+
+    def _mutate_custom_resource_webhook_doc(self, doc: dict[str, Any], name: str) -> dict[str, Any]:
+        """Patch webhook rules for the generated custom resource."""
+        doc = self._mutate_webhook_doc(doc, name)
+        for webhook in doc["webhooks"]:
+            for rule in webhook["rules"]:
+                rule["apiGroups"] = [self._names.crd_group]
+                rule["apiVersions"] = [_API_VERSION]
+                rule["resources"] = [_PLURAL]
+        return doc
+
+    def _delete_custom_resource_command(self, name: str) -> str:
+        """Build a best-effort delete command for a generated custom resource."""
+        return (
+            f"{self._kubectl_base} delete {shlex.quote(self._names.resource)} {shlex.quote(name)} "
+            f"-n {shlex.quote(self._names.namespace)} --ignore-not-found=true"
+        )
+
+    def _cleanup(self) -> None:
+        """Best-effort cleanup for cluster-scoped webhooks, CRDs, and the namespace."""
+        if not hasattr(self, "_names") or not hasattr(self, "_kubectl_base"):
+            return
+        commands = [
+            (
+                f"{self._kubectl_base} delete validatingwebhookconfiguration "
+                f"{shlex.quote(self._names.crd_validator)} --ignore-not-found=true",
+                "CRD validating webhook",
+            ),
+            (
+                f"{self._kubectl_base} delete validatingwebhookconfiguration "
+                f"{shlex.quote(self._names.cr_validator)} --ignore-not-found=true",
+                "custom resource validating webhook",
+            ),
+            (
+                f"{self._kubectl_base} delete mutatingwebhookconfiguration "
+                f"{shlex.quote(self._names.cr_mutator)} --ignore-not-found=true",
+                "custom resource mutating webhook",
+            ),
+            (
+                f"{self._kubectl_base} delete crd {shlex.quote(self._names.crd_name)} --ignore-not-found=true",
+                "custom resource definition",
+            ),
+            (
+                f"{self._kubectl_base} delete crd {shlex.quote(self._names.deny_crd_name)} --ignore-not-found=true",
+                "disallowed custom resource definition",
+            ),
+            (
+                f"{self._kubectl_base} delete namespace {shlex.quote(self._names.namespace)} "
+                "--wait=false --ignore-not-found=true",
+                "namespace",
+            ),
+        ]
+        for cmd, label in commands:
+            self._cleanup_command(cmd, label)
+
+    def _cleanup_command(self, cmd: str, label: str) -> None:
+        """Run one best-effort cleanup command without changing validation state."""
+        try:
+            result = self.run_command(cmd)
+        except Exception as exc:
+            self.log.warning("%s cleanup raised: %s", label, exc)
+            return
+        if result.exit_code != 0:
+            self.log.warning("%s cleanup failed: %s", label, _command_detail(result))
+
+
+def _load_template_docs() -> list[dict[str, Any]]:
+    """Load the K8S21 manifest template as a list of YAML documents."""
+    return [doc for doc in yaml.safe_load_all(_MANIFEST_PATH.read_text()) if isinstance(doc, dict)]
+
+
+def _doc_role(doc: dict[str, Any]) -> str:
+    """Return the K8S21 role annotation for a template document."""
+    return str((_metadata(doc).get("annotations") or {}).get(_ROLE_ANNOTATION, ""))
+
+
+def _metadata(doc: dict[str, Any]) -> dict[str, Any]:
+    """Return a document's metadata dictionary, creating it if needed."""
+    metadata = doc.setdefault("metadata", {})
+    if not isinstance(metadata, dict):
+        msg = f"Kubernetes document metadata must be an object, got {type(metadata).__name__}"
+        raise TypeError(msg)
+    return metadata
+
+
+def _make_names(namespace_prefix: str) -> _RuntimeNames:
+    """Generate names unique enough for one validation run."""
+    suffix = uuid.uuid4().hex[:8]
+    namespace = f"{namespace_prefix}-{suffix}"
+    group = f"k8s21-{suffix}.isvtest.nvidia.com"
+    deny_group = f"k8s21-deny-{suffix}.isvtest.nvidia.com"
+    return _RuntimeNames(
+        suffix=suffix,
+        namespace=namespace,
+        secret="k8s21-webhook-certs",
+        service="k8s21-webhook",
+        deployment="k8s21-webhook",
+        crd_name=f"{_PLURAL}.{group}",
+        crd_group=group,
+        deny_crd_name=f"{_PLURAL}.{deny_group}",
+        deny_crd_group=deny_group,
+        crd_validator=f"k8s21-{suffix}-crd-validator",
+        cr_mutator=f"k8s21-{suffix}-cr-mutator",
+        cr_validator=f"k8s21-{suffix}-cr-validator",
+        resource=f"{_PLURAL}.{group}",
+    )
+
+
+def _service_dns_names(service: str, namespace: str) -> list[str]:
+    """Return DNS SANs accepted for the webhook Service certificate."""
+    return [
+        service,
+        f"{service}.{namespace}",
+        f"{service}.{namespace}.svc",
+        f"{service}.{namespace}.svc.cluster.local",
+    ]
+
+
+def _generate_cert_bundle(dns_names: list[str]) -> _CertBundle:
+    """Generate a CA and server certificate for the webhook Service DNS names."""
+    now = dt.datetime.now(dt.UTC)
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "isvtest-k8s21-ca")])
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(ca_name)
+        .issuer_name(ca_name)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - dt.timedelta(minutes=5))
+        .not_valid_after(now + dt.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    server_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    server_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, dns_names[2])])
+    server_cert = (
+        x509.CertificateBuilder()
+        .subject_name(server_name)
+        .issuer_name(ca_name)
+        .public_key(server_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - dt.timedelta(minutes=5))
+        .not_valid_after(now + dt.timedelta(days=1))
+        .add_extension(x509.SubjectAlternativeName([x509.DNSName(name) for name in dns_names]), critical=False)
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    ca_pem = ca_cert.public_bytes(serialization.Encoding.PEM)
+    cert_pem = server_cert.public_bytes(serialization.Encoding.PEM)
+    key_pem = server_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    )
+    return _CertBundle(
+        ca_bundle=_b64(ca_pem),
+        tls_crt=_b64(cert_pem),
+        tls_key=_b64(key_pem),
+    )
+
+
+def _b64(data: bytes) -> str:
+    """Return base64-encoded text for Kubernetes byte fields."""
+    return base64.b64encode(data).decode("ascii")
+
+
+def _process_detail(proc: subprocess.CompletedProcess[str]) -> str:
+    """Return the most useful stderr/stdout detail from a completed process."""
+    return (proc.stderr or proc.stdout or f"exit code {proc.returncode}").strip()
+
+
+def _command_detail(result: Any) -> str:
+    """Return the most useful stderr/stdout detail from a command result."""
+    return (result.stderr or result.stdout or f"exit code {result.exit_code}").strip()

--- a/isvtest/src/isvtest/validations/k8s_crd_webhook.py
+++ b/isvtest/src/isvtest/validations/k8s_crd_webhook.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Kubernetes CRD and admission webhook validation (K8S21-01)."""
+"""Validate Kubernetes CRD admission and custom-resource webhook behavior."""
 
 from __future__ import annotations
 
@@ -37,15 +37,15 @@ from isvtest.core.k8s import KubectlParseError, get_kubectl_base_shell, get_kube
 from isvtest.core.validation import BaseValidation
 
 _MANIFEST_PATH = Path(__file__).parent / "manifests" / "k8s" / "crd_webhook.yaml"
-_ROLE_ANNOTATION = "isvtest.nvidia.com/k8s21-role"
-_LABEL_KEY = "isvtest-k8s21"
+_ROLE_ANNOTATION = "isvtest.nvidia.com/crd-webhook-role"
+_LABEL_KEY = "isvtest-crd-webhook"
 _DEFAULT_IMAGE = "registry.k8s.io/e2e-test-images/agnhost:2.47"
 _SERVICE_PORT = 443
 _CONTAINER_PORT = 8444
 _API_VERSION = "v1"
-_KIND = "K8s21Widget"
-_PLURAL = "k8s21widgets"
-_SINGULAR = "k8s21widget"
+_KIND = "CrdWebhookWidget"
+_PLURAL = "crdwebhookwidgets"
+_SINGULAR = "crdwebhookwidget"
 
 
 @dataclass(frozen=True)
@@ -59,7 +59,7 @@ class _CertBundle:
 
 @dataclass(frozen=True)
 class _RuntimeNames:
-    """Names generated for one ephemeral K8S21 validation run."""
+    """Names generated for one ephemeral CRD webhook validation run."""
 
     suffix: str
     namespace: str
@@ -94,7 +94,9 @@ class K8sCrdWebhookCheck(BaseValidation):
         poll_interval: Delay between admission propagation retry attempts.
     """
 
-    description: ClassVar[str] = "Create a CRD and verify validating and mutating admission webhooks."
+    description: ClassVar[str] = (
+        "Create a CRD and verify CRD admission rejection, custom-resource mutation, and custom-resource validation."
+    )
     timeout: ClassVar[int] = 300
 
     def run(self) -> None:
@@ -109,7 +111,7 @@ class K8sCrdWebhookCheck(BaseValidation):
         self._image = str(self.config.get("image") or _DEFAULT_IMAGE)
         self._kubectl_parts = get_kubectl_command()
         self._kubectl_base = get_kubectl_base_shell()
-        self._names = _make_names(str(self.config.get("namespace_prefix", "isvtest-k8s21")))
+        self._names = _make_names(str(self.config.get("namespace_prefix", "isvtest-crd-webhook")))
         service_dns_names = _service_dns_names(self._names.service, self._names.namespace)
         self._certs = _generate_cert_bundle(service_dns_names)
 
@@ -343,7 +345,7 @@ class K8sCrdWebhookCheck(BaseValidation):
             return self._mutate_custom_resource_webhook_doc(doc, self._names.cr_mutator)
         if role == "cr-validator":
             return self._mutate_custom_resource_webhook_doc(doc, self._names.cr_validator)
-        msg = f"Unsupported K8S21 manifest role: {role}"
+        msg = f"Unsupported CRD webhook manifest role: {role}"
         raise ValueError(msg)
 
     def _mutate_secret_doc(self, doc: dict[str, Any]) -> dict[str, Any]:
@@ -486,12 +488,12 @@ class K8sCrdWebhookCheck(BaseValidation):
 
 
 def _load_template_docs() -> list[dict[str, Any]]:
-    """Load the K8S21 manifest template as a list of YAML documents."""
+    """Load the CRD webhook manifest template as a list of YAML documents."""
     return [doc for doc in yaml.safe_load_all(_MANIFEST_PATH.read_text()) if isinstance(doc, dict)]
 
 
 def _doc_role(doc: dict[str, Any]) -> str:
-    """Return the K8S21 role annotation for a template document."""
+    """Return the CRD webhook role annotation for a template document."""
     return str((_metadata(doc).get("annotations") or {}).get(_ROLE_ANNOTATION, ""))
 
 
@@ -508,21 +510,21 @@ def _make_names(namespace_prefix: str) -> _RuntimeNames:
     """Generate names unique enough for one validation run."""
     suffix = uuid.uuid4().hex[:8]
     namespace = f"{namespace_prefix}-{suffix}"
-    group = f"k8s21-{suffix}.isvtest.nvidia.com"
-    deny_group = f"k8s21-deny-{suffix}.isvtest.nvidia.com"
+    group = f"crd-webhook-{suffix}.isvtest.nvidia.com"
+    deny_group = f"crd-webhook-deny-{suffix}.isvtest.nvidia.com"
     return _RuntimeNames(
         suffix=suffix,
         namespace=namespace,
-        secret="k8s21-webhook-certs",
-        service="k8s21-webhook",
-        deployment="k8s21-webhook",
+        secret="crd-webhook-certs",
+        service="crd-webhook",
+        deployment="crd-webhook",
         crd_name=f"{_PLURAL}.{group}",
         crd_group=group,
         deny_crd_name=f"{_PLURAL}.{deny_group}",
         deny_crd_group=deny_group,
-        crd_validator=f"k8s21-{suffix}-crd-validator",
-        cr_mutator=f"k8s21-{suffix}-cr-mutator",
-        cr_validator=f"k8s21-{suffix}-cr-validator",
+        crd_validator=f"crd-webhook-{suffix}-crd-validator",
+        cr_mutator=f"crd-webhook-{suffix}-cr-mutator",
+        cr_validator=f"crd-webhook-{suffix}-cr-validator",
         resource=f"{_PLURAL}.{group}",
     )
 
@@ -541,7 +543,7 @@ def _generate_cert_bundle(dns_names: list[str]) -> _CertBundle:
     """Generate a CA and server certificate for the webhook Service DNS names."""
     now = dt.datetime.now(dt.UTC)
     ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "isvtest-k8s21-ca")])
+    ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "isvtest-crd-webhook-ca")])
     ca_cert = (
         x509.CertificateBuilder()
         .subject_name(ca_name)

--- a/isvtest/src/isvtest/validations/manifests/k8s/crd_webhook.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/crd_webhook.yaml
@@ -67,6 +67,13 @@ spec:
         - name: agnhost-webhook
           image: placeholder
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           args:
             - webhook
             - --tls-cert-file=/webhook.local.config/certificates/tls.crt

--- a/isvtest/src/isvtest/validations/manifests/k8s/crd_webhook.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/crd_webhook.yaml
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Admission webhook validation template for K8S21-01.
+#
+# Loaded and mutated by K8sCrdWebhookCheck. Placeholder values keep this file
+# valid YAML; runtime code patches namespace, names, labels, image, certificate
+# data, CA bundle, service DNS names, and webhook rule groups/resources.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: placeholder
+  namespace: placeholder
+  annotations:
+    isvtest.nvidia.com/k8s21-role: secret
+type: kubernetes.io/tls
+data:
+  tls.crt: placeholder
+  tls.key: placeholder
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: placeholder
+  namespace: placeholder
+  annotations:
+    isvtest.nvidia.com/k8s21-role: service
+spec:
+  selector:
+    app: placeholder
+  ports:
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: https
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: placeholder
+  namespace: placeholder
+  annotations:
+    isvtest.nvidia.com/k8s21-role: deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: placeholder
+  template:
+    metadata:
+      labels:
+        app: placeholder
+    spec:
+      containers:
+        - name: agnhost-webhook
+          image: placeholder
+          imagePullPolicy: IfNotPresent
+          args:
+            - webhook
+            - --tls-cert-file=/webhook.local.config/certificates/tls.crt
+            - --tls-private-key-file=/webhook.local.config/certificates/tls.key
+            - --port=8444
+          ports:
+            - name: https
+              containerPort: 8444
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /readyz
+              port: https
+            periodSeconds: 1
+            failureThreshold: 30
+          volumeMounts:
+            - name: webhook-certs
+              readOnly: true
+              mountPath: /webhook.local.config/certificates
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: placeholder
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: placeholder.example.com
+  annotations:
+    isvtest.nvidia.com/k8s21-role: crd
+  labels:
+    isvtest-k8s21: placeholder
+spec:
+  group: placeholder.example.com
+  scope: Namespaced
+  names:
+    plural: placeholders
+    singular: placeholder
+    kind: K8s21Widget
+    listKind: K8s21WidgetList
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            data:
+              type: object
+              additionalProperties:
+                type: string
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: placeholder-crd-validator
+  annotations:
+    isvtest.nvidia.com/k8s21-role: crd-validator
+webhooks:
+  - name: deny-crd-with-unwanted-label.k8s.io
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    failurePolicy: Fail
+    timeoutSeconds: 10
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: ["apiextensions.k8s.io"]
+        apiVersions: ["v1"]
+        resources: ["customresourcedefinitions"]
+    objectSelector:
+      matchLabels:
+        isvtest-k8s21: placeholder
+    clientConfig:
+      caBundle: placeholder
+      service:
+        namespace: placeholder
+        name: placeholder
+        path: /crd
+        port: 443
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: placeholder-cr-mutator
+  annotations:
+    isvtest.nvidia.com/k8s21-role: cr-mutator
+webhooks:
+  - name: mutate-custom-resource-data-stage-1.k8s.io
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    failurePolicy: Fail
+    timeoutSeconds: 10
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["placeholder.example.com"]
+        apiVersions: ["v1"]
+        resources: ["placeholders"]
+    namespaceSelector:
+      matchLabels:
+        isvtest-k8s21: placeholder
+    clientConfig:
+      caBundle: placeholder
+      service:
+        namespace: placeholder
+        name: placeholder
+        path: /mutating-custom-resource
+        port: 443
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: placeholder-cr-validator
+  annotations:
+    isvtest.nvidia.com/k8s21-role: cr-validator
+webhooks:
+  - name: deny-unwanted-custom-resource-data.k8s.io
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    failurePolicy: Fail
+    timeoutSeconds: 10
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["placeholder.example.com"]
+        apiVersions: ["v1"]
+        resources: ["placeholders"]
+    namespaceSelector:
+      matchLabels:
+        isvtest-k8s21: placeholder
+    clientConfig:
+      caBundle: placeholder
+      service:
+        namespace: placeholder
+        name: placeholder
+        path: /custom-resource
+        port: 443

--- a/isvtest/src/isvtest/validations/manifests/k8s/crd_webhook.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/crd_webhook.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Admission webhook validation template for K8S21-01.
+# Admission webhook validation template for CRD and custom-resource probes.
 #
 # Loaded and mutated by K8sCrdWebhookCheck. Placeholder values keep this file
 # valid YAML; runtime code patches namespace, names, labels, image, certificate
@@ -24,7 +24,7 @@ metadata:
   name: placeholder
   namespace: placeholder
   annotations:
-    isvtest.nvidia.com/k8s21-role: secret
+    isvtest.nvidia.com/crd-webhook-role: secret
 type: kubernetes.io/tls
 data:
   tls.crt: placeholder
@@ -36,7 +36,7 @@ metadata:
   name: placeholder
   namespace: placeholder
   annotations:
-    isvtest.nvidia.com/k8s21-role: service
+    isvtest.nvidia.com/crd-webhook-role: service
 spec:
   selector:
     app: placeholder
@@ -52,7 +52,7 @@ metadata:
   name: placeholder
   namespace: placeholder
   annotations:
-    isvtest.nvidia.com/k8s21-role: deployment
+    isvtest.nvidia.com/crd-webhook-role: deployment
 spec:
   replicas: 1
   selector:
@@ -97,9 +97,9 @@ kind: CustomResourceDefinition
 metadata:
   name: placeholder.example.com
   annotations:
-    isvtest.nvidia.com/k8s21-role: crd
+    isvtest.nvidia.com/crd-webhook-role: crd
   labels:
-    isvtest-k8s21: placeholder
+    isvtest-crd-webhook: placeholder
 spec:
   group: placeholder.example.com
   scope: Namespaced
@@ -126,7 +126,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: placeholder-crd-validator
   annotations:
-    isvtest.nvidia.com/k8s21-role: crd-validator
+    isvtest.nvidia.com/crd-webhook-role: crd-validator
 webhooks:
   - name: deny-crd-with-unwanted-label.k8s.io
     admissionReviewVersions: ["v1", "v1beta1"]
@@ -140,7 +140,7 @@ webhooks:
         resources: ["customresourcedefinitions"]
     objectSelector:
       matchLabels:
-        isvtest-k8s21: placeholder
+        isvtest-crd-webhook: placeholder
     clientConfig:
       caBundle: placeholder
       service:
@@ -154,7 +154,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: placeholder-cr-mutator
   annotations:
-    isvtest.nvidia.com/k8s21-role: cr-mutator
+    isvtest.nvidia.com/crd-webhook-role: cr-mutator
 webhooks:
   - name: mutate-custom-resource-data-stage-1.k8s.io
     admissionReviewVersions: ["v1", "v1beta1"]
@@ -168,7 +168,7 @@ webhooks:
         resources: ["placeholders"]
     namespaceSelector:
       matchLabels:
-        isvtest-k8s21: placeholder
+        isvtest-crd-webhook: placeholder
     clientConfig:
       caBundle: placeholder
       service:
@@ -182,7 +182,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: placeholder-cr-validator
   annotations:
-    isvtest.nvidia.com/k8s21-role: cr-validator
+    isvtest.nvidia.com/crd-webhook-role: cr-validator
 webhooks:
   - name: deny-unwanted-custom-resource-data.k8s.io
     admissionReviewVersions: ["v1", "v1beta1"]
@@ -196,7 +196,7 @@ webhooks:
         resources: ["placeholders"]
     namespaceSelector:
       matchLabels:
-        isvtest-k8s21: placeholder
+        isvtest-crd-webhook: placeholder
     clientConfig:
       caBundle: placeholder
       service:

--- a/isvtest/tests/test_k8s_crd_webhook.py
+++ b/isvtest/tests/test_k8s_crd_webhook.py
@@ -1,0 +1,304 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``isvtest.validations.k8s_crd_webhook``."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from base64 import b64decode
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import patch
+
+import yaml
+from cryptography import x509
+
+from isvtest.core.runners import CommandResult
+from isvtest.validations.k8s_crd_webhook import K8sCrdWebhookCheck
+
+
+def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    """Return a successful ``CommandResult`` with the given stdout/stderr."""
+    return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _fail(stdout: str = "", stderr: str = "", exit_code: int = 1) -> CommandResult:
+    """Return a failing ``CommandResult`` with the given output and exit code."""
+    return CommandResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess[str]:
+    """Return a ``subprocess.CompletedProcess`` shaped like ``kubectl apply``."""
+    return subprocess.CompletedProcess(
+        args=["kubectl", "apply", "-f", "-"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def _docs(manifest: str) -> list[dict[str, Any]]:
+    """Parse the Kubernetes docs sent to ``kubectl apply -f -``."""
+    return [doc for doc in yaml.safe_load_all(manifest) if isinstance(doc, dict)]
+
+
+def _custom_resource_json(*, mutated: bool = True) -> str:
+    """Return a custom resource payload as read back from kubectl."""
+    data = {"mutation-start": "yes"}
+    if mutated:
+        data["mutation-stage-1"] = "yes"
+    return json.dumps({"data": data})
+
+
+def _patch_kubectl() -> Any:
+    """Patch kubectl command discovery for deterministic unit tests."""
+    return patch.multiple(
+        "isvtest.validations.k8s_crd_webhook",
+        get_kubectl_command=lambda: ["kubectl"],
+        get_kubectl_base_shell=lambda *args: " ".join(("kubectl", *args)) if args else "kubectl",
+    )
+
+
+def _run_check(
+    *,
+    apply_func: Callable[..., subprocess.CompletedProcess[str]],
+    run_command: Callable[..., CommandResult],
+    config: dict[str, Any] | None = None,
+) -> K8sCrdWebhookCheck:
+    """Run ``K8sCrdWebhookCheck`` with kubectl and sleep mocked out."""
+    check = K8sCrdWebhookCheck(
+        config={
+            "image": "registry.k8s.io/e2e-test-images/agnhost:2.47",
+            "namespace_prefix": "isvtest-k8s21",
+            "wait_timeout": 1,
+            "poll_interval": 1,
+            **(config or {}),
+        }
+    )
+    with (
+        _patch_kubectl(),
+        patch("isvtest.validations.k8s_crd_webhook.subprocess.run", side_effect=apply_func),
+        patch("isvtest.validations.k8s_crd_webhook.time.sleep"),
+        patch.object(check, "run_command", side_effect=run_command),
+    ):
+        check.run()
+    return check
+
+
+def test_crd_webhook_check_passes_with_expected_manifests_and_probes() -> None:
+    """Pass path applies webhook infrastructure, verifies mutation and rejection, and cleans up."""
+    applied_docs: list[dict[str, Any]] = []
+    admission_apply_timeouts: list[float] = []
+    commands: list[str] = []
+
+    def fake_apply(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        assert args == ["kubectl", "apply", "-f", "-"]
+        docs = _docs(kwargs["input"])
+        applied_docs.extend(docs)
+        if any(
+            (doc.get("metadata") or {}).get("labels", {}).get("webhook-e2e-test") == "webhook-disallow"
+            or doc.get("kind") == "K8s21Widget"
+            for doc in docs
+        ):
+            admission_apply_timeouts.append(kwargs["timeout"])
+        if any(
+            (doc.get("metadata") or {}).get("labels", {}).get("webhook-e2e-test") == "webhook-disallow" for doc in docs
+        ):
+            return _completed(returncode=1, stderr="the crd contains unwanted label")
+        if any((doc.get("data") or {}).get("webhook-e2e-test") == "webhook-disallow" for doc in docs):
+            return _completed(returncode=1, stderr="the custom resource contains unwanted data")
+        return _completed()
+
+    def fake_run_command(cmd: str, *_args: Any, **_kwargs: Any) -> CommandResult:
+        commands.append(cmd)
+        if " get " in cmd and " -o json" in cmd:
+            return _ok(stdout=_custom_resource_json())
+        return _ok()
+
+    check = _run_check(apply_func=fake_apply, run_command=fake_run_command)
+
+    assert check.passed
+    assert "CRD admission and custom resource webhook mutation/validation verified" in check.message
+    kinds = {doc["kind"] for doc in applied_docs}
+    assert {
+        "Secret",
+        "Service",
+        "Deployment",
+        "CustomResourceDefinition",
+        "ValidatingWebhookConfiguration",
+        "MutatingWebhookConfiguration",
+    } <= kinds
+
+    deployments = [doc for doc in applied_docs if doc["kind"] == "Deployment"]
+    secret = next(doc for doc in applied_docs if doc["kind"] == "Secret")
+    service = next(doc for doc in applied_docs if doc["kind"] == "Service")
+    valid_crd = next(
+        doc
+        for doc in applied_docs
+        if doc["kind"] == "CustomResourceDefinition"
+        and (doc.get("metadata") or {}).get("labels", {}).get("webhook-e2e-test") != "webhook-disallow"
+    )
+    container = deployments[0]["spec"]["template"]["spec"]["containers"][0]
+    assert container["image"] == "registry.k8s.io/e2e-test-images/agnhost:2.47"
+    assert "webhook" in container["args"]
+    assert {"name": "https", "containerPort": 8444, "protocol": "TCP"} in container["ports"]
+    assert service["spec"]["ports"][0]["targetPort"] == "https"
+
+    ca_bundle = next(
+        webhook["clientConfig"]["caBundle"]
+        for doc in applied_docs
+        if doc["kind"] == "ValidatingWebhookConfiguration"
+        for webhook in doc["webhooks"]
+    )
+    ca_cert = x509.load_pem_x509_certificate(b64decode(ca_bundle))
+    server_cert = x509.load_pem_x509_certificate(b64decode(secret["data"]["tls.crt"]))
+    san_values = server_cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value.get_values_for_type(
+        x509.DNSName
+    )
+    assert server_cert.issuer == ca_cert.subject
+    assert f"{service['metadata']['name']}.{service['metadata']['namespace']}.svc" in san_values
+
+    webhook_paths = {
+        webhook["clientConfig"]["service"]["path"]
+        for doc in applied_docs
+        if doc["kind"] in {"ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"}
+        for webhook in doc["webhooks"]
+    }
+    assert {"/crd", "/custom-resource", "/mutating-custom-resource"} <= webhook_paths
+    assert all(
+        webhook["clientConfig"]["caBundle"]
+        for doc in applied_docs
+        if doc["kind"] in {"ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"}
+        for webhook in doc["webhooks"]
+    )
+    assert all(
+        webhook["clientConfig"]["service"]["name"] == service["metadata"]["name"]
+        and webhook["clientConfig"]["service"]["namespace"] == service["metadata"]["namespace"]
+        for doc in applied_docs
+        if doc["kind"] in {"ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"}
+        for webhook in doc["webhooks"]
+    )
+    label_value = service["metadata"]["labels"]["isvtest-k8s21"]
+    assert deployments[0]["spec"]["template"]["metadata"]["labels"]["isvtest-k8s21"] == label_value
+    assert valid_crd["metadata"]["labels"]["isvtest-k8s21"] == label_value
+    assert all(
+        (webhook.get("objectSelector") or webhook.get("namespaceSelector"))["matchLabels"]["isvtest-k8s21"]
+        == label_value
+        for doc in applied_docs
+        if doc["kind"] in {"ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"}
+        for webhook in doc["webhooks"]
+    )
+    assert all(
+        rule["apiGroups"] == [valid_crd["spec"]["group"]]
+        and rule["resources"] == [valid_crd["spec"]["names"]["plural"]]
+        for doc in applied_docs
+        if doc["kind"] in {"ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"}
+        for webhook in doc["webhooks"]
+        if webhook["clientConfig"]["service"]["path"] in {"/custom-resource", "/mutating-custom-resource"}
+        for rule in webhook["rules"]
+    )
+    assert admission_apply_timeouts
+    assert max(admission_apply_timeouts) <= 1
+    assert any(" wait --for=condition=Available " in cmd for cmd in commands)
+    assert any(" wait --for=condition=Established " in cmd for cmd in commands)
+    assert any(" delete namespace " in cmd for cmd in commands)
+
+
+def test_fails_when_crd_rejection_is_not_enforced() -> None:
+    """The check fails if the CRD validating webhook allows a disallowed CRD."""
+
+    def fake_apply(_args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return _completed()
+
+    def fake_run_command(cmd: str, *_args: Any, **_kwargs: Any) -> CommandResult:
+        if " get " in cmd and " -o json" in cmd:
+            return _ok(stdout=_custom_resource_json())
+        return _ok()
+
+    check = _run_check(apply_func=fake_apply, run_command=fake_run_command)
+
+    assert not check.passed
+    assert "CRD validating webhook did not reject the disallowed CRD" in check._error
+
+
+def test_fails_when_custom_resource_mutation_is_missing() -> None:
+    """The check fails when the mutating webhook does not add ``mutation-stage-1``."""
+
+    def fake_apply(_args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        docs = _docs(kwargs["input"])
+        if any(
+            (doc.get("metadata") or {}).get("labels", {}).get("webhook-e2e-test") == "webhook-disallow" for doc in docs
+        ):
+            return _completed(returncode=1, stderr="the crd contains unwanted label")
+        if any((doc.get("data") or {}).get("webhook-e2e-test") == "webhook-disallow" for doc in docs):
+            return _completed(returncode=1, stderr="the custom resource contains unwanted data")
+        return _completed()
+
+    def fake_run_command(cmd: str, *_args: Any, **_kwargs: Any) -> CommandResult:
+        if " get " in cmd and " -o json" in cmd:
+            return _ok(stdout=_custom_resource_json(mutated=False))
+        return _ok()
+
+    check = _run_check(apply_func=fake_apply, run_command=fake_run_command)
+
+    assert not check.passed
+    assert "Custom resource mutation did not add data.mutation-stage-1=yes" in check._error
+
+
+def test_fails_when_custom_resource_rejection_is_not_enforced() -> None:
+    """The check fails if the custom-resource validating webhook allows disallowed data."""
+
+    def fake_apply(_args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        docs = _docs(kwargs["input"])
+        if any(
+            (doc.get("metadata") or {}).get("labels", {}).get("webhook-e2e-test") == "webhook-disallow" for doc in docs
+        ):
+            return _completed(returncode=1, stderr="the crd contains unwanted label")
+        return _completed()
+
+    def fake_run_command(cmd: str, *_args: Any, **_kwargs: Any) -> CommandResult:
+        if " get " in cmd and " -o json" in cmd:
+            return _ok(stdout=_custom_resource_json())
+        return _ok()
+
+    check = _run_check(apply_func=fake_apply, run_command=fake_run_command)
+
+    assert not check.passed
+    assert "Custom resource validating webhook did not reject disallowed data" in check._error
+
+
+def test_cleanup_failures_do_not_override_success() -> None:
+    """Best-effort cleanup failures must not replace the validation result."""
+
+    def fake_apply(_args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        docs = _docs(kwargs["input"])
+        if any(
+            (doc.get("metadata") or {}).get("labels", {}).get("webhook-e2e-test") == "webhook-disallow" for doc in docs
+        ):
+            return _completed(returncode=1, stderr="the crd contains unwanted label")
+        if any((doc.get("data") or {}).get("webhook-e2e-test") == "webhook-disallow" for doc in docs):
+            return _completed(returncode=1, stderr="the custom resource contains unwanted data")
+        return _completed()
+
+    def fake_run_command(cmd: str, *_args: Any, **_kwargs: Any) -> CommandResult:
+        if " get " in cmd and " -o json" in cmd:
+            return _ok(stdout=_custom_resource_json())
+        if " delete " in cmd:
+            return _fail(stderr="cleanup failed")
+        return _ok()
+
+    check = _run_check(apply_func=fake_apply, run_command=fake_run_command)
+
+    assert check.passed
+    assert check._error == ""

--- a/isvtest/tests/test_k8s_crd_webhook.py
+++ b/isvtest/tests/test_k8s_crd_webhook.py
@@ -229,7 +229,7 @@ def test_fails_when_crd_rejection_is_not_enforced() -> None:
     check = _run_check(apply_func=fake_apply, run_command=fake_run_command)
 
     assert not check.passed
-    assert "CRD validating webhook did not reject the disallowed CRD" in check._error
+    assert "CRD validating webhook did not reject the disallowed CRD" in check.message
 
 
 def test_fails_when_custom_resource_mutation_is_missing() -> None:
@@ -253,7 +253,7 @@ def test_fails_when_custom_resource_mutation_is_missing() -> None:
     check = _run_check(apply_func=fake_apply, run_command=fake_run_command)
 
     assert not check.passed
-    assert "Custom resource mutation did not add data.mutation-stage-1=yes" in check._error
+    assert "Custom resource mutation did not add data.mutation-stage-1=yes" in check.message
 
 
 def test_fails_when_custom_resource_rejection_is_not_enforced() -> None:
@@ -275,7 +275,7 @@ def test_fails_when_custom_resource_rejection_is_not_enforced() -> None:
     check = _run_check(apply_func=fake_apply, run_command=fake_run_command)
 
     assert not check.passed
-    assert "Custom resource validating webhook did not reject disallowed data" in check._error
+    assert "Custom resource validating webhook did not reject disallowed data" in check.message
 
 
 def test_cleanup_failures_do_not_override_success() -> None:

--- a/isvtest/tests/test_k8s_crd_webhook.py
+++ b/isvtest/tests/test_k8s_crd_webhook.py
@@ -80,7 +80,7 @@ def _run_check(
     check = K8sCrdWebhookCheck(
         config={
             "image": "registry.k8s.io/e2e-test-images/agnhost:2.47",
-            "namespace_prefix": "isvtest-k8s21",
+            "namespace_prefix": "isvtest-crd-webhook",
             "wait_timeout": 1,
             "poll_interval": 1,
             **(config or {}),
@@ -108,7 +108,7 @@ def test_crd_webhook_check_passes_with_expected_manifests_and_probes() -> None:
         applied_docs.extend(docs)
         if any(
             (doc.get("metadata") or {}).get("labels", {}).get("webhook-e2e-test") == "webhook-disallow"
-            or doc.get("kind") == "K8s21Widget"
+            or doc.get("kind") == "CrdWebhookWidget"
             for doc in docs
         ):
             admission_apply_timeouts.append(kwargs["timeout"])
@@ -189,11 +189,11 @@ def test_crd_webhook_check_passes_with_expected_manifests_and_probes() -> None:
         if doc["kind"] in {"ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"}
         for webhook in doc["webhooks"]
     )
-    label_value = service["metadata"]["labels"]["isvtest-k8s21"]
-    assert deployments[0]["spec"]["template"]["metadata"]["labels"]["isvtest-k8s21"] == label_value
-    assert valid_crd["metadata"]["labels"]["isvtest-k8s21"] == label_value
+    label_value = service["metadata"]["labels"]["isvtest-crd-webhook"]
+    assert deployments[0]["spec"]["template"]["metadata"]["labels"]["isvtest-crd-webhook"] == label_value
+    assert valid_crd["metadata"]["labels"]["isvtest-crd-webhook"] == label_value
     assert all(
-        (webhook.get("objectSelector") or webhook.get("namespaceSelector"))["matchLabels"]["isvtest-k8s21"]
+        (webhook.get("objectSelector") or webhook.get("namespaceSelector"))["matchLabels"]["isvtest-crd-webhook"]
         == label_value
         for doc in applied_docs
         if doc["kind"] in {"ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"}


### PR DESCRIPTION
## Summary

Adds K8S21-01 provider-neutral Kubernetes validation for CRD and admission webhook behavior. The check creates an ephemeral namespace, deploys the upstream `agnhost webhook`, verifies CRD validation rejection, verifies custom-resource mutation, verifies custom-resource validation rejection, and best-effort cleans up. Ships unreleased; run with `ISVTEST_INCLUDE_UNRELEASED=1`.

## Changes

- Add `K8sCrdWebhookCheck` plus a manifest template for the Secret, Service, Deployment, CRD, and admission webhook resources.
- Generate CA/server certificates in Python and scope transient resources with neutral `isvtest-crd-webhook` labels.
- Wire `K8sCrdWebhookCheck` into `suites/k8s.yaml` with `test_id: K8S21-01`.
- Add unit coverage for the pass path, admission failure modes, mutation failure, cleanup tolerance, and manifest/cert wiring.

## Test plan

- [x] `uv run pytest isvtest/tests/test_k8s_crd_webhook.py -v`
- [x] `uv run pytest isvtest/tests/test_discovery.py isvtest/tests/test_catalog.py -v`
- [x] k3d live run of `K8sCrdWebhookCheck`
- [x] minikube live run of `K8sCrdWebhookCheck`
- [x] AWS EKS live run of `K8sCrdWebhookCheck`

Closes #218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Kubernetes CRD admission webhook validation check covering both mutation and rejection behavior.
  * Included the check in the Kubernetes validation suite for automated execution.
  * Added a reusable Kubernetes manifest template for the webhook service, TLS secret, CRD, and webhook configurations.
* **Tests**
  * Added unit tests for the success path, mutation/rejection enforcement, and best-effort cleanup.
* **Documentation**
  * Updated the K8S21-01 test plan metadata to include Kubernetes in the requirement labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->