### PR TITLE
refactor(test-plan): assign stable test IDs and retarget suite wiring

### DIFF
--- a/docs/test-plan.adoc
+++ b/docs/test-plan.adoc
@@ -114,8 +114,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/44[#44]
 | approved
 |
 
-| [[IMG-XX-01]]IMG-XX-01
-|
+| [[IMG01-01]]IMG01-01
+| IMG01
 |
 |
 |
@@ -128,8 +128,8 @@ a|
 | approved
 |
 
-| [[IMG-XX-02]]IMG-XX-02
-|
+| [[IMG02-01]]IMG02-01
+| IMG02
 |
 |
 |
@@ -142,8 +142,8 @@ a|
 | approved
 |
 
-| [[IMG-XX-03]]IMG-XX-03
-|
+| [[IMG03-01]]IMG03-01
+| IMG03
 |
 |
 |
@@ -159,8 +159,8 @@ a|
 .3+| Key Secret Mgmt
 .3+| Securely stores and manages cryptographic keys, secrets, and certificates. Supports key rotation
 .3+| AWS Secrets Manager / KMS
-| [[AUTH-XX-01]]AUTH-XX-01
-|
+| [[AUTH01-01]]AUTH01-01
+| AUTH01
 |
 |
 |
@@ -173,8 +173,8 @@ a|
 | approved
 |
 
-| [[AUTH-XX-02]]AUTH-XX-02
-|
+| [[AUTH02-01]]AUTH02-01
+| AUTH02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/247[#247]
 | vm
 |
@@ -187,8 +187,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/247[#247]
 | approved
 |
 
-| [[AUTH-XX-03]]AUTH-XX-03
-|
+| [[AUTH03-01]]AUTH03-01
+| AUTH03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/248[#248]
 |
 |
@@ -204,8 +204,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/248[#248]
 .3+| Identity and Asset Mgmt (IAM)
 .3+| Manages users, service identities, roles, and permissions across tenants and services. Forms the security foundation of the platform.
 .3+| AWS: IAM
-| [[IAM-XX-01]]IAM-XX-01
-|
+| [[IAM01-01]]IAM01-01
+| IAM01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/21[#21]
 | iam, min_req
 |
@@ -218,8 +218,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/21[#21]
 | approved
 |
 
-| [[IAM-XX-02]]IAM-XX-02
-|
+| [[IAM02-01]]IAM02-01
+| IAM02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/23[#23]
 |
 |
@@ -232,8 +232,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/23[#23]
 | approved
 |
 
-| [[IAM-XX-03]]IAM-XX-03
-|
+| [[IAM03-01]]IAM03-01
+| IAM03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/341[#341]
 | iam
 |
@@ -249,8 +249,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/341[#341]
 .2+| DDI
 .2+| core network services for name resolution, IP allocation, and address lifecycle management
 .2+| GCP Cloud DNS + IPAM
-| [[CP-XX-01]]CP-XX-01
-|
+| [[IPAM01-01]]IPAM01-01
+| IPAM01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/131[#131]
 | network, ssh
 |
@@ -263,8 +263,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/131[#131]
 | approved
 |
 
-| [[CP-XX-02]]CP-XX-02
-|
+| [[IPAM02-01]]IPAM02-01
+| IPAM02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/132[#132]
 | network
 |
@@ -280,8 +280,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/132[#132]
 | Network Underlay & Mgmt
 | Brings up the physical network fabric for Day 0, base configuration, and network OS installation. Manages switch OS versions, compliance, and safe upgrades over time. Provides base network that overlays and tenants are built upon.
 | Netris
-| [[NETMGMT-XX-01]]NETMGMT-XX-01
-|
+| [[NETMGMT01-01]]NETMGMT01-01
+| NETMGMT01
 |
 |
 |
@@ -297,8 +297,8 @@ a|
 | Resource Database
 | Resource Inventory for useable resources withing the data center
 |
-| [[RESDB-XX-01]]RESDB-XX-01
-|
+| [[RESDB01-01]]RESDB01-01
+| RESDB01
 |
 |
 |
@@ -315,8 +315,8 @@ a|
 .9+| Control Plane accessible
 .9+| Control plane can be accessed
 .9+|
-| [[CP-XX-03]]CP-XX-03
-|
+| [[CP03-01]]CP03-01
+| CP03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/26[#26]
 |
 |
@@ -330,8 +330,8 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/27[#27]
 | approved
 |
 
-| [[CP-XX-04]]CP-XX-04
-|
+| [[CP04-01]]CP04-01
+| CP04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/261[#261]
 |
 |
@@ -344,8 +344,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/261[#261]
 | approved
 |
 
-| [[CP-XX-05]]CP-XX-05
-|
+| [[CP05-01]]CP05-01
+| CP05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/28[#28]
 | control_plane, iam
 |
@@ -358,8 +358,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/28[#28]
 | approved
 |
 
-| [[CP-XX-06]]CP-XX-06
-|
+| [[CP06-01]]CP06-01
+| CP06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/29[#29]
 | control_plane, iam, min_req
 |
@@ -372,8 +372,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/29[#29]
 | approved
 |
 
-| [[CP-XX-07]]CP-XX-07
-|
+| [[CP07-01]]CP07-01
+| CP07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/30[#30]
 | control_plane, iam
 |
@@ -386,8 +386,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/30[#30]
 | approved
 |
 
-| [[CP-XX-08]]CP-XX-08
-|
+| [[CP08-01]]CP08-01
+| CP08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/31[#31]
 | control_plane, iam
 |
@@ -400,8 +400,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/31[#31]
 | approved
 |
 
-| [[CP-XX-09]]CP-XX-09
-|
+| [[CP09-01]]CP09-01
+| CP09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/32[#32]
 | control_plane, iam
 |
@@ -415,8 +415,8 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/33[#33]
 | approved
 |
 
-| [[CP-XX-10]]CP-XX-10
-|
+| [[CP10-01]]CP10-01
+| CP10
 | https://github.com/NVIDIA/ai-cloud-validation/issues/34[#34]
 | control_plane
 |
@@ -429,8 +429,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/34[#34]
 | approved
 |
 
-| [[CP-XX-11]]CP-XX-11
-|
+| [[CP11-01]]CP11-01
+| CP11
 | https://github.com/NVIDIA/ai-cloud-validation/issues/35[#35]
 | min_req
 |
@@ -446,8 +446,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/35[#35]
 .2+| Hardware ingestion
 .2+| Makes sure that all hardware under test has been ingested
 .2+|
-| [[HWING-XX-01]]HWING-XX-01
-|
+| [[HWING01-01]]HWING01-01
+| HWING01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/133[#133]
 | bare_metal, ingestion
 |
@@ -460,8 +460,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/133[#133]
 | approved
 |
 
-| [[HWING-XX-02]]HWING-XX-02
-|
+| [[HWING02-01]]HWING02-01
+| HWING02
 |
 |
 |
@@ -491,8 +491,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/315[#315]
 | approved
 |
 
-| [[ATTEST-XX-01]]ATTEST-XX-01
-|
+| [[ATTEST01-01]]ATTEST01-01
+| ATTEST01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/243[#243]
 |
 |
@@ -519,8 +519,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/316[#316]
 | approved
 |
 
-| [[ATTEST-XX-02]]ATTEST-XX-02
-|
+| [[ATTEST02-01]]ATTEST02-01
+| ATTEST02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/319[#319]
 |
 |
@@ -665,8 +665,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/105[#105]
 | approved
 |
 
-| [[BMAAS-XX-01]]BMAAS-XX-01
-|
+| [[BMAAS01-01]]BMAAS01-01
+| BMAAS01
 |
 |
 | REVIEW
@@ -679,8 +679,8 @@ a|
 | pending
 |
 
-| [[BMAAS-XX-02]]BMAAS-XX-02
-|
+| [[BMAAS02-01]]BMAAS02-01
+| BMAAS02
 |
 |
 | REVIEW
@@ -695,8 +695,8 @@ a|
 
 .8+| Once created, nodes can be accessed for usage, and have the high level support controls of reboot, reinstall.
 .8+| AWS EC2/Forge
-| [[BMAAS-XX-03]]BMAAS-XX-03
-|
+| [[BMAAS03-01]]BMAAS03-01
+| BMAAS03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/48[#48]
 | bare_metal, ssh
 |
@@ -739,8 +739,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/135[#135]
 | approved
 |
 
-| [[BMAAS-XX-04]]BMAAS-XX-04
-|
+| [[BMAAS04-01]]BMAAS04-01
+| BMAAS04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/58[#58]
 |
 |
@@ -814,8 +814,8 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/181[#181]
 
 .2+| Nodes will be able to access expected resources on the local networks
 .2+| AWS EC2/Forge
-| [[BMAAS-XX-05]]BMAAS-XX-05
-|
+| [[BMAAS05-01]]BMAAS05-01
+| BMAAS05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/136[#136]
 | bare_metal, dpu
 |
@@ -828,8 +828,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/136[#136]
 | approved
 |
 
-| [[BMAAS-XX-06]]BMAAS-XX-06
-|
+| [[BMAAS06-01]]BMAAS06-01
+| BMAAS06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/60[#60]
 | bare_metal, gpu, network, ssh
 |
@@ -844,8 +844,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/60[#60]
 
 .8+| Observability & Debug
 .8+| AWS EC2/Forge
-| [[BMAAS-XX-07]]BMAAS-XX-07
-|
+| [[BMAAS07-01]]BMAAS07-01
+| BMAAS07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/250[#250]
 | bare_metal
 | REVIEW
@@ -873,8 +873,8 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/114[#114]
 | approved
 |
 
-| [[BMAAS-XX-08]]BMAAS-XX-08
-|
+| [[BMAAS08-01]]BMAAS08-01
+| BMAAS08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/61[#61]
 | bare_metal, gpu, ssh
 |
@@ -887,8 +887,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/61[#61]
 | approved
 |
 
-| [[BMAAS-XX-09]]BMAAS-XX-09
-|
+| [[BMAAS09-01]]BMAAS09-01
+| BMAAS09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/63[#63]
 | bare_metal, gpu, min_req, ssh, workload
 |
@@ -902,8 +902,8 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/68[#68]
 | approved
 |
 
-| [[BMAAS-XX-10]]BMAAS-XX-10
-|
+| [[BMAAS10-01]]BMAAS10-01
+| BMAAS10
 | https://github.com/NVIDIA/ai-cloud-validation/issues/64[#64]
 | bare_metal, gpu, min_req, slow, ssh, workload
 |
@@ -917,8 +917,8 @@ https://github.com/NVIDIA/ai-cloud-validation/issues/82[#82]
 | approved
 |
 
-| [[BMAAS-XX-11]]BMAAS-XX-11
-|
+| [[BMAAS11-01]]BMAAS11-01
+| BMAAS11
 | https://github.com/NVIDIA/ai-cloud-validation/issues/65[#65]
 | bare_metal, gpu, min_req, ssh, workload
 |
@@ -931,8 +931,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/65[#65]
 | approved
 |
 
-| [[BMAAS-XX-12]]BMAAS-XX-12
-|
+| [[BMAAS12-01]]BMAAS12-01
+| BMAAS12
 | https://github.com/NVIDIA/ai-cloud-validation/issues/66[#66]
 | bare_metal, gpu, min_req, ssh, workload
 |
@@ -1066,8 +1066,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/47[#47]
 
 .7+| Once created, VM nodes can be accessed for usage, and have the high level support controls of reboot, reinstall
 .7+|
-| [[VMAAS-XX-01]]VMAAS-XX-01
-|
+| [[VMAAS01-01]]VMAAS01-01
+| VMAAS01
 |
 | ssh, vm
 |
@@ -1094,8 +1094,8 @@ a|
 | approved
 |
 
-| [[VMAAS-XX-02]]VMAAS-XX-02
-|
+| [[VMAAS02-01]]VMAAS02-01
+| VMAAS02
 |
 |
 |
@@ -1166,8 +1166,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/113[#113]
 
 .2+| Quota should be enforced
 .2+|
-| [[VMAAS-XX-03]]VMAAS-XX-03
-|
+| [[VMAAS03-01]]VMAAS03-01
+| VMAAS03
 |
 |
 |
@@ -1180,8 +1180,8 @@ a|
 | approved
 |
 
-| [[VMAAS-XX-04]]VMAAS-XX-04
-|
+| [[VMAAS04-01]]VMAAS04-01
+| VMAAS04
 |
 |
 |
@@ -1196,8 +1196,8 @@ a|
 
 .6+| The underlying system allows VMs to access the GPU, with high performance, and are running with the correct parameters for optimal performance
 .6+|
-| [[VMAAS-XX-05]]VMAAS-XX-05
-|
+| [[VMAAS05-01]]VMAAS05-01
+| VMAAS05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/55[#55]
 | ssh, vm
 |
@@ -1210,8 +1210,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/55[#55]
 | approved
 |
 
-| [[VMAAS-XX-06]]VMAAS-XX-06
-|
+| [[VMAAS06-01]]VMAAS06-01
+| VMAAS06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/59[#59]
 | gpu, ssh, vm
 |
@@ -1224,8 +1224,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/59[#59]
 | approved
 |
 
-| [[VMAAS-XX-07]]VMAAS-XX-07
-|
+| [[VMAAS07-01]]VMAAS07-01
+| VMAAS07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/62[#62]
 | gpu, ssh, vm
 |
@@ -1238,8 +1238,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/62[#62]
 | approved
 |
 
-| [[VMAAS-XX-08]]VMAAS-XX-08
-|
+| [[VMAAS08-01]]VMAAS08-01
+| VMAAS08
 |
 |
 |
@@ -1252,8 +1252,8 @@ a|
 | approved
 |
 
-| [[VMAAS-XX-09]]VMAAS-XX-09
-|
+| [[VMAAS09-01]]VMAAS09-01
+| VMAAS09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/67[#67]
 | gpu, ssh, vm
 | Does this include GPU Passthrough
@@ -1266,8 +1266,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/67[#67]
 | approved
 |
 
-| [[VMAAS-XX-10]]VMAAS-XX-10
-|
+| [[VMAAS10-01]]VMAAS10-01
+| VMAAS10
 |
 |
 |
@@ -1282,8 +1282,8 @@ a|
 
 .3+| Can run AI/ML Jobs
 .3+|
-| [[VMAAS-XX-11]]VMAAS-XX-11
-|
+| [[VMAAS11-01]]VMAAS11-01
+| VMAAS11
 |
 |
 |
@@ -1296,8 +1296,8 @@ a|
 | approved
 |
 
-| [[VMAAS-XX-12]]VMAAS-XX-12
-|
+| [[VMAAS12-01]]VMAAS12-01
+| VMAAS12
 |
 | gpu, slow, ssh, vm, workload
 |
@@ -1310,8 +1310,8 @@ a|
 | approved
 |
 
-| [[VMAAS-XX-13]]VMAAS-XX-13
-|
+| [[VMAAS13-01]]VMAAS13-01
+| VMAAS13
 |
 |
 |
@@ -1326,8 +1326,8 @@ a|
 
 | nodes will be able to access expected resources on the local networks
 | AWS EC2/Forge
-| [[VMAAS-XX-14]]VMAAS-XX-14
-|
+| [[VMAAS14-01]]VMAAS14-01
+| VMAAS14
 |
 |
 |
@@ -1532,8 +1532,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/115[#115]
 | approved
 |
 
-| [[SDN-XX-01]]SDN-XX-01
-|
+| [[SDN11-01]]SDN11-01
+| SDN11
 | https://github.com/NVIDIA/ai-cloud-validation/issues/116[#116]
 | min_req, network
 |
@@ -1660,8 +1660,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/19[#19]
 | approved
 |
 
-| [[SDN-XX-02]]SDN-XX-02
-|
+| [[SDN12-01]]SDN12-01
+| SDN12
 |
 |
 |
@@ -1674,8 +1674,8 @@ a|
 | approved
 |
 
-| [[SDN-XX-03]]SDN-XX-03
-|
+| [[SDN13-01]]SDN13-01
+| SDN13
 |
 |
 |
@@ -1688,8 +1688,8 @@ a|
 | approved
 |
 
-| [[SDN-XX-04]]SDN-XX-04
-|
+| [[SDN14-01]]SDN14-01
+| SDN14
 |
 |
 |
@@ -1702,8 +1702,8 @@ a|
 | approved
 |
 
-| [[SDN-XX-05]]SDN-XX-05
-|
+| [[SDN15-01]]SDN15-01
+| SDN15
 |
 |
 |
@@ -1716,8 +1716,8 @@ a|
 | approved
 |
 
-| [[SDN-XX-06]]SDN-XX-06
-|
+| [[SDN16-01]]SDN16-01
+| SDN16
 |
 |
 |
@@ -1730,8 +1730,8 @@ a|
 | approved
 |
 
-| [[SDN-XX-07]]SDN-XX-07
-|
+| [[SDN17-01]]SDN17-01
+| SDN17
 |
 |
 |
@@ -1744,8 +1744,8 @@ a|
 | approved
 |
 
-| [[SDN-XX-08]]SDN-XX-08
-|
+| [[SDN18-01]]SDN18-01
+| SDN18
 |
 |
 |
@@ -1758,8 +1758,8 @@ a|
 | approved
 |
 
-| [[SDN-XX-09]]SDN-XX-09
-|
+| [[SDN19-01]]SDN19-01
+| SDN19
 |
 |
 |
@@ -1772,8 +1772,8 @@ a|
 | approved
 |
 
-| [[SDN-XX-10]]SDN-XX-10
-|
+| [[SDN20-01]]SDN20-01
+| SDN20
 |
 |
 |
@@ -1786,8 +1786,8 @@ a|
 | approved
 |
 
-| [[SDN-XX-11]]SDN-XX-11
-|
+| [[SDN21-01]]SDN21-01
+| SDN21
 |
 |
 |
@@ -1800,8 +1800,8 @@ a|
 | approved
 |
 
-| [[SDN-XX-12]]SDN-XX-12
-|
+| [[SDN22-01]]SDN22-01
+| SDN22
 |
 |
 |
@@ -1814,8 +1814,8 @@ a|
 | approved
 |
 
-| [[SDN-XX-13]]SDN-XX-13
-|
+| [[SDN23-01]]SDN23-01
+| SDN23
 |
 |
 |
@@ -1828,8 +1828,8 @@ a|
 | approved
 |
 
-| [[SDN-XX-14]]SDN-XX-14
-|
+| [[SDN24-01]]SDN24-01
+| SDN24
 |
 |
 |
@@ -1842,8 +1842,8 @@ a|
 | approved
 |
 
-| [[SDN-XX-15]]SDN-XX-15
-|
+| [[SDN25-01]]SDN25-01
+| SDN25
 |
 |
 |
@@ -1856,8 +1856,8 @@ a|
 | approved
 |
 
-| [[SDN-XX-16]]SDN-XX-16
-|
+| [[SDN26-01]]SDN26-01
+| SDN26
 |
 |
 |
@@ -1870,8 +1870,8 @@ a|
 | approved
 |
 
-| [[SDN-XX-17]]SDN-XX-17
-|
+| [[SDN27-01]]SDN27-01
+| SDN27
 |
 |
 |
@@ -1884,8 +1884,8 @@ a|
 | approved
 |
 
-| [[SDN-XX-18]]SDN-XX-18
-|
+| [[SDN28-01]]SDN28-01
+| SDN28
 |
 |
 | REVIEW
@@ -2049,8 +2049,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/292[#292]
 | Metadata Service
 | shared service source of truth for resource metadata such as nodes, GPUs, topology, and ownership. Enables scheduling, automation, and lifecycle management.
 | GCP Resource Manager APIs
-| [[META-XX-01]]META-XX-01
-|
+| [[META01-01]]META01-01
+| META01
 |
 |
 |
@@ -2066,8 +2066,8 @@ a|
 .4+| Cloud Control Plane
 .3+| Primary access mechanism for IaaS, provding provision and manage of compute, networking, and storage.
 .3+| AWS EC2 Control Plane
-| [[CTRL-XX-01]]CTRL-XX-01
-|
+| [[CTRL01-01]]CTRL01-01
+| CTRL01
 |
 |
 |
@@ -2127,8 +2127,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/205[#205]
 .4+| Load Balancing
 .4+| Distributes traffic across services (e.g. inference endpoints) for availability and scale.
 .4+| AWS Network Load Balancer
-| [[LB-XX-01]]LB-XX-01
-|
+| [[LB01-01]]LB01-01
+| LB01
 |
 |
 |
@@ -2141,8 +2141,8 @@ a|
 | approved
 |
 
-| [[LB-XX-02]]LB-XX-02
-|
+| [[LB02-01]]LB02-01
+| LB02
 |
 |
 |
@@ -2155,8 +2155,8 @@ a|
 | approved
 |
 
-| [[LB-XX-03]]LB-XX-03
-|
+| [[LB03-01]]LB03-01
+| LB03
 |
 |
 |
@@ -2169,8 +2169,8 @@ a|
 | approved
 |
 
-| [[LB-XX-04]]LB-XX-04
-|
+| [[LB04-01]]LB04-01
+| LB04
 |
 |
 |
@@ -2186,8 +2186,8 @@ a|
 .14+| Break-Fix
 .3+| A break-fix service works with a variety of components to detect, triage, remediate, and validate nodes in an AI factory. The critical focus here is on the GPU nodes, but the system can scale beyond.
 .3+| Lazarus, Shoreline
-| [[BFX-XX-01]]BFX-XX-01
-|
+| [[BFX04-01]]BFX04-01
+| BFX04
 |
 |
 |
@@ -2200,8 +2200,8 @@ a|
 | approved
 |
 
-| [[BFX-XX-02]]BFX-XX-02
-|
+| [[BFX05-01]]BFX05-01
+| BFX05
 |
 |
 |
@@ -2214,8 +2214,8 @@ a|
 | approved
 |
 
-| [[BFX-XX-03]]BFX-XX-03
-|
+| [[BFX06-01]]BFX06-01
+| BFX06
 |
 |
 |
@@ -2462,8 +2462,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/331[#331]
 | pending
 |
 
-| [[STOR-XX-01]]STOR-XX-01
-|
+| [[STOR01-01]]STOR01-01
+| STOR01
 |
 |
 | REVIEW
@@ -2786,8 +2786,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/340[#340]
 | Object Storage Service
 | durable, scalable object storage for things like datasets, model artifacts, logs, backups.
 | S3
-| [[DATASVC-XX-01]]DATASVC-XX-01
-|
+| [[DATASVC01-01]]DATASVC01-01
+| DATASVC01
 | https://github.com/NVIDIA/ai-cloud-validation/issues/262[#262]
 | control_plane, min_req
 |
@@ -2817,8 +2817,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/272[#272]
 | pending
 |
 
-| [[DATASVC-XX-02]]DATASVC-XX-02
-|
+| [[DATASVC02-01]]DATASVC02-01
+| DATASVC02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/321[#321]
 | min_req
 |
@@ -2831,8 +2831,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/321[#321]
 | pending
 |
 
-| [[DATASVC-XX-03]]DATASVC-XX-03
-|
+| [[DATASVC03-01]]DATASVC03-01
+| DATASVC03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/322[#322]
 | min_req
 |
@@ -2845,8 +2845,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/322[#322]
 | pending
 |
 
-| [[DATASVC-XX-04]]DATASVC-XX-04
-|
+| [[DATASVC04-01]]DATASVC04-01
+| DATASVC04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/323[#323]
 | min_req
 |
@@ -2862,8 +2862,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/323[#323]
 | Cache Services
 | in-memory data store for frequently used data
 | ElastiCache
-| [[DATASVC-XX-05]]DATASVC-XX-05
-|
+| [[DATASVC05-01]]DATASVC05-01
+| DATASVC05
 |
 |
 |
@@ -2879,8 +2879,8 @@ a|
 | Vector Store
 | stores and indexes embeddings for semantic search and RAG generation
 | Vertex AI Vector Search
-| [[DATASVC-XX-06]]DATASVC-XX-06
-|
+| [[DATASVC06-01]]DATASVC06-01
+| DATASVC06
 |
 |
 |
@@ -2896,8 +2896,8 @@ a|
 | Relational Database
 | structured database (SQL) service
 | GCP Cloud SQL
-| [[DATASVC-XX-07]]DATASVC-XX-07
-|
+| [[DATASVC07-01]]DATASVC07-01
+| DATASVC07
 |
 |
 |
@@ -2914,8 +2914,8 @@ a|
 | Backup and Recovery
 | Centralized managed service to automate and govern data backup across services
 | AWS backup
-| [[DATASVC-XX-08]]DATASVC-XX-08
-|
+| [[DATASVC08-01]]DATASVC08-01
+| DATASVC08
 |
 |
 |
@@ -2931,8 +2931,8 @@ a|
 | Model Registry
 | storage with versioning for models and AI artifacts
 | AWS Sagemaker Model Registry
-| [[DATASVC-XX-09]]DATASVC-XX-09
-|
+| [[DATASVC09-01]]DATASVC09-01
+| DATASVC09
 |
 |
 |
@@ -2948,8 +2948,8 @@ a|
 .10+| Slurm Control Plane
 .10+| control plane to schedule and manage large-scale GPU batch training with SLURM semantics.
 .10+| AWS ParallelCluster
-| [[SLURM-XX-01]]SLURM-XX-01
-|
+| [[SLURM01-01]]SLURM01-01
+| SLURM01
 |
 |
 |
@@ -2962,8 +2962,8 @@ a|
 | done
 |
 
-| [[SLURM-XX-02]]SLURM-XX-02
-|
+| [[SLURM02-01]]SLURM02-01
+| SLURM02
 |
 | slurm
 |
@@ -2976,8 +2976,8 @@ a|
 | done
 |
 
-| [[SLURM-XX-03]]SLURM-XX-03
-|
+| [[SLURM03-01]]SLURM03-01
+| SLURM03
 |
 | slurm
 |
@@ -2990,8 +2990,8 @@ a|
 | done
 |
 
-| [[SLURM-XX-04]]SLURM-XX-04
-|
+| [[SLURM04-01]]SLURM04-01
+| SLURM04
 |
 | slurm
 |
@@ -3004,8 +3004,8 @@ a|
 | done
 |
 
-| [[SLURM-XX-05]]SLURM-XX-05
-|
+| [[SLURM05-01]]SLURM05-01
+| SLURM05
 |
 | slurm
 |
@@ -3018,8 +3018,8 @@ a|
 | done
 |
 
-| [[SLURM-XX-06]]SLURM-XX-06
-|
+| [[SLURM06-01]]SLURM06-01
+| SLURM06
 |
 | slurm
 |
@@ -3032,8 +3032,8 @@ a|
 | done
 |
 
-| [[SLURM-XX-07]]SLURM-XX-07
-|
+| [[SLURM07-01]]SLURM07-01
+| SLURM07
 |
 | gpu, slow, slurm, workload
 |
@@ -3046,8 +3046,8 @@ a|
 | done
 |
 
-| [[SLURM-XX-08]]SLURM-XX-08
-|
+| [[SLURM08-01]]SLURM08-01
+| SLURM08
 |
 | gpu, slow, slurm, workload
 |
@@ -3060,8 +3060,8 @@ a|
 | done
 |
 
-| [[SLURM-XX-09]]SLURM-XX-09
-|
+| [[SLURM09-01]]SLURM09-01
+| SLURM09
 |
 | slow, slurm, workload
 |
@@ -3074,8 +3074,8 @@ a|
 | done
 |
 
-| [[SLURM-XX-10]]SLURM-XX-10
-|
+| [[SLURM10-01]]SLURM10-01
+| SLURM10
 |
 |
 |
@@ -3107,8 +3107,8 @@ a|
 
 .3+| Full lifecycle management
 .3+|
-| [[K8S-XX-01]]K8S-XX-01
-|
+| [[K8S38-01]]K8S38-01
+| K8S38
 |
 | min_req
 |
@@ -3121,10 +3121,10 @@ a|
 | approved
 |
 
-| [[SEC23-01]]SEC23-01
-| SEC23
+| [[K8S41-01]]K8S41-01
+| K8S41
 |
-| min_req
+|
 |
 |
 a|
@@ -3165,8 +3165,8 @@ a|
 | approved
 |
 
-| [[K8S-XX-02]]K8S-XX-02
-|
+| [[K8S39-01]]K8S39-01
+| K8S39
 |
 | min_req
 |
@@ -3179,8 +3179,8 @@ a|
 | done
 |
 
-| [[K8S-XX-03]]K8S-XX-03
-|
+| [[K8S40-01]]K8S40-01
+| K8S40
 |
 | gpu, kubernetes, slow, workload
 |
@@ -3193,8 +3193,8 @@ a|
 | done
 |
 
-| [[K8S-XX-04]]K8S-XX-04
-|
+| [[K8S32-01]]K8S32-01
+| K8S32
 |
 | gpu, kubernetes, slow, workload
 |
@@ -3209,8 +3209,8 @@ a|
 
 | Topology based placement
 |
-| [[K8S-XX-05]]K8S-XX-05
-|
+| [[K8S33-01]]K8S33-01
+| K8S33
 |
 | gpu, kubernetes, min_req, slow, workload
 |
@@ -3225,8 +3225,8 @@ a|
 
 | k8s upstream proxy
 |
-| [[K8S-XX-06]]K8S-XX-06
-|
+| [[K8S34-01]]K8S34-01
+| K8S34
 |
 | min_req
 | k8s05
@@ -3305,8 +3305,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/218[#218]
 
 | TODO: L3 networking logging
 |
-| [[K8S-XX-07]]K8S-XX-07
-|
+| [[K8S35-01]]K8S35-01
+| K8S35
 |
 | min_req
 | K8s16
@@ -3607,8 +3607,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/302[#302]
 
 | Autoscaling
 |
-| [[K8S-XX-08]]K8S-XX-08
-|
+| [[K8S36-01]]K8S36-01
+| K8S36
 | https://github.com/NVIDIA/ai-cloud-validation/issues/267[#267]
 | kubernetes, min_req
 |
@@ -3715,8 +3715,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/225[#225]
 
 | Public OIDC Endpoint
 |
-| [[K8S18-01]]K8S18-01
-| K8S18
+| [[K8S17-02]]K8S17-02
+| K8S17
 | https://github.com/NVIDIA/ai-cloud-validation/issues/226[#226]
 | kubernetes, min_req
 |
@@ -3747,8 +3747,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/227[#227]
 
 | K8s Performance
 |
-| [[K8S-XX-09]]K8S-XX-09
-|
+| [[K8S37-01]]K8S37-01
+| K8S37
 | https://github.com/NVIDIA/ai-cloud-validation/issues/268[#268]
 | min_req
 |
@@ -3780,8 +3780,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/277[#277]
 | Power Policy Management
 | Control plane to manage power allocation (re-allocation) based on need and availability
 | Boost and Flex (DPS)
-| [[POWER-XX-01]]POWER-XX-01
-|
+| [[POWER01-01]]POWER01-01
+| POWER01
 |
 |
 |
@@ -3798,8 +3798,8 @@ a|
 | Host API Gateway
 | Service control plane "front door" that enforces authn/authz via IAM
 | AWS/GCP API Gateway
-| [[APIGW-XX-01]]APIGW-XX-01
-|
+| [[APIGW01-01]]APIGW01-01
+| APIGW01
 |
 |
 |
@@ -3815,8 +3815,8 @@ a|
 | Al Platform 1..N Control Planes
 | Placeholder for all AI platform CPs you might run. E.g. Run:ai, NVCF, Redhat Inference Server
 |
-| [[AICP-XX-01]]AICP-XX-01
-|
+| [[AICP01-01]]AICP01-01
+| AICP01
 |
 |
 |
@@ -3832,8 +3832,8 @@ a|
 | Web Management Dashboard
 |
 |
-| [[WEBUI-XX-01]]WEBUI-XX-01
-|
+| [[WEBUI01-01]]WEBUI01-01
+| WEBUI01
 |
 |
 |
@@ -3850,8 +3850,8 @@ a|
 .19+| Observability Collectors
 .4+|
 .4+|
-| [[OBS-XX-01]]OBS-XX-01
-|
+| [[OBS01-01]]OBS01-01
+| OBS01
 |
 |
 |
@@ -3864,8 +3864,8 @@ a|
 | done
 |
 
-| [[OBS-XX-02]]OBS-XX-02
-|
+| [[OBS02-01]]OBS02-01
+| OBS02
 |
 |
 |
@@ -3878,8 +3878,8 @@ a|
 | done
 |
 
-| [[OBS-XX-03]]OBS-XX-03
-|
+| [[OBS03-01]]OBS03-01
+| OBS03
 |
 |
 |
@@ -3892,8 +3892,8 @@ a|
 | done
 |
 
-| [[OBS-XX-04]]OBS-XX-04
-|
+| [[OBS04-01]]OBS04-01
+| OBS04
 |
 |
 |
@@ -3908,8 +3908,8 @@ a|
 
 | Telemetry Delivery
 |
-| [[OBS-XX-05]]OBS-XX-05
-|
+| [[OBS05-01]]OBS05-01
+| OBS05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/342[#342]
 | min_req
 |
@@ -3924,8 +3924,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/342[#342]
 
 .5+| Network Telemetry
 .5+|
-| [[OBS-XX-06]]OBS-XX-06
-|
+| [[OBS06-01]]OBS06-01
+| OBS06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/343[#343]
 | min_req
 |
@@ -3938,8 +3938,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/343[#343]
 | pending
 |
 
-| [[OBS-XX-07]]OBS-XX-07
-|
+| [[OBS07-01]]OBS07-01
+| OBS07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/344[#344]
 | min_req
 |
@@ -3952,8 +3952,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/344[#344]
 | pending
 |
 
-| [[OBS-XX-08]]OBS-XX-08
-|
+| [[OBS08-01]]OBS08-01
+| OBS08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/345[#345]
 | min_req
 |
@@ -3966,8 +3966,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/345[#345]
 | pending
 |
 
-| [[OBS-XX-09]]OBS-XX-09
-|
+| [[OBS09-01]]OBS09-01
+| OBS09
 | https://github.com/NVIDIA/ai-cloud-validation/issues/346[#346]
 | min_req
 |
@@ -3980,8 +3980,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/346[#346]
 | pending
 |
 
-| [[OBS-XX-10]]OBS-XX-10
-|
+| [[OBS10-01]]OBS10-01
+| OBS10
 | https://github.com/NVIDIA/ai-cloud-validation/issues/347[#347]
 | min_req
 |
@@ -3996,8 +3996,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/347[#347]
 
 .9+| Required Logs
 .9+|
-| [[OBS-XX-11]]OBS-XX-11
-|
+| [[OBS11-01]]OBS11-01
+| OBS11
 | https://github.com/NVIDIA/ai-cloud-validation/issues/348[#348]
 | min_req
 |
@@ -4010,8 +4010,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/348[#348]
 | pending
 |
 
-| [[OBS-XX-12]]OBS-XX-12
-|
+| [[OBS12-01]]OBS12-01
+| OBS12
 | https://github.com/NVIDIA/ai-cloud-validation/issues/349[#349]
 | min_req
 |
@@ -4024,8 +4024,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/349[#349]
 | pending
 |
 
-| [[OBS-XX-13]]OBS-XX-13
-|
+| [[OBS13-01]]OBS13-01
+| OBS13
 | https://github.com/NVIDIA/ai-cloud-validation/issues/350[#350]
 | min_req
 |
@@ -4038,8 +4038,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/350[#350]
 | pending
 |
 
-| [[OBS-XX-14]]OBS-XX-14
-|
+| [[OBS14-01]]OBS14-01
+| OBS14
 | https://github.com/NVIDIA/ai-cloud-validation/issues/351[#351]
 | min_req
 |
@@ -4052,8 +4052,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/351[#351]
 | pending
 |
 
-| [[OBS-XX-15]]OBS-XX-15
-|
+| [[OBS15-01]]OBS15-01
+| OBS15
 | https://github.com/NVIDIA/ai-cloud-validation/issues/352[#352]
 | min_req
 |
@@ -4066,8 +4066,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/352[#352]
 | pending
 |
 
-| [[OBS-XX-16]]OBS-XX-16
-|
+| [[OBS16-01]]OBS16-01
+| OBS16
 | https://github.com/NVIDIA/ai-cloud-validation/issues/353[#353]
 | min_req
 |
@@ -4080,8 +4080,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/353[#353]
 | pending
 |
 
-| [[OBS-XX-17]]OBS-XX-17
-|
+| [[OBS17-01]]OBS17-01
+| OBS17
 | https://github.com/NVIDIA/ai-cloud-validation/issues/354[#354]
 | min_req, observability, security
 |
@@ -4094,8 +4094,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/354[#354]
 | pending
 |
 
-| [[OBS-XX-18]]OBS-XX-18
-|
+| [[OBS18-01]]OBS18-01
+| OBS18
 | https://github.com/NVIDIA/ai-cloud-validation/issues/355[#355]
 | bare_metal, min_req, observability
 |
@@ -4108,8 +4108,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/355[#355]
 | pending
 |
 
-| [[OBS-XX-19]]OBS-XX-19
-|
+| [[OBS19-01]]OBS19-01
+| OBS19
 | https://github.com/NVIDIA/ai-cloud-validation/issues/356[#356]
 | min_req, network, observability
 |
@@ -4125,8 +4125,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/356[#356]
 .8+| Telemetry / Data Lakes
 .3+|
 .3+|
-| [[TELEM-XX-01]]TELEM-XX-01
-|
+| [[TELEM01-01]]TELEM01-01
+| TELEM01
 |
 |
 |
@@ -4139,8 +4139,8 @@ a|
 | approved
 |
 
-| [[TELEM-XX-02]]TELEM-XX-02
-|
+| [[TELEM02-01]]TELEM02-01
+| TELEM02
 | https://github.com/NVIDIA/ai-cloud-validation/issues/120[#120]
 | min_req
 | MinAPI
@@ -4153,8 +4153,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/120[#120]
 | approved
 |
 
-| [[TELEM-XX-03]]TELEM-XX-03
-|
+| [[TELEM03-01]]TELEM03-01
+| TELEM03
 | https://github.com/NVIDIA/ai-cloud-validation/issues/121[#121]
 | min_req
 | MinAPI
@@ -4169,8 +4169,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/121[#121]
 
 | BMC/Redfish Telemetry
 |
-| [[TELEM-XX-04]]TELEM-XX-04
-|
+| [[TELEM04-01]]TELEM04-01
+| TELEM04
 | https://github.com/NVIDIA/ai-cloud-validation/issues/362[#362]
 | gpu, min_req, observability, security
 |
@@ -4185,8 +4185,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/362[#362]
 
 .2+| Storage Telemetry
 .2+|
-| [[TELEM-XX-05]]TELEM-XX-05
-|
+| [[TELEM05-01]]TELEM05-01
+| TELEM05
 | https://github.com/NVIDIA/ai-cloud-validation/issues/363[#363]
 | min_req
 |
@@ -4199,8 +4199,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/363[#363]
 | pending
 |
 
-| [[TELEM-XX-06]]TELEM-XX-06
-|
+| [[TELEM06-01]]TELEM06-01
+| TELEM06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/364[#364]
 | min_req
 |
@@ -4215,8 +4215,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/364[#364]
 
 .2+| NVLink Switch Telemetry
 .2+|
-| [[TELEM-XX-07]]TELEM-XX-07
-|
+| [[TELEM07-01]]TELEM07-01
+| TELEM07
 | https://github.com/NVIDIA/ai-cloud-validation/issues/365[#365]
 | min_req
 |
@@ -4229,8 +4229,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/365[#365]
 | pending
 |
 
-| [[TELEM-XX-08]]TELEM-XX-08
-|
+| [[TELEM08-01]]TELEM08-01
+| TELEM08
 | https://github.com/NVIDIA/ai-cloud-validation/issues/366[#366]
 | min_req
 |
@@ -4414,8 +4414,8 @@ a| https://github.com/NVIDIA/ai-cloud-validation/issues/293[#293]
 
 | In-Cluster Authentication
 |
-| [[SEC02-01]]SEC02-01
-| SEC02
+| [[SEC06-01]]SEC06-01
+| SEC06
 | https://github.com/NVIDIA/ai-cloud-validation/issues/294[#294]
 | iam, min_req, security
 |
@@ -4809,8 +4809,8 @@ a|
 | pending
 |
 
-| [[BENCH-XX-01]]BENCH-XX-01
-|
+| [[BENCH01-01]]BENCH01-01
+| BENCH01
 |
 |
 | REVIEW
@@ -4823,8 +4823,8 @@ a|
 | pending
 |
 
-| [[BENCH-XX-02]]BENCH-XX-02
-|
+| [[BENCH02-01]]BENCH02-01
+| BENCH02
 |
 |
 | REVIEW

--- a/docs/test-plan.yaml
+++ b/docs/test-plan.yaml
@@ -121,22 +121,25 @@ domains:
               - summary: Verify that an OS image (iso file) with full NVIDIA support is readily available
                 priority: P1
                 milestone: M4
-                req_id: ""
-                test_id: IMG-XX-01
+                req_id: IMG01
+                test_id: IMG01-01
+                legacy_ids: [IMG-XX-01]
                 status: approved
                 notes: ""
               - summary: Verify that an OS install configuration (e.g. iPXE config like Carbide) with full NVIDIA support is readily available
                 priority: P1
                 milestone: M4
-                req_id: ""
-                test_id: IMG-XX-02
+                req_id: IMG02
+                test_id: IMG02-01
+                legacy_ids: [IMG-XX-02]
                 status: approved
                 notes: ""
               - summary: Verify that an VM image with full NVIDIA support is readily available
                 priority: P1
                 milestone: M4
-                req_id: ""
-                test_id: IMG-XX-03
+                req_id: IMG03
+                test_id: IMG03-01
+                legacy_ids: [IMG-XX-03]
                 status: approved
                 notes: ""
       - name: Key Secret Mgmt
@@ -149,14 +152,16 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: AUTH-XX-01
+                req_id: AUTH01
+                test_id: AUTH01-01
+                legacy_ids: [AUTH-XX-01]
                 status: approved
                 notes: ""
               - summary: Spin up an instance which uses a specified key
                 milestone: M5
-                req_id: ""
-                test_id: AUTH-XX-02
+                req_id: AUTH02
+                test_id: AUTH02-01
+                legacy_ids: [AUTH-XX-02]
                 status: approved
                 priority: P1
                 notes: ""
@@ -166,8 +171,9 @@ domains:
                   - vm
               - summary: Access other components via a specified key as possible (SOL, Network devices)
                 milestone: M5
-                req_id: ""
-                test_id: AUTH-XX-03
+                req_id: AUTH03
+                test_id: AUTH03-01
+                legacy_ids: [AUTH-XX-03]
                 status: approved
                 priority: P1
                 notes: ""
@@ -188,8 +194,9 @@ domains:
                 milestone: M0
                 github_issues:
                   - "#21"
-                req_id: ""
-                test_id: IAM-XX-01
+                req_id: IAM01
+                test_id: IAM01-01
+                legacy_ids: [IAM-XX-01]
                 status: approved
                 notes: ""
               - summary: Delete user
@@ -199,8 +206,9 @@ domains:
                 milestone: M0
                 github_issues:
                   - "#23"
-                req_id: ""
-                test_id: IAM-XX-02
+                req_id: IAM02
+                test_id: IAM02-01
+                legacy_ids: [IAM-XX-02]
                 status: approved
                 notes: ""
               - summary: Validate that a user created can access the API and authorized resources
@@ -208,8 +216,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M5
-                req_id: ""
-                test_id: IAM-XX-03
+                req_id: IAM03
+                test_id: IAM03-01
+                legacy_ids: [IAM-XX-03]
                 status: approved
                 notes: ""
                 github_issues:
@@ -228,8 +237,9 @@ domains:
                 milestone: M4
                 github_issues:
                   - "#131"
-                req_id: ""
-                test_id: CP-XX-01
+                req_id: IPAM01
+                test_id: IPAM01-01
+                legacy_ids: [CP-XX-01]
                 status: approved
                 notes: ""
                 labels:
@@ -242,8 +252,9 @@ domains:
                 milestone: M4
                 github_issues:
                   - "#132"
-                req_id: ""
-                test_id: CP-XX-02
+                req_id: IPAM02
+                test_id: IPAM02-01
+                legacy_ids: [CP-XX-02]
                 status: approved
                 notes: ""
                 labels:
@@ -258,8 +269,9 @@ domains:
                 dependencies:
                   - MiniCloud
                 milestone: M4
-                req_id: ""
-                test_id: NETMGMT-XX-01
+                req_id: NETMGMT01
+                test_id: NETMGMT01-01
+                legacy_ids: [NETMGMT-XX-01]
                 status: pending
                 notes: ""
       - name: Resource Database
@@ -271,8 +283,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: RESDB-XX-01
+                req_id: RESDB01
+                test_id: RESDB01-01
+                legacy_ids: [RESDB-XX-01]
                 status: pending
                 notes: ""
   - name: Infrastructure and Data Services
@@ -289,8 +302,9 @@ domains:
                 github_issues:
                   - "#26"
                   - "#27"
-                req_id: ""
-                test_id: CP-XX-03
+                req_id: CP03
+                test_id: CP03-01
+                legacy_ids: [CP-XX-03]
                 status: approved
                 notes: ""
               - summary: Control Plane can be upgraded (measure impact)
@@ -298,8 +312,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M5
-                req_id: ""
-                test_id: CP-XX-04
+                req_id: CP04
+                test_id: CP04-01
+                legacy_ids: [CP-XX-04]
                 status: approved
                 notes: ""
                 github_issues:
@@ -311,8 +326,9 @@ domains:
                 milestone: M0
                 github_issues:
                   - "#28"
-                req_id: ""
-                test_id: CP-XX-05
+                req_id: CP05
+                test_id: CP05-01
+                legacy_ids: [CP-XX-05]
                 status: approved
                 notes: ""
                 labels:
@@ -329,8 +345,9 @@ domains:
                 milestone: M0
                 github_issues:
                   - "#29"
-                req_id: ""
-                test_id: CP-XX-06
+                req_id: CP06
+                test_id: CP06-01
+                legacy_ids: [CP-XX-06]
                 status: approved
                 notes: ""
               - summary: Create tenants
@@ -340,8 +357,9 @@ domains:
                 milestone: M0
                 github_issues:
                   - "#30"
-                req_id: ""
-                test_id: CP-XX-07
+                req_id: CP07
+                test_id: CP07-01
+                legacy_ids: [CP-XX-07]
                 status: approved
                 notes: ""
                 labels:
@@ -354,8 +372,9 @@ domains:
                 milestone: M0
                 github_issues:
                   - "#31"
-                req_id: ""
-                test_id: CP-XX-08
+                req_id: CP08
+                test_id: CP08-01
+                legacy_ids: [CP-XX-08]
                 status: approved
                 notes: ""
                 labels:
@@ -369,8 +388,9 @@ domains:
                 github_issues:
                   - "#32"
                   - "#33"
-                req_id: ""
-                test_id: CP-XX-09
+                req_id: CP09
+                test_id: CP09-01
+                legacy_ids: [CP-XX-09]
                 status: approved
                 notes: ""
                 labels:
@@ -383,8 +403,9 @@ domains:
                 milestone: M0
                 github_issues:
                   - "#34"
-                req_id: ""
-                test_id: CP-XX-10
+                req_id: CP10
+                test_id: CP10-01
+                legacy_ids: [CP-XX-10]
                 status: approved
                 notes: ""
                 labels:
@@ -398,8 +419,9 @@ domains:
                 milestone: M0
                 github_issues:
                   - "#35"
-                req_id: ""
-                test_id: CP-XX-11
+                req_id: CP11
+                test_id: CP11-01
+                legacy_ids: [CP-XX-11]
                 status: approved
                 notes: ""
       - name: Hardware ingestion
@@ -413,8 +435,9 @@ domains:
                 milestone: M4
                 github_issues:
                   - "#133"
-                req_id: ""
-                test_id: HWING-XX-01
+                req_id: HWING01
+                test_id: HWING01-01
+                legacy_ids: [HWING-XX-01]
                 status: approved
                 notes: ""
                 labels:
@@ -425,8 +448,9 @@ domains:
                 dependencies:
                   - MiniCloud
                 milestone: M4
-                req_id: ""
-                test_id: HWING-XX-02
+                req_id: HWING02
+                test_id: HWING02-01
+                legacy_ids: [HWING-XX-02]
                 status: approved
                 notes: ""
       - name: Attestation
@@ -453,8 +477,9 @@ domains:
                 dependencies:
                   - MiniCloud
                 milestone: M5
-                req_id: ""
-                test_id: ATTEST-XX-01
+                req_id: ATTEST01
+                test_id: ATTEST01-01
+                legacy_ids: [ATTEST-XX-01]
                 status: approved
                 notes: ""
                 github_issues:
@@ -475,8 +500,9 @@ domains:
                 dependencies:
                   - MiniCloud
                 milestone: M5
-                req_id: ""
-                test_id: ATTEST-XX-02
+                req_id: ATTEST02
+                test_id: ATTEST02-01
+                legacy_ids: [ATTEST-XX-02]
                 status: approved
                 notes: ""
                 github_issues:
@@ -606,14 +632,16 @@ domains:
                 notes: ""
               - summary: Node attached storage
                 notes: REVIEW
-                req_id: ""
-                test_id: BMAAS-XX-01
+                req_id: BMAAS01
+                test_id: BMAAS01-01
+                legacy_ids: [BMAAS-XX-01]
                 status: pending
                 priority: ""
               - summary: "Storage: Config/default/access to local NVME drives"
                 notes: REVIEW
-                req_id: ""
-                test_id: BMAAS-XX-02
+                req_id: BMAAS02
+                test_id: BMAAS02-01
+                legacy_ids: [BMAAS-XX-02]
                 status: pending
                 priority: ""
           - description: Once created, nodes can be accessed for usage, and have the high level support controls of reboot, reinstall.
@@ -627,8 +655,9 @@ domains:
                 github_issues:
                   - "#48"
                   - "#56"
-                req_id: ""
-                test_id: BMAAS-XX-03
+                req_id: BMAAS03
+                test_id: BMAAS03-01
+                legacy_ids: [BMAAS-XX-03]
                 status: approved
                 notes: ""
                 labels:
@@ -669,8 +698,9 @@ domains:
                 github_issues:
                   - "#58"
                   - "#69"
-                req_id: ""
-                test_id: BMAAS-XX-04
+                req_id: BMAAS04
+                test_id: BMAAS04-01
+                legacy_ids: [BMAAS-XX-04]
                 status: approved
                 notes: ""
               - summary: A running node can be powered off (Without being destroyed)
@@ -740,8 +770,9 @@ domains:
                 milestone: M4
                 github_issues:
                   - "#136"
-                req_id: ""
-                test_id: BMAAS-XX-05
+                req_id: BMAAS05
+                test_id: BMAAS05-01
+                legacy_ids: [BMAAS-XX-05]
                 status: approved
                 notes: ""
                 labels:
@@ -754,8 +785,9 @@ domains:
                 milestone: M1
                 github_issues:
                   - "#60"
-                req_id: ""
-                test_id: BMAAS-XX-06
+                req_id: BMAAS06
+                test_id: BMAAS06-01
+                legacy_ids: [BMAAS-XX-06]
                 status: approved
                 notes: ""
                 labels:
@@ -770,8 +802,9 @@ domains:
                 notes: REVIEW
                 priority: P1
                 milestone: M5
-                req_id: ""
-                test_id: BMAAS-XX-07
+                req_id: BMAAS07
+                test_id: BMAAS07-01
+                legacy_ids: [BMAAS-XX-07]
                 status: approved
                 github_issues:
                   - "#250"
@@ -799,8 +832,9 @@ domains:
                 milestone: M1
                 github_issues:
                   - "#61"
-                req_id: ""
-                test_id: BMAAS-XX-08
+                req_id: BMAAS08
+                test_id: BMAAS08-01
+                legacy_ids: [BMAAS-XX-08]
                 status: approved
                 notes: ""
                 labels:
@@ -821,8 +855,9 @@ domains:
                 github_issues:
                   - "#63"
                   - "#68"
-                req_id: ""
-                test_id: BMAAS-XX-09
+                req_id: BMAAS09
+                test_id: BMAAS09-01
+                legacy_ids: [BMAAS-XX-09]
                 status: approved
                 notes: ""
               - summary: Nim Inference jobs (Bare Metal)
@@ -841,8 +876,9 @@ domains:
                 github_issues:
                   - "#64"
                   - "#82"
-                req_id: ""
-                test_id: BMAAS-XX-10
+                req_id: BMAAS10
+                test_id: BMAAS10-01
+                legacy_ids: [BMAAS-XX-10]
                 status: approved
               - summary: NCCL tests
                 labels:
@@ -857,8 +893,9 @@ domains:
                 milestone: M1
                 github_issues:
                   - "#65"
-                req_id: ""
-                test_id: BMAAS-XX-11
+                req_id: BMAAS11
+                test_id: BMAAS11-01
+                legacy_ids: [BMAAS-XX-11]
                 status: approved
                 notes: ""
               - summary: Training workload test
@@ -875,8 +912,9 @@ domains:
                 milestone: M1
                 github_issues:
                   - "#66"
-                req_id: ""
-                test_id: BMAAS-XX-12
+                req_id: BMAAS12
+                test_id: BMAAS12-01
+                legacy_ids: [BMAAS-XX-12]
                 status: approved
               - summary: Verify that serial console output is logged and queryable for at least 1 month of history
                 labels:
@@ -994,8 +1032,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: VMAAS-XX-01
+                req_id: VMAAS01
+                test_id: VMAAS01-01
+                legacy_ids: [VMAAS-XX-01]
                 status: approved
                 notes: ""
                 labels:
@@ -1017,8 +1056,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M1
-                req_id: ""
-                test_id: VMAAS-XX-02
+                req_id: VMAAS02
+                test_id: VMAAS02-01
+                legacy_ids: [VMAAS-XX-02]
                 status: pending
                 notes: ""
               - summary: A running VM can be stopped (Without being destroyed)
@@ -1080,14 +1120,16 @@ domains:
             tests:
               - summary: Noisy Neighbor CPU/GPU tests
                 priority: P2
-                req_id: ""
-                test_id: VMAAS-XX-03
+                req_id: VMAAS03
+                test_id: VMAAS03-01
+                legacy_ids: [VMAAS-XX-03]
                 status: approved
                 notes: ""
               - summary: Tenant cannot allocate more VMs than their quota allows
                 priority: P2
-                req_id: ""
-                test_id: VMAAS-XX-04
+                req_id: VMAAS04
+                test_id: VMAAS04-01
+                legacy_ids: [VMAAS-XX-04]
                 status: approved
                 notes: ""
           - description: The underlying system allows VMs to access the GPU, with high performance, and are running with the correct parameters for optimal performance
@@ -1099,8 +1141,9 @@ domains:
                 milestone: M0
                 github_issues:
                   - "#55"
-                req_id: ""
-                test_id: VMAAS-XX-05
+                req_id: VMAAS05
+                test_id: VMAAS05-01
+                legacy_ids: [VMAAS-XX-05]
                 status: approved
                 notes: ""
                 labels:
@@ -1113,8 +1156,9 @@ domains:
                 milestone: M0
                 github_issues:
                   - "#59"
-                req_id: ""
-                test_id: VMAAS-XX-06
+                req_id: VMAAS06
+                test_id: VMAAS06-01
+                legacy_ids: [VMAAS-XX-06]
                 status: approved
                 notes: ""
                 labels:
@@ -1128,8 +1172,9 @@ domains:
                 milestone: M0
                 github_issues:
                   - "#62"
-                req_id: ""
-                test_id: VMAAS-XX-07
+                req_id: VMAAS07
+                test_id: VMAAS07-01
+                legacy_ids: [VMAAS-XX-07]
                 status: approved
                 notes: ""
                 labels:
@@ -1141,8 +1186,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M1
-                req_id: ""
-                test_id: VMAAS-XX-08
+                req_id: VMAAS08
+                test_id: VMAAS08-01
+                legacy_ids: [VMAAS-XX-08]
                 status: approved
                 notes: ""
               - summary: Check that vCPU pinning is set correctly, PCI bus is configured correctly
@@ -1153,8 +1199,9 @@ domains:
                 milestone: M0
                 github_issues:
                   - "#67"
-                req_id: ""
-                test_id: VMAAS-XX-09
+                req_id: VMAAS09
+                test_id: VMAAS09-01
+                legacy_ids: [VMAAS-XX-09]
                 status: approved
                 labels:
                   - gpu
@@ -1165,8 +1212,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M5
-                req_id: ""
-                test_id: VMAAS-XX-10
+                req_id: VMAAS10
+                test_id: VMAAS10-01
+                legacy_ids: [VMAAS-XX-10]
                 status: approved
                 notes: ""
           - description: Can run AI/ML Jobs
@@ -1176,8 +1224,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: VMAAS-XX-11
+                req_id: VMAAS11
+                test_id: VMAAS11-01
+                legacy_ids: [VMAAS-XX-11]
                 status: approved
                 notes: ""
               - summary: Nim Inference jobs (VM)
@@ -1185,8 +1234,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M1
-                req_id: ""
-                test_id: VMAAS-XX-12
+                req_id: VMAAS12
+                test_id: VMAAS12-01
+                legacy_ids: [VMAAS-XX-12]
                 status: approved
                 notes: ""
                 labels:
@@ -1198,8 +1248,9 @@ domains:
               - summary: Run NCCL tests
                 priority: P0
                 milestone: M5
-                req_id: ""
-                test_id: VMAAS-XX-13
+                req_id: VMAAS13
+                test_id: VMAAS13-01
+                legacy_ids: [VMAAS-XX-13]
                 status: approved
                 notes: ""
           - description: nodes will be able to access expected resources on the local networks
@@ -1210,8 +1261,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M5
-                req_id: ""
-                test_id: VMAAS-XX-14
+                req_id: VMAAS14
+                test_id: VMAAS14-01
+                legacy_ids: [VMAAS-XX-14]
                 status: approved
                 notes: ""
           - description: "Observability & Debug"
@@ -1401,8 +1453,9 @@ domains:
                 milestone: M3
                 github_issues:
                   - "#116"
-                req_id: ""
-                test_id: SDN-XX-01
+                req_id: SDN11
+                test_id: SDN11-01
+                legacy_ids: [SDN-XX-01]
                 status: approved
                 notes: ""
               - summary: "Atomically switch a floating private IP between nodes via API within <10 seconds without requiring an instance reboot."
@@ -1506,134 +1559,151 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: SDN-XX-02
+                req_id: SDN12
+                test_id: SDN12-01
+                legacy_ids: [SDN-XX-02]
                 status: approved
                 notes: ""
               - summary: "NVLink: List partitions; retrieve a specific partition by partition ID"
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: SDN-XX-03
+                req_id: SDN13
+                test_id: SDN13-01
+                legacy_ids: [SDN-XX-03]
                 status: approved
                 notes: ""
               - summary: "NVLink: Delete an empty partition (no instances); retrieve by ID and verify not found."
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: SDN-XX-04
+                req_id: SDN14
+                test_id: SDN14-01
+                legacy_ids: [SDN-XX-04]
                 status: approved
                 notes: ""
               - summary: "NVLink: Create a partition, create instance in that partition, make sure the instance becomes ready, delete instance, verify GPUs removed from partition."
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: SDN-XX-05
+                req_id: SDN15
+                test_id: SDN15-01
+                legacy_ids: [SDN-XX-05]
                 status: approved
                 notes: ""
               - summary: "NVLink: Create partition, create 2 instances, verify both share the same nvlink_partition_id and both GPUs are reported for that partition"
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: SDN-XX-06
+                req_id: SDN16
+                test_id: SDN16-01
+                legacy_ids: [SDN-XX-06]
                 status: approved
                 notes: ""
               - summary: "IMEX: Assert nvidia-imex and nvidia-imex-ctl packages are installed and nvidia-imex.service unit is registered with systemd."
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: SDN-XX-07
+                req_id: SDN17
+                test_id: SDN17-01
+                legacy_ids: [SDN-XX-07]
                 status: approved
                 notes: ""
               - summary: "IMEX: Start nvidia-imex via systemctl start nvidia-imex and assert the service reaches active/ready state."
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: SDN-XX-08
+                req_id: SDN18
+                test_id: SDN18-01
+                legacy_ids: [SDN-XX-08]
                 status: approved
                 notes: ""
               - summary: "IMEX: Stop nvidia-imex via systemctl stop nvidia-imex and assert clean shutdown (other nodes show disabled node status)."
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: SDN-XX-09
+                req_id: SDN19
+                test_id: SDN19-01
+                legacy_ids: [SDN-XX-09]
                 status: approved
                 notes: ""
               - summary: "IMEX: Enable IMEX at boot with systemctl enable nvidia-imex, reboot, and confirm IMEX starts automatically."
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: SDN-XX-10
+                req_id: SDN20
+                test_id: SDN20-01
+                legacy_ids: [SDN-XX-10]
                 status: approved
                 notes: ""
               - summary: "IMEX: After all nodes start IMEX, query domain state via nvidia-imex-ctl -N and assert state is UP, fully connected matrix"
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: SDN-XX-11
+                req_id: SDN21
+                test_id: SDN21-01
+                legacy_ids: [SDN-XX-11]
                 status: approved
                 notes: ""
               - summary: "IMEX: With IMEX_ENABLE_AUTH_ENCRYPTION=0, form a multi-node domain and assert connectivity without any auth/encryption."
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: SDN-XX-12
+                req_id: SDN22
+                test_id: SDN22-01
+                legacy_ids: [SDN-XX-12]
                 status: approved
                 notes: ""
               - summary: "IMEX: Enable IMEX_ENABLE_AUTH_ENCRYPTION=1 with SSL_TLS mode, provide valid server/client certs, and assert mutual authentication and encrypted communication."
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: SDN-XX-13
+                req_id: SDN23
+                test_id: SDN23-01
+                legacy_ids: [SDN-XX-13]
                 status: approved
                 notes: ""
               - summary: "IMEX: Enable GSSAPI/Kerberos mode (GSS_AUTH_ENCRYPT), configure KDC/keytabs, and assert mutual auth + encryption between nodes."
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: SDN-XX-14
+                req_id: SDN24
+                test_id: SDN24-01
+                legacy_ids: [SDN-XX-14]
                 status: approved
                 notes: ""
               - summary: "IMEX: IMEX/K8s: Submit a workload requesting a ComputeDomain; assert ComputeDomain pods are created on each allocated node."
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: SDN-XX-15
+                req_id: SDN25
+                test_id: SDN25-01
+                legacy_ids: [SDN-XX-15]
                 status: approved
                 notes: ""
               - summary: "IMEX: From workload pods in a ComputeDomain run nvbandwidth-test-job"
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: SDN-XX-16
+                req_id: SDN26
+                test_id: SDN26-01
+                legacy_ids: [SDN-XX-16]
                 status: approved
                 notes: ""
               - summary: "IMEX: After workload completes, assert ComputeDomain and associated IMEX resources are cleaned up."
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: SDN-XX-17
+                req_id: SDN27
+                test_id: SDN27-01
+                legacy_ids: [SDN-XX-17]
                 status: approved
                 notes: ""
               - summary: Redundant Gateways
                 notes: REVIEW
-                req_id: ""
-                test_id: SDN-XX-18
+                req_id: SDN28
+                test_id: SDN28-01
+                legacy_ids: [SDN-XX-18]
                 status: pending
                 priority: ""
           - description: "Security Group Scope & Timing"
@@ -1781,8 +1851,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M4
-                req_id: ""
-                test_id: META-XX-01
+                req_id: META01
+                test_id: META01-01
+                legacy_ids: [META-XX-01]
                 status: approved
                 notes: ""
       - name: Cloud Control Plane
@@ -1793,8 +1864,9 @@ domains:
               - summary: Needs to have an API we can access from our tests to do actions
                 priority: P0
                 milestone: M4
-                req_id: ""
-                test_id: CTRL-XX-01
+                req_id: CTRL01
+                test_id: CTRL01-01
+                legacy_ids: [CTRL-XX-01]
                 status: approved
                 notes: ""
               - summary: "Verify that fleet management API provides full set of information requested below: Node ID (Unique identifier for a GPU node) Health State (Healthy/Unhealthy classification) Instance ID (Identifier for virtual workload) Creation Timestamp (Time workload/node was created) Hardware Type (Descriptor for the hardware model) GPU Count (Number of GPUs per node) Top-levelAccount/ID (Identifier for the top-level organization/account) Sub-LevelProject/ID (Identifier for the nested project/sub-account) In Use (True/False status indicating if the GPU Node is turned on and in use) Region (Region of the data center where nodes are deployed)"
@@ -1835,27 +1907,31 @@ domains:
                 priority: P2
                 dependencies:
                   - LimitedEnv
-                req_id: ""
-                test_id: LB-XX-01
+                req_id: LB01
+                test_id: LB01-01
+                legacy_ids: [LB-XX-01]
                 status: approved
                 notes: ""
               - summary: Verify that traffic is distributed across multiple nodes
                 dependencies:
                   - LimitedEnv
-                req_id: ""
-                test_id: LB-XX-02
+                req_id: LB02
+                test_id: LB02-01
+                legacy_ids: [LB-XX-02]
                 status: approved
                 notes: ""
               - summary: Verify that nodes can be marked as down or up (for rolling deployments/etc)
-                req_id: ""
-                test_id: LB-XX-03
+                req_id: LB03
+                test_id: LB03-01
+                legacy_ids: [LB-XX-03]
                 status: approved
                 notes: ""
               - summary: Verify that no traffic is dropped during outages
                 dependencies:
                   - LimitedEnv
-                req_id: ""
-                test_id: LB-XX-04
+                req_id: LB04
+                test_id: LB04-01
+                legacy_ids: [LB-XX-04]
                 status: approved
                 notes: ""
       - name: Break-Fix
@@ -1867,22 +1943,25 @@ domains:
                 priority: P1
                 dependencies:
                   - LimitedEnv
-                req_id: ""
-                test_id: BFX-XX-01
+                req_id: BFX04
+                test_id: BFX04-01
+                legacy_ids: [BFX-XX-01]
                 status: approved
                 notes: ""
               - summary: Verify that Tenants can be notified, by some communication system, of planned future node maintenance
                 dependencies:
                   - LimitedEnv
-                req_id: ""
-                test_id: BFX-XX-02
+                req_id: BFX05
+                test_id: BFX05-01
+                legacy_ids: [BFX-XX-02]
                 status: approved
                 notes: ""
               - summary: Verify that Tenants can be notified, by some communication system, of immediate node failure
                 dependencies:
                   - LimitedEnv
-                req_id: ""
-                test_id: BFX-XX-03
+                req_id: BFX06
+                test_id: BFX06-01
+                legacy_ids: [BFX-XX-03]
                 status: approved
                 notes: ""
           - description: Breakfix API Lifecycle
@@ -2076,8 +2155,9 @@ domains:
                 status: pending
               - summary: "Storage: Config/default/access to network provided storage"
                 notes: REVIEW
-                req_id: ""
-                test_id: STOR-XX-01
+                req_id: STOR01
+                test_id: STOR01-01
+                legacy_ids: [STOR-XX-01]
                 status: pending
           - description: Home Directory Storage
             tests:
@@ -2341,8 +2421,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#262"
-                req_id: ""
-                test_id: DATASVC-XX-01
+                req_id: DATASVC01
+                test_id: DATASVC01-01
+                legacy_ids: [DATASVC-XX-01]
                 status: pending
       - name: Block Storage Services
         capabilities:
@@ -2368,8 +2449,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#321"
-                req_id: ""
-                test_id: DATASVC-XX-02
+                req_id: DATASVC02
+                test_id: DATASVC02-01
+                legacy_ids: [DATASVC-XX-02]
                 status: pending
               - summary: Verify volume resizing
                 labels:
@@ -2379,8 +2461,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#322"
-                req_id: ""
-                test_id: DATASVC-XX-03
+                req_id: DATASVC03
+                test_id: DATASVC03-01
+                legacy_ids: [DATASVC-XX-03]
                 status: pending
               - summary: Verify persistent block volumes survive instance restarts
                 labels:
@@ -2390,8 +2473,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#323"
-                req_id: ""
-                test_id: DATASVC-XX-04
+                req_id: DATASVC04
+                test_id: DATASVC04-01
+                legacy_ids: [DATASVC-XX-04]
                 status: pending
       - name: Cache Services
         capabilities:
@@ -2402,8 +2486,9 @@ domains:
                 priority: P2
                 dependencies:
                   - LimitedEnv
-                req_id: ""
-                test_id: DATASVC-XX-05
+                req_id: DATASVC05
+                test_id: DATASVC05-01
+                legacy_ids: [DATASVC-XX-05]
                 status: pending
                 notes: ""
       - name: Vector Store
@@ -2415,8 +2500,9 @@ domains:
                 priority: P2
                 dependencies:
                   - LimitedEnv
-                req_id: ""
-                test_id: DATASVC-XX-06
+                req_id: DATASVC06
+                test_id: DATASVC06-01
+                legacy_ids: [DATASVC-XX-06]
                 status: pending
                 notes: ""
       - name: Relational Database
@@ -2428,8 +2514,9 @@ domains:
                 priority: P2
                 dependencies:
                   - LimitedEnv
-                req_id: ""
-                test_id: DATASVC-XX-07
+                req_id: DATASVC07
+                test_id: DATASVC07-01
+                legacy_ids: [DATASVC-XX-07]
                 status: pending
                 notes: ""
   - name: Workload Orchestration
@@ -2442,8 +2529,9 @@ domains:
               - summary: Create a backup of a block volume, delete original, restore from backup, verify data is the same as the original
                 priority: P2
                 milestone: M4
-                req_id: ""
-                test_id: DATASVC-XX-08
+                req_id: DATASVC08
+                test_id: DATASVC08-01
+                legacy_ids: [DATASVC-XX-08]
                 status: pending
                 notes: ""
       - name: Model Registry
@@ -2453,8 +2541,9 @@ domains:
             tests:
               - summary: Push a model artifact with a version tag, retrieve by version, verify it matches (prefer a smaller reference model)
                 priority: P2
-                req_id: ""
-                test_id: DATASVC-XX-09
+                req_id: DATASVC09
+                test_id: DATASVC09-01
+                legacy_ids: [DATASVC-XX-09]
                 status: pending
                 notes: ""
       - name: Slurm Control Plane
@@ -2468,8 +2557,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: SLURM-XX-01
+                req_id: SLURM01
+                test_id: SLURM01-01
+                legacy_ids: [SLURM-XX-01]
                 status: done
               - summary: SlurmInfoAvailable
                 notes: ""
@@ -2477,8 +2567,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: SLURM-XX-02
+                req_id: SLURM02
+                test_id: SLURM02-01
+                legacy_ids: [SLURM-XX-02]
                 status: done
                 labels:
                   - slurm
@@ -2488,8 +2579,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: SLURM-XX-03
+                req_id: SLURM03
+                test_id: SLURM03-01
+                legacy_ids: [SLURM-XX-03]
                 status: done
                 labels:
                   - slurm
@@ -2499,8 +2591,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: SLURM-XX-04
+                req_id: SLURM04
+                test_id: SLURM04-01
+                legacy_ids: [SLURM-XX-04]
                 status: done
                 labels:
                   - slurm
@@ -2510,8 +2603,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: SLURM-XX-05
+                req_id: SLURM05
+                test_id: SLURM05-01
+                legacy_ids: [SLURM-XX-05]
                 status: done
                 labels:
                   - slurm
@@ -2521,8 +2615,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: SLURM-XX-06
+                req_id: SLURM06
+                test_id: SLURM06-01
+                legacy_ids: [SLURM-XX-06]
                 status: done
                 labels:
                   - slurm
@@ -2532,8 +2627,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: SLURM-XX-07
+                req_id: SLURM07
+                test_id: SLURM07-01
+                legacy_ids: [SLURM-XX-07]
                 status: done
                 labels:
                   - gpu
@@ -2546,8 +2642,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: SLURM-XX-08
+                req_id: SLURM08
+                test_id: SLURM08-01
+                legacy_ids: [SLURM-XX-08]
                 status: done
                 labels:
                   - gpu
@@ -2560,8 +2657,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: SLURM-XX-09
+                req_id: SLURM09
+                test_id: SLURM09-01
+                legacy_ids: [SLURM-XX-09]
                 status: done
                 labels:
                   - slow
@@ -2573,8 +2671,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: SLURM-XX-10
+                req_id: SLURM10
+                test_id: SLURM10-01
+                legacy_ids: [SLURM-XX-10]
                 status: done
       - name: Managed Kubernetes Control Plane
         capabilities:
@@ -2599,15 +2698,15 @@ domains:
                 labels:
                   - min_req
                 milestone: M4
-                req_id: ""
-                test_id: K8S-XX-01
+                req_id: K8S38
+                test_id: K8S38-01
+                legacy_ids: [K8S-XX-01]
                 status: approved
                 notes: ""
               - summary: The control plane should automatically add more capacity when load increases
-                labels:
-                  - min_req
-                req_id: SEC23
-                test_id: SEC23-01
+                req_id: K8S41
+                test_id: K8S41-01
+                legacy_ids: [SEC23-01]
                 status: pending
                 notes: ""
                 priority: ""
@@ -2638,8 +2737,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: K8S-XX-02
+                req_id: K8S39
+                test_id: K8S39-01
+                legacy_ids: [K8S-XX-02]
                 status: done
               - summary: K8s Nim Inference
                 notes: ""
@@ -2647,8 +2747,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: K8S-XX-03
+                req_id: K8S40
+                test_id: K8S40-01
+                legacy_ids: [K8S-XX-03]
                 status: done
                 labels:
                   - gpu
@@ -2661,8 +2762,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: K8S-XX-04
+                req_id: K8S32
+                test_id: K8S32-01
+                legacy_ids: [K8S-XX-04]
                 status: done
                 labels:
                   - gpu
@@ -2679,8 +2781,9 @@ domains:
                   - slow
                   - workload
                 priority: P0
-                req_id: ""
-                test_id: K8S-XX-05
+                req_id: K8S33
+                test_id: K8S33-01
+                legacy_ids: [K8S-XX-05]
                 status: approved
                 notes: ""
           - description: k8s upstream proxy
@@ -2689,8 +2792,9 @@ domains:
                 labels:
                   - min_req
                 notes: k8s05
-                req_id: ""
-                test_id: K8S-XX-06
+                req_id: K8S34
+                test_id: K8S34-01
+                legacy_ids: [K8S-XX-06]
                 status: approved
                 priority: P0
           - description: Dynamic Resource Allocaiton
@@ -2746,8 +2850,9 @@ domains:
                 labels:
                   - min_req
                 notes: K8s16
-                req_id: ""
-                test_id: K8S-XX-07
+                req_id: K8S35
+                test_id: K8S35-01
+                legacy_ids: [K8S-XX-07]
                 status: approved
                 priority: P1
           - description: CNI Compliance
@@ -2982,8 +3087,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#267"
-                req_id: ""
-                test_id: K8S-XX-08
+                req_id: K8S36
+                test_id: K8S36-01
+                legacy_ids: [K8S-XX-08]
                 status: pending
           - description: Kubernetes Security Response
             tests:
@@ -3076,8 +3182,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#226"
-                req_id: K8S18
-                test_id: K8S18-01
+                req_id: K8S17
+                test_id: K8S17-02
+                legacy_ids: [K8S18-01]
                 status: pending
           - description: K8s Control Plane Logging
             tests:
@@ -3103,8 +3210,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#268"
-                req_id: ""
-                test_id: K8S-XX-09
+                req_id: K8S37
+                test_id: K8S37-01
+                legacy_ids: [K8S-XX-09]
                 status: pending
           - description: Multi-Cluster Support
             tests:
@@ -3129,8 +3237,9 @@ domains:
                 priority: P2
                 dependencies:
                   - MiniCloud
-                req_id: ""
-                test_id: POWER-XX-01
+                req_id: POWER01
+                test_id: POWER01-01
+                legacy_ids: [POWER-XX-01]
                 status: approved
                 notes: ""
   - name: "AI Platform & User Access"
@@ -3142,8 +3251,9 @@ domains:
             tests:
               - summary: TODO
                 priority: P2
-                req_id: ""
-                test_id: APIGW-XX-01
+                req_id: APIGW01
+                test_id: APIGW01-01
+                legacy_ids: [APIGW-XX-01]
                 status: approved
                 notes: ""
       - name: Al Platform 1..N Control Planes
@@ -3152,8 +3262,9 @@ domains:
             tests:
               - summary: TODO
                 priority: P2
-                req_id: ""
-                test_id: AICP-XX-01
+                req_id: AICP01
+                test_id: AICP01-01
+                legacy_ids: [AICP-XX-01]
                 status: approved
                 notes: ""
       - name: Web Management Dashboard
@@ -3165,8 +3276,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M5
-                req_id: ""
-                test_id: WEBUI-XX-01
+                req_id: WEBUI01
+                test_id: WEBUI01-01
+                legacy_ids: [WEBUI-XX-01]
                 status: approved
                 notes: ""
   - name: Observability
@@ -3181,8 +3293,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: OBS-XX-01
+                req_id: OBS01
+                test_id: OBS01-01
+                legacy_ids: [OBS-XX-01]
                 status: done
               - summary: Logging information about the control plane is available
                 notes: ""
@@ -3190,8 +3303,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: OBS-XX-02
+                req_id: OBS02
+                test_id: OBS02-01
+                legacy_ids: [OBS-XX-02]
                 status: done
               - summary: Logging information from instances
                 notes: ""
@@ -3199,8 +3313,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: OBS-XX-03
+                req_id: OBS03
+                test_id: OBS03-01
+                legacy_ids: [OBS-XX-03]
                 status: done
               - summary: Alerts can be issued by the system in case of problems
                 notes: ""
@@ -3208,8 +3323,9 @@ domains:
                 dependencies:
                   - LimitedEnv
                 milestone: M0
-                req_id: ""
-                test_id: OBS-XX-04
+                req_id: OBS04
+                test_id: OBS04-01
+                legacy_ids: [OBS-XX-04]
                 status: done
           - description: Telemetry Delivery
             tests:
@@ -3221,8 +3337,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#342"
-                req_id: ""
-                test_id: OBS-XX-05
+                req_id: OBS05
+                test_id: OBS05-01
+                legacy_ids: [OBS-XX-05]
                 status: pending
           - description: Network Telemetry
             tests:
@@ -3234,8 +3351,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#343"
-                req_id: ""
-                test_id: OBS-XX-06
+                req_id: OBS06
+                test_id: OBS06-01
+                legacy_ids: [OBS-XX-06]
                 status: pending
               - summary: Verify telemetry is available for East-West (back-end / GPU interconnect) network
                 labels:
@@ -3245,8 +3363,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#344"
-                req_id: ""
-                test_id: OBS-XX-07
+                req_id: OBS07
+                test_id: OBS07-01
+                legacy_ids: [OBS-XX-07]
                 status: pending
               - summary: Verify telemetry is available for Management network
                 labels:
@@ -3256,8 +3375,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#345"
-                req_id: ""
-                test_id: OBS-XX-08
+                req_id: OBS08
+                test_id: OBS08-01
+                legacy_ids: [OBS-XX-08]
                 status: pending
               - summary: Verify telemetry is available for NVSwitch Fabric (GB200+)
                 labels:
@@ -3267,8 +3387,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#346"
-                req_id: ""
-                test_id: OBS-XX-09
+                req_id: OBS09
+                test_id: OBS09-01
+                legacy_ids: [OBS-XX-09]
                 status: pending
               - summary: Verify telemetry is available for Host network (NIC-level)
                 labels:
@@ -3278,8 +3399,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#347"
-                req_id: ""
-                test_id: OBS-XX-10
+                req_id: OBS10
+                test_id: OBS10-01
+                legacy_ids: [OBS-XX-10]
                 status: pending
           - description: Required Logs
             tests:
@@ -3291,8 +3413,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#348"
-                req_id: ""
-                test_id: OBS-XX-11
+                req_id: OBS11
+                test_id: OBS11-01
+                legacy_ids: [OBS-XX-11]
                 status: pending
               - summary: Verify Subnet Manager logs are available (where applicable)
                 labels:
@@ -3302,8 +3425,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#349"
-                req_id: ""
-                test_id: OBS-XX-12
+                req_id: OBS12
+                test_id: OBS12-01
+                legacy_ids: [OBS-XX-12]
                 status: pending
               - summary: Verify UFM Event logs are available
                 labels:
@@ -3313,8 +3437,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#350"
-                req_id: ""
-                test_id: OBS-XX-13
+                req_id: OBS13
+                test_id: OBS13-01
+                legacy_ids: [OBS-XX-13]
                 status: pending
               - summary: Verify general switch logs are available
                 labels:
@@ -3324,8 +3449,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#351"
-                req_id: ""
-                test_id: OBS-XX-14
+                req_id: OBS14
+                test_id: OBS14-01
+                legacy_ids: [OBS-XX-14]
                 status: pending
               - summary: Verify switch syslogs are available
                 labels:
@@ -3335,8 +3461,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#352"
-                req_id: ""
-                test_id: OBS-XX-15
+                req_id: OBS15
+                test_id: OBS15-01
+                legacy_ids: [OBS-XX-15]
                 status: pending
               - summary: Verify switch kernel logs are available
                 labels:
@@ -3346,8 +3473,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#353"
-                req_id: ""
-                test_id: OBS-XX-16
+                req_id: OBS16
+                test_id: OBS16-01
+                legacy_ids: [OBS-XX-16]
                 status: pending
               - summary: Verify BMC SEL logs are available
                 labels:
@@ -3359,8 +3487,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#354"
-                req_id: ""
-                test_id: OBS-XX-17
+                req_id: OBS17
+                test_id: OBS17-01
+                legacy_ids: [OBS-XX-17]
                 status: pending
               - summary: Verify host syslogs are available
                 labels:
@@ -3372,8 +3501,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#355"
-                req_id: ""
-                test_id: OBS-XX-18
+                req_id: OBS18
+                test_id: OBS18-01
+                legacy_ids: [OBS-XX-18]
                 status: pending
               - summary: Verify VPC Flow logs (all ingress/egress traffic) are available
                 labels:
@@ -3385,8 +3515,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#356"
-                req_id: ""
-                test_id: OBS-XX-19
+                req_id: OBS19
+                test_id: OBS19-01
+                legacy_ids: [OBS-XX-19]
                 status: pending
       - name: Telemetry / Data Lakes
         capabilities:
@@ -3396,8 +3527,9 @@ domains:
                 priority: P1
                 dependencies:
                   - LimitedEnv
-                req_id: ""
-                test_id: TELEM-XX-01
+                req_id: TELEM01
+                test_id: TELEM01-01
+                legacy_ids: [TELEM-XX-01]
                 status: approved
                 notes: ""
               - summary: Read only access to a BMaaS system's serial console
@@ -3410,8 +3542,9 @@ domains:
                 milestone: M3
                 github_issues:
                   - "#120"
-                req_id: ""
-                test_id: TELEM-XX-02
+                req_id: TELEM02
+                test_id: TELEM02-01
+                legacy_ids: [TELEM-XX-02]
                 status: approved
               - summary: Read only access to a VM serial console
                 labels:
@@ -3423,8 +3556,9 @@ domains:
                 milestone: M3
                 github_issues:
                   - "#121"
-                req_id: ""
-                test_id: TELEM-XX-03
+                req_id: TELEM03
+                test_id: TELEM03-01
+                legacy_ids: [TELEM-XX-03]
                 status: approved
           - description: BMC/Redfish Telemetry
             tests:
@@ -3439,8 +3573,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#362"
-                req_id: ""
-                test_id: TELEM-XX-04
+                req_id: TELEM04
+                test_id: TELEM04-01
+                legacy_ids: [TELEM-XX-04]
                 status: pending
           - description: Storage Telemetry
             tests:
@@ -3452,8 +3587,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#363"
-                req_id: ""
-                test_id: TELEM-XX-05
+                req_id: TELEM05
+                test_id: TELEM05-01
+                legacy_ids: [TELEM-XX-05]
                 status: pending
               - summary: Verify storage performance metrics are available (bandwidth, IOPS, latency)
                 labels:
@@ -3463,8 +3599,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#364"
-                req_id: ""
-                test_id: TELEM-XX-06
+                req_id: TELEM06
+                test_id: TELEM06-01
+                legacy_ids: [TELEM-XX-06]
                 status: pending
           - description: NVLink Switch Telemetry
             tests:
@@ -3476,8 +3613,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#365"
-                req_id: ""
-                test_id: TELEM-XX-07
+                req_id: TELEM07
+                test_id: TELEM07-01
+                legacy_ids: [TELEM-XX-07]
                 status: pending
               - summary: Verify NVLink metrics are available from the switch perspective (port-level counters, error rates)
                 labels:
@@ -3487,8 +3625,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#366"
-                req_id: ""
-                test_id: TELEM-XX-08
+                req_id: TELEM08
+                test_id: TELEM08-01
+                legacy_ids: [TELEM-XX-08]
                 status: pending
   - name: "Security & Identity"
     components:
@@ -3666,8 +3805,9 @@ domains:
                 notes: ""
                 github_issues:
                   - "#294"
-                req_id: SEC02
-                test_id: SEC02-01
+                req_id: SEC06
+                test_id: SEC06-01
+                legacy_ids: [SEC02-01]
                 status: pending
           - description: External Service Authentication
             tests:
@@ -4021,14 +4161,16 @@ domains:
                 notes: ""
               - summary: "NVMesh checks?"
                 notes: REVIEW
-                req_id: ""
-                test_id: BENCH-XX-01
+                req_id: BENCH01
+                test_id: BENCH01-01
+                legacy_ids: [BENCH-XX-01]
                 status: pending
                 priority: ""
               - summary: "IPv4 and IPv6 checks?"
                 notes: REVIEW
-                req_id: ""
-                test_id: BENCH-XX-02
+                req_id: BENCH02
+                test_id: BENCH02-01
+                legacy_ids: [BENCH-XX-02]
                 status: pending
                 priority: ""
               - summary: "Verify performance is within 5% of NVIDIA Reference"

--- a/isvctl/configs/suites/bare_metal.yaml
+++ b/isvctl/configs/suites/bare_metal.yaml
@@ -112,7 +112,7 @@ tests:
       step: describe_instance
       checks:
         ConnectivityCheck:
-          test_id: "BMAAS-XX-03"
+          test_id: "BMAAS03-01"
           labels: ["bare_metal", "ssh"]
         OsCheck:
           # No BMaaS plan item for a host-OS image check (VMAAS-XX-05 is VM-only).
@@ -124,7 +124,7 @@ tests:
       step: describe_instance
       checks:
         GpuCheck:
-          test_id: "BMAAS-XX-08"
+          test_id: "BMAAS08-01"
           labels: ["bare_metal", "ssh", "gpu"]
           expected_gpus: 8
 
@@ -154,7 +154,7 @@ tests:
           test_id: "N/A"
           labels: ["bare_metal"]
         BmHostStatusLog:
-          test_id: "BMAAS-XX-07"
+          test_id: "BMAAS07-01"
           labels: ["bare_metal"]
 
     # GPU stress test - PyTorch matrix multiplications on all GPUs
@@ -162,7 +162,7 @@ tests:
       step: describe_instance
       checks:
         GpuStressCheck:
-          test_id: "BMAAS-XX-09"
+          test_id: "BMAAS09-01"
           labels: ["bare_metal", "gpu", "min_req", "ssh", "workload"]
           runtime: 30
           memory_gb: 16
@@ -172,7 +172,7 @@ tests:
       step: describe_instance
       checks:
         NcclCheck:
-          test_id: "BMAAS-XX-11"
+          test_id: "BMAAS11-01"
           labels: ["bare_metal", "gpu", "min_req", "ssh", "workload"]
 
     # DDP training workload - validates full training stack
@@ -180,7 +180,7 @@ tests:
       step: describe_instance
       checks:
         TrainingCheck:
-          test_id: "BMAAS-XX-12"
+          test_id: "BMAAS12-01"
           labels: ["bare_metal", "gpu", "min_req", "ssh", "workload"]
           steps: 50
 
@@ -189,21 +189,21 @@ tests:
       step: describe_instance
       checks:
         NvlinkCheck:
-          test_id: "BMAAS-XX-06"
+          test_id: "BMAAS06-01"
           labels: ["bare_metal", "ssh", "gpu", "network"]
 
     infiniband:
       step: describe_instance
       checks:
         InfiniBandCheck:
-          test_id: "BMAAS-XX-06"
+          test_id: "BMAAS06-01"
           labels: ["bare_metal", "gpu", "network", "ssh"]
 
     ethernet:
       step: describe_instance
       checks:
         EthernetCheck:
-          test_id: "BMAAS-XX-06"
+          test_id: "BMAAS06-01"
           labels: ["bare_metal", "gpu", "network", "ssh"]
           ping_target: "8.8.8.8"
 
@@ -256,7 +256,7 @@ tests:
       checks:
         # ConnectivityCheck -> BMAAS-XX-03, OsCheck -> N/A (declared in the "ssh" section)
         ConnectivityCheck:
-          test_id: "BMAAS-XX-03"
+          test_id: "BMAAS03-01"
           labels: ["bare_metal", "ssh"]
           host: "{{steps.describe_instance.public_ip}}"
           key_file: "{{steps.describe_instance.key_file}}"
@@ -272,7 +272,7 @@ tests:
       checks:
         # GpuCheck -> BMAAS-XX-08 (declared in the "gpu" section)
         GpuCheck:
-          test_id: "BMAAS-XX-08"
+          test_id: "BMAAS08-01"
           labels: ["bare_metal", "ssh", "gpu"]
           host: "{{steps.describe_instance.public_ip}}"
           key_file: "{{steps.describe_instance.key_file}}"
@@ -303,7 +303,7 @@ tests:
       checks:
         # ConnectivityCheck -> BMAAS-XX-03, OsCheck -> N/A (declared in the "ssh" section)
         ConnectivityCheck:
-          test_id: "BMAAS-XX-03"
+          test_id: "BMAAS03-01"
           labels: ["bare_metal", "ssh"]
           host: "{{steps.describe_instance.public_ip}}"
           key_file: "{{steps.describe_instance.key_file}}"
@@ -319,7 +319,7 @@ tests:
       checks:
         # GpuCheck -> BMAAS-XX-08 (declared in the "gpu" section)
         GpuCheck:
-          test_id: "BMAAS-XX-08"
+          test_id: "BMAAS08-01"
           labels: ["bare_metal", "ssh", "gpu"]
           host: "{{steps.describe_instance.public_ip}}"
           key_file: "{{steps.describe_instance.key_file}}"
@@ -351,7 +351,7 @@ tests:
       checks:
         # ConnectivityCheck -> BMAAS-XX-03, OsCheck -> N/A (declared in the "ssh" section)
         ConnectivityCheck:
-          test_id: "BMAAS-XX-03"
+          test_id: "BMAAS03-01"
           labels: ["bare_metal", "ssh"]
         OsCheck:
           test_id: "N/A"
@@ -363,7 +363,7 @@ tests:
       checks:
         # GpuCheck -> BMAAS-XX-08 (declared in the "gpu" section)
         GpuCheck:
-          test_id: "BMAAS-XX-08"
+          test_id: "BMAAS08-01"
           labels: ["bare_metal", "ssh", "gpu"]
           expected_gpus: 8
 
@@ -385,7 +385,7 @@ tests:
       checks:
         # ConnectivityCheck -> BMAAS-XX-03, OsCheck -> N/A (declared in the "ssh" section)
         ConnectivityCheck:
-          test_id: "BMAAS-XX-03"
+          test_id: "BMAAS03-01"
           labels: ["bare_metal", "ssh"]
         OsCheck:
           test_id: "N/A"
@@ -397,28 +397,28 @@ tests:
       checks:
         # GpuCheck -> BMAAS-XX-08 (declared in the "gpu" section)
         GpuCheck:
-          test_id: "BMAAS-XX-08"
+          test_id: "BMAAS08-01"
           labels: ["bare_metal", "ssh", "gpu"]
 
     nim_health:
       step: deploy_nim
       checks:
         NimHealthCheck:
-          test_id: "BMAAS-XX-10"
+          test_id: "BMAAS10-01"
           labels: ["bare_metal", "gpu", "min_req", "slow", "ssh", "workload"]
 
     nim_models:
       step: deploy_nim
       checks:
         NimModelCheck:
-          test_id: "BMAAS-XX-10"
+          test_id: "BMAAS10-01"
           labels: ["bare_metal", "gpu", "min_req", "slow", "ssh", "workload"]
 
     nim_inference:
       step: deploy_nim
       checks:
         NimInferenceCheck:
-          test_id: "BMAAS-XX-10"
+          test_id: "BMAAS10-01"
           labels: ["bare_metal", "gpu", "min_req", "slow", "ssh", "workload"]
           prompt: "What is CUDA?"
           max_tokens: 50
@@ -450,7 +450,7 @@ tests:
       step: verify_ingestion
       checks:
         HardwareIngestionCheck:
-          test_id: "HWING-XX-01"
+          test_id: "HWING01-01"
           labels: ["bare_metal", "ingestion"]
           min_machines: 1
           expected_status: ["Ready", "InUse"]
@@ -462,7 +462,7 @@ tests:
       step: check_dpu_health
       checks:
         DpuHealthCheck:
-          test_id: "BMAAS-XX-05"
+          test_id: "BMAAS05-01"
           labels: ["bare_metal", "dpu"]
           require_heartbeat: true
 

--- a/isvctl/configs/suites/control-plane.yaml
+++ b/isvctl/configs/suites/control-plane.yaml
@@ -66,7 +66,7 @@ tests:
         # response. The data-path half is the CrudOperationsCheck in the
         # "s3_object_lifecycle" section, which declares the same test_id.
         FieldValueCheck:
-          test_id: "DATASVC-XX-01"
+          test_id: "DATASVC01-01"
           labels: ["control_plane", "min_req"]
           field: "success"
           expected: true
@@ -74,37 +74,37 @@ tests:
     setup_checks:
       checks:
         AccessKeyCreatedCheck:
-          test_id: "CP-XX-05"
+          test_id: "CP05-01"
           labels: ["control_plane", "iam"]
           step: create_access_key
         TenantCreatedCheck:
-          test_id: "CP-XX-07"
+          test_id: "CP07-01"
           labels: ["control_plane", "iam"]
           step: create_tenant
 
     access_key_lifecycle:
       checks:
         AccessKeyAuthenticatedCheck:
-          test_id: "CP-XX-05"
+          test_id: "CP05-01"
           labels: ["control_plane", "iam"]
           step: test_access_key
         AccessKeyDisabledCheck:
-          test_id: "CP-XX-06"
+          test_id: "CP06-01"
           labels: ["control_plane", "iam", "min_req"]
           step: disable_access_key
         AccessKeyRejectedCheck:
-          test_id: "CP-XX-06"
+          test_id: "CP06-01"
           labels: ["control_plane", "iam", "min_req"]
           step: verify_key_rejected
 
     tenant_lifecycle:
       checks:
         TenantListedCheck:
-          test_id: "CP-XX-08"
+          test_id: "CP08-01"
           labels: ["control_plane", "iam"]
           step: list_tenants
         TenantInfoCheck:
-          test_id: "CP-XX-09"
+          test_id: "CP09-01"
           labels: ["control_plane", "iam"]
           step: get_tenant
 
@@ -121,7 +121,7 @@ tests:
           labels: ["control_plane"]
           fields: ["bucket_name", "object_key", "operations"]
         CrudOperationsCheck:
-          test_id: "DATASVC-XX-01"
+          test_id: "DATASVC01-01"
           labels: ["control_plane", "min_req"]
           operations: ["put", "get", "delete"]
 
@@ -134,7 +134,7 @@ tests:
           labels: ["control_plane"]
           step: delete_access_key
         StepSuccessCheck-delete_tenant:
-          test_id: "CP-XX-10"
+          test_id: "CP10-01"
           labels: ["control_plane"]
           step: delete_tenant
 

--- a/isvctl/configs/suites/iam.yaml
+++ b/isvctl/configs/suites/iam.yaml
@@ -52,7 +52,7 @@ tests:
       step: create_user
       checks:
         FieldExistsCheck:
-          test_id: "IAM-XX-01"
+          test_id: "IAM01-01"
           labels: ["iam", "min_req"]
           fields: ["username", "access_key_id"]
         StepSuccessCheck:
@@ -63,7 +63,7 @@ tests:
       step: test_credentials
       checks:
         FieldExistsCheck:
-          test_id: "IAM-XX-03"
+          test_id: "IAM03-01"
           labels: ["iam"]
           field: "account_id"
         StepSuccessCheck:

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -212,7 +212,7 @@ tests:
           labels: ["kubernetes", "min_req"]
           require_dual_stack: "auto" # true | false | "auto"
         K8sClusterAutoscalerCheck:
-          test_id: "K8S-XX-08"
+          test_id: "K8S36-01"
           labels: ["kubernetes", "min_req"]
           require_autoscaler: false
           namespace: "{{ steps.setup.kubernetes.cluster_autoscaler_namespace | default('kube-system', true) }}"
@@ -300,7 +300,7 @@ tests:
     k8s_identity:
       checks:
         K8sOidcIssuerCheck:
-          test_id: "K8S18-01"
+          test_id: "K8S17-02"
           labels: ["kubernetes", "min_req"]
 
     k8s_conformance:
@@ -324,12 +324,12 @@ tests:
     k8s_workloads:
       checks:
         K8sNcclWorkload:
-          test_id: "K8S-XX-05"
+          test_id: "K8S33-01"
           labels: ["gpu", "kubernetes", "min_req", "slow", "workload"]
           min_bus_bw_gbps: 100
           timeout: 600
         K8sNcclMultiNodeWorkload:
-          test_id: "K8S-XX-05"
+          test_id: "K8S33-01"
           labels: ["gpu", "kubernetes", "min_req", "slow", "workload"]
           nodes: "{{ steps.setup.kubernetes.gpu_node_count | default(2, true) }}"
           min_bus_bw_gbps: 100
@@ -343,11 +343,11 @@ tests:
           runtime: 30
           timeout: 300
         K8sNimInferenceWorkload:
-          test_id: "K8S-XX-03"
+          test_id: "K8S40-01"
           labels: ["kubernetes", "gpu", "workload", "slow"]
           timeout: 1500
         K8sNimHelmWorkload-1b:
-          test_id: "K8S-XX-04"
+          test_id: "K8S32-01"
           labels: ["kubernetes", "gpu", "workload", "slow"]
           model: "meta/llama-3.2-1b-instruct"
           model_tag: "latest"
@@ -356,7 +356,7 @@ tests:
           genai_perf_requests: 100
           genai_perf_concurrency: 4
         K8sNimHelmWorkload-3b:
-          test_id: "K8S-XX-04"
+          test_id: "K8S32-01"
           labels: ["kubernetes", "gpu", "workload", "slow"]
           model: "meta/llama-3.2-3b-instruct"
           model_tag: "latest"

--- a/isvctl/configs/suites/network.yaml
+++ b/isvctl/configs/suites/network.yaml
@@ -127,11 +127,11 @@ tests:
           labels: ["network"]
           step: traffic_validation
         VpcIpConfigCheck:
-          test_id: "CP-XX-02"
+          test_id: "IPAM02-01"
           labels: ["network"]
           step: vpc_ip_config
         DhcpIpManagementCheck:
-          test_id: "CP-XX-01"
+          test_id: "IPAM01-01"
           labels: ["network", "ssh"]
           step: dhcp_ip_test
 
@@ -188,7 +188,7 @@ tests:
           labels: ["min_req", "network"]
           step: byoip_test
         StablePrivateIpCheck:
-          test_id: "SDN-XX-01"
+          test_id: "SDN11-01"
           labels: ["min_req", "network"]
           step: stable_ip_test
         StableEgressIpCheck:

--- a/isvctl/configs/suites/observability.yaml
+++ b/isvctl/configs/suites/observability.yaml
@@ -33,28 +33,28 @@ tests:
     network_logs:
       checks:
         VpcFlowLogsCheck:
-          test_id: "OBS-XX-19"
+          test_id: "OBS19-01"
           labels: ["min_req", "network", "observability"]
           step: vpc_flow_logs
 
     host_logs:
       checks:
         HostSyslogCheck:
-          test_id: "OBS-XX-18"
+          test_id: "OBS18-01"
           labels: ["bare_metal", "min_req", "observability"]
           step: host_syslogs
 
     bmc_logs:
       checks:
         BmcSelLogsCheck:
-          test_id: "OBS-XX-17"
+          test_id: "OBS17-01"
           labels: ["min_req", "observability", "security"]
           step: bmc_sel_logs
 
     bmc_telemetry:
       checks:
         BmcGpuTelemetryCheck:
-          test_id: "TELEM-XX-04"
+          test_id: "TELEM04-01"
           labels: ["gpu", "min_req", "observability", "security"]
           step: bmc_gpu_telemetry
 

--- a/isvctl/configs/suites/security.yaml
+++ b/isvctl/configs/suites/security.yaml
@@ -144,7 +144,7 @@ tests:
     short_lived_credentials:
       checks:
         ShortLivedCredentialsCheck:
-          test_id: "SEC02-01"
+          test_id: "SEC06-01"
           labels: ["iam", "min_req", "security"]
           step: short_lived_credentials_test
 

--- a/isvctl/configs/suites/slurm.yaml
+++ b/isvctl/configs/suites/slurm.yaml
@@ -53,41 +53,41 @@ tests:
     slurm:
       checks:
         SlurmInfoAvailable:
-          test_id: "SLURM-XX-02"
+          test_id: "SLURM02-01"
           labels: ["slurm"]
           min_partitions: 1
         SlurmPartition-cpu:
-          test_id: "SLURM-XX-03"
+          test_id: "SLURM03-01"
           labels: ["slurm"]
           partition_name: "cpu"
           expected_nodes: "{{ steps.setup.slurm.partitions.cpu.nodes | default([]) | length }}"
           required_nodes: '{{ steps.setup.slurm.partitions.cpu.nodes | default([]) | tojson }}'
           require_available: true
         SlurmPartition-gpu:
-          test_id: "SLURM-XX-03"
+          test_id: "SLURM03-01"
           labels: ["slurm"]
           partition_name: "gpu"
           expected_nodes: "{{ steps.setup.slurm.partitions.gpu.nodes | default([]) | length }}"
           required_nodes: '{{ steps.setup.slurm.partitions.gpu.nodes | default([]) | tojson }}'
           require_available: true
         SlurmJobSubmission:
-          test_id: "SLURM-XX-04"
+          test_id: "SLURM04-01"
           labels: ["slurm"]
         SlurmGpuAllocation-1gpu:
-          test_id: "SLURM-XX-05"
+          test_id: "SLURM05-01"
           labels: ["slurm"]
           num_gpus: 1
         SlurmGpuAllocation-2gpu:
-          test_id: "SLURM-XX-05"
+          test_id: "SLURM05-01"
           labels: ["slurm"]
           num_gpus: 2
         SlurmNodeJobExecution-cpu:
-          test_id: "SLURM-XX-06"
+          test_id: "SLURM06-01"
           labels: ["slurm"]
           partition_name: "cpu"
           storage_path: "{{ steps.setup.slurm.storage_path | default('/tmp') }}"
         SlurmNodeJobExecution-gpu:
-          test_id: "SLURM-XX-06"
+          test_id: "SLURM06-01"
           labels: ["slurm"]
           partition_name: "gpu"
           storage_path: "{{ steps.setup.slurm.storage_path | default('/tmp') }}"
@@ -96,7 +96,7 @@ tests:
     slurm_workloads:
       checks:
         SlurmGpuStressWorkload:
-          test_id: "SLURM-XX-07"
+          test_id: "SLURM07-01"
           labels: ["slurm", "gpu", "workload", "slow"]
           partition: "{{ steps.setup.slurm.default_partition | default('gpu') }}"
           runtime: 30
@@ -106,7 +106,7 @@ tests:
 
         # Multi-node NCCL test - validates GPU communication across nodes
         SlurmNcclMultiNodeWorkload:
-          test_id: "SLURM-XX-08"
+          test_id: "SLURM08-01"
           labels: ["slurm", "gpu", "workload", "slow"]
           partition: "{{ steps.setup.slurm.default_partition | default('gpu') }}"
           nodes: "{{ steps.setup.slurm.partitions.gpu.nodes | default([]) | length }}"
@@ -117,7 +117,7 @@ tests:
 
         # Run GPU job from manifest file with variable substitution
         SlurmSbatchWorkload-gpu:
-          test_id: "SLURM-XX-09"
+          test_id: "SLURM09-01"
           labels: ["slurm", "workload", "slow"]
           script: "example_gpu_job.sbatch"
           variables:
@@ -131,7 +131,7 @@ tests:
 
         # Run CPU job from manifest file
         SlurmSbatchWorkload-cpu:
-          test_id: "SLURM-XX-09"
+          test_id: "SLURM09-01"
           labels: ["slurm", "workload", "slow"]
           script: "example_cpu_job.sbatch"
           variables:
@@ -144,7 +144,7 @@ tests:
 
         # Inline script (no manifest file needed)
         SlurmSbatchWorkload-inline:
-          test_id: "SLURM-XX-09"
+          test_id: "SLURM09-01"
           labels: ["slurm", "workload", "slow"]
           script_content: |
             #!/bin/bash

--- a/isvctl/configs/suites/vm.yaml
+++ b/isvctl/configs/suites/vm.yaml
@@ -66,7 +66,7 @@ tests:
       step: launch_instance
       checks:
         InstanceSpecifiedKeyCheck:
-          test_id: "AUTH-XX-02"
+          test_id: "AUTH02-01"
           labels: ["vm"]
 
     instance_created:
@@ -135,10 +135,10 @@ tests:
       step: describe_instance
       checks:
         ConnectivityCheck:
-          test_id: "VMAAS-XX-01"
+          test_id: "VMAAS01-01"
           labels: ["vm", "ssh"]
         OsCheck:
-          test_id: "VMAAS-XX-05"
+          test_id: "VMAAS05-01"
           labels: ["vm", "ssh"]
           expected_os: "ubuntu"
 
@@ -146,7 +146,7 @@ tests:
       step: describe_instance
       checks:
         GpuCheck:
-          test_id: "VMAAS-XX-06"
+          test_id: "VMAAS06-01"
           labels: ["vm", "ssh", "gpu"]
           expected_gpus: 1
 
@@ -154,21 +154,21 @@ tests:
       step: describe_instance
       checks:
         VcpuPinningCheck:
-          test_id: "VMAAS-XX-09"
+          test_id: "VMAAS09-01"
           labels: ["gpu", "ssh", "vm"]
         PciBusCheck:
-          test_id: "VMAAS-XX-09"
+          test_id: "VMAAS09-01"
           labels: ["vm", "ssh", "gpu"]
           expected_gpus: 1
         HostSoftwareCheck:
-          test_id: "VMAAS-XX-07"
+          test_id: "VMAAS07-01"
           labels: ["gpu", "ssh", "vm"]
 
     driver_info:
       step: describe_instance
       checks:
         DriverCheck:
-          test_id: "VMAAS-XX-07"
+          test_id: "VMAAS07-01"
           labels: ["vm", "ssh", "gpu"]
 
     cpu_info:
@@ -209,10 +209,10 @@ tests:
       checks:
         # ConnectivityCheck -> VMAAS-XX-01, OsCheck -> VMAAS-XX-05 (declared in the "ssh" section)
         ConnectivityCheck:
-          test_id: "VMAAS-XX-01"
+          test_id: "VMAAS01-01"
           labels: ["vm", "ssh"]
         OsCheck:
-          test_id: "VMAAS-XX-05"
+          test_id: "VMAAS05-01"
           labels: ["vm", "ssh"]
           expected_os: "ubuntu"
 
@@ -221,7 +221,7 @@ tests:
       checks:
         # GpuCheck -> VMAAS-XX-06 (declared in the "gpu" section)
         GpuCheck:
-          test_id: "VMAAS-XX-06"
+          test_id: "VMAAS06-01"
           labels: ["vm", "ssh", "gpu"]
           expected_gpus: 1
 
@@ -251,10 +251,10 @@ tests:
       checks:
         # ConnectivityCheck -> VMAAS-XX-01, OsCheck -> VMAAS-XX-05 (declared in the "ssh" section)
         ConnectivityCheck:
-          test_id: "VMAAS-XX-01"
+          test_id: "VMAAS01-01"
           labels: ["vm", "ssh"]
         OsCheck:
-          test_id: "VMAAS-XX-05"
+          test_id: "VMAAS05-01"
           labels: ["vm", "ssh"]
           expected_os: "ubuntu"
 
@@ -263,7 +263,7 @@ tests:
       checks:
         # GpuCheck -> VMAAS-XX-06 (declared in the "gpu" section)
         GpuCheck:
-          test_id: "VMAAS-XX-06"
+          test_id: "VMAAS06-01"
           labels: ["vm", "ssh", "gpu"]
           expected_gpus: 1
 
@@ -272,21 +272,21 @@ tests:
       step: deploy_nim
       checks:
         NimHealthCheck:
-          test_id: "VMAAS-XX-12"
+          test_id: "VMAAS12-01"
           labels: ["gpu", "slow", "ssh", "vm", "workload"]
 
     nim_models:
       step: deploy_nim
       checks:
         NimModelCheck:
-          test_id: "VMAAS-XX-12"
+          test_id: "VMAAS12-01"
           labels: ["gpu", "slow", "ssh", "vm", "workload"]
 
     nim_inference:
       step: deploy_nim
       checks:
         NimInferenceCheck:
-          test_id: "VMAAS-XX-12"
+          test_id: "VMAAS12-01"
           labels: ["vm", "ssh", "gpu", "workload", "slow"]
           prompt: "What is CUDA?"
           max_tokens: 50


### PR DESCRIPTION
Replace the temporary `-XX-` placeholder test IDs with stable, globally-unique IDs (e.g. `IMG-XX-01` -> `IMG01-01`) across all 144 affected tests, and populate each test's matching `req_id`. Every renamed test records its prior ID(s) in `legacy_ids` so history and traceability survive the rename.

Retarget the `test_id` wiring in isvctl/configs/suites/*.yaml to the new IDs, keeping the code to test-plan up to date.

A few tests are additionally re-homed to the correct domain/number as part of the cleanup:
  - SEC23-01 -> K8S41-01  (CP autoscaling; had been mis-filed under SEC)
  - K8S18-01 -> K8S17-02  (merged into the existing K8s capability)
  - SEC02-01 -> SEC06-01  (de-duplicated)

No test behavior changes, this is an ID cleanup (hopefully the last) before we wire up the traceability between various requirements documents to the test-plan, and the test-plan to the actual tests.

Tested with:
make plan-coverage CHECK=1
make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced placeholder validation identifiers with concrete IDs across many suites, including bare metal, VM, Kubernetes, network, observability, security, Slurm, control plane, IAM, and storage-related checks.
  * Updated several lifecycle and workload checks so validation mappings are consistent and easier to track.
  * Added clearer test metadata in the documentation-generated test plan, including legacy identifier mappings where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->