### PR TITLE
feat(requirements): add test<->requirement reconciliation layer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MY_ISV_DOMAINS := bare_metal control-plane iam image-registry network observabil
 DEMO_TARGETS := $(addprefix demo-,$(MY_ISV_DOMAINS))
 
 .PHONY: help pre-commit build test coverage clean lint format install bump-patch bump-fix bump-minor bump-feat bump-major bump bump-check \
-	security-trivy security-trivy-detail security-trufflehog ci-security demo-test demo-all $(DEMO_TARGETS) plan plan-coverage validate-suites
+	security-trivy security-trivy-detail security-trufflehog ci-security demo-test demo-all $(DEMO_TARGETS) plan plan-coverage validate-suites reqcheck
 
 PACKAGES := isvctl isvreporter isvtest
 BUMP_SCRIPT := scripts/bump-version.py
@@ -180,10 +180,17 @@ update-spdx-headers: ## Update SPDX headers in all packages
 	@uv run python scripts/add_spdx_headers.py
 	@echo "✅ SPDX headers updated!"
 
-plan: ## Render docs/test-plan.yaml to AsciiDoc
+plan: ## Render docs/test-plan.yaml + requirements mapping to AsciiDoc
 	@echo "Rendering test plan..."
 	@uv run python scripts/test_plan_yaml_to_adoc.py
-	@echo "✅ Test plan rendered!"
+	@echo "Rendering requirements traceability mapping..."
+	@uv run python scripts/requirements_matrix_to_adoc.py
+	@echo "Rendering source requirement listings (yaml -> md)..."
+	@uv run python scripts/requirements_source_to_md.py
+	@echo "✅ Test plan + requirements mapping + source listings rendered!"
+
+reqcheck: ## Validate requirements <-> test mapping consistency
+	@uv run python scripts/reqtrace.py validate
 
 plan-coverage: ## Report test-plan coverage + gaps via wired test_ids (CHECK=1 for pre-commit guardrail)
 	@uv run python scripts/test_plan_coverage.py $(if $(CHECK),--check,)

--- a/docs/requirements/.gitignore
+++ b/docs/requirements/.gitignore
@@ -1,0 +1,2 @@
+# One-off Asciidoctor HTML renders (regenerate via npx @asciidoctor/cli).
+*.html

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -1,0 +1,140 @@
+# Requirements <-> Test Reconciliation - Policy & Guide
+
+Our test suite supports many overlapping goals and interests. This document
+outlines how we make a single test plan, with unique IDs and labels, which
+reconciles all of these different goals.
+
+## Files
+
+| File | Role |
+| ---- | ---- |
+| `../test-plan.yaml` | **Primary source of truth** for tests (lives one level up). |
+| `offtake-requirements.yaml` | **Source of record** for offtake requirements (curated in-repo copy of the public "NVIDIA Requirements Guide for AI Clouds"). |
+| `offtake-requirements.md` | Generated, publishable rendering of the offtake YAML (`make plan`). |
+| `software-reference-requirements.yaml` | **Source of record** for the NSRG-derived reference requirements. |
+| `software-reference-requirements.md` | Generated rendering of the reference YAML (`make plan`); one contributing requirements doc among several. |
+| `test-requirements-matrix.yaml` | The **traceability matrix (index)**: which requirement(s) each test relates to, across documents (`source`). |
+| `test-requirements-matrix.adoc` | Generated and committed traceability matrix, viewable in github (or renderable to html) |
+| `../../scripts/reqtrace.py` | Integrity checks (`reqtrace validate`; `make reqcheck`). |
+| `../../scripts/requirements_matrix_to_adoc.py` | Renders the matrix to AsciiDoc (`make plan`). |
+| `../../scripts/requirements_source_to_md.py` | Renders a source-requirements YAML to publishable Markdown (`make plan`). |
+
+## 1. Organization
+
+- `test-plan.yaml` is the point of reconciliation and provides primary keys.
+  The act of adding tests to this file implies that IDs and overlap with other
+  tests have been reviewed and reconciled.
+- The matrix is an index, a lookup from each test to the various upstream
+  requirement documents. It is secondary/derived, not the authority, and should
+  be updated as needed to match the `test-plan.yaml` file.
+- There should be requirements from some source for each test, and when possible
+  we should have the test id reflect the requirement ID. But this will not always
+  be possible.
+
+> Why this matters: upstream requirement docs are *inputs*. We deliberately
+> "break rules" (renumber, re-prefix) to get from a state where the rules
+> *cannot* all hold to one where they can - and we record the result as official
+> here.
+
+## 2. ID & naming rules
+
+**Format.** A test id is `<req_id>-<seq>` (e.g. `BOOT01-01`, `OBS01-01`). A
+requirement id is `<PREFIX><NN>` (offtake style, no internal separator). Because
+a requirement can have several tests, `seq` disambiguates them; today most
+reference reqs are 1:1, so `seq` is `01`.
+
+**Uniqueness (primary keys).** `test_id`s and `req_id`s must each be **globally
+unique across all documents**. A `test_id` must never equal a `req_id`. These
+are meant to fill the role of primary keys, unique and unchanging, as much as
+possible. We can add references to them from the code, and cross-reference them
+from the upstream requirements. Ideally conflicts and collisions will be
+detected and resolved before they get here, and if they get this far they
+should become apparent at this point. If absolutely needed, changes may
+be required, but we should always record the old id in the `legacy_ids` list.
+
+**Prefix governance (anti-overload).** Every prefix maps to exactly one owning
+concern. The `CP` overload (DDI/IP vs. control-plane) is the cautionary tale -
+it was split into `IPAM` (DDI/IP) and `CP` (control plane). Before minting a new
+prefix, check the registry below and add to it.
+
+**Collision policy (shared prefixes).** When a new reference requirement shares a
+prefix with offtake, **continue offtake's number space** rather than inventing a
+distinguished prefix - edge overlap is a *feature* (two groups independently
+validating the same idea). Concretely we did `SDN`+10, `K8S`+28, `BFX`+3 (offtake
+maxes `SDN10`/`K8S28`/`BFX03`). Selectivity is allowed per case. Accepted cost:
+this couples us to offtake's current max, so a future offtake addition could
+collide - `reqtrace validate` is the backstop, and the map remains the lineage
+record.
+
+### Prefix registry
+
+| Prefix | Owner | Concern |
+| ------ | ----- | ------- |
+| `CNP` `BOOT` `SDN` `K8S` `SEC` `BFX` `DIR` `HSS` `DMS` `STG` `NET` `CAP` `BM` | offtake | min-req domains (see offtake doc) |
+| `IMG` | reference | image registry / golden images |
+| `AUTH` | reference | key & secret mgmt |
+| `IAM` | reference | identity & access mgmt |
+| `IPAM` | reference | DNS/DHCP/IP address mgmt (was `CP-01/02`) |
+| `CP` | reference | control plane & tenant lifecycle |
+| `NETMGMT` | reference | network underlay / switch mgmt |
+| `RESDB` | reference | resource database / inventory |
+| `HWING` | reference | hardware ingestion |
+| `ATTEST` | reference | boot / attestation |
+| `BMAAS` / `VMAAS` | reference | bare-metal / VM compute services |
+| `SDN` (11+) | reference | NVLink partitions + IMEX (continues offtake `SDN`) |
+| `META` | reference | metadata service |
+| `CTRL` | reference | cloud control plane API |
+| `LB` | reference | load balancing |
+| `STOR` `DATASVC` | reference | SDS / object / block / cache / vector / SQL / backup / model registry |
+| `SLURM` | reference | Slurm control plane |
+| `K8S` (29+) | reference | managed Kubernetes (continues offtake `K8S`) |
+| `POWER` | reference | power policy mgmt |
+| `APIGW` `AICP` `WEBUI` | reference | AI platform & user access |
+| `OBS` `TELEM` | reference | observability collectors / data lakes |
+| `BFX` (04+) | reference | break-fix health (continues offtake `BFX`) |
+| `BENCH` | reference | exemplar benchmarking |
+
+## 3. `legacy_ids`
+
+We attempt to keep the test ID as permanent as possible. However, there have
+already been complications that were best resolved by changing IDs. When an
+ID must change, we keep the previous ID in a list in the `test-plan.yaml` file
+in a field called `legacy_ids`. This list should only be appended to, never
+removed from.
+
+## 4. Labels & selective runs
+
+The end goal is to run **subsets** of tests - an arbitrary tag, or *every test
+belonging to a given requirements document*. We keep the data flexible for this:
+
+- A test may carry many `labels` in `test-plan.yaml` (e.g. `min_req`); this list
+  is open-ended and multi-valued.
+- **Requirement-document membership is derivable from the index**: a test
+  "belongs to" document *X* if any of its `requirements[].source == X` in
+  `test-requirements-matrix.yaml`. So "run all offtake tests" = select tests
+  with an `offtake`-source requirement; "run all NSRG/reference tests" = `reference`.
+- Therefore membership is **derived, not duplicated** by default. Materialized
+  convenience labels (e.g. a generated `doc:offtake` tag) may be produced later
+  from the index, but the index stays the source of truth.
+
+## 5. Onboarding a new requirements document (runbook)
+
+When a new team's requirements document is blessed, reconcile it here:
+
+1. **Register prefix(es)** for the new doc in the registry (sec. 2). Resolve
+   any overload before proceeding (see the `CP` lesson).
+2. **Assign IDs.** Prefer mirroring the upstream requirement IDs. On collision
+   with an existing prefix, apply the collision policy (sec. 2): continue the
+   number space, or (selectively) choose another resolution and record why.
+3. **Add/adjust tests** in `test-plan.yaml` (the canonical truth). Use
+   `legacy_ids` for any renames.
+4. **Update the matrix** (`test-requirements-matrix.yaml`): add each
+   test->requirement edge with the new `source`, plus `annotations`/`notes`.
+5. **Validate**: `make reqcheck` must pass; **regenerate**: `make plan`.
+
+> Kept as a subsection for now; promote to its own `ONBOARDING.md` if it grows.
+
+## 6. Validation & enforcement
+
+`reqtrace validate` (run via `make reqcheck`, and in CI through
+`scripts/tests/test_reqtrace.py`) is the machine-checked guard.

--- a/docs/requirements/offtake-requirements.md
+++ b/docs/requirements/offtake-requirements.md
@@ -1,0 +1,261 @@
+<!-- GENERATED FILE - DO NOT EDIT BY HAND. Source: offtake-requirements.yaml. Run `make plan`. -->
+
+# NVIDIA Requirements Guide for AI Clouds
+
+> Structured source of record: `offtake-requirements.yaml` (version 2.3.1).
+> Curated, in-repo copy of the publicly-published *NVIDIA Requirements Guide
+> for AI Clouds*. Edit the YAML, not this file.
+
+## Exemplar Cloud Workload Performance
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| BM01 | Run per Scalable Unit (e.g. 512 GPU cluster) | Achieve within 5% of an NVIDIA provided target performance number; this should be run on every Scalable Unit (SU) handed off | Benchmarking for exemplar cloud | active |
+
+## Compute and Network Provisioning
+
+### General, Compute & Lifecycle Management
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| CNP01 | API/CLI Access | DGXC must have API or CLI access to the NCP provisioning system for: (1) Node lifecycle management (create, update, delete, list, or manage power states (reboot, on/off power cycle); (2) Network configuration; (3) Inventory and topology discovery; (4) security configuration (users, service accounts, groups, roles); (5) Maintenance and operations (see later section) (storage discussed in storage section) | BM: #49, #52, #53, #57, #106, #108, #105, VM: #42, #45, #46, #47, #50, #110, #111, TBD-topo | active |
+| CNP02 | Declarative Resource Interfaces | For resources requiring multiple steps and a workflow, please provide the appropriate mechanism. A terraform provider is preferred. E.g. automating filesystem provisioning | INFO | active |
+| CNP03 | NVLink-Aware Allocation | For NVL72 the API must support NVLink domain-aware allocation | TBD-topo | active |
+| CNP04 | Resource States | Must support clear resource (e.g. instance, network) states where applicable. For example, provisioning, running, degraded, maintenance required, stopping, stopped, terminating, terminated. | BM: #51 VM: #45 | active |
+| CNP05 | Tagging | Support for user-defined tags/labels and cloud-init metadata on instances. | VM: #112 TBD-tag | active |
+| CNP06 | Console Access | Serial console access is required (read-only sufficient, interactive preferred).Serial console output shall be logged and be available for historic queries (at least 1 month retention). | TBD-console | active |
+| CNP07 | If VMaaS present: # VMs/Node | GPU Nodes: no more than one VM per Node General Purpose CPU Nodes: More than one per node, with ability to select via memory/core count shape. | INFO | active |
+| CNP08 | Stable Identifiers | All resources (e.g. nodes, switches) must have a stable and persistent ID that does not change during the lifespan, even when it goes offline for a service event. VMs must also have a stable identifier. | add | active |
+| CNP09 | Firmware | Between tenants, all firmware must be brought to a known good state, all firmware must be cryptographically signed and attested during boot. | TBD | active |
+| CNP10 | Remote Management | Platform management solutions (e.g., BMC) must support Redfish over TLS (Disable IPMI). | add | active |
+
+### Boot Process & Disks
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| BOOT01 | Image Deployment & Updates | API-driven workflow allowing DGXC to deploy, update, and manage vendor-provided or custom disk images via bare-metal, VM, or k8s node pool provisioning. | #38, #39, #4 , #43, #44, #58, add-k8s | active |
+| BOOT02 | Access to Instance Metadata from Guest OS | Support for cloud-init and instance metadata discovery via link-local addresses or virtual devices. | BM: #107 VM: #113 | active |
+| BOOT03 | Custom Disk Images | Support for tenant created custom OS images (either of: raw, qcow2, etc). API calls: get, list, create, delete. Images should be accessible across all tenant projects/clusters/environments. | #104, #40 | active |
+| BOOT04 | Node Local Storage | GPU and CPU nodes support access to node local storage (NVMe / SSD) for use as scratch storage or for caching services | TBD | active |
+
+### SDN & Virtual Networking
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| SDN01 | Virtual Networking | Full API/CLI lifecycle management (Create, Read, Update, Delete, List) for software-defined private networks. Must support non-conflicting BYOIP (including 7.0.0.0/8) and stable private IP allocations. Applicable to all types of resource nodes (CPU, GPU, Storage, etc). | #11, #12, #13, #14: #115 #116 | active |
+| SDN02 | Security Groups | Support for VPC-style security groups (or equivalent), including IP/CIDR-based allow and deny rules. Must define scope/application at workload, node, service (e.g. K8s API Service) and subnet/tenant levels. | TBD (assign GH issue) | active |
+| SDN03 | Security Operations | Full API/CLI capabilities to Create, Read, Update, and Delete security groups, including defined audit processes | add | active |
+| SDN04 | Tenant Isolation | Hard logical or physical network segmentation for out-of-band management (BMC), user traffic, and storage-specific operations. | #16, #17, #18 | active |
+| SDN05 | Floating/Movable IP | Ability to automatically or API-driven switch a floating private IP between nodes via API within <10 seconds without requiring an instance reboot. | #117 | active |
+| SDN06 | Localized DNS | Support for tenant-defined localized DNS configuration to enable internal domain resolution to private endpoints (e.g. storage endpoints) | #118 | active |
+| SDN07 | VPC Peering | Support for cross-virtual-network connectivity with full bandwidth and no "hairpin" routing. | #119 | active |
+| SDN08 | Storage Mesh Connectivity | The virtual network (from SDN01) must provide unrestricted L3 routing between all storage hosts, enabling full-mesh, all-to-all communication across different subnet (w/o going thru a gateway) | INFO | active |
+| SDN09 | Observability | The platform shall provide comprehensive logging for network infrastructure, including hardware faults, latency/performance fluctuations, and a detailed audit trail of all configuration changes to network filtering rules.. | INFO | active |
+| SDN10 | DNS private domain | must allow each nodes DNS resolver to forward a tenant-defined private domains (e.g. *.nvidia.com) to a tenant specified DNS server |  | active |
+
+## Kubernetes As a Service (KaaS) Requirements
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| K8S01 | Certified Versions | Certified Upstream Versions: Official CNCF-certified versions only; no proprietary forks, and passes the standard Kubernetes conformance tests. | TBD-cncf tests | active |
+| K8S02 | Version Updates | Support the three most recent minor releases (in the maintenance window); new minor versions must be available within 4-6 weeks of the upstream release; automated control plane security patching. | INFO | active |
+| K8S03 | EOL Policy | Defined notification periods for version deprecation. | INFO | active |
+| K8S04 | Kubernetes Security Response | Must participate in the Kubernetes Security Response Committee (SRC) process. Must be attempting to join if not part of the security committee. Must be able to: Responsibly disclose any discovered vulnerabilities to the Kubernetes SRC Receive and respond to embargo notifications from the SRC Patch disclosed vulnerabilities in the managed service during embargo prior to public disclosure and in compliance with direction provided from the Kubernetes SRC ensuring that the patching process does not violate embargo or SRC guidance. | INFO | active |
+
+### Kubernetes Operational Excellence
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| K8S05 | Lifecycle Management - control plane | API/CLI/Terraform Provider for CRUD provisioning; <30 min control plane bring-up. | #2, #5, #6 | active |
+| K8S06 | Lifecycle Management - node pool | API/CLI/Terraform for CRUD provisioning ( e.g., create node pool, update node pool, delete node pool, scale a node pool to a target count). Must be able to specify node type (specific CPU or GPU instance type) including CPU-only node pools with high-performance networking for data movement and ingest workloads Ability to specify default node labels and node taints within a node pool when a node joins the cluster. When down-scaling a node pool, ability to down-scale bad/specific nodes. | add | active |
+| K8S07 | API Server Metrics | Share API Server metrics in a Prometheus scrapable format to allow NVIDIA to measure API Server SLO |  | active |
+| K8S08 | Versioning | Provider-managed control plane upgrade processes. | INFO | active |
+| K8S09 | Zero-Downtime Upgrades | Minor version control plane updates without app downtime or maintenance windows. | INFO | active |
+| K8S10 | Node Upgrades | user-initiated rolling updates respecting pod disruption budgets. | TBD | active |
+| K8S11 | HA Control Plane | Redundant architecture with etcd separation. | INFO | active |
+| K8S12 | Backup & Disaster Recovery | Supported recovery within defined RPO/RTO; needs to be auditable & testable | INFO | active |
+
+### Robust K8s Security
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| K8S14 | Control Plane Isolation | Per tenant k8s control plane nodes must be separate from worker nodes and outside of the tenant cluster/VPC. | TBD | active |
+| K8S15 | Access Controls | Cluster endpoint must provide network access controls. | TBD | active |
+| K8S16 | IAM Integration | Kubernetes Service Accounts shall integrate with the platform IAM system to enable workloads to assume platform-managed identities and roles with appropriate scopes. | TBD | active |
+| K8S17 | Service Accounts | Kubernetes shall support standard Service Accounts and projected tokens as the workload identity mechanism, including a cluster-specific OIDC issuer to enable workload identity federation. The cluster shall expose OIDC discovery and JWKS endpoints that are reachable by configured external identity consumers (e.g. AWS IAM, GCP workload identity) | TBD | active |
+| K8S19 | Encryption | at-rest encryption for etcd and secrets | INFO | active |
+| K8S20 | Logging | Ability to view or export Kubernetes control plane logs (apiserver, kcm). | add | active |
+
+### Kubernetes Component and Extension Requirements
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| K8S21 | API Extensions | Mandatory support for CRDs and Validating/Mutating Admission Controllers. | add | active |
+| K8S22 | CNI | Standard compliance; supports Network Policies; IPv4/IPv6 dual-stack desired. | add | active |
+| K8S23 | CSI | NCP provides CSI Driver installable by NVIDIA (helm or kustomize) for Block, shared FS, and NFS Support for static and dynamic provisioning, snapshots, and resizing via PVs and PVCs. CSI credentials are tenant cluster scoped (no cross cluster) APIs to query storage usage against overall cluster quota with per PVC/Volume usage to manage utilization across PVCs and manage quotas using provided credentials Vendor provided storage kernel modules and tools provided via (1) installed by CSI driver, (2) pre-installed in NCP provided machine image or (3) installable packages provided | add | active |
+| K8S24 | DRA | Enabled Dynamic Resource Allocation (DRA) regardless of upstream feature status (Beta/GA). Some DRA features require enabling feature gates for the control plane, in case our customers want to run AI workload with new DRA features | TBD | active |
+| K8S25 | Operator Support | Support standard operator-based management of hardware accelerators and associated drivers. Provider-default accelerator operators and drivers shall be replaceable or overridable to allow installation of tenant-required operator and driver versions (e.g., GPU Operator, Network Operator). Provide golden configurations for GPU Operator and Network Operator. | add | active |
+
+### Kubernetes Functionality
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| K8S26 | Clusters | Support multiple clusters in the same tenancy; support multiple clusters in the same VPC. | add | active |
+| K8S27 | Kubernetes Control Plane size pinning | Pin Control Plane instances to handle a particular load-limit | add | active |
+| K8S28 | Performance | Meet the standard Kubernetes performance test certified up to 5000 nodes (or to the maximum size of the cluster, whichever is smaller) - size CP as necessary. Managed Kubernetes Control Plane SLO and Performance meets or better than the Kubernetes standards results. | add | active |
+| K8S29 | Kubernetes LoadBalancer Service Support | The platform shall support Kubernetes Service resources of type LoadBalancer, including: External load balancers with publicly routable IPs Internal load balancers with private IPs reachable via private network access Static IP assignment |  | active |
+| K8S30 | DNS Configuration | The platform shall support configuring Kubernetes internal DNS (e.g. CoreDNS) with conditional forwarding rules for specified DNS zones to designated enterprise or internal DNS resolvers. |  | active |
+| K8S31 | Configurable Kubernetes CIDR ranges | Ability to configure Kubernetes service IP range, Node IP range, and Pod IP range. |  | active |
+
+## Security & Identity Management
+
+### Identity & Access Management (IAM)
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| SEC01 | Authentication | Users: Support standards-based user authentication via OIDC and SAML 2.0, including federation with external identity providers (e.g. NVIDIA’s enterprise IdP) for single sign-on (SSO) across platform and tenant-facing services. Validate OIDC-issued tokens including signature, issuer, audience, expiration, and required claims for identity and authorization decisions. | add | active |
+| SEC03 | Authentication | External Services: Support authentication of out of cluster service accounts for service-to-service access. Must support credential-based access, including long-lived credentials where required. If long-lived credentials (e.g. API keys) are issued, the platform will support configurable expiration and rotation. Need ownership attribution for all service accounts. The platform shall provide account information (such as detection of unused accounts). | add | active |
+| SEC04 | Authorization (RBAC) | The platform shall enforce least-privilege RBAC for all managed services and infrastructure, featuring granular API actions (e.g. CRUD), scopes (e.g. dev vs staging vs prod), and function (e.g. image builder, provisioner, auditor). Roles and permissions shall be assignable to groups, with users inheriting access through group membership (GBAC); group membership may be sourced from OIDC claims and/or SCIM-provisioned groups. | add INFO | active |
+| SEC05 | Identity / Directory Services | The platform shall integrate with the NVIDIA LDAP (RFC2307bis) directory service such that users identities and group membership can be resolved by dependent services for authentication and authorization decisions (e.g. storage - POSIX-based access control ) | INFO | active |
+| SEC06 | Workload/Service Identity | Support standard workload, service, and node security identities using short-lived credentials, including OIDC-based workload identity federation and Kubernetes Service Accounts where applicable. | INFO | active |
+| SEC07 | Admin Interfaces | All administrative interfaces—whether UI, CLI, or API—must be protected by Multi-Factor Authentication (e.g. mgmt API) | INFO | active |
+| SEC08 | Audit Logs | Audit logs must be generated and retained for all security-relevant events, including management and control plane API calls, authentication events, and authorization decisions. Audit logs shall be retained for a minimum of 30 days and accessible to authorized platform operators. Must provide a log export mechanism (such as publishing to an S3 bucket). Exported logs should include sufficient metadata to identify tenant, project/account, region, service, resource identifier, actor, event timestamp, source IP where applicable, action, and authorization result. | add | active |
+| SEC23 | Provisioning | The platform shall support SCIM 2.0 for automated user and group lifecycle management from enterprise identity providers. SCIM endpoints shall require authenticated and authorized access, support core User and Group resource operations, and synchronize group membership changes with the platform authorization engine. Synchronized groups shall be first-class RBAC objects targetable by role bindings and IAM policies; membership changes shall propagate promptly across all managed services. |  | active |
+| SEC24 | Authentication | Must support domain-based IdP routing, mapping multiple email domains to a designated identity provider (e.g., nvidia.com and nvw.nvidia.com to the NVIDIA enterprise IdP) |  | active |
+| SEC25 | Organization-Level Guardrail Policies | The platform shall support organization-level security guardrail policies that cascade across all subordinate tenant resources (networks, clusters, storage, compute) and cannot be weakened or bypassed by lower-level configuration. Policy violations shall be denied at resource creation/update time and recorded in audit logs. | add | active |
+| SEC26 | SSO Enforcement | The platform shall allow authorized administrators to enforce federated SSO for a tenant, restricting local username/password and other non-federated login for regular users. Enforcement shall apply consistently across UI, CLI, API, and administrative interfaces. | add | active |
+| SEC27 |  | The platform shall expose a programmatic mechanism to create and manage: - Isolation Units (e.g., projects, sub-project) - IAM Users - Service Accounts - Logs | add | active |
+
+### Cryptography and Key Management
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| SEC09 | Key & Certificate Lifecycle | The platform shall support secure issuance, distribution, storage, rotation, and revocation of cryptographic keys and certificates used across platform services. It shall support automated rotation of provider-managed and customer-managed keys and certificates, with configurable rotation intervals. Must be auditable. Must have an expiration date. | Add INFO | active |
+| SEC10 | Key Usage | The platform shall support use of managed keys and certificates across platform services for encryption, authentication, and signing. | add | active |
+
+### Network Isolation & Encryption
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| SEC11 | Tenancy Model | Hard physical or logical isolation for network, data, and compute. Separation of control planes and tenants is mandatory. This includes separation of storage resources. Provide hierarchical tenancy (at least organization → project). | add | active |
+| SEC12 | BMC Security | Out-of-band management (BMC) must be on a dedicated, restricted network (physically separate or VLAN/VRF-isolated). Direct access from the public internet or general corporate networks must be blocked, and only accessed via a hardened bastion (jumphost) server. | add | active |
+| SEC13 | Network Traffic Encryption | Encryption and mutual authentication (mTLS or equivalent) for all east-west and north-south network traffic | add | active |
+
+### Edge Network Security
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| SEC14 | Private Access | No public internet access by default; all API endpoints (e.g. K8s API Server) must be restricted via firewall/private link. | INFO | active |
+| SEC15 | Edge Network Security Policy | All traffic must be filtered via Security Groups and/or user customizable ACLs using 5-tuple rules. | INFO | active |
+| SEC16 | Enforcement | NCP must specify the enforcement technology (e.g., Hardware firewalls, SDN, DPUs/SmartNICs) and its specific placement in the packet path. | INFO | active |
+| SEC17 | Threat Intelligence & Scale | Ability to subscribe to GeoIP threat & Embargo feeds and import them into security groups. NCP should share the max supported records/rules. | INFO | active |
+| SEC18 | MACSec protection links: | Protect links between NCP Data Center and NVIDIA POP | INFO | active |
+
+### Hardware Security & Compliance
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| SEC19 | SOC 2 | SOC2 type 1 or better is required covering Security, Availability, and Confidentiality across all services and DC infrastructure | INFO | active |
+| SEC20 | At-Rest Data Protection | Mandatory encryption of all data at rest (e.g. local NVMe/SSD, network-attached storage) via Self-Encrypted Drives (SED). | INFO | active |
+| SEC21 | Data Sanitization | Data sanitization must be performed between tenants or on a hardware replacement, including cryptographic erase of all data drives between tenants; sanitization/wipe of any persistent or volatile memory including SRAM/GPU memory; resetting of TPM and BIOS | add | active |
+| SEC22 | Root of Trust + Secure Boot. | Mandatory support across all platforms for Hardware Root of Trust mechanisms (TPM 2.0). The platform must enable UEFI OS Secure Boot w/ TPM 2.0. | INFO | active |
+
+## Breakfix Requirements
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| BFX01 | Breakfix lifecycle | Compute: Power-cycle individual nodes or reset a VM instance. GPU: Reset GPUs on an individual node (as needed - k8s) Maintenance: Return/Report an individual node and a rack to the Provider for maintenance Cordon: Mark a node as unschedulable for new workloads (but finish existing) Replace: Request a host-replacement when health thresholds are breached | add | active |
+| BFX02 | Breakfix Events | Query for any upcoming/current maintenance events for a node or rack Query for any retirement notices for a node/rack. Query for historical / status information for equipment repair. Event information should include: ticket open date ticket update date ticket close date Hardware Stable Identifier (e.g., node ID) Hardware category/type impacted (e.g., GPU, fan, interconnect) Maintenance/Error/fault description (some short description of the issue) Action: Categorization of action (e.g. repairs done on faulty GPUs to resolve the fault) Provider Account ID ticket ID Node Handover Date (Date when the node was deployed in Production) |  | active |
+| BFX03 | Diagnostics | Identify serial numbers of installed hardware (chassis, baseboard, network adapters, CPU, GPU, etc). Obfuscated but stable identifiers are also OK. Inspect firmware versions of compute nodes and NV switch trays. |  | active |
+
+## Storage Requirements
+
+### Home Directory Storage
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| DIR01 | File Service uid/gid Quota feature | Configurable filesystem-wide limit, default user/gid quota settings, and per uid/gid overrides available. Usage accounting for uid/gids when the feature is enabled. | INFO | active |
+| DIR02 | Must be NFS storage | NVIDIA requires NFSv4 protocol shared storage to work Access control based on DLs requires POSIX | INFO | active |
+| DIR03 | Snapshots | The file system must support the ability to provide snapshot / restore functionality. |  | active |
+| DIR04 | LDAP | File Service must support integration with an NVIDIA-managed LDAP (see SEC05) |  | active |
+
+### High-Speed Storage Service Requirements
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| HSS01 | Provisioning APIs | Storage provisioning may be via vendor portal/API or NCP portal/API. | add | active |
+| HSS02 | Performance | Must provision needed throughput requested for minimum bandwidth and IOPS. | INFO | active |
+| HSS03 | Integration | K8s: CSI support Breakfix API required to report storage issues | INFO | active |
+| HSS04 | Quota Support | Configurable filesystem-wide limit, default user/gid quota settings, and per uid/gid overrides available. Usage accounting for uid/gids when the feature is enabled. Configurable directory quota settings … it must be possible to apply a quota for a given directory. Usage accounting for directory quotas when enabled. | INFO | active |
+| HSS05 | Upgrade, maintenance | Provider / NCP initiates desired maintenance. NVIDIA can schedule actual maintenance and can defer maintenance up to 2 weeks. Upgrades should be non-disruptive. | INFO | active |
+| HSS06 | RDMA Memory Protection | Storage systems using RDMA must enforce memory protection via authorization keys for both local and remote access | INFO | active |
+
+## These are capabilities required of the high-speed filesystem.
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| HSS07 | Parallel high speed filesystem | Parallel or multi-path high-speed filesystem that supports scaling to thousands of simultaneous clients while sustaining requested performance. | INFO | active |
+| HSS08 | Single file system size | It must be possible to allocate a file system of at least 1 PiB even if the initial request is less. Growing to > 10PiB as cluster size increases. This hard requirement may be higher for a specific site and if so will be communicated via the ancillary services document. | INFO | active |
+| HSS09 | Multiple Filesystems (fungible total capacity) | Can have >1 filesystem within our total capacity. Minimal file system size <= 50 TiB. | INFO | active |
+| HSS10 | Filesystem expansion | Live file system expansion is supported, in terms of capacity, inodes, IO performance, and metadata operations performance. Performance should scale linearly with capacity. | INFO | active |
+| HSS11 | Client | Ability to describe your client: In-Kernel, userspace, or bare-metal client installation requirements. Support integration with client kernels / OS used by NVIDIA, as needed. DKMS-enabled packages available for Ubuntu 20.04, 22.04, and 24.04-based operating systems. ARM64 versions compatible with GB200-ready kernels are mandatory, e.g. Linux 6.8.x. Managed Storage Service Provider will provide client configuration best practices and configuration guidelines for filesystem options and kernel module configuration to reliably achieve optimal performance on ARM and x86_64-based clients. | INFO | active |
+| HSS12 | Quota (User, project & group) | Must support soft and hard quotas - uid / gid / project(directory)-id quotas with enforcement. | INFO | active |
+| HSS13 | Root-squash | Nvidia needs to be able to enable or disable and manage root-squash at any time. | INFO | active |
+| HSS14 | flock | It must be possible to mount the file system with flock. | INFO | active |
+| HSS15 | Ability to Audit Changes | Enable Nvidia to have access to changelog data for filesystem auditing and detailed user operations tracking. Tracking by uid/gid, create files, create dirs, rename files, rename dirs, delete files, delete dirs | INFO | active |
+| HSS16 | HA | All services are required to tolerate any critical component failure in the backend and provide continued client access to all storage services in such cases. | INFO | active |
+| HSS17 | Multi-Node Coherency | One second or less for client attribute and dentry cache updates/invalidates | INFO | active |
+| HSS18 | Client Multipathing | Clients must have multipathing to all storage servers | INFO | active |
+| HSS19 | LDAP (for NFS) | NFS-based high-speed filesystem services must support integration with an NVIDIA-managed LDAP server (including unix uid group membership for users with > 16 group memberships) as per SEC05 |  | active |
+
+### Data Movement Systems Requirements
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| DMS01 | Dedicated K8s Cluster | Provider-managed k8s cluster (or ability to stand up our own) for Data Mover stack available ahead of the GPU cluster bringup to pre-stage data | add | active |
+| DMS02 | Data Mover Nodes (CPU) | Dedicated CPU nodes for running data mover - needs high performance networking (exact quantity will be communicated via ancillary services doc) | INFO | active |
+| DMS03 | Access to same GPU storage | Same filesystem as mounted on GPU nodes mounted on the Data Mover nodes (or ability to mount the same filesystem via CSI) | INFO | active |
+| DMS04 | Access to nvidia corp net | Dedicate link (as described in network transport) to NVIDIA corp net, preferably with vpn, but otherwise with stable IP for allowlisting | INFO | active |
+| DMS05 | Stable egress IP | Stable IP to IP allowlist access to Nvidia services. (e.g. similar to NAT Gateway) | add | active |
+
+## Host Provisioning & Lifecycle
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| STG01 | Operating System Support | NCP must support a workflow that allows DGXC storage operators to integrate vendor-provided or storage-specific operating system images via bare-metal or VM provisioning for storage servers. The workflow must: (a) Allow DGXC to deploy custom OS images (e.g., vendor-enhanced kernels for Lustre, Rocky Linux, Ubuntu 20.04/22.04/24.04). | INFO | active |
+| STG02 | Drive Sanitization Policy | Cryptographically erase data drive contents between storage system tenants with full attestation of host firmware. Must support an optional flag to skip drive sanitization during break/fix flows (e.g., power supply replacement) where tenancy does not change. Critical hardware component replacements may require sanitization without override, this is inclusive of GPU / CPU node local storage | add | active |
+| STG03 | Stable IP Assignment | Storage nodes must support static IP addressing that remains stable during host lifecycle operations and does not reset between maintenance events. | INFO | active |
+| STG04 | Out-of-Band Failure Detection | NCP must provide the ability to detect system failures out-of-band, including device, network, memory, and drive failures, enabling DGXC to proactively respond to hardware issues. | INFO | active |
+| STG05 | Topology Observability | NCP must provide visibility into failure domains to enable DGXC to provision storage nodes with physical diversity. Storage systems must be able to provision nodes that purposefully span failure domains for resilience. | INFO | active |
+| STG06 | BlueField/DPU Support | For storage systems utilizing BlueField-based architectures, the host provisioning system must support lifecycle management and specific configuration requirements for BlueField "JBOF" systems that export NVMe-oF to hosts. | INFO | active |
+
+## Network Transport & Fabric Visibility
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| NET01 | Backend Switch Fabric API | For each compute node, the API must provide visibility into the backend network switches connecting the node to the core. Identification: Each switch must be identified by a unique, stable identifier. A "switch" may represent a physical switch or a logical connectivity domain. Structure: API may be gRPC or REST. Response structure may include multiple nodes (pagination expected). Topology: Switch info can be returned as an ordered array of IDs (e.g., leaf, spine, core) or separate fields for each tier | INFO | active |
+| NET02 | NVLink Domain API | Requirement: For compute nodes supporting NVLink (e.g., GB200, GB300, Vera Rubin), the API shall return the unique identifier of the NVLink domain associated with each node. Implementation: Can be a separate API method or part of the Backend Switch Fabric API. | INFO | active |
+
+## Transport and Networking requirements
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| NET03 | Non-Conflicting IP space allocation for the DGXC cluster | Bring Your Own IP (BYOIP): NCP shall support the ability for NVIDIA to bring and allocate its own IP private address space for DGXC GPU clusters. Stable IP: NCP shall provide a possibility to create static IP allocations that persist across instance restarts and re-creations. That includes floating IP allocations. DoD space: NCP shall support allocation and use of the 7.0.0.0/8 IPv4 address space for DGXC GPU cluster deployments. This IP space shall be considered equivalent to RFC1918 addresses Routing Support: NCP must support advertising and routing of BYOIP prefixes within the NCP environment and across interconnects (Private Cloud Interconnect, IPSec, etc.) | add | active |
+| NET04 | Connection to NVIDIA CorpIT Network | Bandwidth: Low bandwidth (Up to 10Gbps). Transport: Private Cloud interconnect + VIF + BGP (preferred for better performance/security). DGXC will establish connectivity to NCP through a mutually agreed Point of Presence (POP) using Private Cloud Interconnect, functionally equivalent to AWS Direct Connect, GCP Dedicated Interconnect, Azure ExpressRoute, and OCI FastConnect. Connectivity will be provisioned with a Virtual Interface (VIF) and routing established via BGP. The interconnect will be used to exchange private IP space (RFC1918, as well as 7.0.0.0/8) between DGXC and NCP. | INFO | active |
+
+## Connection to DGXC Storage
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| NET05 | Connection to DGXC Storage | Transport: Private Cloud interconnect + VIF + BGP (preferred for better performance/security). DGXC will establish connectivity to NCP through a mutually agreed Point of Presence (POP) using Private Cloud Interconnect, functionally equivalent to AWS Direct Connect, GCP Dedicated Interconnect, Azure ExpressRoute, and OCI FastConnect. Connectivity will be provisioned with a Virtual Interface (VIF) and routing established via BGP. The interconnect will be used to exchange private IP space (RFC1918, as well as 7.0.0.0/8) between DGXC and NCP. | INFO | active |
+| NET06 | Cluster Local Internet Access | Cluster Internet access: Egress NAT IPs should be a static pool dedicated to only Nvidia Cluster/Tenancy/VPC. These persistent IP addresses must be used exclusively for DGXC traffic and shall not be shared with or carry traffic from other NCP tenants. Availability: Must support redundant upstream paths to ensure connectivity under failure. | INFO | active |
+
+## Capacity & Fleet Management
+
+| Req ID | Requirement Area | Description | Test details | Status |
+| :----- | :--------------- | :---------- | :----------- | :----- |
+| CAP01 | Governance metrics | Required Governance Metrics The core metrics needed to track fleet health are: Delivered: Nodes/GPUs provisioned and available to NVIDIA, allocated to a specific account/project/tenant. Healthy: Nodes/GPUs functioning and meeting SLA requirements, allocated to a specific account/project/tenant. Reserved: Resources allocated to a specific account/project/tenant. Total Active/In-Use: Nodes/GPUs currently in use within a specific account/project/tenant. | INFO | active |
+| CAP02 | Resource Governance API Metrics | The Resource Governance API must return the following information for each node: Node ID (Unique identifier for a GPU node) Health State (Healthy/Unhealthy classification) Instance ID (Identifier for virtual workload) Creation Timestamp (Time workload/node was created) Hardware Type (Descriptor for the hardware model) GPU Count (Number of GPUs per node) Top-levelAccount/ID (Identifier for the top-level organization/account) Sub-LevelProject/ID (Identifier for the nested project/sub-account) In Use (True/False status indicating if the GPU Node is turned on and in use) Region (Region of the data center where nodes are deployed) | add | active |
+| CAP03 | Resource Discovery APIs | It is not acceptable to have capacity be “handed” to DGXC through a phone, slack or email message. For example, when cluster first comes online, nodes/racks are likely being handed off weekly (or more frequently). Instead, please provide the following mechanism (and we can poll): Programmatic Capacity Discovery: All newly delivered capacity must be discoverable via a centralized API. This "Resource Index" must provide a stable resource identifier and some information on why it’s being provided (e.g. capacity fulfillment on gb300 project, break-fix / RMA return to cluster, etc) | add | active |
+| CAP04 | Logical Compartmentalization & Resource Isolation | To ensure performance consistency and security, the NCP must support strict logical and physical isolation of NVIDIA’s reserved capacity. Capacity Reservations: A mechanism to logically group and "pin" a set of resources (compute, network, storage) to accounts (or equivalent constructs) in an NVIDIA tenancy Atomic Allocation: Support for reserving a "topology block" as a single unit, ensuring all resources in that block share identical performance characteristics and security boundaries. | INFO | active |
+| CAP05 | Unified Health & Lifecycle APIs | NVIDIA requires a "single source of truth" for the health of both physical hosts and logical compute primitives. Per-Host Health: Real-time API access to the health bits of physical hardware (GPU state, thermal status, memory health). Primitive-Level Status: Health aggregation at the cluster, nodegroup, or reservation level to identify broad infrastructure failures (e.g., a spine switch failure affecting a whole block). | INFO | active |

--- a/docs/requirements/offtake-requirements.yaml
+++ b/docs/requirements/offtake-requirements.yaml
@@ -1,0 +1,778 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Offtake requirements - structured source of record (in-repo, public).
+# Curated from the publicly-published 'NVIDIA Requirements Guide for AI Clouds'
+
+source: offtake
+title: NVIDIA Requirements Guide for AI Clouds
+version: 2.3.1
+requirements:
+  - req_id: BM01
+    section: Exemplar Cloud Workload Performance
+    subsection: ''
+    area: Run per Scalable Unit (e.g. 512 GPU cluster)
+    test_details: Benchmarking for exemplar cloud
+    description: Achieve within 5% of an NVIDIA provided target performance number; this should be run on every Scalable Unit (SU) handed off
+  - req_id: CNP01
+    section: Compute and Network Provisioning
+    subsection: General, Compute & Lifecycle Management
+    area: API/CLI Access
+    test_details: 'BM: #49, #52, #53, #57, #106, #108, #105, VM: #42, #45, #46, #47, #50, #110, #111, TBD-topo'
+    description: 'DGXC must have API or CLI access to the NCP provisioning system for: (1) Node lifecycle management (create, update, delete, list, or manage power states (reboot, on/off power cycle); (2) Network configuration; (3) Inventory and topology discovery; (4) security configuration (users, service accounts, groups, roles); (5) Maintenance and operations (see later section) (storage discussed in storage section)'
+  - req_id: CNP02
+    section: Compute and Network Provisioning
+    subsection: General, Compute & Lifecycle Management
+    area: Declarative Resource Interfaces
+    test_details: INFO
+    description: For resources requiring multiple steps and a workflow, please provide the appropriate mechanism. A terraform provider is preferred. E.g. automating filesystem provisioning
+  - req_id: CNP03
+    section: Compute and Network Provisioning
+    subsection: General, Compute & Lifecycle Management
+    area: NVLink-Aware Allocation
+    test_details: TBD-topo
+    description: For NVL72 the API must support NVLink domain-aware allocation
+  - req_id: CNP04
+    section: Compute and Network Provisioning
+    subsection: General, Compute & Lifecycle Management
+    area: Resource States
+    test_details: 'BM: #51 VM: #45'
+    description: Must support clear resource (e.g. instance, network) states where applicable. For example, provisioning, running, degraded, maintenance required, stopping, stopped, terminating, terminated.
+  - req_id: CNP05
+    section: Compute and Network Provisioning
+    subsection: General, Compute & Lifecycle Management
+    area: Tagging
+    test_details: 'VM: #112 TBD-tag'
+    description: Support for user-defined tags/labels and cloud-init metadata on instances.
+  - req_id: CNP06
+    section: Compute and Network Provisioning
+    subsection: General, Compute & Lifecycle Management
+    area: Console Access
+    test_details: TBD-console
+    description: Serial console access is required (read-only sufficient, interactive preferred).Serial console output shall be logged and be available for historic queries (at least 1 month retention).
+  - req_id: CNP07
+    section: Compute and Network Provisioning
+    subsection: General, Compute & Lifecycle Management
+    area: 'If VMaaS present: # VMs/Node'
+    test_details: INFO
+    description: 'GPU Nodes: no more than one VM per Node General Purpose CPU Nodes: More than one per node, with ability to select via memory/core count shape.'
+  - req_id: CNP08
+    section: Compute and Network Provisioning
+    subsection: General, Compute & Lifecycle Management
+    area: Stable Identifiers
+    test_details: add
+    description: All resources (e.g. nodes, switches) must have a stable and persistent ID that does not change during the lifespan, even when it goes offline for a service event. VMs must also have a stable identifier.
+  - req_id: CNP09
+    section: Compute and Network Provisioning
+    subsection: General, Compute & Lifecycle Management
+    area: Firmware
+    test_details: TBD
+    description: Between tenants, all firmware must be brought to a known good state, all firmware must be cryptographically signed and attested during boot.
+  - req_id: CNP10
+    section: Compute and Network Provisioning
+    subsection: General, Compute & Lifecycle Management
+    area: Remote Management
+    test_details: add
+    description: Platform management solutions (e.g., BMC) must support Redfish over TLS (Disable IPMI).
+  - req_id: BOOT01
+    section: Compute and Network Provisioning
+    subsection: Boot Process & Disks
+    area: Image Deployment & Updates
+    test_details: '#38, #39, #4 , #43, #44, #58, add-k8s'
+    description: API-driven workflow allowing DGXC to deploy, update, and manage vendor-provided or custom disk images via bare-metal, VM, or k8s node pool provisioning.
+  - req_id: BOOT02
+    section: Compute and Network Provisioning
+    subsection: Boot Process & Disks
+    area: Access to Instance Metadata from Guest OS
+    test_details: 'BM: #107 VM: #113'
+    description: Support for cloud-init and instance metadata discovery via link-local addresses or virtual devices.
+  - req_id: BOOT03
+    section: Compute and Network Provisioning
+    subsection: Boot Process & Disks
+    area: Custom Disk Images
+    test_details: '#104, #40'
+    description: 'Support for tenant created custom OS images (either of: raw, qcow2, etc). API calls: get, list, create, delete. Images should be accessible across all tenant projects/clusters/environments.'
+  - req_id: BOOT04
+    section: Compute and Network Provisioning
+    subsection: Boot Process & Disks
+    area: Node Local Storage
+    test_details: TBD
+    description: GPU and CPU nodes support access to node local storage (NVMe / SSD) for use as scratch storage or for caching services
+  - req_id: SDN01
+    section: Compute and Network Provisioning
+    subsection: SDN & Virtual Networking
+    area: Virtual Networking
+    test_details: '#11, #12, #13, #14: #115 #116'
+    description: Full API/CLI lifecycle management (Create, Read, Update, Delete, List) for software-defined private networks. Must support non-conflicting BYOIP (including 7.0.0.0/8) and stable private IP allocations. Applicable to all types of resource nodes (CPU, GPU, Storage, etc).
+  - req_id: SDN02
+    section: Compute and Network Provisioning
+    subsection: SDN & Virtual Networking
+    area: Security Groups
+    test_details: TBD (assign GH issue)
+    description: Support for VPC-style security groups (or equivalent), including IP/CIDR-based allow and deny rules. Must define scope/application at workload, node, service (e.g. K8s API Service) and subnet/tenant levels.
+  - req_id: SDN03
+    section: Compute and Network Provisioning
+    subsection: SDN & Virtual Networking
+    area: Security Operations
+    test_details: add
+    description: Full API/CLI capabilities to Create, Read, Update, and Delete security groups, including defined audit processes
+  - req_id: SDN04
+    section: Compute and Network Provisioning
+    subsection: SDN & Virtual Networking
+    area: Tenant Isolation
+    test_details: '#16, #17, #18'
+    description: Hard logical or physical network segmentation for out-of-band management (BMC), user traffic, and storage-specific operations.
+  - req_id: SDN05
+    section: Compute and Network Provisioning
+    subsection: SDN & Virtual Networking
+    area: Floating/Movable IP
+    test_details: '#117'
+    description: Ability to automatically or API-driven switch a floating private IP between nodes via API within <10 seconds without requiring an instance reboot.
+  - req_id: SDN06
+    section: Compute and Network Provisioning
+    subsection: SDN & Virtual Networking
+    area: Localized DNS
+    test_details: '#118'
+    description: Support for tenant-defined localized DNS configuration to enable internal domain resolution to private endpoints (e.g. storage endpoints)
+  - req_id: SDN07
+    section: Compute and Network Provisioning
+    subsection: SDN & Virtual Networking
+    area: VPC Peering
+    test_details: '#119'
+    description: Support for cross-virtual-network connectivity with full bandwidth and no "hairpin" routing.
+  - req_id: SDN08
+    section: Compute and Network Provisioning
+    subsection: SDN & Virtual Networking
+    area: Storage Mesh Connectivity
+    test_details: INFO
+    description: The virtual network (from SDN01) must provide unrestricted L3 routing between all storage hosts, enabling full-mesh, all-to-all communication across different subnet (w/o going thru a gateway)
+  - req_id: SDN09
+    section: Compute and Network Provisioning
+    subsection: SDN & Virtual Networking
+    area: Observability
+    test_details: INFO
+    description: The platform shall provide comprehensive logging for network infrastructure, including hardware faults, latency/performance fluctuations, and a detailed audit trail of all configuration changes to network filtering rules..
+  - req_id: SDN10
+    section: Compute and Network Provisioning
+    subsection: SDN & Virtual Networking
+    area: DNS private domain
+    test_details: ''
+    description: must allow each nodes DNS resolver to forward a tenant-defined private domains (e.g. *.nvidia.com) to a tenant specified DNS server
+  - req_id: K8S01
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: ''
+    area: Certified Versions
+    test_details: TBD-cncf tests
+    description: 'Certified Upstream Versions: Official CNCF-certified versions only; no proprietary forks, and passes the standard Kubernetes conformance tests.'
+  - req_id: K8S02
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: ''
+    area: Version Updates
+    test_details: INFO
+    description: Support the three most recent minor releases (in the maintenance window); new minor versions must be available within 4-6 weeks of the upstream release; automated control plane security patching.
+  - req_id: K8S03
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: ''
+    area: EOL Policy
+    test_details: INFO
+    description: Defined notification periods for version deprecation.
+  - req_id: K8S04
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: ''
+    area: Kubernetes Security Response
+    test_details: INFO
+    description: 'Must participate in the Kubernetes Security Response Committee (SRC) process. Must be attempting to join if not part of the security committee. Must be able to: Responsibly disclose any discovered vulnerabilities to the Kubernetes SRC Receive and respond to embargo notifications from the SRC Patch disclosed vulnerabilities in the managed service during embargo prior to public disclosure and in compliance with direction provided from the Kubernetes SRC ensuring that the patching process does not violate embargo or SRC guidance.'
+  - req_id: K8S05
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Operational Excellence
+    area: Lifecycle Management - control plane
+    test_details: '#2, #5, #6'
+    description: API/CLI/Terraform Provider for CRUD provisioning; <30 min control plane bring-up.
+  - req_id: K8S06
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Operational Excellence
+    area: Lifecycle Management - node pool
+    test_details: add
+    description: API/CLI/Terraform for CRUD provisioning ( e.g., create node pool, update node pool, delete node pool, scale a node pool to a target count). Must be able to specify node type (specific CPU or GPU instance type) including CPU-only node pools with high-performance networking for data movement and ingest workloads Ability to specify default node labels and node taints within a node pool when a node joins the cluster. When down-scaling a node pool, ability to down-scale bad/specific nodes.
+  - req_id: K8S07
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Operational Excellence
+    area: API Server Metrics
+    test_details: ''
+    description: Share API Server metrics in a Prometheus scrapable format to allow NVIDIA to measure API Server SLO
+  - req_id: K8S08
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Operational Excellence
+    area: Versioning
+    test_details: INFO
+    description: Provider-managed control plane upgrade processes.
+  - req_id: K8S09
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Operational Excellence
+    area: Zero-Downtime Upgrades
+    test_details: INFO
+    description: Minor version control plane updates without app downtime or maintenance windows.
+  - req_id: K8S10
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Operational Excellence
+    area: Node Upgrades
+    test_details: TBD
+    description: user-initiated rolling updates respecting pod disruption budgets.
+  - req_id: K8S11
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Operational Excellence
+    area: HA Control Plane
+    test_details: INFO
+    description: Redundant architecture with etcd separation.
+  - req_id: K8S12
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Operational Excellence
+    area: Backup & Disaster Recovery
+    test_details: INFO
+    description: Supported recovery within defined RPO/RTO; needs to be auditable & testable
+  - req_id: K8S14
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Robust K8s Security
+    area: Control Plane Isolation
+    test_details: TBD
+    description: Per tenant k8s control plane nodes must be separate from worker nodes and outside of the tenant cluster/VPC.
+  - req_id: K8S15
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Robust K8s Security
+    area: Access Controls
+    test_details: TBD
+    description: Cluster endpoint must provide network access controls.
+  - req_id: K8S16
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Robust K8s Security
+    area: IAM Integration
+    test_details: TBD
+    description: Kubernetes Service Accounts shall integrate with the platform IAM system to enable workloads to assume platform-managed identities and roles with appropriate scopes.
+  - req_id: K8S17
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Robust K8s Security
+    area: Service Accounts
+    test_details: TBD
+    description: Kubernetes shall support standard Service Accounts and projected tokens as the workload identity mechanism, including a cluster-specific OIDC issuer to enable workload identity federation. The cluster shall expose OIDC discovery and JWKS endpoints that are reachable by configured external identity consumers (e.g. AWS IAM, GCP workload identity)
+  - req_id: K8S19
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Robust K8s Security
+    area: Encryption
+    test_details: INFO
+    description: at-rest encryption for etcd and secrets
+  - req_id: K8S20
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Robust K8s Security
+    area: Logging
+    test_details: add
+    description: Ability to view or export Kubernetes control plane logs (apiserver, kcm).
+  - req_id: K8S21
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Component and Extension Requirements
+    area: API Extensions
+    test_details: add
+    description: Mandatory support for CRDs and Validating/Mutating Admission Controllers.
+  - req_id: K8S22
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Component and Extension Requirements
+    area: CNI
+    test_details: add
+    description: Standard compliance; supports Network Policies; IPv4/IPv6 dual-stack desired.
+  - req_id: K8S23
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Component and Extension Requirements
+    area: CSI
+    test_details: add
+    description: NCP provides CSI Driver installable by NVIDIA (helm or kustomize) for Block, shared FS, and NFS Support for static and dynamic provisioning, snapshots, and resizing via PVs and PVCs. CSI credentials are tenant cluster scoped (no cross cluster) APIs to query storage usage against overall cluster quota with per PVC/Volume usage to manage utilization across PVCs and manage quotas using provided credentials Vendor provided storage kernel modules and tools provided via (1) installed by CSI driver, (2) pre-installed in NCP provided machine image or (3) installable packages provided
+  - req_id: K8S24
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Component and Extension Requirements
+    area: DRA
+    test_details: TBD
+    description: Enabled Dynamic Resource Allocation (DRA) regardless of upstream feature status (Beta/GA). Some DRA features require enabling feature gates for the control plane, in case our customers want to run AI workload with new DRA features
+  - req_id: K8S25
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Component and Extension Requirements
+    area: Operator Support
+    test_details: add
+    description: Support standard operator-based management of hardware accelerators and associated drivers. Provider-default accelerator operators and drivers shall be replaceable or overridable to allow installation of tenant-required operator and driver versions (e.g., GPU Operator, Network Operator). Provide golden configurations for GPU Operator and Network Operator.
+  - req_id: K8S26
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Functionality
+    area: Clusters
+    test_details: add
+    description: Support multiple clusters in the same tenancy; support multiple clusters in the same VPC.
+  - req_id: K8S27
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Functionality
+    area: Kubernetes Control Plane size pinning
+    test_details: add
+    description: Pin Control Plane instances to handle a particular load-limit
+  - req_id: K8S28
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Functionality
+    area: Performance
+    test_details: add
+    description: Meet the standard Kubernetes performance test certified up to 5000 nodes (or to the maximum size of the cluster, whichever is smaller) - size CP as necessary. Managed Kubernetes Control Plane SLO and Performance meets or better than the Kubernetes standards results.
+  - req_id: K8S29
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Functionality
+    area: Kubernetes LoadBalancer Service Support
+    test_details: ''
+    description: 'The platform shall support Kubernetes Service resources of type LoadBalancer, including: External load balancers with publicly routable IPs Internal load balancers with private IPs reachable via private network access Static IP assignment'
+  - req_id: K8S30
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Functionality
+    area: DNS Configuration
+    test_details: ''
+    description: The platform shall support configuring Kubernetes internal DNS (e.g. CoreDNS) with conditional forwarding rules for specified DNS zones to designated enterprise or internal DNS resolvers.
+  - req_id: K8S31
+    section: Kubernetes As a Service (KaaS) Requirements
+    subsection: Kubernetes Functionality
+    area: Configurable Kubernetes CIDR ranges
+    test_details: ''
+    description: Ability to configure Kubernetes service IP range, Node IP range, and Pod IP range.
+  - req_id: SEC01
+    section: Security & Identity Management
+    subsection: Identity & Access Management (IAM)
+    area: Authentication
+    test_details: add
+    description: 'Users: Support standards-based user authentication via OIDC and SAML 2.0, including federation with external identity providers (e.g. NVIDIA’s enterprise IdP) for single sign-on (SSO) across platform and tenant-facing services. Validate OIDC-issued tokens including signature, issuer, audience, expiration, and required claims for identity and authorization decisions.'
+  - req_id: SEC03
+    section: Security & Identity Management
+    subsection: Identity & Access Management (IAM)
+    area: Authentication
+    test_details: add
+    description: 'External Services: Support authentication of out of cluster service accounts for service-to-service access. Must support credential-based access, including long-lived credentials where required. If long-lived credentials (e.g. API keys) are issued, the platform will support configurable expiration and rotation. Need ownership attribution for all service accounts. The platform shall provide account information (such as detection of unused accounts).'
+  - req_id: SEC04
+    section: Security & Identity Management
+    subsection: Identity & Access Management (IAM)
+    area: Authorization (RBAC)
+    test_details: add INFO
+    description: The platform shall enforce least-privilege RBAC for all managed services and infrastructure, featuring granular API actions (e.g. CRUD), scopes (e.g. dev vs staging vs prod), and function (e.g. image builder, provisioner, auditor). Roles and permissions shall be assignable to groups, with users inheriting access through group membership (GBAC); group membership may be sourced from OIDC claims and/or SCIM-provisioned groups.
+  - req_id: SEC05
+    section: Security & Identity Management
+    subsection: Identity & Access Management (IAM)
+    area: Identity / Directory Services
+    test_details: INFO
+    description: The platform shall integrate with the NVIDIA LDAP (RFC2307bis) directory service such that users identities and group membership can be resolved by dependent services for authentication and authorization decisions (e.g. storage - POSIX-based access control )
+  - req_id: SEC06
+    section: Security & Identity Management
+    subsection: Identity & Access Management (IAM)
+    area: Workload/Service Identity
+    test_details: INFO
+    description: Support standard workload, service, and node security identities using short-lived credentials, including OIDC-based workload identity federation and Kubernetes Service Accounts where applicable.
+  - req_id: SEC07
+    section: Security & Identity Management
+    subsection: Identity & Access Management (IAM)
+    area: Admin Interfaces
+    test_details: INFO
+    description: All administrative interfaces—whether UI, CLI, or API—must be protected by Multi-Factor Authentication (e.g. mgmt API)
+  - req_id: SEC08
+    section: Security & Identity Management
+    subsection: Identity & Access Management (IAM)
+    area: Audit Logs
+    test_details: add
+    description: Audit logs must be generated and retained for all security-relevant events, including management and control plane API calls, authentication events, and authorization decisions. Audit logs shall be retained for a minimum of 30 days and accessible to authorized platform operators. Must provide a log export mechanism (such as publishing to an S3 bucket). Exported logs should include sufficient metadata to identify tenant, project/account, region, service, resource identifier, actor, event timestamp, source IP where applicable, action, and authorization result.
+  - req_id: SEC23
+    section: Security & Identity Management
+    subsection: Identity & Access Management (IAM)
+    area: Provisioning
+    test_details: ''
+    description: The platform shall support SCIM 2.0 for automated user and group lifecycle management from enterprise identity providers. SCIM endpoints shall require authenticated and authorized access, support core User and Group resource operations, and synchronize group membership changes with the platform authorization engine. Synchronized groups shall be first-class RBAC objects targetable by role bindings and IAM policies; membership changes shall propagate promptly across all managed services.
+  - req_id: SEC24
+    section: Security & Identity Management
+    subsection: Identity & Access Management (IAM)
+    area: Authentication
+    test_details: ''
+    description: Must support domain-based IdP routing, mapping multiple email domains to a designated identity provider (e.g., nvidia.com and nvw.nvidia.com to the NVIDIA enterprise IdP)
+  - req_id: SEC25
+    section: Security & Identity Management
+    subsection: Identity & Access Management (IAM)
+    area: Organization-Level Guardrail Policies
+    test_details: add
+    description: The platform shall support organization-level security guardrail policies that cascade across all subordinate tenant resources (networks, clusters, storage, compute) and cannot be weakened or bypassed by lower-level configuration. Policy violations shall be denied at resource creation/update time and recorded in audit logs.
+  - req_id: SEC26
+    section: Security & Identity Management
+    subsection: Identity & Access Management (IAM)
+    area: SSO Enforcement
+    test_details: add
+    description: The platform shall allow authorized administrators to enforce federated SSO for a tenant, restricting local username/password and other non-federated login for regular users. Enforcement shall apply consistently across UI, CLI, API, and administrative interfaces.
+  - req_id: SEC27
+    section: Security & Identity Management
+    subsection: Identity & Access Management (IAM)
+    area: ''
+    test_details: add
+    description: 'The platform shall expose a programmatic mechanism to create and manage: - Isolation Units (e.g., projects, sub-project) - IAM Users - Service Accounts - Logs'
+  - req_id: SEC09
+    section: Security & Identity Management
+    subsection: Cryptography and Key Management
+    area: Key & Certificate Lifecycle
+    test_details: Add INFO
+    description: The platform shall support secure issuance, distribution, storage, rotation, and revocation of cryptographic keys and certificates used across platform services. It shall support automated rotation of provider-managed and customer-managed keys and certificates, with configurable rotation intervals. Must be auditable. Must have an expiration date.
+  - req_id: SEC10
+    section: Security & Identity Management
+    subsection: Cryptography and Key Management
+    area: Key Usage
+    test_details: add
+    description: The platform shall support use of managed keys and certificates across platform services for encryption, authentication, and signing.
+  - req_id: SEC11
+    section: Security & Identity Management
+    subsection: Network Isolation & Encryption
+    area: Tenancy Model
+    test_details: add
+    description: Hard physical or logical isolation for network, data, and compute. Separation of control planes and tenants is mandatory. This includes separation of storage resources. Provide hierarchical tenancy (at least organization → project).
+  - req_id: SEC12
+    section: Security & Identity Management
+    subsection: Network Isolation & Encryption
+    area: BMC Security
+    test_details: add
+    description: Out-of-band management (BMC) must be on a dedicated, restricted network (physically separate or VLAN/VRF-isolated). Direct access from the public internet or general corporate networks must be blocked, and only accessed via a hardened bastion (jumphost) server.
+  - req_id: SEC13
+    section: Security & Identity Management
+    subsection: Network Isolation & Encryption
+    area: Network Traffic Encryption
+    test_details: add
+    description: Encryption and mutual authentication (mTLS or equivalent) for all east-west and north-south network traffic
+  - req_id: SEC14
+    section: Security & Identity Management
+    subsection: Edge Network Security
+    area: Private Access
+    test_details: INFO
+    description: No public internet access by default; all API endpoints (e.g. K8s API Server) must be restricted via firewall/private link.
+  - req_id: SEC15
+    section: Security & Identity Management
+    subsection: Edge Network Security
+    area: Edge Network Security Policy
+    test_details: INFO
+    description: All traffic must be filtered via Security Groups and/or user customizable ACLs using 5-tuple rules.
+  - req_id: SEC16
+    section: Security & Identity Management
+    subsection: Edge Network Security
+    area: Enforcement
+    test_details: INFO
+    description: NCP must specify the enforcement technology (e.g., Hardware firewalls, SDN, DPUs/SmartNICs) and its specific placement in the packet path.
+  - req_id: SEC17
+    section: Security & Identity Management
+    subsection: Edge Network Security
+    area: Threat Intelligence & Scale
+    test_details: INFO
+    description: Ability to subscribe to GeoIP threat & Embargo feeds and import them into security groups. NCP should share the max supported records/rules.
+  - req_id: SEC18
+    section: Security & Identity Management
+    subsection: Edge Network Security
+    area: 'MACSec protection links:'
+    test_details: INFO
+    description: Protect links between NCP Data Center and NVIDIA POP
+  - req_id: SEC19
+    section: Security & Identity Management
+    subsection: Hardware Security & Compliance
+    area: SOC 2
+    test_details: INFO
+    description: SOC2 type 1 or better is required covering Security, Availability, and Confidentiality across all services and DC infrastructure
+  - req_id: SEC20
+    section: Security & Identity Management
+    subsection: Hardware Security & Compliance
+    area: At-Rest Data Protection
+    test_details: INFO
+    description: Mandatory encryption of all data at rest (e.g. local NVMe/SSD, network-attached storage) via Self-Encrypted Drives (SED).
+  - req_id: SEC21
+    section: Security & Identity Management
+    subsection: Hardware Security & Compliance
+    area: Data Sanitization
+    test_details: add
+    description: Data sanitization must be performed between tenants or on a hardware replacement, including cryptographic erase of all data drives between tenants; sanitization/wipe of any persistent or volatile memory including SRAM/GPU memory; resetting of TPM and BIOS
+  - req_id: SEC22
+    section: Security & Identity Management
+    subsection: Hardware Security & Compliance
+    area: Root of Trust + Secure Boot.
+    test_details: INFO
+    description: Mandatory support across all platforms for Hardware Root of Trust mechanisms (TPM 2.0). The platform must enable UEFI OS Secure Boot w/ TPM 2.0.
+  - req_id: BFX01
+    section: Breakfix Requirements
+    subsection: ''
+    area: Breakfix lifecycle
+    test_details: add
+    description: 'Compute: Power-cycle individual nodes or reset a VM instance. GPU: Reset GPUs on an individual node (as needed - k8s) Maintenance: Return/Report an individual node and a rack to the Provider for maintenance Cordon: Mark a node as unschedulable for new workloads (but finish existing) Replace: Request a host-replacement when health thresholds are breached'
+  - req_id: BFX02
+    section: Breakfix Requirements
+    subsection: ''
+    area: Breakfix Events
+    test_details: ''
+    description: 'Query for any upcoming/current maintenance events for a node or rack Query for any retirement notices for a node/rack. Query for historical / status information for equipment repair. Event information should include: ticket open date ticket update date ticket close date Hardware Stable Identifier (e.g., node ID) Hardware category/type impacted (e.g., GPU, fan, interconnect) Maintenance/Error/fault description (some short description of the issue) Action: Categorization of action (e.g. repairs done on faulty GPUs to resolve the fault) Provider Account ID ticket ID Node Handover Date (Date when the node was deployed in Production)'
+  - req_id: BFX03
+    section: Breakfix Requirements
+    subsection: ''
+    area: Diagnostics
+    test_details: ''
+    description: Identify serial numbers of installed hardware (chassis, baseboard, network adapters, CPU, GPU, etc). Obfuscated but stable identifiers are also OK. Inspect firmware versions of compute nodes and NV switch trays.
+  - req_id: DIR01
+    section: Storage Requirements
+    subsection: Home Directory Storage
+    area: File Service uid/gid Quota feature
+    test_details: INFO
+    description: Configurable filesystem-wide limit, default user/gid quota settings, and per uid/gid overrides available. Usage accounting for uid/gids when the feature is enabled.
+  - req_id: DIR02
+    section: Storage Requirements
+    subsection: Home Directory Storage
+    area: Must be NFS storage
+    test_details: INFO
+    description: NVIDIA requires NFSv4 protocol shared storage to work Access control based on DLs requires POSIX
+  - req_id: DIR03
+    section: Storage Requirements
+    subsection: Home Directory Storage
+    area: Snapshots
+    test_details: ''
+    description: The file system must support the ability to provide snapshot / restore functionality.
+  - req_id: DIR04
+    section: Storage Requirements
+    subsection: Home Directory Storage
+    area: LDAP
+    test_details: ''
+    description: File Service must support integration with an NVIDIA-managed LDAP (see SEC05)
+  - req_id: HSS01
+    section: Storage Requirements
+    subsection: High-Speed Storage Service Requirements
+    area: Provisioning APIs
+    test_details: add
+    description: Storage provisioning may be via vendor portal/API or NCP portal/API.
+  - req_id: HSS02
+    section: Storage Requirements
+    subsection: High-Speed Storage Service Requirements
+    area: Performance
+    test_details: INFO
+    description: Must provision needed throughput requested for minimum bandwidth and IOPS.
+  - req_id: HSS03
+    section: Storage Requirements
+    subsection: High-Speed Storage Service Requirements
+    area: Integration
+    test_details: INFO
+    description: 'K8s: CSI support Breakfix API required to report storage issues'
+  - req_id: HSS04
+    section: Storage Requirements
+    subsection: High-Speed Storage Service Requirements
+    area: Quota Support
+    test_details: INFO
+    description: Configurable filesystem-wide limit, default user/gid quota settings, and per uid/gid overrides available. Usage accounting for uid/gids when the feature is enabled. Configurable directory quota settings … it must be possible to apply a quota for a given directory. Usage accounting for directory quotas when enabled.
+  - req_id: HSS05
+    section: Storage Requirements
+    subsection: High-Speed Storage Service Requirements
+    area: Upgrade, maintenance
+    test_details: INFO
+    description: Provider / NCP initiates desired maintenance. NVIDIA can schedule actual maintenance and can defer maintenance up to 2 weeks. Upgrades should be non-disruptive.
+  - req_id: HSS06
+    section: Storage Requirements
+    subsection: High-Speed Storage Service Requirements
+    area: RDMA Memory Protection
+    test_details: INFO
+    description: Storage systems using RDMA must enforce memory protection via authorization keys for both local and remote access
+  - req_id: HSS07
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: ''
+    area: Parallel high speed filesystem
+    test_details: INFO
+    description: Parallel or multi-path high-speed filesystem that supports scaling to thousands of simultaneous clients while sustaining requested performance.
+  - req_id: HSS08
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: ''
+    area: Single file system size
+    test_details: INFO
+    description: It must be possible to allocate a file system of at least 1 PiB even if the initial request is less. Growing to > 10PiB as cluster size increases. This hard requirement may be higher for a specific site and if so will be communicated via the ancillary services document.
+  - req_id: HSS09
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: ''
+    area: Multiple Filesystems (fungible total capacity)
+    test_details: INFO
+    description: Can have >1 filesystem within our total capacity. Minimal file system size <= 50 TiB.
+  - req_id: HSS10
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: ''
+    area: Filesystem expansion
+    test_details: INFO
+    description: Live file system expansion is supported, in terms of capacity, inodes, IO performance, and metadata operations performance. Performance should scale linearly with capacity.
+  - req_id: HSS11
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: ''
+    area: Client
+    test_details: INFO
+    description: 'Ability to describe your client: In-Kernel, userspace, or bare-metal client installation requirements. Support integration with client kernels / OS used by NVIDIA, as needed. DKMS-enabled packages available for Ubuntu 20.04, 22.04, and 24.04-based operating systems. ARM64 versions compatible with GB200-ready kernels are mandatory, e.g. Linux 6.8.x. Managed Storage Service Provider will provide client configuration best practices and configuration guidelines for filesystem options and kernel module configuration to reliably achieve optimal performance on ARM and x86_64-based clients.'
+  - req_id: HSS12
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: ''
+    area: Quota (User, project & group)
+    test_details: INFO
+    description: Must support soft and hard quotas - uid / gid / project(directory)-id quotas with enforcement.
+  - req_id: HSS13
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: ''
+    area: Root-squash
+    test_details: INFO
+    description: Nvidia needs to be able to enable or disable and manage root-squash at any time.
+  - req_id: HSS14
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: ''
+    area: flock
+    test_details: INFO
+    description: It must be possible to mount the file system with flock.
+  - req_id: HSS15
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: ''
+    area: Ability to Audit Changes
+    test_details: INFO
+    description: Enable Nvidia to have access to changelog data for filesystem auditing and detailed user operations tracking. Tracking by uid/gid, create files, create dirs, rename files, rename dirs, delete files, delete dirs
+  - req_id: HSS16
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: ''
+    area: HA
+    test_details: INFO
+    description: All services are required to tolerate any critical component failure in the backend and provide continued client access to all storage services in such cases.
+  - req_id: HSS17
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: ''
+    area: Multi-Node Coherency
+    test_details: INFO
+    description: One second or less for client attribute and dentry cache updates/invalidates
+  - req_id: HSS18
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: ''
+    area: Client Multipathing
+    test_details: INFO
+    description: Clients must have multipathing to all storage servers
+  - req_id: HSS19
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: ''
+    area: LDAP (for NFS)
+    test_details: ''
+    description: NFS-based high-speed filesystem services must support integration with an NVIDIA-managed LDAP server (including unix uid group membership for users with > 16 group memberships) as per SEC05
+  - req_id: DMS01
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: Data Movement Systems Requirements
+    area: Dedicated K8s Cluster
+    test_details: add
+    description: Provider-managed k8s cluster (or ability to stand up our own) for Data Mover stack available ahead of the GPU cluster bringup to pre-stage data
+  - req_id: DMS02
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: Data Movement Systems Requirements
+    area: Data Mover Nodes (CPU)
+    test_details: INFO
+    description: Dedicated CPU nodes for running data mover - needs high performance networking (exact quantity will be communicated via ancillary services doc)
+  - req_id: DMS03
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: Data Movement Systems Requirements
+    area: Access to same GPU storage
+    test_details: INFO
+    description: Same filesystem as mounted on GPU nodes mounted on the Data Mover nodes (or ability to mount the same filesystem via CSI)
+  - req_id: DMS04
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: Data Movement Systems Requirements
+    area: Access to nvidia corp net
+    test_details: INFO
+    description: Dedicate link (as described in network transport) to NVIDIA corp net, preferably with vpn, but otherwise with stable IP for allowlisting
+  - req_id: DMS05
+    section: These are capabilities required of the high-speed filesystem.
+    subsection: Data Movement Systems Requirements
+    area: Stable egress IP
+    test_details: add
+    description: Stable IP to IP allowlist access to Nvidia services. (e.g. similar to NAT Gateway)
+  - req_id: STG01
+    section: Host Provisioning & Lifecycle
+    subsection: ''
+    area: Operating System Support
+    test_details: INFO
+    description: 'NCP must support a workflow that allows DGXC storage operators to integrate vendor-provided or storage-specific operating system images via bare-metal or VM provisioning for storage servers. The workflow must: (a) Allow DGXC to deploy custom OS images (e.g., vendor-enhanced kernels for Lustre, Rocky Linux, Ubuntu 20.04/22.04/24.04).'
+  - req_id: STG02
+    section: Host Provisioning & Lifecycle
+    subsection: ''
+    area: Drive Sanitization Policy
+    test_details: add
+    description: Cryptographically erase data drive contents between storage system tenants with full attestation of host firmware. Must support an optional flag to skip drive sanitization during break/fix flows (e.g., power supply replacement) where tenancy does not change. Critical hardware component replacements may require sanitization without override, this is inclusive of GPU / CPU node local storage
+  - req_id: STG03
+    section: Host Provisioning & Lifecycle
+    subsection: ''
+    area: Stable IP Assignment
+    test_details: INFO
+    description: Storage nodes must support static IP addressing that remains stable during host lifecycle operations and does not reset between maintenance events.
+  - req_id: STG04
+    section: Host Provisioning & Lifecycle
+    subsection: ''
+    area: Out-of-Band Failure Detection
+    test_details: INFO
+    description: NCP must provide the ability to detect system failures out-of-band, including device, network, memory, and drive failures, enabling DGXC to proactively respond to hardware issues.
+  - req_id: STG05
+    section: Host Provisioning & Lifecycle
+    subsection: ''
+    area: Topology Observability
+    test_details: INFO
+    description: NCP must provide visibility into failure domains to enable DGXC to provision storage nodes with physical diversity. Storage systems must be able to provision nodes that purposefully span failure domains for resilience.
+  - req_id: STG06
+    section: Host Provisioning & Lifecycle
+    subsection: ''
+    area: BlueField/DPU Support
+    test_details: INFO
+    description: For storage systems utilizing BlueField-based architectures, the host provisioning system must support lifecycle management and specific configuration requirements for BlueField "JBOF" systems that export NVMe-oF to hosts.
+  - req_id: NET01
+    section: Network Transport & Fabric Visibility
+    subsection: ''
+    area: Backend Switch Fabric API
+    test_details: INFO
+    description: 'For each compute node, the API must provide visibility into the backend network switches connecting the node to the core. Identification: Each switch must be identified by a unique, stable identifier. A "switch" may represent a physical switch or a logical connectivity domain. Structure: API may be gRPC or REST. Response structure may include multiple nodes (pagination expected). Topology: Switch info can be returned as an ordered array of IDs (e.g., leaf, spine, core) or separate fields for each tier'
+  - req_id: NET02
+    section: Network Transport & Fabric Visibility
+    subsection: ''
+    area: NVLink Domain API
+    test_details: INFO
+    description: 'Requirement: For compute nodes supporting NVLink (e.g., GB200, GB300, Vera Rubin), the API shall return the unique identifier of the NVLink domain associated with each node. Implementation: Can be a separate API method or part of the Backend Switch Fabric API.'
+  - req_id: NET03
+    section: Transport and Networking requirements
+    subsection: ''
+    area: Non-Conflicting IP space allocation for the DGXC cluster
+    test_details: add
+    description: 'Bring Your Own IP (BYOIP): NCP shall support the ability for NVIDIA to bring and allocate its own IP private address space for DGXC GPU clusters. Stable IP: NCP shall provide a possibility to create static IP allocations that persist across instance restarts and re-creations. That includes floating IP allocations. DoD space: NCP shall support allocation and use of the 7.0.0.0/8 IPv4 address space for DGXC GPU cluster deployments. This IP space shall be considered equivalent to RFC1918 addresses Routing Support: NCP must support advertising and routing of BYOIP prefixes within the NCP environment and across interconnects (Private Cloud Interconnect, IPSec, etc.)'
+  - req_id: NET04
+    section: Transport and Networking requirements
+    subsection: ''
+    area: Connection to NVIDIA CorpIT Network
+    test_details: INFO
+    description: 'Bandwidth: Low bandwidth (Up to 10Gbps). Transport: Private Cloud interconnect + VIF + BGP (preferred for better performance/security). DGXC will establish connectivity to NCP through a mutually agreed Point of Presence (POP) using Private Cloud Interconnect, functionally equivalent to AWS Direct Connect, GCP Dedicated Interconnect, Azure ExpressRoute, and OCI FastConnect. Connectivity will be provisioned with a Virtual Interface (VIF) and routing established via BGP. The interconnect will be used to exchange private IP space (RFC1918, as well as 7.0.0.0/8) between DGXC and NCP.'
+  - req_id: NET05
+    section: Connection to DGXC Storage
+    subsection: ''
+    area: Connection to DGXC Storage
+    test_details: INFO
+    description: 'Transport: Private Cloud interconnect + VIF + BGP (preferred for better performance/security). DGXC will establish connectivity to NCP through a mutually agreed Point of Presence (POP) using Private Cloud Interconnect, functionally equivalent to AWS Direct Connect, GCP Dedicated Interconnect, Azure ExpressRoute, and OCI FastConnect. Connectivity will be provisioned with a Virtual Interface (VIF) and routing established via BGP. The interconnect will be used to exchange private IP space (RFC1918, as well as 7.0.0.0/8) between DGXC and NCP.'
+  - req_id: NET06
+    section: Connection to DGXC Storage
+    subsection: ''
+    area: Cluster Local Internet Access
+    test_details: INFO
+    description: 'Cluster Internet access: Egress NAT IPs should be a static pool dedicated to only Nvidia Cluster/Tenancy/VPC. These persistent IP addresses must be used exclusively for DGXC traffic and shall not be shared with or carry traffic from other NCP tenants. Availability: Must support redundant upstream paths to ensure connectivity under failure.'
+  - req_id: CAP01
+    section: Capacity & Fleet Management
+    subsection: ''
+    area: Governance metrics
+    test_details: INFO
+    description: 'Required Governance Metrics The core metrics needed to track fleet health are: Delivered: Nodes/GPUs provisioned and available to NVIDIA, allocated to a specific account/project/tenant. Healthy: Nodes/GPUs functioning and meeting SLA requirements, allocated to a specific account/project/tenant. Reserved: Resources allocated to a specific account/project/tenant. Total Active/In-Use: Nodes/GPUs currently in use within a specific account/project/tenant.'
+  - req_id: CAP02
+    section: Capacity & Fleet Management
+    subsection: ''
+    area: Resource Governance API Metrics
+    test_details: add
+    description: 'The Resource Governance API must return the following information for each node: Node ID (Unique identifier for a GPU node) Health State (Healthy/Unhealthy classification) Instance ID (Identifier for virtual workload) Creation Timestamp (Time workload/node was created) Hardware Type (Descriptor for the hardware model) GPU Count (Number of GPUs per node) Top-levelAccount/ID (Identifier for the top-level organization/account) Sub-LevelProject/ID (Identifier for the nested project/sub-account) In Use (True/False status indicating if the GPU Node is turned on and in use) Region (Region of the data center where nodes are deployed)'
+  - req_id: CAP03
+    section: Capacity & Fleet Management
+    subsection: ''
+    area: Resource Discovery APIs
+    test_details: add
+    description: 'It is not acceptable to have capacity be “handed” to DGXC through a phone, slack or email message. For example, when cluster first comes online, nodes/racks are likely being handed off weekly (or more frequently). Instead, please provide the following mechanism (and we can poll): Programmatic Capacity Discovery: All newly delivered capacity must be discoverable via a centralized API. This "Resource Index" must provide a stable resource identifier and some information on why it’s being provided (e.g. capacity fulfillment on gb300 project, break-fix / RMA return to cluster, etc)'
+  - req_id: CAP04
+    section: Capacity & Fleet Management
+    subsection: ''
+    area: Logical Compartmentalization & Resource Isolation
+    test_details: INFO
+    description: 'To ensure performance consistency and security, the NCP must support strict logical and physical isolation of NVIDIA’s reserved capacity. Capacity Reservations: A mechanism to logically group and "pin" a set of resources (compute, network, storage) to accounts (or equivalent constructs) in an NVIDIA tenancy Atomic Allocation: Support for reserving a "topology block" as a single unit, ensuring all resources in that block share identical performance characteristics and security boundaries.'
+  - req_id: CAP05
+    section: Capacity & Fleet Management
+    subsection: ''
+    area: Unified Health & Lifecycle APIs
+    test_details: INFO
+    description: 'NVIDIA requires a "single source of truth" for the health of both physical hosts and logical compute primitives. Per-Host Health: Real-time API access to the health bits of physical hardware (GPU state, thermal status, memory health). Primitive-Level Status: Health aggregation at the cluster, nodegroup, or reservation level to identify broad infrastructure failures (e.g., a spine switch failure affecting a whole block).'

--- a/docs/requirements/software-reference-requirements.md
+++ b/docs/requirements/software-reference-requirements.md
@@ -1,0 +1,326 @@
+<!-- GENERATED FILE - DO NOT EDIT BY HAND. Source: software-reference-requirements.yaml. Run `make plan`. -->
+
+# Software Reference Requirements
+
+This document lists requirements derived from the *NCP Software Reference Guide* (NSRG).
+
+## Foundational Services
+
+### Image Registry
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| IMG01 | Image Registry | Verify that an OS image (iso file) with full NVIDIA support is readily available | NSRG: Compute Service (PXE/image deploy) | `IMG01-01` |  |
+| IMG02 | Image Registry | Verify that an OS install configuration (e.g. iPXE config like Carbide) with full NVIDIA support is readily available | NSRG: Compute Service (PXE Boot Server) | `IMG02-01` |  |
+| IMG03 | Image Registry | Verify that an VM image with full NVIDIA support is readily available | NSRG: Compute Service (VM Control Plane) | `IMG03-01` |  |
+
+### Key Secret Mgmt
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| AUTH01 | Key Secret Mgmt | CRUD an SSH/Teleport compatible public key for system login | NSRG: Cloud Control Plane (IAM) | `AUTH01-01` |  |
+| AUTH02 | Key Secret Mgmt | Spin up an instance which uses a specified key | NSRG: Compute Service (instance lifecycle) | `AUTH02-01` |  |
+| AUTH03 | Key Secret Mgmt | Access other components via a specified key as possible (SOL, Network devices) | NSRG: Compute Service (serial console / SMN) | `AUTH03-01` |  |
+
+### Identity and Asset Mgmt (IAM)
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| IAM01 | Identity and Asset Mgmt (IAM) | Create user and log in as that user | NSRG: Cloud Control Plane (IAM) | `IAM01-01` |  |
+| IAM02 | Identity and Asset Mgmt (IAM) | Delete user | NSRG: Cloud Control Plane (IAM) | `IAM02-01` |  |
+| IAM03 | Identity and Asset Mgmt (IAM) | Validate that a user created can access the API and authorized resources | NSRG: Cloud Control Plane (IAM authz) | `IAM03-01` |  |
+
+### DDI
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| IPAM01 | DDI | Check that IP addresses are managed by the platform, and that DHCP is able to provide IP addresses | NSRG: SDN Layer (Network Manager IPAM/DHCP) | `IPAM01-01` |  |
+| IPAM02 | DDI | Check that IP addresses are managed sensibly as VPCs are configured (Move to SDN section?) | NSRG: SDN Layer / Creating VPCs | `IPAM02-01` |  |
+
+### Network Underlay & Mgmt
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| NETMGMT01 | Network Underlay & Mgmt | Verify that all switches in the are reachable and healthy (SSH, API, etc) | NSRG: SDN Layer / Networking (switch mgmt) | `NETMGMT01-01` |  |
+
+### Resource Database
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| RESDB01 | Resource Database | Verify that all resources assigned to the cluster are accounted for | NSRG: Compute Service (Instance Database / inventory) | `RESDB01-01` |  |
+
+## Infrastructure and Data Services
+
+### Control Plane accessible
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| CP03 | Control Plane accessible | Make sure we can ping the control plane, or get a heart beat/status code | NSRG: Cloud Control Plane | `CP03-01` |  |
+| CP04 | Control Plane accessible | Control Plane can be upgraded (measure impact) | NSRG: Cloud Control Plane | `CP04-01` |  |
+| CP05 | Control Plane accessible | Access keys can be created, received, used to log in | NSRG: Cloud Control Plane (IAM) | `CP05-01` |  |
+| CP06 | Control Plane accessible | Access keys can expire or be disabled | NSRG: Cloud Control Plane (IAM) | `CP06-01` |  |
+| CP07 | Control Plane accessible | Create tenants | NSRG: Cloud Control Plane (per-tenant quotas) | `CP07-01` |  |
+| CP08 | Control Plane accessible | Retrieve list of tenants | NSRG: Cloud Control Plane | `CP08-01` |  |
+| CP09 | Control Plane accessible | Retrieve info about individual tenant | NSRG: Cloud Control Plane | `CP09-01` |  |
+| CP10 | Control Plane accessible | Delete Tenant | NSRG: Cloud Control Plane | `CP10-01` |  |
+| CP11 | Control Plane accessible | Add user to tenant | NSRG: Cloud Control Plane (IAM) | `CP11-01` |  |
+
+### Hardware ingestion
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| HWING01 | Hardware ingestion | Makes sure that all hardware under test has been ingested, and matches the provided hardware | NSRG: Compute Service (Machine Lifecycle Manager - discovery/ingestion) | `HWING01-01` |  |
+| HWING02 | Hardware ingestion | Make sure that a device can be removed from the system | NSRG: Compute Service (Machine Lifecycle Manager) | `HWING02-01` |  |
+
+### Attestation
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| ATTEST01 | Attestation | Check that OS is approved | NSRG: Boot and Attestation / Remote Attestation | `ATTEST01-01` |  |
+| ATTEST02 | Attestation | Check that an updated BIOS is installed on all hardware | NSRG: Boot and Attestation / Measured Boot | `ATTEST02-01` |  |
+
+### Compute Services: BMaaS
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| BMAAS01 | Compute Services: BMaaS | Node attached storage | NSRG: Virtual Storage / SDS Layer | `BMAAS01-01` |  |
+| BMAAS02 | Compute Services: BMaaS | Storage: Config/default/access to local NVME drives | NSRG: Virtual Storage (Ephemeral Storage) | `BMAAS02-01` |  |
+| BMAAS03 | Compute Services: BMaaS | A running node can be accessed via SSH/Teleport for further configuration (Bare Metal) | NSRG: Compute Service | `BMAAS03-01` |  |
+| BMAAS04 | Compute Services: BMaaS | DEPRECATED: A node can be reinstalled from its configured stock operating system | NSRG: Compute Service (Machine Lifecycle Manager) | `BMAAS04-01` |  |
+| BMAAS05 | Compute Services: BMaaS | Check the health and status of the DPU on instantiation | NSRG: Break-Fix (Initial Node Validation) | `BMAAS05-01` |  |
+| BMAAS06 | Compute Services: BMaaS | Nodes can communicate across ethernet, infiniband, and NVLink (Bare Metal) | NSRG: Networking (TAN/CIN/NVLink) / Performance Requirements | `BMAAS06-01` |  |
+| BMAAS07 | Compute Services: BMaaS | Check for any per-host status log over time. | NSRG: Telemetry & Observability (Compute) | `BMAAS07-01` |  |
+| BMAAS08 | Compute Services: BMaaS | Verify NVIDIA hardware | NSRG: Break-Fix (Initial Node Validation) | `BMAAS08-01` |  |
+| BMAAS09 | Compute Services: BMaaS | GPU Stress workload (Bare Metal) | NSRG: Break-Fix / Node Level Health Checks | `BMAAS09-01` |  |
+| BMAAS10 | Compute Services: BMaaS | Nim Inference jobs (Bare Metal) | NSRG: AI Platform-as-a-Service | `BMAAS10-01` |  |
+| BMAAS11 | Compute Services: BMaaS | NCCL tests | NSRG: Performance Requirements / Networking (CIN) | `BMAAS11-01` |  |
+| BMAAS12 | Compute Services: BMaaS | Training workload test | NSRG: AI Platform-as-a-Service / Performance Requirements | `BMAAS12-01` |  |
+
+### Compute Service: VMaaS
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| VMAAS01 | Compute Service: VMaaS | A running node can be accessed via SSH/Teleport for further configuration (VM) | NSRG: Compute Service (VM Control Plane) | `VMAAS01-01` |  |
+| VMAAS02 | Compute Service: VMaaS | DEPRECATED: A node can be reinstalled from its configured stock operating system | NSRG: Compute Service (VM Control Plane) | `VMAAS02-01` |  |
+| VMAAS03 | Compute Service: VMaaS | Noisy Neighbor CPU/GPU tests | NSRG: Workload Isolation | `VMAAS03-01` |  |
+| VMAAS04 | Compute Service: VMaaS | Tenant cannot allocate more VMs than their quota allows | NSRG: Cloud Control Plane (per-tenant quotas) | `VMAAS04-01` |  |
+| VMAAS05 | Compute Service: VMaaS | Check that the host OS is a known acceptable image (like Ubuntu/DGXOS) | NSRG: Compute Service / Boot and Attestation | `VMAAS05-01` |  |
+| VMAAS06 | Compute Service: VMaaS | Check that the GPU is visible and accessible from the VM | NSRG: Virtualizing a GPU | `VMAAS06-01` |  |
+| VMAAS07 | Compute Service: VMaaS | Check that the correct Linux Kernel, libvirt, sbios, and NVIDIA drivers are installed | NSRG: Virtualizing a GPU / Performance Requirements | `VMAAS07-01` |  |
+| VMAAS08 | Compute Service: VMaaS | Check that vEGM is configured correctly | NSRG: Virtualizing a GPU / Performance Requirements | `VMAAS08-01` |  |
+| VMAAS09 | Compute Service: VMaaS | Check that vCPU pinning is set correctly, PCI bus is configured correctly | NSRG: Performance Requirements (VM Networking) / Virtualizing a GPU | `VMAAS09-01` |  |
+| VMAAS10 | Compute Service: VMaaS | TODO: More things from the "NVIDIA Grace I/O Virtualization Guide" | NSRG: Performance Requirements / Virtualizing a GPU | `VMAAS10-01` |  |
+| VMAAS11 | Compute Service: VMaaS | GPU Stress workload (VM) | NSRG: Break-Fix / Node Level Health Checks | `VMAAS11-01` |  |
+| VMAAS12 | Compute Service: VMaaS | Nim Inference jobs (VM) | NSRG: AI Platform-as-a-Service | `VMAAS12-01` |  |
+| VMAAS13 | Compute Service: VMaaS | Run NCCL tests | NSRG: Performance Requirements (VM Networking) | `VMAAS13-01` |  |
+| VMAAS14 | Compute Service: VMaaS | Nodes can communicate across ethernet, infiniband, and NVLink (VM) | NSRG: Performance Requirements (VM Networking) / Networking | `VMAAS14-01` |  |
+
+### SDN Controller
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| SDN11 | SDN Controller | Support Stable Private IP allocations, where if a VM crashes and restarts the same IP address remains pinned until the node is deleted | NSRG: SDN Layer / Creating VPCs | `SDN11-01` |  |
+| SDN12 | SDN Controller | NVLink: Create a new partition; verify success response with partition key. | NSRG: Partitioning the NVLink Network (Scale-Up) | `SDN12-01` |  |
+| SDN13 | SDN Controller | NVLink: List partitions; retrieve a specific partition by partition ID | NSRG: Partitioning the NVLink Network (Scale-Up) | `SDN13-01` |  |
+| SDN14 | SDN Controller | NVLink: Delete an empty partition (no instances); retrieve by ID and verify not found. | NSRG: Partitioning the NVLink Network (Scale-Up) | `SDN14-01` |  |
+| SDN15 | SDN Controller | NVLink: Create a partition, create instance in that partition, make sure the instance becomes ready, delete instance, verify GPUs removed from partition. | NSRG: Partitioning the NVLink Network (Scale-Up) | `SDN15-01` |  |
+| SDN16 | SDN Controller | NVLink: Create partition, create 2 instances, verify both share the same nvlink_partition_id and both GPUs are reported for that partition | NSRG: Partitioning the NVLink Network (Scale-Up) | `SDN16-01` |  |
+| SDN17 | SDN Controller | IMEX: Assert nvidia-imex and nvidia-imex-ctl packages are installed and nvidia-imex.service unit is registered with systemd. | NSRG: Kubernetes Architecture for ML/AI (IMEX) | `SDN17-01` |  |
+| SDN18 | SDN Controller | IMEX: Start nvidia-imex via systemctl start nvidia-imex and assert the service reaches active/ready state. | NSRG: Kubernetes Architecture for ML/AI (IMEX) | `SDN18-01` |  |
+| SDN19 | SDN Controller | IMEX: Stop nvidia-imex via systemctl stop nvidia-imex and assert clean shutdown (other nodes show disabled node status). | NSRG: Kubernetes Architecture for ML/AI (IMEX) | `SDN19-01` |  |
+| SDN20 | SDN Controller | IMEX: Enable IMEX at boot with systemctl enable nvidia-imex, reboot, and confirm IMEX starts automatically. | NSRG: Kubernetes Architecture for ML/AI (IMEX) | `SDN20-01` |  |
+| SDN21 | SDN Controller | IMEX: After all nodes start IMEX, query domain state via nvidia-imex-ctl -N and assert state is UP, fully connected matrix | NSRG: Kubernetes Architecture for ML/AI (IMEX) | `SDN21-01` |  |
+| SDN22 | SDN Controller | IMEX: With IMEX_ENABLE_AUTH_ENCRYPTION=0, form a multi-node domain and assert connectivity without any auth/encryption. | NSRG: Kubernetes Architecture for ML/AI (IMEX) | `SDN22-01` |  |
+| SDN23 | SDN Controller | IMEX: Enable IMEX_ENABLE_AUTH_ENCRYPTION=1 with SSL_TLS mode, provide valid server/client certs, and assert mutual authentication and encrypted communication. | NSRG: Kubernetes Architecture for ML/AI (IMEX) | `SDN23-01` |  |
+| SDN24 | SDN Controller | IMEX: Enable GSSAPI/Kerberos mode (GSS_AUTH_ENCRYPT), configure KDC/keytabs, and assert mutual auth + encryption between nodes. | NSRG: Kubernetes Architecture for ML/AI (IMEX) | `SDN24-01` |  |
+| SDN25 | SDN Controller | IMEX: IMEX/K8s: Submit a workload requesting a ComputeDomain; assert ComputeDomain pods are created on each allocated node. | NSRG: Kubernetes Architecture for ML/AI (DRA/IMEX) | `SDN25-01` |  |
+| SDN26 | SDN Controller | IMEX: From workload pods in a ComputeDomain run nvbandwidth-test-job | NSRG: Kubernetes Architecture for ML/AI (IMEX) / Performance Requirements | `SDN26-01` |  |
+| SDN27 | SDN Controller | IMEX: After workload completes, assert ComputeDomain and associated IMEX resources are cleaned up. | NSRG: Kubernetes Architecture for ML/AI (IMEX) | `SDN27-01` |  |
+| SDN28 | SDN Controller | Redundant Gateways | NSRG: SDN Layer | `SDN28-01` |  |
+
+### Metadata Service
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| META01 | Metadata Service | TODO | NSRG: Creating VPCs (Metadata Network) | `META01-01` |  |
+
+### Cloud Control Plane
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| CTRL01 | Cloud Control Plane | Needs to have an API we can access from our tests to do actions | NSRG: Cloud Control Plane | `CTRL01-01` |  |
+
+### Load Balancing
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| LB01 | Load Balancing | CRUD a load balancer | NSRG: SDN Layer | `LB01-01` |  |
+| LB02 | Load Balancing | Verify that traffic is distributed across multiple nodes | NSRG: SDN Layer | `LB02-01` |  |
+| LB03 | Load Balancing | Verify that nodes can be marked as down or up (for rolling deployments/etc) | NSRG: SDN Layer | `LB03-01` |  |
+| LB04 | Load Balancing | Verify that no traffic is dropped during outages | NSRG: SDN Layer | `LB04-01` |  |
+
+### Break-Fix
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| BFX04 | Break-Fix | Check that GPUd or Sentinel is running | NSRG: Node Level Health Checks (DCGM) | `BFX04-01` |  |
+| BFX05 | Break-Fix | Verify that Tenants can be notified, by some communication system, of planned future node maintenance | NSRG: Break-Fix Architecture | `BFX05-01` |  |
+| BFX06 | Break-Fix | Verify that Tenants can be notified, by some communication system, of immediate node failure | NSRG: Break-Fix Architecture | `BFX06-01` |  |
+
+## Data Services
+
+### SDS Controller
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| STOR01 | SDS Controller | Storage: Config/default/access to network provided storage | NSRG: Software Defined Storage (SDS) Layer | `STOR01-01` |  |
+
+### Object Storage Service
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| DATASVC01 | Object Storage Service | Verify S3-compatible API access with authenticated endpoints | NSRG: SDS Layer (object storage) / Storage | `DATASVC01-01` |  |
+
+### Block Storage Services
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| DATASVC02 | Block Storage Services | Verify volume snapshots | NSRG: SDS Layer | `DATASVC02-01` |  |
+| DATASVC03 | Block Storage Services | Verify volume resizing | NSRG: SDS Layer | `DATASVC03-01` |  |
+| DATASVC04 | Block Storage Services | Verify persistent block volumes survive instance restarts | NSRG: SDS Layer | `DATASVC04-01` |  |
+
+### Cache Services
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| DATASVC05 | Cache Services | Create a managed cache instance, write a key-value pair, read it back, verify data integrity | NSRG: Other Workloads/Native Applications | `DATASVC05-01` |  |
+
+### Vector Store
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| DATASVC06 | Vector Store | Create a vector store, insert an embedding, perform similarity search, verify result | NSRG: Other Workloads/Native Applications | `DATASVC06-01` |  |
+
+### Relational Database
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| DATASVC07 | Relational Database | Create a managed SQL database, create a table, insert/query data, verify results | NSRG: Other Workloads/Native Applications | `DATASVC07-01` |  |
+
+## Workload Orchestration
+
+### Backup and Recovery
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| DATASVC08 | Backup and Recovery | Create a backup of a block volume, delete original, restore from backup, verify data is the same as the original | NSRG: SDS Layer | `DATASVC08-01` |  |
+
+### Model Registry
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| DATASVC09 | Model Registry | Push a model artifact with a version tag, retrieve by version, verify it matches (prefer a smaller reference model) | NSRG: K8s-Native ML/AI Frameworks / CaaS (OCI registries) | `DATASVC09-01` |  |
+
+### Slurm Control Plane
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| SLURM01 | Slurm Control Plane | Create a SLURM instance using the software platform | NSRG: AI Platform-as-a-Service (Slurm) | `SLURM01-01` |  |
+| SLURM02 | Slurm Control Plane | SlurmInfoAvailable | NSRG: AI Platform-as-a-Service (Slurm) | `SLURM02-01` |  |
+| SLURM03 | Slurm Control Plane | SlurmPartition cpu and gpu | NSRG: AI Platform-as-a-Service (Slurm) | `SLURM03-01` |  |
+| SLURM04 | Slurm Control Plane | SlurmJobSubmission | NSRG: AI Platform-as-a-Service (Slurm) | `SLURM04-01` |  |
+| SLURM05 | Slurm Control Plane | SlurmGpuAllocation 1gpu and 2gpu | NSRG: AI Platform-as-a-Service (Slurm) | `SLURM05-01` |  |
+| SLURM06 | Slurm Control Plane | SlurmNodeJobExecution cpu and gpu | NSRG: AI Platform-as-a-Service (Slurm) | `SLURM06-01` |  |
+| SLURM07 | Slurm Control Plane | SlurmGpuStressWorkload | NSRG: AI Platform-as-a-Service (Slurm) / Node Level Health Checks | `SLURM07-01` |  |
+| SLURM08 | Slurm Control Plane | SlurmNcclMultiNodeWorkload | NSRG: AI Platform-as-a-Service (Slurm) / Performance Requirements | `SLURM08-01` |  |
+| SLURM09 | Slurm Control Plane | SlurmSbatchWorkload gpu and cpu | NSRG: AI Platform-as-a-Service (Slurm) | `SLURM09-01` |  |
+| SLURM10 | Slurm Control Plane | SlurmSbatchWorkload-inline | NSRG: AI Platform-as-a-Service (Slurm) | `SLURM10-01` |  |
+
+### Managed Kubernetes Control Plane
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| K8S38 | Managed Kubernetes Control Plane | Run through all the steps of the k8s lifecycle management, including user-initated CP update | NSRG: Container-as-a-Service: Kubernetes | `K8S38-01` |  |
+| K8S39 | Managed Kubernetes Control Plane | Be able to run k8s workloads | NSRG: Container-as-a-Service: Kubernetes | `K8S39-01` |  |
+| K8S40 | Managed Kubernetes Control Plane | K8s Nim Inference | NSRG: K8s-Native ML/AI Frameworks (Dynamo/NIM) | `K8S40-01` |  |
+| K8S32 | Managed Kubernetes Control Plane | K8s Nim Helm | NSRG: K8s-Native ML/AI Frameworks | `K8S32-01` |  |
+| K8S33 | Managed Kubernetes Control Plane | K8s Nccl | NSRG: Kubernetes Architecture for ML/AI / Performance Requirements | `K8S33-01` |  |
+| K8S34 | Managed Kubernetes Control Plane | validate adherence to upstream proxy requirements (service to pod load balancing, acces to internal services) | NSRG: Container-as-a-Service: Kubernetes | `K8S34-01` |  |
+| K8S35 | Managed Kubernetes Control Plane | Verify that pod-to-pod L3 traffic flow logs are available and queryable | NSRG: Container-as-a-Service: Kubernetes / Telemetry | `K8S35-01` |  |
+| K8S36 | Managed Kubernetes Control Plane | Verify Cluster Autoscaler integration (upstream) | NSRG: Container-as-a-Service: Kubernetes (autoscaling/Karpenter) | `K8S36-01` |  |
+| K8S37 | Managed Kubernetes Control Plane | Verify the managed K8s service meets standard Kubernetes performance tests to max cluster size | NSRG: Container-as-a-Service: Kubernetes | `K8S37-01` |  |
+| K8S41 | Managed Kubernetes Control Plane | The control plane should automatically add more capacity when load increases (control-plane autoscaling) | NSRG: Container-as-a-Service: Kubernetes (autoscaling) | `K8S41-01` |  |
+
+### Power Policy Management
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| POWER01 | Power Policy Management | TODO | NSRG: Operator View / Compute Service (power states) | `POWER01-01` |  |
+
+## AI Platform & User Access
+
+### Host API Gateway
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| APIGW01 | Host API Gateway | TODO | NSRG: AI Platform-as-a-Service / Host API Gateway | `APIGW01-01` |  |
+
+### Al Platform 1..N Control Planes
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| AICP01 | Al Platform 1..N Control Planes | TODO | NSRG: AI Platform-as-a-Service (Lepton/Run:ai/NVCF) | `AICP01-01` |  |
+
+### Web Management Dashboard
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| WEBUI01 | Web Management Dashboard | TODO | NSRG: Cloud Control Plane (UI) | `WEBUI01-01` |  |
+
+## Observability
+
+### Observability Collectors
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| OBS01 | Observability Collectors | Validate that an OTel endpoint is provided and some data can be pulled from it | NSRG: Telemetry & Observability (Reference Architecture, OTel) | `OBS01-01` |  |
+| OBS02 | Observability Collectors | Logging information about the control plane is available | NSRG: Telemetry & Observability (Logging Baseline) | `OBS02-01` |  |
+| OBS03 | Observability Collectors | Logging information from instances | NSRG: Telemetry & Observability (Host-Conditional Logs) | `OBS03-01` |  |
+| OBS04 | Observability Collectors | Alerts can be issued by the system in case of problems | NSRG: Telemetry & Observability (Hot Path / operational) | `OBS04-01` |  |
+| OBS05 | Observability Collectors | Verify telemetry latency is no longer than 120 seconds | NSRG: Telemetry & Observability (Delivery Method) | `OBS05-01` |  |
+| OBS06 | Observability Collectors | Verify telemetry is available for North-South (front-end) network | NSRG: Telemetry & Observability (Network) | `OBS06-01` |  |
+| OBS07 | Observability Collectors | Verify telemetry is available for East-West (back-end / GPU interconnect) network | NSRG: Telemetry & Observability (Network) | `OBS07-01` |  |
+| OBS08 | Observability Collectors | Verify telemetry is available for Management network | NSRG: Telemetry & Observability (Network) | `OBS08-01` |  |
+| OBS09 | Observability Collectors | Verify telemetry is available for NVSwitch Fabric (GB200+) | NSRG: Telemetry & Observability (Network) | `OBS09-01` |  |
+| OBS10 | Observability Collectors | Verify telemetry is available for Host network (NIC-level) | NSRG: Telemetry & Observability (Network) | `OBS10-01` |  |
+| OBS11 | Observability Collectors | Verify Fabric Manager logs are available (where applicable) | NSRG: Telemetry & Observability (Logs) | `OBS11-01` |  |
+| OBS12 | Observability Collectors | Verify Subnet Manager logs are available (where applicable) | NSRG: Telemetry & Observability (Logs) | `OBS12-01` |  |
+| OBS13 | Observability Collectors | Verify UFM Event logs are available | NSRG: Telemetry & Observability (Logs) | `OBS13-01` |  |
+| OBS14 | Observability Collectors | Verify general switch logs are available | NSRG: Telemetry & Observability (Logs) | `OBS14-01` |  |
+| OBS15 | Observability Collectors | Verify switch syslogs are available | NSRG: Telemetry & Observability (Logs) | `OBS15-01` |  |
+| OBS16 | Observability Collectors | Verify switch kernel logs are available | NSRG: Telemetry & Observability (Logs) | `OBS16-01` |  |
+| OBS17 | Observability Collectors | Verify BMC SEL logs are available | NSRG: Telemetry & Observability (Universal / Out-of-Band Logs) | `OBS17-01` |  |
+| OBS18 | Observability Collectors | Verify host syslogs are available | NSRG: Telemetry & Observability (Host-Conditional Logs) | `OBS18-01` |  |
+| OBS19 | Observability Collectors | Verify VPC Flow logs (all ingress/egress traffic) are available | NSRG: Telemetry & Observability (Network / Logs) | `OBS19-01` |  |
+
+### Telemetry / Data Lakes
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| TELEM01 | Telemetry / Data Lakes | TODO | NSRG: Telemetry & Observability (Cold Path / Data Lake) | `TELEM01-01` |  |
+| TELEM02 | Telemetry / Data Lakes | Read only access to a BMaaS system's serial console | NSRG: Compute Service (serial console) | `TELEM02-01` |  |
+| TELEM03 | Telemetry / Data Lakes | Read only access to a VM serial console | NSRG: Compute Service (serial console) | `TELEM03-01` |  |
+| TELEM04 | Telemetry / Data Lakes | Verify BMC/Redfish telemetry is accessible via API for GPU metrics not available from the host OS | NSRG: Telemetry & Observability (Hardware Management, Redfish) | `TELEM04-01` |  |
+| TELEM05 | Telemetry / Data Lakes | Verify storage resource capacity metrics are available (used/free/total) | NSRG: Telemetry & Observability (Storage) | `TELEM05-01` |  |
+| TELEM06 | Telemetry / Data Lakes | Verify storage performance metrics are available (bandwidth, IOPS, latency) | NSRG: Telemetry & Observability (Storage) | `TELEM06-01` |  |
+| TELEM07 | Telemetry / Data Lakes | Verify NVLink metrics are available from the GPU perspective (per-link counters, bandwidth utilization) | NSRG: Telemetry & Observability (GPU / Network) | `TELEM07-01` |  |
+| TELEM08 | Telemetry / Data Lakes | Verify NVLink metrics are available from the switch perspective (port-level counters, error rates) | NSRG: Telemetry & Observability (Network / Fabric) | `TELEM08-01` |  |
+
+## Benchmarking
+
+### Exemplar
+
+| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |
+| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |
+| BENCH01 | Exemplar | NVMesh checks? | NSRG: Performance Requirements / Exemplar | `BENCH01-01` |  |
+| BENCH02 | Exemplar | IPv4 and IPv6 checks? | NSRG: Networking | `BENCH02-01` |  |

--- a/docs/requirements/software-reference-requirements.yaml
+++ b/docs/requirements/software-reference-requirements.yaml
@@ -1,0 +1,1005 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Software reference requirements - structured source of record.
+# Derived from the NCP Software Reference Guide (NSRG). Render to Markdown
+# with make plan (scripts/requirements_source_to_md.py).
+
+source: reference
+title: Software Reference Requirements
+preamble: This document lists requirements derived from the *NCP Software Reference Guide* (NSRG).
+requirements:
+  - req_id: IMG01
+    domain: Foundational Services
+    component: Image Registry
+    description: Verify that an OS image (iso file) with full NVIDIA support is readily available
+    reference_mapping: 'NSRG: Compute Service (PXE/image deploy)'
+    covers_test: IMG01-01
+    status: ''
+  - req_id: IMG02
+    domain: Foundational Services
+    component: Image Registry
+    description: Verify that an OS install configuration (e.g. iPXE config like Carbide) with full NVIDIA support is readily available
+    reference_mapping: 'NSRG: Compute Service (PXE Boot Server)'
+    covers_test: IMG02-01
+    status: ''
+  - req_id: IMG03
+    domain: Foundational Services
+    component: Image Registry
+    description: Verify that an VM image with full NVIDIA support is readily available
+    reference_mapping: 'NSRG: Compute Service (VM Control Plane)'
+    covers_test: IMG03-01
+    status: ''
+  - req_id: AUTH01
+    domain: Foundational Services
+    component: Key Secret Mgmt
+    description: CRUD an SSH/Teleport compatible public key for system login
+    reference_mapping: 'NSRG: Cloud Control Plane (IAM)'
+    covers_test: AUTH01-01
+    status: ''
+  - req_id: AUTH02
+    domain: Foundational Services
+    component: Key Secret Mgmt
+    description: Spin up an instance which uses a specified key
+    reference_mapping: 'NSRG: Compute Service (instance lifecycle)'
+    covers_test: AUTH02-01
+    status: ''
+  - req_id: AUTH03
+    domain: Foundational Services
+    component: Key Secret Mgmt
+    description: Access other components via a specified key as possible (SOL, Network devices)
+    reference_mapping: 'NSRG: Compute Service (serial console / SMN)'
+    covers_test: AUTH03-01
+    status: ''
+  - req_id: IAM01
+    domain: Foundational Services
+    component: Identity and Asset Mgmt (IAM)
+    description: Create user and log in as that user
+    reference_mapping: 'NSRG: Cloud Control Plane (IAM)'
+    covers_test: IAM01-01
+    status: ''
+  - req_id: IAM02
+    domain: Foundational Services
+    component: Identity and Asset Mgmt (IAM)
+    description: Delete user
+    reference_mapping: 'NSRG: Cloud Control Plane (IAM)'
+    covers_test: IAM02-01
+    status: ''
+  - req_id: IAM03
+    domain: Foundational Services
+    component: Identity and Asset Mgmt (IAM)
+    description: Validate that a user created can access the API and authorized resources
+    reference_mapping: 'NSRG: Cloud Control Plane (IAM authz)'
+    covers_test: IAM03-01
+    status: ''
+  - req_id: IPAM01
+    domain: Foundational Services
+    component: DDI
+    description: Check that IP addresses are managed by the platform, and that DHCP is able to provide IP addresses
+    reference_mapping: 'NSRG: SDN Layer (Network Manager IPAM/DHCP)'
+    covers_test: IPAM01-01
+    status: ''
+  - req_id: IPAM02
+    domain: Foundational Services
+    component: DDI
+    description: Check that IP addresses are managed sensibly as VPCs are configured (Move to SDN section?)
+    reference_mapping: 'NSRG: SDN Layer / Creating VPCs'
+    covers_test: IPAM02-01
+    status: ''
+  - req_id: NETMGMT01
+    domain: Foundational Services
+    component: Network Underlay & Mgmt
+    description: Verify that all switches in the are reachable and healthy (SSH, API, etc)
+    reference_mapping: 'NSRG: SDN Layer / Networking (switch mgmt)'
+    covers_test: NETMGMT01-01
+    status: ''
+  - req_id: RESDB01
+    domain: Foundational Services
+    component: Resource Database
+    description: Verify that all resources assigned to the cluster are accounted for
+    reference_mapping: 'NSRG: Compute Service (Instance Database / inventory)'
+    covers_test: RESDB01-01
+    status: ''
+  - req_id: CP03
+    domain: Infrastructure and Data Services
+    component: Control Plane accessible
+    description: Make sure we can ping the control plane, or get a heart beat/status code
+    reference_mapping: 'NSRG: Cloud Control Plane'
+    covers_test: CP03-01
+    status: ''
+  - req_id: CP04
+    domain: Infrastructure and Data Services
+    component: Control Plane accessible
+    description: Control Plane can be upgraded (measure impact)
+    reference_mapping: 'NSRG: Cloud Control Plane'
+    covers_test: CP04-01
+    status: ''
+  - req_id: CP05
+    domain: Infrastructure and Data Services
+    component: Control Plane accessible
+    description: Access keys can be created, received, used to log in
+    reference_mapping: 'NSRG: Cloud Control Plane (IAM)'
+    covers_test: CP05-01
+    status: ''
+  - req_id: CP06
+    domain: Infrastructure and Data Services
+    component: Control Plane accessible
+    description: Access keys can expire or be disabled
+    reference_mapping: 'NSRG: Cloud Control Plane (IAM)'
+    covers_test: CP06-01
+    status: ''
+  - req_id: CP07
+    domain: Infrastructure and Data Services
+    component: Control Plane accessible
+    description: Create tenants
+    reference_mapping: 'NSRG: Cloud Control Plane (per-tenant quotas)'
+    covers_test: CP07-01
+    status: ''
+  - req_id: CP08
+    domain: Infrastructure and Data Services
+    component: Control Plane accessible
+    description: Retrieve list of tenants
+    reference_mapping: 'NSRG: Cloud Control Plane'
+    covers_test: CP08-01
+    status: ''
+  - req_id: CP09
+    domain: Infrastructure and Data Services
+    component: Control Plane accessible
+    description: Retrieve info about individual tenant
+    reference_mapping: 'NSRG: Cloud Control Plane'
+    covers_test: CP09-01
+    status: ''
+  - req_id: CP10
+    domain: Infrastructure and Data Services
+    component: Control Plane accessible
+    description: Delete Tenant
+    reference_mapping: 'NSRG: Cloud Control Plane'
+    covers_test: CP10-01
+    status: ''
+  - req_id: CP11
+    domain: Infrastructure and Data Services
+    component: Control Plane accessible
+    description: Add user to tenant
+    reference_mapping: 'NSRG: Cloud Control Plane (IAM)'
+    covers_test: CP11-01
+    status: ''
+  - req_id: HWING01
+    domain: Infrastructure and Data Services
+    component: Hardware ingestion
+    description: Makes sure that all hardware under test has been ingested, and matches the provided hardware
+    reference_mapping: 'NSRG: Compute Service (Machine Lifecycle Manager - discovery/ingestion)'
+    covers_test: HWING01-01
+    status: ''
+  - req_id: HWING02
+    domain: Infrastructure and Data Services
+    component: Hardware ingestion
+    description: Make sure that a device can be removed from the system
+    reference_mapping: 'NSRG: Compute Service (Machine Lifecycle Manager)'
+    covers_test: HWING02-01
+    status: ''
+  - req_id: ATTEST01
+    domain: Infrastructure and Data Services
+    component: Attestation
+    description: Check that OS is approved
+    reference_mapping: 'NSRG: Boot and Attestation / Remote Attestation'
+    covers_test: ATTEST01-01
+    status: ''
+  - req_id: ATTEST02
+    domain: Infrastructure and Data Services
+    component: Attestation
+    description: Check that an updated BIOS is installed on all hardware
+    reference_mapping: 'NSRG: Boot and Attestation / Measured Boot'
+    covers_test: ATTEST02-01
+    status: ''
+  - req_id: BMAAS01
+    domain: Infrastructure and Data Services
+    component: 'Compute Services: BMaaS'
+    description: Node attached storage
+    reference_mapping: 'NSRG: Virtual Storage / SDS Layer'
+    covers_test: BMAAS01-01
+    status: ''
+  - req_id: BMAAS02
+    domain: Infrastructure and Data Services
+    component: 'Compute Services: BMaaS'
+    description: 'Storage: Config/default/access to local NVME drives'
+    reference_mapping: 'NSRG: Virtual Storage (Ephemeral Storage)'
+    covers_test: BMAAS02-01
+    status: ''
+  - req_id: BMAAS03
+    domain: Infrastructure and Data Services
+    component: 'Compute Services: BMaaS'
+    description: A running node can be accessed via SSH/Teleport for further configuration (Bare Metal)
+    reference_mapping: 'NSRG: Compute Service'
+    covers_test: BMAAS03-01
+    status: ''
+  - req_id: BMAAS04
+    domain: Infrastructure and Data Services
+    component: 'Compute Services: BMaaS'
+    description: 'DEPRECATED: A node can be reinstalled from its configured stock operating system'
+    reference_mapping: 'NSRG: Compute Service (Machine Lifecycle Manager)'
+    covers_test: BMAAS04-01
+    status: ''
+  - req_id: BMAAS05
+    domain: Infrastructure and Data Services
+    component: 'Compute Services: BMaaS'
+    description: Check the health and status of the DPU on instantiation
+    reference_mapping: 'NSRG: Break-Fix (Initial Node Validation)'
+    covers_test: BMAAS05-01
+    status: ''
+  - req_id: BMAAS06
+    domain: Infrastructure and Data Services
+    component: 'Compute Services: BMaaS'
+    description: Nodes can communicate across ethernet, infiniband, and NVLink (Bare Metal)
+    reference_mapping: 'NSRG: Networking (TAN/CIN/NVLink) / Performance Requirements'
+    covers_test: BMAAS06-01
+    status: ''
+  - req_id: BMAAS07
+    domain: Infrastructure and Data Services
+    component: 'Compute Services: BMaaS'
+    description: Check for any per-host status log over time.
+    reference_mapping: 'NSRG: Telemetry & Observability (Compute)'
+    covers_test: BMAAS07-01
+    status: ''
+  - req_id: BMAAS08
+    domain: Infrastructure and Data Services
+    component: 'Compute Services: BMaaS'
+    description: Verify NVIDIA hardware
+    reference_mapping: 'NSRG: Break-Fix (Initial Node Validation)'
+    covers_test: BMAAS08-01
+    status: ''
+  - req_id: BMAAS09
+    domain: Infrastructure and Data Services
+    component: 'Compute Services: BMaaS'
+    description: GPU Stress workload (Bare Metal)
+    reference_mapping: 'NSRG: Break-Fix / Node Level Health Checks'
+    covers_test: BMAAS09-01
+    status: ''
+  - req_id: BMAAS10
+    domain: Infrastructure and Data Services
+    component: 'Compute Services: BMaaS'
+    description: Nim Inference jobs (Bare Metal)
+    reference_mapping: 'NSRG: AI Platform-as-a-Service'
+    covers_test: BMAAS10-01
+    status: ''
+  - req_id: BMAAS11
+    domain: Infrastructure and Data Services
+    component: 'Compute Services: BMaaS'
+    description: NCCL tests
+    reference_mapping: 'NSRG: Performance Requirements / Networking (CIN)'
+    covers_test: BMAAS11-01
+    status: ''
+  - req_id: BMAAS12
+    domain: Infrastructure and Data Services
+    component: 'Compute Services: BMaaS'
+    description: Training workload test
+    reference_mapping: 'NSRG: AI Platform-as-a-Service / Performance Requirements'
+    covers_test: BMAAS12-01
+    status: ''
+  - req_id: VMAAS01
+    domain: Infrastructure and Data Services
+    component: 'Compute Service: VMaaS'
+    description: A running node can be accessed via SSH/Teleport for further configuration (VM)
+    reference_mapping: 'NSRG: Compute Service (VM Control Plane)'
+    covers_test: VMAAS01-01
+    status: ''
+  - req_id: VMAAS02
+    domain: Infrastructure and Data Services
+    component: 'Compute Service: VMaaS'
+    description: 'DEPRECATED: A node can be reinstalled from its configured stock operating system'
+    reference_mapping: 'NSRG: Compute Service (VM Control Plane)'
+    covers_test: VMAAS02-01
+    status: ''
+  - req_id: VMAAS03
+    domain: Infrastructure and Data Services
+    component: 'Compute Service: VMaaS'
+    description: Noisy Neighbor CPU/GPU tests
+    reference_mapping: 'NSRG: Workload Isolation'
+    covers_test: VMAAS03-01
+    status: ''
+  - req_id: VMAAS04
+    domain: Infrastructure and Data Services
+    component: 'Compute Service: VMaaS'
+    description: Tenant cannot allocate more VMs than their quota allows
+    reference_mapping: 'NSRG: Cloud Control Plane (per-tenant quotas)'
+    covers_test: VMAAS04-01
+    status: ''
+  - req_id: VMAAS05
+    domain: Infrastructure and Data Services
+    component: 'Compute Service: VMaaS'
+    description: Check that the host OS is a known acceptable image (like Ubuntu/DGXOS)
+    reference_mapping: 'NSRG: Compute Service / Boot and Attestation'
+    covers_test: VMAAS05-01
+    status: ''
+  - req_id: VMAAS06
+    domain: Infrastructure and Data Services
+    component: 'Compute Service: VMaaS'
+    description: Check that the GPU is visible and accessible from the VM
+    reference_mapping: 'NSRG: Virtualizing a GPU'
+    covers_test: VMAAS06-01
+    status: ''
+  - req_id: VMAAS07
+    domain: Infrastructure and Data Services
+    component: 'Compute Service: VMaaS'
+    description: Check that the correct Linux Kernel, libvirt, sbios, and NVIDIA drivers are installed
+    reference_mapping: 'NSRG: Virtualizing a GPU / Performance Requirements'
+    covers_test: VMAAS07-01
+    status: ''
+  - req_id: VMAAS08
+    domain: Infrastructure and Data Services
+    component: 'Compute Service: VMaaS'
+    description: Check that vEGM is configured correctly
+    reference_mapping: 'NSRG: Virtualizing a GPU / Performance Requirements'
+    covers_test: VMAAS08-01
+    status: ''
+  - req_id: VMAAS09
+    domain: Infrastructure and Data Services
+    component: 'Compute Service: VMaaS'
+    description: Check that vCPU pinning is set correctly, PCI bus is configured correctly
+    reference_mapping: 'NSRG: Performance Requirements (VM Networking) / Virtualizing a GPU'
+    covers_test: VMAAS09-01
+    status: ''
+  - req_id: VMAAS10
+    domain: Infrastructure and Data Services
+    component: 'Compute Service: VMaaS'
+    description: 'TODO: More things from the "NVIDIA Grace I/O Virtualization Guide"'
+    reference_mapping: 'NSRG: Performance Requirements / Virtualizing a GPU'
+    covers_test: VMAAS10-01
+    status: ''
+  - req_id: VMAAS11
+    domain: Infrastructure and Data Services
+    component: 'Compute Service: VMaaS'
+    description: GPU Stress workload (VM)
+    reference_mapping: 'NSRG: Break-Fix / Node Level Health Checks'
+    covers_test: VMAAS11-01
+    status: ''
+  - req_id: VMAAS12
+    domain: Infrastructure and Data Services
+    component: 'Compute Service: VMaaS'
+    description: Nim Inference jobs (VM)
+    reference_mapping: 'NSRG: AI Platform-as-a-Service'
+    covers_test: VMAAS12-01
+    status: ''
+  - req_id: VMAAS13
+    domain: Infrastructure and Data Services
+    component: 'Compute Service: VMaaS'
+    description: Run NCCL tests
+    reference_mapping: 'NSRG: Performance Requirements (VM Networking)'
+    covers_test: VMAAS13-01
+    status: ''
+  - req_id: VMAAS14
+    domain: Infrastructure and Data Services
+    component: 'Compute Service: VMaaS'
+    description: Nodes can communicate across ethernet, infiniband, and NVLink (VM)
+    reference_mapping: 'NSRG: Performance Requirements (VM Networking) / Networking'
+    covers_test: VMAAS14-01
+    status: ''
+  - req_id: SDN11
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: Support Stable Private IP allocations, where if a VM crashes and restarts the same IP address remains pinned until the node is deleted
+    reference_mapping: 'NSRG: SDN Layer / Creating VPCs'
+    covers_test: SDN11-01
+    status: ''
+  - req_id: SDN12
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: 'NVLink: Create a new partition; verify success response with partition key.'
+    reference_mapping: 'NSRG: Partitioning the NVLink Network (Scale-Up)'
+    covers_test: SDN12-01
+    status: ''
+  - req_id: SDN13
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: 'NVLink: List partitions; retrieve a specific partition by partition ID'
+    reference_mapping: 'NSRG: Partitioning the NVLink Network (Scale-Up)'
+    covers_test: SDN13-01
+    status: ''
+  - req_id: SDN14
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: 'NVLink: Delete an empty partition (no instances); retrieve by ID and verify not found.'
+    reference_mapping: 'NSRG: Partitioning the NVLink Network (Scale-Up)'
+    covers_test: SDN14-01
+    status: ''
+  - req_id: SDN15
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: 'NVLink: Create a partition, create instance in that partition, make sure the instance becomes ready, delete instance, verify GPUs removed from partition.'
+    reference_mapping: 'NSRG: Partitioning the NVLink Network (Scale-Up)'
+    covers_test: SDN15-01
+    status: ''
+  - req_id: SDN16
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: 'NVLink: Create partition, create 2 instances, verify both share the same nvlink_partition_id and both GPUs are reported for that partition'
+    reference_mapping: 'NSRG: Partitioning the NVLink Network (Scale-Up)'
+    covers_test: SDN16-01
+    status: ''
+  - req_id: SDN17
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: 'IMEX: Assert nvidia-imex and nvidia-imex-ctl packages are installed and nvidia-imex.service unit is registered with systemd.'
+    reference_mapping: 'NSRG: Kubernetes Architecture for ML/AI (IMEX)'
+    covers_test: SDN17-01
+    status: ''
+  - req_id: SDN18
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: 'IMEX: Start nvidia-imex via systemctl start nvidia-imex and assert the service reaches active/ready state.'
+    reference_mapping: 'NSRG: Kubernetes Architecture for ML/AI (IMEX)'
+    covers_test: SDN18-01
+    status: ''
+  - req_id: SDN19
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: 'IMEX: Stop nvidia-imex via systemctl stop nvidia-imex and assert clean shutdown (other nodes show disabled node status).'
+    reference_mapping: 'NSRG: Kubernetes Architecture for ML/AI (IMEX)'
+    covers_test: SDN19-01
+    status: ''
+  - req_id: SDN20
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: 'IMEX: Enable IMEX at boot with systemctl enable nvidia-imex, reboot, and confirm IMEX starts automatically.'
+    reference_mapping: 'NSRG: Kubernetes Architecture for ML/AI (IMEX)'
+    covers_test: SDN20-01
+    status: ''
+  - req_id: SDN21
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: 'IMEX: After all nodes start IMEX, query domain state via nvidia-imex-ctl -N and assert state is UP, fully connected matrix'
+    reference_mapping: 'NSRG: Kubernetes Architecture for ML/AI (IMEX)'
+    covers_test: SDN21-01
+    status: ''
+  - req_id: SDN22
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: 'IMEX: With IMEX_ENABLE_AUTH_ENCRYPTION=0, form a multi-node domain and assert connectivity without any auth/encryption.'
+    reference_mapping: 'NSRG: Kubernetes Architecture for ML/AI (IMEX)'
+    covers_test: SDN22-01
+    status: ''
+  - req_id: SDN23
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: 'IMEX: Enable IMEX_ENABLE_AUTH_ENCRYPTION=1 with SSL_TLS mode, provide valid server/client certs, and assert mutual authentication and encrypted communication.'
+    reference_mapping: 'NSRG: Kubernetes Architecture for ML/AI (IMEX)'
+    covers_test: SDN23-01
+    status: ''
+  - req_id: SDN24
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: 'IMEX: Enable GSSAPI/Kerberos mode (GSS_AUTH_ENCRYPT), configure KDC/keytabs, and assert mutual auth + encryption between nodes.'
+    reference_mapping: 'NSRG: Kubernetes Architecture for ML/AI (IMEX)'
+    covers_test: SDN24-01
+    status: ''
+  - req_id: SDN25
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: 'IMEX: IMEX/K8s: Submit a workload requesting a ComputeDomain; assert ComputeDomain pods are created on each allocated node.'
+    reference_mapping: 'NSRG: Kubernetes Architecture for ML/AI (DRA/IMEX)'
+    covers_test: SDN25-01
+    status: ''
+  - req_id: SDN26
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: 'IMEX: From workload pods in a ComputeDomain run nvbandwidth-test-job'
+    reference_mapping: 'NSRG: Kubernetes Architecture for ML/AI (IMEX) / Performance Requirements'
+    covers_test: SDN26-01
+    status: ''
+  - req_id: SDN27
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: 'IMEX: After workload completes, assert ComputeDomain and associated IMEX resources are cleaned up.'
+    reference_mapping: 'NSRG: Kubernetes Architecture for ML/AI (IMEX)'
+    covers_test: SDN27-01
+    status: ''
+  - req_id: SDN28
+    domain: Infrastructure and Data Services
+    component: SDN Controller
+    description: Redundant Gateways
+    reference_mapping: 'NSRG: SDN Layer'
+    covers_test: SDN28-01
+    status: ''
+  - req_id: META01
+    domain: Infrastructure and Data Services
+    component: Metadata Service
+    description: TODO
+    reference_mapping: 'NSRG: Creating VPCs (Metadata Network)'
+    covers_test: META01-01
+    status: ''
+  - req_id: CTRL01
+    domain: Infrastructure and Data Services
+    component: Cloud Control Plane
+    description: Needs to have an API we can access from our tests to do actions
+    reference_mapping: 'NSRG: Cloud Control Plane'
+    covers_test: CTRL01-01
+    status: ''
+  - req_id: LB01
+    domain: Infrastructure and Data Services
+    component: Load Balancing
+    description: CRUD a load balancer
+    reference_mapping: 'NSRG: SDN Layer'
+    covers_test: LB01-01
+    status: ''
+  - req_id: LB02
+    domain: Infrastructure and Data Services
+    component: Load Balancing
+    description: Verify that traffic is distributed across multiple nodes
+    reference_mapping: 'NSRG: SDN Layer'
+    covers_test: LB02-01
+    status: ''
+  - req_id: LB03
+    domain: Infrastructure and Data Services
+    component: Load Balancing
+    description: Verify that nodes can be marked as down or up (for rolling deployments/etc)
+    reference_mapping: 'NSRG: SDN Layer'
+    covers_test: LB03-01
+    status: ''
+  - req_id: LB04
+    domain: Infrastructure and Data Services
+    component: Load Balancing
+    description: Verify that no traffic is dropped during outages
+    reference_mapping: 'NSRG: SDN Layer'
+    covers_test: LB04-01
+    status: ''
+  - req_id: BFX04
+    domain: Infrastructure and Data Services
+    component: Break-Fix
+    description: Check that GPUd or Sentinel is running
+    reference_mapping: 'NSRG: Node Level Health Checks (DCGM)'
+    covers_test: BFX04-01
+    status: ''
+  - req_id: BFX05
+    domain: Infrastructure and Data Services
+    component: Break-Fix
+    description: Verify that Tenants can be notified, by some communication system, of planned future node maintenance
+    reference_mapping: 'NSRG: Break-Fix Architecture'
+    covers_test: BFX05-01
+    status: ''
+  - req_id: BFX06
+    domain: Infrastructure and Data Services
+    component: Break-Fix
+    description: Verify that Tenants can be notified, by some communication system, of immediate node failure
+    reference_mapping: 'NSRG: Break-Fix Architecture'
+    covers_test: BFX06-01
+    status: ''
+  - req_id: STOR01
+    domain: Data Services
+    component: SDS Controller
+    description: 'Storage: Config/default/access to network provided storage'
+    reference_mapping: 'NSRG: Software Defined Storage (SDS) Layer'
+    covers_test: STOR01-01
+    status: ''
+  - req_id: DATASVC01
+    domain: Data Services
+    component: Object Storage Service
+    description: Verify S3-compatible API access with authenticated endpoints
+    reference_mapping: 'NSRG: SDS Layer (object storage) / Storage'
+    covers_test: DATASVC01-01
+    status: ''
+  - req_id: DATASVC02
+    domain: Data Services
+    component: Block Storage Services
+    description: Verify volume snapshots
+    reference_mapping: 'NSRG: SDS Layer'
+    covers_test: DATASVC02-01
+    status: ''
+  - req_id: DATASVC03
+    domain: Data Services
+    component: Block Storage Services
+    description: Verify volume resizing
+    reference_mapping: 'NSRG: SDS Layer'
+    covers_test: DATASVC03-01
+    status: ''
+  - req_id: DATASVC04
+    domain: Data Services
+    component: Block Storage Services
+    description: Verify persistent block volumes survive instance restarts
+    reference_mapping: 'NSRG: SDS Layer'
+    covers_test: DATASVC04-01
+    status: ''
+  - req_id: DATASVC05
+    domain: Data Services
+    component: Cache Services
+    description: Create a managed cache instance, write a key-value pair, read it back, verify data integrity
+    reference_mapping: 'NSRG: Other Workloads/Native Applications'
+    covers_test: DATASVC05-01
+    status: ''
+  - req_id: DATASVC06
+    domain: Data Services
+    component: Vector Store
+    description: Create a vector store, insert an embedding, perform similarity search, verify result
+    reference_mapping: 'NSRG: Other Workloads/Native Applications'
+    covers_test: DATASVC06-01
+    status: ''
+  - req_id: DATASVC07
+    domain: Data Services
+    component: Relational Database
+    description: Create a managed SQL database, create a table, insert/query data, verify results
+    reference_mapping: 'NSRG: Other Workloads/Native Applications'
+    covers_test: DATASVC07-01
+    status: ''
+  - req_id: DATASVC08
+    domain: Workload Orchestration
+    component: Backup and Recovery
+    description: Create a backup of a block volume, delete original, restore from backup, verify data is the same as the original
+    reference_mapping: 'NSRG: SDS Layer'
+    covers_test: DATASVC08-01
+    status: ''
+  - req_id: DATASVC09
+    domain: Workload Orchestration
+    component: Model Registry
+    description: Push a model artifact with a version tag, retrieve by version, verify it matches (prefer a smaller reference model)
+    reference_mapping: 'NSRG: K8s-Native ML/AI Frameworks / CaaS (OCI registries)'
+    covers_test: DATASVC09-01
+    status: ''
+  - req_id: SLURM01
+    domain: Workload Orchestration
+    component: Slurm Control Plane
+    description: Create a SLURM instance using the software platform
+    reference_mapping: 'NSRG: AI Platform-as-a-Service (Slurm)'
+    covers_test: SLURM01-01
+    status: ''
+  - req_id: SLURM02
+    domain: Workload Orchestration
+    component: Slurm Control Plane
+    description: SlurmInfoAvailable
+    reference_mapping: 'NSRG: AI Platform-as-a-Service (Slurm)'
+    covers_test: SLURM02-01
+    status: ''
+  - req_id: SLURM03
+    domain: Workload Orchestration
+    component: Slurm Control Plane
+    description: SlurmPartition cpu and gpu
+    reference_mapping: 'NSRG: AI Platform-as-a-Service (Slurm)'
+    covers_test: SLURM03-01
+    status: ''
+  - req_id: SLURM04
+    domain: Workload Orchestration
+    component: Slurm Control Plane
+    description: SlurmJobSubmission
+    reference_mapping: 'NSRG: AI Platform-as-a-Service (Slurm)'
+    covers_test: SLURM04-01
+    status: ''
+  - req_id: SLURM05
+    domain: Workload Orchestration
+    component: Slurm Control Plane
+    description: SlurmGpuAllocation 1gpu and 2gpu
+    reference_mapping: 'NSRG: AI Platform-as-a-Service (Slurm)'
+    covers_test: SLURM05-01
+    status: ''
+  - req_id: SLURM06
+    domain: Workload Orchestration
+    component: Slurm Control Plane
+    description: SlurmNodeJobExecution cpu and gpu
+    reference_mapping: 'NSRG: AI Platform-as-a-Service (Slurm)'
+    covers_test: SLURM06-01
+    status: ''
+  - req_id: SLURM07
+    domain: Workload Orchestration
+    component: Slurm Control Plane
+    description: SlurmGpuStressWorkload
+    reference_mapping: 'NSRG: AI Platform-as-a-Service (Slurm) / Node Level Health Checks'
+    covers_test: SLURM07-01
+    status: ''
+  - req_id: SLURM08
+    domain: Workload Orchestration
+    component: Slurm Control Plane
+    description: SlurmNcclMultiNodeWorkload
+    reference_mapping: 'NSRG: AI Platform-as-a-Service (Slurm) / Performance Requirements'
+    covers_test: SLURM08-01
+    status: ''
+  - req_id: SLURM09
+    domain: Workload Orchestration
+    component: Slurm Control Plane
+    description: SlurmSbatchWorkload gpu and cpu
+    reference_mapping: 'NSRG: AI Platform-as-a-Service (Slurm)'
+    covers_test: SLURM09-01
+    status: ''
+  - req_id: SLURM10
+    domain: Workload Orchestration
+    component: Slurm Control Plane
+    description: SlurmSbatchWorkload-inline
+    reference_mapping: 'NSRG: AI Platform-as-a-Service (Slurm)'
+    covers_test: SLURM10-01
+    status: ''
+  - req_id: K8S38
+    domain: Workload Orchestration
+    component: Managed Kubernetes Control Plane
+    description: Run through all the steps of the k8s lifecycle management, including user-initated CP update
+    reference_mapping: 'NSRG: Container-as-a-Service: Kubernetes'
+    covers_test: K8S38-01
+    status: ''
+  - req_id: K8S39
+    domain: Workload Orchestration
+    component: Managed Kubernetes Control Plane
+    description: Be able to run k8s workloads
+    reference_mapping: 'NSRG: Container-as-a-Service: Kubernetes'
+    covers_test: K8S39-01
+    status: ''
+  - req_id: K8S40
+    domain: Workload Orchestration
+    component: Managed Kubernetes Control Plane
+    description: K8s Nim Inference
+    reference_mapping: 'NSRG: K8s-Native ML/AI Frameworks (Dynamo/NIM)'
+    covers_test: K8S40-01
+    status: ''
+  - req_id: K8S32
+    domain: Workload Orchestration
+    component: Managed Kubernetes Control Plane
+    description: K8s Nim Helm
+    reference_mapping: 'NSRG: K8s-Native ML/AI Frameworks'
+    covers_test: K8S32-01
+    status: ''
+  - req_id: K8S33
+    domain: Workload Orchestration
+    component: Managed Kubernetes Control Plane
+    description: K8s Nccl
+    reference_mapping: 'NSRG: Kubernetes Architecture for ML/AI / Performance Requirements'
+    covers_test: K8S33-01
+    status: ''
+  - req_id: K8S34
+    domain: Workload Orchestration
+    component: Managed Kubernetes Control Plane
+    description: validate adherence to upstream proxy requirements (service to pod load balancing, acces to internal services)
+    reference_mapping: 'NSRG: Container-as-a-Service: Kubernetes'
+    covers_test: K8S34-01
+    status: ''
+  - req_id: K8S35
+    domain: Workload Orchestration
+    component: Managed Kubernetes Control Plane
+    description: Verify that pod-to-pod L3 traffic flow logs are available and queryable
+    reference_mapping: 'NSRG: Container-as-a-Service: Kubernetes / Telemetry'
+    covers_test: K8S35-01
+    status: ''
+  - req_id: K8S36
+    domain: Workload Orchestration
+    component: Managed Kubernetes Control Plane
+    description: Verify Cluster Autoscaler integration (upstream)
+    reference_mapping: 'NSRG: Container-as-a-Service: Kubernetes (autoscaling/Karpenter)'
+    covers_test: K8S36-01
+    status: ''
+  - req_id: K8S37
+    domain: Workload Orchestration
+    component: Managed Kubernetes Control Plane
+    description: Verify the managed K8s service meets standard Kubernetes performance tests to max cluster size
+    reference_mapping: 'NSRG: Container-as-a-Service: Kubernetes'
+    covers_test: K8S37-01
+    status: ''
+  - req_id: K8S41
+    domain: Workload Orchestration
+    component: Managed Kubernetes Control Plane
+    description: The control plane should automatically add more capacity when load increases (control-plane autoscaling)
+    reference_mapping: 'NSRG: Container-as-a-Service: Kubernetes (autoscaling)'
+    covers_test: K8S41-01
+    status: ''
+  - req_id: POWER01
+    domain: Workload Orchestration
+    component: Power Policy Management
+    description: TODO
+    reference_mapping: 'NSRG: Operator View / Compute Service (power states)'
+    covers_test: POWER01-01
+    status: ''
+  - req_id: APIGW01
+    domain: AI Platform & User Access
+    component: Host API Gateway
+    description: TODO
+    reference_mapping: 'NSRG: AI Platform-as-a-Service / Host API Gateway'
+    covers_test: APIGW01-01
+    status: ''
+  - req_id: AICP01
+    domain: AI Platform & User Access
+    component: Al Platform 1..N Control Planes
+    description: TODO
+    reference_mapping: 'NSRG: AI Platform-as-a-Service (Lepton/Run:ai/NVCF)'
+    covers_test: AICP01-01
+    status: ''
+  - req_id: WEBUI01
+    domain: AI Platform & User Access
+    component: Web Management Dashboard
+    description: TODO
+    reference_mapping: 'NSRG: Cloud Control Plane (UI)'
+    covers_test: WEBUI01-01
+    status: ''
+  - req_id: OBS01
+    domain: Observability
+    component: Observability Collectors
+    description: Validate that an OTel endpoint is provided and some data can be pulled from it
+    reference_mapping: 'NSRG: Telemetry & Observability (Reference Architecture, OTel)'
+    covers_test: OBS01-01
+    status: ''
+  - req_id: OBS02
+    domain: Observability
+    component: Observability Collectors
+    description: Logging information about the control plane is available
+    reference_mapping: 'NSRG: Telemetry & Observability (Logging Baseline)'
+    covers_test: OBS02-01
+    status: ''
+  - req_id: OBS03
+    domain: Observability
+    component: Observability Collectors
+    description: Logging information from instances
+    reference_mapping: 'NSRG: Telemetry & Observability (Host-Conditional Logs)'
+    covers_test: OBS03-01
+    status: ''
+  - req_id: OBS04
+    domain: Observability
+    component: Observability Collectors
+    description: Alerts can be issued by the system in case of problems
+    reference_mapping: 'NSRG: Telemetry & Observability (Hot Path / operational)'
+    covers_test: OBS04-01
+    status: ''
+  - req_id: OBS05
+    domain: Observability
+    component: Observability Collectors
+    description: Verify telemetry latency is no longer than 120 seconds
+    reference_mapping: 'NSRG: Telemetry & Observability (Delivery Method)'
+    covers_test: OBS05-01
+    status: ''
+  - req_id: OBS06
+    domain: Observability
+    component: Observability Collectors
+    description: Verify telemetry is available for North-South (front-end) network
+    reference_mapping: 'NSRG: Telemetry & Observability (Network)'
+    covers_test: OBS06-01
+    status: ''
+  - req_id: OBS07
+    domain: Observability
+    component: Observability Collectors
+    description: Verify telemetry is available for East-West (back-end / GPU interconnect) network
+    reference_mapping: 'NSRG: Telemetry & Observability (Network)'
+    covers_test: OBS07-01
+    status: ''
+  - req_id: OBS08
+    domain: Observability
+    component: Observability Collectors
+    description: Verify telemetry is available for Management network
+    reference_mapping: 'NSRG: Telemetry & Observability (Network)'
+    covers_test: OBS08-01
+    status: ''
+  - req_id: OBS09
+    domain: Observability
+    component: Observability Collectors
+    description: Verify telemetry is available for NVSwitch Fabric (GB200+)
+    reference_mapping: 'NSRG: Telemetry & Observability (Network)'
+    covers_test: OBS09-01
+    status: ''
+  - req_id: OBS10
+    domain: Observability
+    component: Observability Collectors
+    description: Verify telemetry is available for Host network (NIC-level)
+    reference_mapping: 'NSRG: Telemetry & Observability (Network)'
+    covers_test: OBS10-01
+    status: ''
+  - req_id: OBS11
+    domain: Observability
+    component: Observability Collectors
+    description: Verify Fabric Manager logs are available (where applicable)
+    reference_mapping: 'NSRG: Telemetry & Observability (Logs)'
+    covers_test: OBS11-01
+    status: ''
+  - req_id: OBS12
+    domain: Observability
+    component: Observability Collectors
+    description: Verify Subnet Manager logs are available (where applicable)
+    reference_mapping: 'NSRG: Telemetry & Observability (Logs)'
+    covers_test: OBS12-01
+    status: ''
+  - req_id: OBS13
+    domain: Observability
+    component: Observability Collectors
+    description: Verify UFM Event logs are available
+    reference_mapping: 'NSRG: Telemetry & Observability (Logs)'
+    covers_test: OBS13-01
+    status: ''
+  - req_id: OBS14
+    domain: Observability
+    component: Observability Collectors
+    description: Verify general switch logs are available
+    reference_mapping: 'NSRG: Telemetry & Observability (Logs)'
+    covers_test: OBS14-01
+    status: ''
+  - req_id: OBS15
+    domain: Observability
+    component: Observability Collectors
+    description: Verify switch syslogs are available
+    reference_mapping: 'NSRG: Telemetry & Observability (Logs)'
+    covers_test: OBS15-01
+    status: ''
+  - req_id: OBS16
+    domain: Observability
+    component: Observability Collectors
+    description: Verify switch kernel logs are available
+    reference_mapping: 'NSRG: Telemetry & Observability (Logs)'
+    covers_test: OBS16-01
+    status: ''
+  - req_id: OBS17
+    domain: Observability
+    component: Observability Collectors
+    description: Verify BMC SEL logs are available
+    reference_mapping: 'NSRG: Telemetry & Observability (Universal / Out-of-Band Logs)'
+    covers_test: OBS17-01
+    status: ''
+  - req_id: OBS18
+    domain: Observability
+    component: Observability Collectors
+    description: Verify host syslogs are available
+    reference_mapping: 'NSRG: Telemetry & Observability (Host-Conditional Logs)'
+    covers_test: OBS18-01
+    status: ''
+  - req_id: OBS19
+    domain: Observability
+    component: Observability Collectors
+    description: Verify VPC Flow logs (all ingress/egress traffic) are available
+    reference_mapping: 'NSRG: Telemetry & Observability (Network / Logs)'
+    covers_test: OBS19-01
+    status: ''
+  - req_id: TELEM01
+    domain: Observability
+    component: Telemetry / Data Lakes
+    description: TODO
+    reference_mapping: 'NSRG: Telemetry & Observability (Cold Path / Data Lake)'
+    covers_test: TELEM01-01
+    status: ''
+  - req_id: TELEM02
+    domain: Observability
+    component: Telemetry / Data Lakes
+    description: Read only access to a BMaaS system's serial console
+    reference_mapping: 'NSRG: Compute Service (serial console)'
+    covers_test: TELEM02-01
+    status: ''
+  - req_id: TELEM03
+    domain: Observability
+    component: Telemetry / Data Lakes
+    description: Read only access to a VM serial console
+    reference_mapping: 'NSRG: Compute Service (serial console)'
+    covers_test: TELEM03-01
+    status: ''
+  - req_id: TELEM04
+    domain: Observability
+    component: Telemetry / Data Lakes
+    description: Verify BMC/Redfish telemetry is accessible via API for GPU metrics not available from the host OS
+    reference_mapping: 'NSRG: Telemetry & Observability (Hardware Management, Redfish)'
+    covers_test: TELEM04-01
+    status: ''
+  - req_id: TELEM05
+    domain: Observability
+    component: Telemetry / Data Lakes
+    description: Verify storage resource capacity metrics are available (used/free/total)
+    reference_mapping: 'NSRG: Telemetry & Observability (Storage)'
+    covers_test: TELEM05-01
+    status: ''
+  - req_id: TELEM06
+    domain: Observability
+    component: Telemetry / Data Lakes
+    description: Verify storage performance metrics are available (bandwidth, IOPS, latency)
+    reference_mapping: 'NSRG: Telemetry & Observability (Storage)'
+    covers_test: TELEM06-01
+    status: ''
+  - req_id: TELEM07
+    domain: Observability
+    component: Telemetry / Data Lakes
+    description: Verify NVLink metrics are available from the GPU perspective (per-link counters, bandwidth utilization)
+    reference_mapping: 'NSRG: Telemetry & Observability (GPU / Network)'
+    covers_test: TELEM07-01
+    status: ''
+  - req_id: TELEM08
+    domain: Observability
+    component: Telemetry / Data Lakes
+    description: Verify NVLink metrics are available from the switch perspective (port-level counters, error rates)
+    reference_mapping: 'NSRG: Telemetry & Observability (Network / Fabric)'
+    covers_test: TELEM08-01
+    status: ''
+  - req_id: BENCH01
+    domain: Benchmarking
+    component: Exemplar
+    description: NVMesh checks?
+    reference_mapping: 'NSRG: Performance Requirements / Exemplar'
+    covers_test: BENCH01-01
+    status: ''
+  - req_id: BENCH02
+    domain: Benchmarking
+    component: Exemplar
+    description: IPv4 and IPv6 checks?
+    reference_mapping: 'NSRG: Networking'
+    covers_test: BENCH02-01
+    status: ''

--- a/docs/requirements/test-requirements-matrix.adoc
+++ b/docs/requirements/test-requirements-matrix.adoc
@@ -1,0 +1,3021 @@
+////
+GENERATED FILE - DO NOT EDIT BY HAND.
+Produced by scripts/requirements_matrix_to_adoc.py from
+docs/requirements/test-requirements-matrix.yaml. Run `make plan` to regenerate.
+////
+= Test ↔ Requirement Traceability
+:toc:
+:icons: font
+:max-width: none
+
+[cols="2,2,5,2,2,1,3,3",options="header"]
+|===
+| Test ID | Test Domain | Function | Test Summary | Req ID | Source | Coverage | Notes
+
+| [[BOOT01-01]]BOOT01-01
+| Foundational Services
+| Image Registry
+| CRUD an custom OS image (iso file) (Upload an ISO file if supported, or remote URL if supported).
+| BOOT01
+| offtake
+| full
+|
+
+| [[BOOT01-02]]BOOT01-02
+| Foundational Services
+| Image Registry
+| CRUD an OS install configuration (e.g. iPXE config like Carbide)
+| BOOT01
+| offtake
+| full
+|
+
+| [[BOOT03-01]]BOOT03-01
+| Foundational Services
+| Image Registry
+| CRUD a custom VM image
+| BOOT03
+| offtake
+| full
+|
+
+| [[BOOT03-02]]BOOT03-02
+| Foundational Services
+| Image Registry
+| CRUD (get, list, create, delete) custom OS images for fast boot (raw, qcow2, img, etc) for BM/VM
+| BOOT03
+| offtake
+| full
+|
+
+| [[BOOT01-03]]BOOT01-03
+| Foundational Services
+| Image Registry
+| Check that an OS image can be installed on a BMaaS system
+| BOOT01
+| offtake
+| full
+|
+
+| [[BOOT01-04]]BOOT01-04
+| Foundational Services
+| Image Registry
+| Check that an OS install configuration can be installed on a BMaaS system
+| BOOT01
+| offtake
+| full
+|
+
+| [[BOOT01-05]]BOOT01-05
+| Foundational Services
+| Image Registry
+| Check that a VM image can be installed onto a VMaaS system
+| BOOT01
+| offtake
+| full
+|
+
+| [[IMG01-01]]IMG01-01
+| Foundational Services
+| Image Registry
+| Verify that an OS image (iso file) with full NVIDIA support is readily available
+| IMG01
+| reference
+| full
+|
+
+| [[IMG02-01]]IMG02-01
+| Foundational Services
+| Image Registry
+| Verify that an OS install configuration (e.g. iPXE config like Carbide) with full NVIDIA support is readily available
+| IMG02
+| reference
+| full
+|
+
+| [[IMG03-01]]IMG03-01
+| Foundational Services
+| Image Registry
+| Verify that an VM image with full NVIDIA support is readily available
+| IMG03
+| reference
+| full
+|
+
+| [[AUTH01-01]]AUTH01-01
+| Foundational Services
+| Key Secret Mgmt
+| CRUD an SSH/Teleport compatible public key for system login
+| AUTH01
+| reference
+| full
+|
+
+| [[AUTH02-01]]AUTH02-01
+| Foundational Services
+| Key Secret Mgmt
+| Spin up an instance which uses a specified key
+| AUTH02
+| reference
+| full
+|
+
+| [[AUTH03-01]]AUTH03-01
+| Foundational Services
+| Key Secret Mgmt
+| Access other components via a specified key as possible (SOL, Network devices)
+| AUTH03
+| reference
+| full
+|
+
+| [[IAM01-01]]IAM01-01
+| Foundational Services
+| Identity and Asset Mgmt (IAM)
+| Create user and log in as that user
+| IAM01
+| reference
+| full
+|
+
+| [[IAM02-01]]IAM02-01
+| Foundational Services
+| Identity and Asset Mgmt (IAM)
+| Delete user
+| IAM02
+| reference
+| full
+|
+
+| [[IAM03-01]]IAM03-01
+| Foundational Services
+| Identity and Asset Mgmt (IAM)
+| Validate that a user created can access the API and authorized resources
+| IAM03
+| reference
+| full
+|
+
+| [[IPAM01-01]]IPAM01-01
+| Foundational Services
+| DDI
+| Check that IP addresses are managed by the platform, and that DHCP is able to provide IP addresses
+| IPAM01
+| reference
+| full
+|
+
+| [[IPAM02-01]]IPAM02-01
+| Foundational Services
+| DDI
+| Check that IP addresses are managed sensibly as VPCs are configured (Move to SDN section?)
+| IPAM02
+| reference
+| full
+|
+
+| [[NETMGMT01-01]]NETMGMT01-01
+| Foundational Services
+| Network Underlay & Mgmt
+| Verify that all switches in the are reachable and healthy (SSH, API, etc)
+| NETMGMT01
+| reference
+| full
+|
+
+| [[RESDB01-01]]RESDB01-01
+| Foundational Services
+| Resource Database
+| Verify that all resources assigned to the cluster are accounted for
+| RESDB01
+| reference
+| full
+|
+
+| [[CP03-01]]CP03-01
+| Infrastructure and Data Services
+| Control Plane accessible
+| Make sure we can ping the control plane, or get a heart beat/status code
+| CP03
+| reference
+| full
+|
+
+| [[CP04-01]]CP04-01
+| Infrastructure and Data Services
+| Control Plane accessible
+| Control Plane can be upgraded (measure impact)
+| CP04
+| reference
+| full
+|
+
+| [[CP05-01]]CP05-01
+| Infrastructure and Data Services
+| Control Plane accessible
+| Access keys can be created, received, used to log in
+| CP05
+| reference
+| full
+|
+
+| [[CP06-01]]CP06-01
+| Infrastructure and Data Services
+| Control Plane accessible
+| Access keys can expire or be disabled
+| CP06
+| reference
+| full
+|
+
+| [[CP07-01]]CP07-01
+| Infrastructure and Data Services
+| Control Plane accessible
+| Create tenants
+| CP07
+| reference
+| full
+|
+
+| [[CP08-01]]CP08-01
+| Infrastructure and Data Services
+| Control Plane accessible
+| Retrieve list of tenants
+| CP08
+| reference
+| full
+|
+
+| [[CP09-01]]CP09-01
+| Infrastructure and Data Services
+| Control Plane accessible
+| Retrieve info about individual tenant
+| CP09
+| reference
+| full
+|
+
+| [[CP10-01]]CP10-01
+| Infrastructure and Data Services
+| Control Plane accessible
+| Delete Tenant
+| CP10
+| reference
+| full
+|
+
+| [[CP11-01]]CP11-01
+| Infrastructure and Data Services
+| Control Plane accessible
+| Add user to tenant
+| CP11
+| reference
+| full
+|
+
+| [[HWING01-01]]HWING01-01
+| Infrastructure and Data Services
+| Hardware ingestion
+| Makes sure that all hardware under test has been ingested, and matches the provided hardware
+| HWING01
+| reference
+| full
+|
+
+| [[HWING02-01]]HWING02-01
+| Infrastructure and Data Services
+| Hardware ingestion
+| Make sure that a device can be removed from the system
+| HWING02
+| reference
+| full
+|
+
+| [[SEC22-01]]SEC22-01
+| Infrastructure and Data Services
+| Attestation
+| Check that hardware passes nonce check
+| SEC22
+| offtake
+| full
+|
+
+| [[ATTEST01-01]]ATTEST01-01
+| Infrastructure and Data Services
+| Attestation
+| Check that OS is approved
+| ATTEST01
+| reference
+| full
+|
+
+| [[SEC22-02]]SEC22-02
+| Infrastructure and Data Services
+| Attestation
+| Check that TPM Configuration can be set per host
+| SEC22
+| offtake
+| full
+|
+
+| [[ATTEST02-01]]ATTEST02-01
+| Infrastructure and Data Services
+| Attestation
+| Check that an updated BIOS is installed on all hardware
+| ATTEST02
+| reference
+| full
+|
+
+| [[CNP09-01]]CNP09-01
+| Infrastructure and Data Services
+| Attestation
+| Check that the updated firmware is installed
+| CNP09
+| offtake
+| full
+|
+
+| [[CNP09-02]]CNP09-02
+| Infrastructure and Data Services
+| Attestation
+| Verify all firmware is cryptographically signed and attested during boot
+| CNP09
+| offtake
+| full
+|
+
+| [[SEC22-03]]SEC22-03
+| Infrastructure and Data Services
+| Attestation
+| TPM Secure Boot in BIOS
+| SEC22
+| offtake
+| full
+|
+
+| [[CNP01-01]]CNP01-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Create a Bare Metal node
+| CNP01
+| offtake
+| full
+|
+
+| [[CNP01-02]]CNP01-02
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Supports the basic lifecycle of Bare Metal nodes, following the standard CRUD pattern
+| CNP01
+| offtake
+| full
+|
+
+| CNP01-02
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Supports the basic lifecycle of Bare Metal nodes, following the standard CRUD pattern
+| CNP04
+| offtake
+| full
+|
+
+| [[CNP01-03]]CNP01-03
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Delete a Bare Metal node
+| CNP01
+| offtake
+| full
+|
+
+| [[SEC21-01]]SEC21-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Confirm sanitization on delete - Tenant View
+| SEC21
+| offtake
+| full
+|
+
+| [[SEC21-02]]SEC21-02
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Confirm sanitization on delete - Low Level
+| SEC21
+| offtake
+| full
+|
+
+| [[CNP01-04]]CNP01-04
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Topology-based placement
+| CNP01
+| offtake
+| full
+|
+
+| [[BMAAS01-01]]BMAAS01-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Node attached storage
+| BMAAS01
+| reference
+| full
+|
+
+| [[BMAAS02-01]]BMAAS02-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Storage: Config/default/access to local NVME drives
+| BMAAS02
+| reference
+| full
+|
+
+| [[BMAAS03-01]]BMAAS03-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| A running node can be accessed via SSH/Teleport for further configuration (Bare Metal)
+| BMAAS03
+| reference
+| full
+|
+
+| [[CNP01-05]]CNP01-05
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| A running node can be rebooted in case of issue (Bare Metal)
+| CNP01
+| offtake
+| full
+|
+
+| [[CNP01-06]]CNP01-06
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| A running node can be power-cycled in case of issue
+| CNP01
+| offtake
+| full
+|
+
+| [[BMAAS04-01]]BMAAS04-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| DEPRECATED: A node can be reinstalled from its configured stock operating system
+| BMAAS04
+| reference
+| full
+|
+
+| [[CNP01-07]]CNP01-07
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| A running node can be powered off (Without being destroyed)
+| CNP01
+| offtake
+| full
+|
+
+| [[BOOT02-01]]BOOT02-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Support for cloud-init and instance metadata discovery via link-local addresses (e.g. 169.254.169.254) or virtual devices (Bare Metal)
+| BOOT02
+| offtake
+| full
+|
+
+| [[CNP01-08]]CNP01-08
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| A powered off node can be powered back on
+| CNP01
+| offtake
+| full
+|
+
+| [[CNP05-01]]CNP05-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Support for user-defined tags/labels and cloud-init metadata on instances. (Bare Metal)
+| CNP05
+| offtake
+| full
+|
+
+| [[BMAAS05-01]]BMAAS05-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Check the health and status of the DPU on instantiation
+| BMAAS05
+| reference
+| full
+|
+
+| [[BMAAS06-01]]BMAAS06-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Nodes can communicate across ethernet, infiniband, and NVLink (Bare Metal)
+| BMAAS06
+| reference
+| full
+|
+
+| [[BMAAS07-01]]BMAAS07-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Check for any per-host status log over time.
+| BMAAS07
+| reference
+| full
+|
+
+| [[CNP06-01]]CNP06-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Serial console access is required (read-only sufficient, interactive preferred) (Bare Metal)
+| CNP06
+| offtake
+| full
+|
+
+| [[BMAAS08-01]]BMAAS08-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Verify NVIDIA hardware
+| BMAAS08
+| reference
+| full
+|
+
+| [[BMAAS09-01]]BMAAS09-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| GPU Stress workload (Bare Metal)
+| BMAAS09
+| reference
+| full
+|
+
+| [[BMAAS10-01]]BMAAS10-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Nim Inference jobs (Bare Metal)
+| BMAAS10
+| reference
+| full
+|
+
+| [[BMAAS11-01]]BMAAS11-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| NCCL tests
+| BMAAS11
+| reference
+| full
+|
+
+| [[BMAAS12-01]]BMAAS12-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Training workload test
+| BMAAS12
+| reference
+| full
+|
+
+| [[CNP06-02]]CNP06-02
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Verify that serial console output is logged and queryable for at least 1 month of history
+| CNP06
+| offtake
+| full
+|
+
+| [[CNP08-01]]CNP08-01
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Verify that a BM node's ID does not change after a reboot
+| CNP08
+| offtake
+| full
+|
+
+| [[CNP08-02]]CNP08-02
+| Infrastructure and Data Services
+| Compute Services: BMaaS
+| Verify that a BM node's ID does not change after a maintenance/reprovision event
+| CNP08
+| offtake
+| full
+|
+
+| [[CNP01-09]]CNP01-09
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Create a VM node
+| CNP01
+| offtake
+| full
+|
+
+| [[CNP01-10]]CNP01-10
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Get info about a specific VM node, including if it is ready for use
+| CNP01
+| offtake
+| full
+|
+
+| CNP01-10
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Get info about a specific VM node, including if it is ready for use
+| CNP04
+| offtake
+| full
+|
+
+| [[CNP01-11]]CNP01-11
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Get a list of all VM nodes in a VPC
+| CNP01
+| offtake
+| full
+|
+
+| [[CNP01-12]]CNP01-12
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Delete a VM node
+| CNP01
+| offtake
+| full
+|
+
+| [[SEC21-03]]SEC21-03
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Confirm sanitization on delete
+| SEC21
+| offtake
+| full
+|
+
+| [[VMAAS01-01]]VMAAS01-01
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| A running node can be accessed via SSH/Teleport for further configuration (VM)
+| VMAAS01
+| reference
+| full
+|
+
+| [[CNP01-13]]CNP01-13
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| A running node can be rebooted in case of issue (VM)
+| CNP01
+| offtake
+| full
+|
+
+| [[VMAAS02-01]]VMAAS02-01
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| DEPRECATED: A node can be reinstalled from its configured stock operating system
+| VMAAS02
+| reference
+| full
+|
+
+| [[CNP01-14]]CNP01-14
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| A running VM can be stopped (Without being destroyed)
+| CNP01
+| offtake
+| full
+|
+
+| [[CNP01-15]]CNP01-15
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| A powered off VM can be started
+| CNP01
+| offtake
+| full
+|
+
+| [[CNP05-02]]CNP05-02
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Support for user-defined tags/labels and cloud-init metadata on instances. (VM)
+| CNP05
+| offtake
+| full
+|
+
+| [[BOOT02-02]]BOOT02-02
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Support for cloud-init and instance metadata discovery via link-local addresses (e.g. 169.254.169.254) or virtual devices (VM)
+| BOOT02
+| offtake
+| full
+|
+
+| [[VMAAS03-01]]VMAAS03-01
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Noisy Neighbor CPU/GPU tests
+| VMAAS03
+| reference
+| full
+|
+
+| [[VMAAS04-01]]VMAAS04-01
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Tenant cannot allocate more VMs than their quota allows
+| VMAAS04
+| reference
+| full
+|
+
+| [[VMAAS05-01]]VMAAS05-01
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Check that the host OS is a known acceptable image (like Ubuntu/DGXOS)
+| VMAAS05
+| reference
+| full
+|
+
+| [[VMAAS06-01]]VMAAS06-01
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Check that the GPU is visible and accessible from the VM
+| VMAAS06
+| reference
+| full
+|
+
+| [[VMAAS07-01]]VMAAS07-01
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Check that the correct Linux Kernel, libvirt, sbios, and NVIDIA drivers are installed
+| VMAAS07
+| reference
+| full
+|
+
+| [[VMAAS08-01]]VMAAS08-01
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Check that vEGM is configured correctly
+| VMAAS08
+| reference
+| full
+|
+
+| [[VMAAS09-01]]VMAAS09-01
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Check that vCPU pinning is set correctly, PCI bus is configured correctly
+| VMAAS09
+| reference
+| full
+|
+
+| [[VMAAS10-01]]VMAAS10-01
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| TODO: More things from the "NVIDIA Grace I/O Virtualization Guide"
+| VMAAS10
+| reference
+| full
+|
+
+| [[VMAAS11-01]]VMAAS11-01
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| GPU Stress workload (VM)
+| VMAAS11
+| reference
+| full
+|
+
+| [[VMAAS12-01]]VMAAS12-01
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Nim Inference jobs (VM)
+| VMAAS12
+| reference
+| full
+|
+
+| [[VMAAS13-01]]VMAAS13-01
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Run NCCL tests
+| VMAAS13
+| reference
+| full
+|
+
+| [[VMAAS14-01]]VMAAS14-01
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Nodes can communicate across ethernet, infiniband, and NVLink (VM)
+| VMAAS14
+| reference
+| full
+|
+
+| [[CNP06-03]]CNP06-03
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Serial console access is required (read-only sufficient, interactive preferred) (VM)
+| CNP06
+| offtake
+| full
+|
+
+| [[CNP08-03]]CNP08-03
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Verify that a VM's ID does not change after a stop/start cycle
+| CNP08
+| offtake
+| full
+|
+
+| [[CNP08-04]]CNP08-04
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Verify that a VM's ID does not change after a live migration or maintenance event
+| CNP08
+| offtake
+| full
+|
+
+| [[CNP01-16]]CNP01-16
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Verify console access is restricted via RBAC
+| CNP01
+| offtake
+| full
+|
+
+| [[CNP01-17]]CNP01-17
+| Infrastructure and Data Services
+| Compute Service: VMaaS
+| Verify USB, clipboard, and unnecessary virtual devices are disabled
+| CNP01
+| offtake
+| full
+|
+
+| [[SDN01-01]]SDN01-01
+| Infrastructure and Data Services
+| SDN Controller
+| Create a VPC
+| SDN01
+| offtake
+| full
+|
+
+| [[SDN01-02]]SDN01-02
+| Infrastructure and Data Services
+| SDN Controller
+| Retrieve a VPC
+| SDN01
+| offtake
+| full
+|
+
+| [[SDN01-03]]SDN01-03
+| Infrastructure and Data Services
+| SDN Controller
+| Update a VPC
+| SDN01
+| offtake
+| full
+|
+
+| [[SDN01-04]]SDN01-04
+| Infrastructure and Data Services
+| SDN Controller
+| Delete a VPC
+| SDN01
+| offtake
+| full
+|
+
+| [[SDN04-01]]SDN04-01
+| Infrastructure and Data Services
+| SDN Controller
+| Verify that a VPC has an exclusive subnet
+| SDN04
+| offtake
+| full
+|
+
+| [[SDN04-02]]SDN04-02
+| Infrastructure and Data Services
+| SDN Controller
+| Verify that nodes in two VPCs cannot communicate over the N/S (TAN) network
+| SDN04
+| offtake
+| full
+|
+
+| [[SDN04-03]]SDN04-03
+| Infrastructure and Data Services
+| SDN Controller
+| Verify that nodes in two VPCs cannot communicate over the E/W (CIN) network
+| SDN04
+| offtake
+| full
+|
+
+| [[NET03-01]]NET03-01
+| Infrastructure and Data Services
+| SDN Controller
+| Support non-conflicting Bring-Your-Own-IP (including 7.0.0.0/8)
+| NET03
+| offtake
+| full
+|
+
+| NET03-01
+| Infrastructure and Data Services
+| SDN Controller
+| Support non-conflicting Bring-Your-Own-IP (including 7.0.0.0/8)
+| SDN01
+| offtake
+| full
+|
+
+| [[SDN11-01]]SDN11-01
+| Infrastructure and Data Services
+| SDN Controller
+| Support Stable Private IP allocations, where if a VM crashes and restarts the same IP address remains pinned until the node is deleted
+| SDN11
+| reference
+| full
+|
+
+| [[SDN05-01]]SDN05-01
+| Infrastructure and Data Services
+| SDN Controller
+| Atomically switch a floating private IP between nodes via API within <10 seconds without requiring an instance reboot.
+| SDN05
+| offtake
+| full
+|
+
+| [[SDN06-01]]SDN06-01
+| Infrastructure and Data Services
+| SDN Controller
+| Localized DNS: Support for custom, localized DNS settings to enable internal domain resolution to private endpoints (e.g. storage endpoints)
+| SDN06
+| offtake
+| full
+|
+
+| [[SDN07-01]]SDN07-01
+| Infrastructure and Data Services
+| SDN Controller
+| Support for VPC peering with full bandwidth and no "hairpin" routing.
+| SDN07
+| offtake
+| full
+|
+
+| [[SDN02-01]]SDN02-01
+| Infrastructure and Data Services
+| SDN Controller
+| Create a Security Group
+| SDN02
+| offtake
+| full
+|
+
+| SDN02-01
+| Infrastructure and Data Services
+| SDN Controller
+| Create a Security Group
+| SDN03
+| offtake
+| full
+|
+
+| [[SDN02-02]]SDN02-02
+| Infrastructure and Data Services
+| SDN Controller
+| Retrieve a Security Group/list Security Groups
+| SDN02
+| offtake
+| full
+|
+
+| SDN02-02
+| Infrastructure and Data Services
+| SDN Controller
+| Retrieve a Security Group/list Security Groups
+| SDN03
+| offtake
+| full
+|
+
+| [[SDN02-03]]SDN02-03
+| Infrastructure and Data Services
+| SDN Controller
+| Update a Security Group
+| SDN02
+| offtake
+| full
+|
+
+| SDN02-03
+| Infrastructure and Data Services
+| SDN Controller
+| Update a Security Group
+| SDN03
+| offtake
+| full
+|
+
+| [[SDN02-04]]SDN02-04
+| Infrastructure and Data Services
+| SDN Controller
+| Delete a Security Group
+| SDN02
+| offtake
+| full
+|
+
+| SDN02-04
+| Infrastructure and Data Services
+| SDN Controller
+| Delete a Security Group
+| SDN03
+| offtake
+| full
+|
+
+| [[CNP03-01]]CNP03-01
+| Infrastructure and Data Services
+| SDN Controller
+| NVLink Partitioning
+| CNP03
+| offtake
+| full
+|
+
+| [[SDN12-01]]SDN12-01
+| Infrastructure and Data Services
+| SDN Controller
+| NVLink: Create a new partition; verify success response with partition key.
+| SDN12
+| reference
+| full
+|
+
+| [[SDN13-01]]SDN13-01
+| Infrastructure and Data Services
+| SDN Controller
+| NVLink: List partitions; retrieve a specific partition by partition ID
+| SDN13
+| reference
+| full
+|
+
+| [[SDN14-01]]SDN14-01
+| Infrastructure and Data Services
+| SDN Controller
+| NVLink: Delete an empty partition (no instances); retrieve by ID and verify not found.
+| SDN14
+| reference
+| full
+|
+
+| [[SDN15-01]]SDN15-01
+| Infrastructure and Data Services
+| SDN Controller
+| NVLink: Create a partition, create instance in that partition, make sure the instance becomes ready, delete instance, verify GPUs removed from partition.
+| SDN15
+| reference
+| full
+|
+
+| [[SDN16-01]]SDN16-01
+| Infrastructure and Data Services
+| SDN Controller
+| NVLink: Create partition, create 2 instances, verify both share the same nvlink_partition_id and both GPUs are reported for that partition
+| SDN16
+| reference
+| full
+|
+
+| [[SDN17-01]]SDN17-01
+| Infrastructure and Data Services
+| SDN Controller
+| IMEX: Assert nvidia-imex and nvidia-imex-ctl packages are installed and nvidia-imex.service unit is registered with systemd.
+| SDN17
+| reference
+| full
+|
+
+| [[SDN18-01]]SDN18-01
+| Infrastructure and Data Services
+| SDN Controller
+| IMEX: Start nvidia-imex via systemctl start nvidia-imex and assert the service reaches active/ready state.
+| SDN18
+| reference
+| full
+|
+
+| [[SDN19-01]]SDN19-01
+| Infrastructure and Data Services
+| SDN Controller
+| IMEX: Stop nvidia-imex via systemctl stop nvidia-imex and assert clean shutdown (other nodes show disabled node status).
+| SDN19
+| reference
+| full
+|
+
+| [[SDN20-01]]SDN20-01
+| Infrastructure and Data Services
+| SDN Controller
+| IMEX: Enable IMEX at boot with systemctl enable nvidia-imex, reboot, and confirm IMEX starts automatically.
+| SDN20
+| reference
+| full
+|
+
+| [[SDN21-01]]SDN21-01
+| Infrastructure and Data Services
+| SDN Controller
+| IMEX: After all nodes start IMEX, query domain state via nvidia-imex-ctl -N and assert state is UP, fully connected matrix
+| SDN21
+| reference
+| full
+|
+
+| [[SDN22-01]]SDN22-01
+| Infrastructure and Data Services
+| SDN Controller
+| IMEX: With IMEX_ENABLE_AUTH_ENCRYPTION=0, form a multi-node domain and assert connectivity without any auth/encryption.
+| SDN22
+| reference
+| full
+|
+
+| [[SDN23-01]]SDN23-01
+| Infrastructure and Data Services
+| SDN Controller
+| IMEX: Enable IMEX_ENABLE_AUTH_ENCRYPTION=1 with SSL_TLS mode, provide valid server/client certs, and assert mutual authentication and encrypted communication.
+| SDN23
+| reference
+| full
+|
+
+| [[SDN24-01]]SDN24-01
+| Infrastructure and Data Services
+| SDN Controller
+| IMEX: Enable GSSAPI/Kerberos mode (GSS_AUTH_ENCRYPT), configure KDC/keytabs, and assert mutual auth + encryption between nodes.
+| SDN24
+| reference
+| full
+|
+
+| [[SDN25-01]]SDN25-01
+| Infrastructure and Data Services
+| SDN Controller
+| IMEX: IMEX/K8s: Submit a workload requesting a ComputeDomain; assert ComputeDomain pods are created on each allocated node.
+| SDN25
+| reference
+| full
+|
+
+| [[SDN26-01]]SDN26-01
+| Infrastructure and Data Services
+| SDN Controller
+| IMEX: From workload pods in a ComputeDomain run nvbandwidth-test-job
+| SDN26
+| reference
+| full
+|
+
+| [[SDN27-01]]SDN27-01
+| Infrastructure and Data Services
+| SDN Controller
+| IMEX: After workload completes, assert ComputeDomain and associated IMEX resources are cleaned up.
+| SDN27
+| reference
+| full
+|
+
+| [[SDN28-01]]SDN28-01
+| Infrastructure and Data Services
+| SDN Controller
+| Redundant Gateways
+| SDN28
+| reference
+| full
+|
+
+| [[SDN02-05]]SDN02-05
+| Infrastructure and Data Services
+| SDN Controller
+| Verify security group rules can be scoped at workload level
+| SDN02
+| offtake
+| full
+|
+
+| [[SDN02-06]]SDN02-06
+| Infrastructure and Data Services
+| SDN Controller
+| Verify security group rules can be scoped at node level
+| SDN02
+| offtake
+| full
+|
+
+| [[SDN02-07]]SDN02-07
+| Infrastructure and Data Services
+| SDN Controller
+| Verify security group rules can be scoped at subnet/tenant level
+| SDN02
+| offtake
+| full
+|
+
+| [[SDN02-08]]SDN02-08
+| Infrastructure and Data Services
+| SDN Controller
+| Measure and verify policy propagation timing is within acceptable bounds
+| SDN02
+| offtake
+| full
+|
+
+| [[SDN02-09]]SDN02-09
+| Infrastructure and Data Services
+| SDN Controller
+| Verify security group rules can be scoped at K8s API service level
+| SDN02
+| offtake
+| full
+|
+
+| [[SDN08-01]]SDN08-01
+| Infrastructure and Data Services
+| SDN Controller
+| Verify that storage hosts can route to each other with all-to-all L3 communication
+| SDN08
+| offtake
+| full
+|
+
+| [[SDN02-10]]SDN02-10
+| Infrastructure and Data Services
+| SDN Controller
+| Verify customizable port security policies can be applied to virtual interfaces
+| SDN02
+| offtake
+| full
+|
+
+| [[SDN09-01]]SDN09-01
+| Infrastructure and Data Services
+| SDN Controller
+| Verify logging is available for network hardware faults
+| SDN09
+| offtake
+| full
+|
+
+| [[SDN09-02]]SDN09-02
+| Infrastructure and Data Services
+| SDN Controller
+| Verify logging captures latency/performance fluctuations
+| SDN09
+| offtake
+| full
+|
+
+| [[SDN09-03]]SDN09-03
+| Infrastructure and Data Services
+| SDN Controller
+| Verify a detailed audit trail exists for all configuration changes to network filtering rules
+| SDN09
+| offtake
+| full
+|
+
+| [[META01-01]]META01-01
+| Infrastructure and Data Services
+| Metadata Service
+| TODO
+| META01
+| reference
+| full
+|
+
+| [[CTRL01-01]]CTRL01-01
+| Infrastructure and Data Services
+| Cloud Control Plane
+| Needs to have an API we can access from our tests to do actions
+| CTRL01
+| reference
+| full
+|
+
+| [[CAP02-01]]CAP02-01
+| Infrastructure and Data Services
+| Cloud Control Plane
+| Verify that fleet management API provides full set of information requested below: Node ID (Unique identifier for a GPU node) Health State (Healthy/Unhealthy classification) Instance ID (Identifier for virtual workload) Creation Timestamp (Time workload/node was created) Hardware Type (Descriptor for the hardware model) GPU Count (Number of GPUs per node) Top-levelAccount/ID (Identifier for the top-level organization/account) Sub-LevelProject/ID (Identifier for the nested project/sub-account) In Use (True/False status indicating if the GPU Node is turned on and in use) Region (Region of the data center where nodes are deployed)
+| CAP02
+| offtake
+| full
+|
+
+| [[CAP03-01]]CAP03-01
+| Infrastructure and Data Services
+| Cloud Control Plane
+| Resource discovery API: newly delivered capacity must be discoverable. This "Resource Index" must provide a stable resource identifer.
+| CAP03
+| offtake
+| full
+|
+
+| [[CNP08-05]]CNP08-05
+| Infrastructure and Data Services
+| Cloud Control Plane
+| Verify that switch identifiers are stable across reboots and firmware updates
+| CNP08
+| offtake
+| full
+|
+
+| [[LB01-01]]LB01-01
+| Infrastructure and Data Services
+| Load Balancing
+| CRUD a load balancer
+| LB01
+| reference
+| full
+|
+
+| [[LB02-01]]LB02-01
+| Infrastructure and Data Services
+| Load Balancing
+| Verify that traffic is distributed across multiple nodes
+| LB02
+| reference
+| full
+|
+
+| [[LB03-01]]LB03-01
+| Infrastructure and Data Services
+| Load Balancing
+| Verify that nodes can be marked as down or up (for rolling deployments/etc)
+| LB03
+| reference
+| full
+|
+
+| [[LB04-01]]LB04-01
+| Infrastructure and Data Services
+| Load Balancing
+| Verify that no traffic is dropped during outages
+| LB04
+| reference
+| full
+|
+
+| [[BFX04-01]]BFX04-01
+| Infrastructure and Data Services
+| Break-Fix
+| Check that GPUd or Sentinel is running
+| BFX04
+| reference
+| full
+|
+
+| [[BFX05-01]]BFX05-01
+| Infrastructure and Data Services
+| Break-Fix
+| Verify that Tenants can be notified, by some communication system, of planned future node maintenance
+| BFX05
+| reference
+| full
+|
+
+| [[BFX06-01]]BFX06-01
+| Infrastructure and Data Services
+| Break-Fix
+| Verify that Tenants can be notified, by some communication system, of immediate node failure
+| BFX06
+| reference
+| full
+|
+
+| [[BFX01-01]]BFX01-01
+| Infrastructure and Data Services
+| Break-Fix
+| Reset GPUs on an individual node via the Breakfix API
+| BFX01
+| offtake
+| full
+|
+
+| [[BFX01-02]]BFX01-02
+| Infrastructure and Data Services
+| Break-Fix
+| Return an individual node to the provider for maintenance via the API
+| BFX01
+| offtake
+| full
+|
+
+| [[BFX01-03]]BFX01-03
+| Infrastructure and Data Services
+| Break-Fix
+| Return a rack to the provider for maintenance via the API
+| BFX01
+| offtake
+| full
+|
+
+| [[BFX01-04]]BFX01-04
+| Infrastructure and Data Services
+| Break-Fix
+| Cordon a node (mark unschedulable); verify no new workloads are placed; verify existing workloads continue
+| BFX01
+| offtake
+| full
+|
+
+| [[BFX01-05]]BFX01-05
+| Infrastructure and Data Services
+| Break-Fix
+| Request a host replacement when health thresholds are breached; verify the node is removed from the pool
+| BFX01
+| offtake
+| full
+|
+
+| [[BFX02-01]]BFX02-01
+| Infrastructure and Data Services
+| Break-Fix
+| Query upcoming/current maintenance events for a node
+| BFX02
+| offtake
+| full
+|
+
+| [[BFX02-02]]BFX02-02
+| Infrastructure and Data Services
+| Break-Fix
+| Query retirement notices for a node/rack
+| BFX02
+| offtake
+| full
+|
+
+| [[BFX02-03]]BFX02-03
+| Infrastructure and Data Services
+| Break-Fix
+| Query historical repair status for a node
+| BFX02
+| offtake
+| full
+|
+
+| [[BFX03-01]]BFX03-01
+| Infrastructure and Data Services
+| Break-Fix
+| Query serial numbers of installed hardware (chassis, baseboard, NICs, CPU, GPU) — obfuscated but stable IDs are OK
+| BFX03
+| offtake
+| full
+|
+
+| [[BFX03-02]]BFX03-02
+| Infrastructure and Data Services
+| Break-Fix
+| Inspect firmware versions of NV switch trays
+| BFX03
+| offtake
+| full
+|
+
+| [[BFX03-03]]BFX03-03
+| Infrastructure and Data Services
+| Break-Fix
+| Obtain BMC kernel log messages for a node
+| BFX03
+| offtake
+| full
+|
+
+| [[HSS01-01]]HSS01-01
+| Data Services
+| SDS Controller
+| Verify storage provisioning via vendor/NCP API
+| HSS01
+| offtake
+| full
+|
+
+| [[HSS02-01]]HSS02-01
+| Data Services
+| SDS Controller
+| Verify QoS — provisioned throughput meets requested minimum bandwidth and IOPS
+| HSS02
+| offtake
+| full
+|
+
+| [[HSS03-01]]HSS03-01
+| Data Services
+| SDS Controller
+| Verify K8s CSI integration for storage
+| HSS03
+| offtake
+| full
+|
+
+| HSS03-01
+| Data Services
+| SDS Controller
+| Verify K8s CSI integration for storage
+| K8S23
+| offtake
+| full
+|
+
+| [[HSS04-01]]HSS04-01
+| Data Services
+| SDS Controller
+| Verify quota limits can be set on user workloads/volumes
+| HSS04
+| offtake
+| full
+|
+
+| [[HSS05-01]]HSS05-01
+| Data Services
+| SDS Controller
+| Verify non-disruptive upgrades (NVIDIA can defer maintenance up to 2 weeks)
+| HSS05
+| offtake
+| full
+|
+
+| [[STOR01-01]]STOR01-01
+| Data Services
+| SDS Controller
+| Storage: Config/default/access to network provided storage
+| STOR01
+| reference
+| full
+|
+
+| [[DIR02-01]]DIR02-01
+| Data Services
+| SDS Controller
+| Verify NFS protocol shared storage is available
+| DIR02
+| offtake
+| full
+|
+
+| [[DIR01-01]]DIR01-01
+| Data Services
+| SDS Controller
+| Verify configurable filesystem-wide quota limits
+| DIR01
+| offtake
+| full
+|
+
+| [[DIR01-02]]DIR01-02
+| Data Services
+| SDS Controller
+| Verify usage accounting for uid/gids
+| DIR01
+| offtake
+| full
+|
+
+| [[DMS01-01]]DMS01-01
+| Data Services
+| SDS Controller
+| Verify a dedicated K8s cluster (or ability to create one) for the data mover stack
+| DMS01
+| offtake
+| full
+|
+
+| [[DMS02-01]]DMS02-01
+| Data Services
+| SDS Controller
+| Verify dedicated CPU nodes are available for data mover with high-performance networking
+| DMS02
+| offtake
+| full
+|
+
+| [[DMS03-01]]DMS03-01
+| Data Services
+| SDS Controller
+| Verify the same filesystem mounted on GPU nodes is accessible from data mover nodes
+| DMS03
+| offtake
+| full
+|
+
+| [[DMS05-01]]DMS05-01
+| Data Services
+| SDS Controller
+| Verify stable egress IP for allowlisting access to NVIDIA services
+| DMS05
+| offtake
+| full
+|
+
+| [[STG02-01]]STG02-01
+| Data Services
+| SDS Controller
+| Verify optional skip-sanitization flag during break/fix where tenancy doesn't change
+| STG02
+| offtake
+| full
+|
+
+| [[STG03-01]]STG03-01
+| Data Services
+| SDS Controller
+| Verify stable IP assignment for storage nodes across lifecycle operations
+| STG03
+| offtake
+| full
+|
+
+| [[STG04-01]]STG04-01
+| Data Services
+| SDS Controller
+| Verify out-of-band failure detection (device, network, memory, drive)
+| STG04
+| offtake
+| full
+|
+
+| [[STG05-01]]STG05-01
+| Data Services
+| SDS Controller
+| Verify topology observability — visibility into failure domains for physical diversity
+| STG05
+| offtake
+| full
+|
+
+| [[SEC04-01]]SEC04-01
+| Data Services
+| SDS Controller
+| Verify least-privilege access policies (resource-based, user-based, network-based)
+| SEC04
+| offtake
+| full
+|
+
+| [[HSS06-01]]HSS06-01
+| Data Services
+| SDS Controller
+| Verify storage systems using RDMA enforce memory protection via authorization keys for both local and remote access
+| HSS06
+| offtake
+| full
+|
+
+| [[HSS07-01]]HSS07-01
+| Data Services
+| Parallel File System Services
+| Verify that a parallel high-speed filesystem can be provisioned via API
+| HSS07
+| offtake
+| full
+|
+
+| [[HSS09-01]]HSS09-01
+| Data Services
+| Parallel File System Services
+| Verify multiple filesystems can exist within total capacity (minimum FS size <= 50 TiB)
+| HSS09
+| offtake
+| full
+|
+
+| [[HSS10-01]]HSS10-01
+| Data Services
+| Parallel File System Services
+| Verify live filesystem expansion (capacity, inodes, IO, metadata)
+| HSS10
+| offtake
+| full
+|
+
+| [[HSS12-01]]HSS12-01
+| Data Services
+| Parallel File System Services
+| Verify uid/gid/project-id soft and hard quotas with enforcement
+| HSS12
+| offtake
+| full
+|
+
+| [[HSS13-01]]HSS13-01
+| Data Services
+| Parallel File System Services
+| Verify root-squash can be enabled and disabled at any time
+| HSS13
+| offtake
+| full
+|
+
+| [[HSS14-01]]HSS14-01
+| Data Services
+| Parallel File System Services
+| Verify the filesystem can be mounted with flock
+| HSS14
+| offtake
+| full
+|
+
+| [[HSS15-01]]HSS15-01
+| Data Services
+| Parallel File System Services
+| Verify changelog/audit data is accessible (tracking by uid/gid, file/dir operations)
+| HSS15
+| offtake
+| full
+|
+
+| [[HSS18-01]]HSS18-01
+| Data Services
+| Parallel File System Services
+| Verify client multipathing to all storage servers
+| HSS18
+| offtake
+| full
+|
+
+| [[DATASVC01-01]]DATASVC01-01
+| Data Services
+| Object Storage Service
+| Verify S3-compatible API access with authenticated endpoints
+| DATASVC01
+| reference
+| full
+|
+
+| [[K8S23-01]]K8S23-01
+| Data Services
+| Block Storage Services
+| Verify dynamic volume provisioning via CSI
+| K8S23
+| offtake
+| full
+|
+
+| [[DATASVC02-01]]DATASVC02-01
+| Data Services
+| Block Storage Services
+| Verify volume snapshots
+| DATASVC02
+| reference
+| full
+|
+
+| [[DATASVC03-01]]DATASVC03-01
+| Data Services
+| Block Storage Services
+| Verify volume resizing
+| DATASVC03
+| reference
+| full
+|
+
+| [[DATASVC04-01]]DATASVC04-01
+| Data Services
+| Block Storage Services
+| Verify persistent block volumes survive instance restarts
+| DATASVC04
+| reference
+| full
+|
+
+| [[DATASVC05-01]]DATASVC05-01
+| Data Services
+| Cache Services
+| Create a managed cache instance, write a key-value pair, read it back, verify data integrity
+| DATASVC05
+| reference
+| full
+|
+
+| [[DATASVC06-01]]DATASVC06-01
+| Data Services
+| Vector Store
+| Create a vector store, insert an embedding, perform similarity search, verify result
+| DATASVC06
+| reference
+| full
+|
+
+| [[DATASVC07-01]]DATASVC07-01
+| Data Services
+| Relational Database
+| Create a managed SQL database, create a table, insert/query data, verify results
+| DATASVC07
+| reference
+| full
+|
+
+| [[DATASVC08-01]]DATASVC08-01
+| Workload Orchestration
+| Backup and Recovery
+| Create a backup of a block volume, delete original, restore from backup, verify data is the same as the original
+| DATASVC08
+| reference
+| full
+|
+
+| [[DATASVC09-01]]DATASVC09-01
+| Workload Orchestration
+| Model Registry
+| Push a model artifact with a version tag, retrieve by version, verify it matches (prefer a smaller reference model)
+| DATASVC09
+| reference
+| full
+|
+
+| [[SLURM01-01]]SLURM01-01
+| Workload Orchestration
+| Slurm Control Plane
+| Create a SLURM instance using the software platform
+| SLURM01
+| reference
+| full
+|
+
+| [[SLURM02-01]]SLURM02-01
+| Workload Orchestration
+| Slurm Control Plane
+| SlurmInfoAvailable
+| SLURM02
+| reference
+| full
+|
+
+| [[SLURM03-01]]SLURM03-01
+| Workload Orchestration
+| Slurm Control Plane
+| SlurmPartition cpu and gpu
+| SLURM03
+| reference
+| full
+|
+
+| [[SLURM04-01]]SLURM04-01
+| Workload Orchestration
+| Slurm Control Plane
+| SlurmJobSubmission
+| SLURM04
+| reference
+| full
+|
+
+| [[SLURM05-01]]SLURM05-01
+| Workload Orchestration
+| Slurm Control Plane
+| SlurmGpuAllocation 1gpu and 2gpu
+| SLURM05
+| reference
+| full
+|
+
+| [[SLURM06-01]]SLURM06-01
+| Workload Orchestration
+| Slurm Control Plane
+| SlurmNodeJobExecution cpu and gpu
+| SLURM06
+| reference
+| full
+|
+
+| [[SLURM07-01]]SLURM07-01
+| Workload Orchestration
+| Slurm Control Plane
+| SlurmGpuStressWorkload
+| SLURM07
+| reference
+| full
+|
+
+| [[SLURM08-01]]SLURM08-01
+| Workload Orchestration
+| Slurm Control Plane
+| SlurmNcclMultiNodeWorkload
+| SLURM08
+| reference
+| full
+|
+
+| [[SLURM09-01]]SLURM09-01
+| Workload Orchestration
+| Slurm Control Plane
+| SlurmSbatchWorkload gpu and cpu
+| SLURM09
+| reference
+| full
+|
+
+| [[SLURM10-01]]SLURM10-01
+| Workload Orchestration
+| Slurm Control Plane
+| SlurmSbatchWorkload-inline
+| SLURM10
+| reference
+| full
+|
+
+| [[K8S05-01]]K8S05-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Create a K8s Instance using the software platform (CLI, Terraform)
+| K8S05
+| offtake
+| full
+|
+
+| [[K8S38-01]]K8S38-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Run through all the steps of the k8s lifecycle management, including user-initated CP update
+| K8S38
+| reference
+| full
+|
+
+| [[K8S41-01]]K8S41-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| The control plane should automatically add more capacity when load increases
+| K8S41
+| reference
+| full
+|
+
+| [[K8S27-01]]K8S27-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Pin Control Plane instances to a specific count to handle a particular load-limit
+| K8S27
+| offtake
+| full
+|
+
+| [[K8S14-01]]K8S14-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| per tenant k8s control plane outside of the tenant cluster/VPC
+| K8S14
+| offtake
+| full
+|
+
+| [[K8S39-01]]K8S39-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Be able to run k8s workloads
+| K8S39
+| reference
+| full
+|
+
+| [[K8S40-01]]K8S40-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| K8s Nim Inference
+| K8S40
+| reference
+| full
+|
+
+| [[K8S32-01]]K8S32-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| K8s Nim Helm
+| K8S32
+| reference
+| full
+|
+
+| [[K8S33-01]]K8S33-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| K8s Nccl
+| K8S33
+| reference
+| full
+|
+
+| [[K8S34-01]]K8S34-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| validate adherence to upstream proxy requirements (service to pod load balancing, acces to internal services)
+| K8S34
+| reference
+| full
+|
+
+| [[K8S24-01]]K8S24-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| verify that the k8s cluster supports the DRA API (resources.k8s.io) to get GPUs on the same nvlink
+| K8S24
+| offtake
+| full
+|
+
+| [[K8S01-01]]K8S01-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| get versions, topology, core APIs by: (a) pass CNCF k8s conformance: https://github.com/cncf/k8s-conformance (b) add AI conformance: [https://github.com/cncf/k8s-ai-conformance](https://github.com/cncf/k8s-ai-conformance)
+| K8S01
+| offtake
+| full
+|
+
+| [[K8S17-01]]K8S17-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| test that the service account can be authorized with OIDC
+| K8S17
+| offtake
+| full
+|
+
+| [[K8S21-01]]K8S21-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| create a CRD, create webhook, and test validation/mutation requirement
+| K8S21
+| offtake
+| full
+|
+
+| [[K8S35-01]]K8S35-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify that pod-to-pod L3 traffic flow logs are available and queryable
+| K8S35
+| reference
+| full
+|
+
+| [[K8S22-01]]K8S22-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Apply a NetworkPolicy; verify pod connectivity is restricted as expected; verify IPv4 and IPv6 addresses are assigned on dual-stack nodes
+| K8S22
+| offtake
+| full
+|
+
+| [[K8S23-02]]K8S23-02
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| TODO: Helm version
+| K8S23
+| offtake
+| full
+|
+
+| [[K8S23-03]]K8S23-03
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| TODO: Kustomize version
+| K8S23
+| offtake
+| full
+|
+
+| [[K8S23-04]]K8S23-04
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify CSI supports block, shared filesystem, and NFS storage
+| K8S23
+| offtake
+| full
+|
+
+| [[K8S23-05]]K8S23-05
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify CSI supports both static and dynamic provisioning via PVs and PVCs
+| K8S23
+| offtake
+| full
+|
+
+| [[K8S23-06]]K8S23-06
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify CSI credentials are tenant cluster scoped (no cross-cluster access)
+| K8S23
+| offtake
+| full
+|
+
+| [[K8S23-07]]K8S23-07
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify APIs to query storage usage against overall cluster quota with per-PVC/Volume breakdown
+| K8S23
+| offtake
+| full
+|
+
+| [[K8S25-01]]K8S25-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| TODO: Compatibility with the mainline NVIDIA GPU Operator
+| K8S25
+| offtake
+| full
+|
+
+| [[K8S25-02]]K8S25-02
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify provider-default accelerator operators and drivers can be replaced or overridden with tenant-required versions
+| K8S25
+| offtake
+| full
+|
+
+| [[K8S02-01]]K8S02-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify support for the three most recent minor releases (N-2)
+| K8S02
+| offtake
+| full
+|
+
+| [[K8S02-02]]K8S02-02
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify automated control plane security patching with no/minimal downtime
+| K8S02
+| offtake
+| full
+|
+
+| [[K8S09-01]]K8S09-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Perform a minor version control plane upgrade and verify zero application downtime
+| K8S09
+| offtake
+| full
+|
+
+| [[K8S10-01]]K8S10-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Perform a rolling node upgrade and verify disruption budgets are respected
+| K8S10
+| offtake
+| full
+|
+
+| [[K8S11-01]]K8S11-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify the control plane recovers from a single-node failure
+| K8S11
+| offtake
+| full
+|
+
+| [[K8S12-01]]K8S12-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify backup and recovery within defined RPO/RTO
+| K8S12
+| offtake
+| full
+|
+
+| [[K8S15-01]]K8S15-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify the K8s API endpoint has network access controls (firewall/private link)
+| K8S15
+| offtake
+| full
+|
+
+| [[K8S19-01]]K8S19-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify at-rest encryption is enabled for etcd
+| K8S19
+| offtake
+| full
+|
+
+| [[SEC09-01]]SEC09-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify certificates are rotated on a 60-day cycle
+| SEC09
+| offtake
+| full
+|
+
+| [[SEC09-02]]SEC09-02
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify support for both provider-managed and customer-managed keys
+| SEC09
+| offtake
+| full
+|
+
+| [[K8S36-01]]K8S36-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify Cluster Autoscaler integration (upstream)
+| K8S36
+| reference
+| full
+|
+
+| [[K8S04-01]]K8S04-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify NCP participates in the Kubernetes Security Response Committee (SRC) process and can patch disclosed vulnerabilities during embargo
+| K8S04
+| offtake
+| full
+|
+
+| [[K8S06-01]]K8S06-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Create a K8s node pool via API/CLI specifying node type (CPU or GPU instance type)
+| K8S06
+| offtake
+| full
+|
+
+| [[K8S06-02]]K8S06-02
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Update a K8s node pool (e.g., scale to a target count)
+| K8S06
+| offtake
+| full
+|
+
+| [[K8S06-03]]K8S06-03
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Delete a K8s node pool
+| K8S06
+| offtake
+| full
+|
+
+| [[K8S06-04]]K8S06-04
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify default node labels and taints can be specified when a node joins the cluster via node pool
+| K8S06
+| offtake
+| full
+|
+
+| [[K8S07-01]]K8S07-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify API Server metrics are available in a Prometheus-scrapable format for SLO measurement
+| K8S07
+| offtake
+| full
+|
+
+| [[K8S17-02]]K8S17-02
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify the cluster exposes a cluster-specific OIDC Issuer endpoint for workload identity federation
+| K8S17
+| offtake
+| full
+|
+
+| [[K8S20-01]]K8S20-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify ability to view or export Kubernetes control plane logs (apiserver, kcm)
+| K8S20
+| offtake
+| full
+|
+
+| [[K8S37-01]]K8S37-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Verify the managed K8s service meets standard Kubernetes performance tests to max cluster size
+| K8S37
+| reference
+| full
+|
+
+| [[K8S26-01]]K8S26-01
+| Workload Orchestration
+| Managed Kubernetes Control Plane
+| Support multiple clusters in the same tenancy and in the same VPC
+| K8S26
+| offtake
+| full
+|
+
+| [[POWER01-01]]POWER01-01
+| Workload Orchestration
+| Power Policy Management
+| TODO
+| POWER01
+| reference
+| full
+|
+
+| [[APIGW01-01]]APIGW01-01
+| AI Platform & User Access
+| Host API Gateway
+| TODO
+| APIGW01
+| reference
+| full
+|
+
+| [[AICP01-01]]AICP01-01
+| AI Platform & User Access
+| Al Platform 1..N Control Planes
+| TODO
+| AICP01
+| reference
+| full
+|
+
+| [[WEBUI01-01]]WEBUI01-01
+| AI Platform & User Access
+| Web Management Dashboard
+| TODO
+| WEBUI01
+| reference
+| full
+|
+
+| [[OBS01-01]]OBS01-01
+| Observability
+| Observability Collectors
+| Validate that an OTel endpoint is provided and some data can be pulled from it
+| OBS01
+| reference
+| full
+|
+
+| [[OBS02-01]]OBS02-01
+| Observability
+| Observability Collectors
+| Logging information about the control plane is available
+| OBS02
+| reference
+| full
+|
+
+| [[OBS03-01]]OBS03-01
+| Observability
+| Observability Collectors
+| Logging information from instances
+| OBS03
+| reference
+| full
+|
+
+| [[OBS04-01]]OBS04-01
+| Observability
+| Observability Collectors
+| Alerts can be issued by the system in case of problems
+| OBS04
+| reference
+| full
+|
+
+| [[OBS05-01]]OBS05-01
+| Observability
+| Observability Collectors
+| Verify telemetry latency is no longer than 120 seconds
+| OBS05
+| reference
+| full
+|
+
+| [[OBS06-01]]OBS06-01
+| Observability
+| Observability Collectors
+| Verify telemetry is available for North-South (front-end) network
+| OBS06
+| reference
+| full
+|
+
+| [[OBS07-01]]OBS07-01
+| Observability
+| Observability Collectors
+| Verify telemetry is available for East-West (back-end / GPU interconnect) network
+| OBS07
+| reference
+| full
+|
+
+| [[OBS08-01]]OBS08-01
+| Observability
+| Observability Collectors
+| Verify telemetry is available for Management network
+| OBS08
+| reference
+| full
+|
+
+| [[OBS09-01]]OBS09-01
+| Observability
+| Observability Collectors
+| Verify telemetry is available for NVSwitch Fabric (GB200+)
+| OBS09
+| reference
+| full
+|
+
+| [[OBS10-01]]OBS10-01
+| Observability
+| Observability Collectors
+| Verify telemetry is available for Host network (NIC-level)
+| OBS10
+| reference
+| full
+|
+
+| [[OBS11-01]]OBS11-01
+| Observability
+| Observability Collectors
+| Verify Fabric Manager logs are available (where applicable)
+| OBS11
+| reference
+| full
+|
+
+| [[OBS12-01]]OBS12-01
+| Observability
+| Observability Collectors
+| Verify Subnet Manager logs are available (where applicable)
+| OBS12
+| reference
+| full
+|
+
+| [[OBS13-01]]OBS13-01
+| Observability
+| Observability Collectors
+| Verify UFM Event logs are available
+| OBS13
+| reference
+| full
+|
+
+| [[OBS14-01]]OBS14-01
+| Observability
+| Observability Collectors
+| Verify general switch logs are available
+| OBS14
+| reference
+| full
+|
+
+| [[OBS15-01]]OBS15-01
+| Observability
+| Observability Collectors
+| Verify switch syslogs are available
+| OBS15
+| reference
+| full
+|
+
+| [[OBS16-01]]OBS16-01
+| Observability
+| Observability Collectors
+| Verify switch kernel logs are available
+| OBS16
+| reference
+| full
+|
+
+| [[OBS17-01]]OBS17-01
+| Observability
+| Observability Collectors
+| Verify BMC SEL logs are available
+| OBS17
+| reference
+| full
+|
+
+| [[OBS18-01]]OBS18-01
+| Observability
+| Observability Collectors
+| Verify host syslogs are available
+| OBS18
+| reference
+| full
+|
+
+| [[OBS19-01]]OBS19-01
+| Observability
+| Observability Collectors
+| Verify VPC Flow logs (all ingress/egress traffic) are available
+| OBS19
+| reference
+| full
+|
+
+| [[TELEM01-01]]TELEM01-01
+| Observability
+| Telemetry / Data Lakes
+| TODO
+| TELEM01
+| reference
+| full
+|
+
+| [[TELEM02-01]]TELEM02-01
+| Observability
+| Telemetry / Data Lakes
+| Read only access to a BMaaS system's serial console
+| TELEM02
+| reference
+| full
+|
+
+| [[TELEM03-01]]TELEM03-01
+| Observability
+| Telemetry / Data Lakes
+| Read only access to a VM serial console
+| TELEM03
+| reference
+| full
+|
+
+| [[TELEM04-01]]TELEM04-01
+| Observability
+| Telemetry / Data Lakes
+| Verify BMC/Redfish telemetry is accessible via API for GPU metrics not available from the host OS
+| TELEM04
+| reference
+| full
+|
+
+| [[TELEM05-01]]TELEM05-01
+| Observability
+| Telemetry / Data Lakes
+| Verify storage resource capacity metrics are available (used/free/total)
+| TELEM05
+| reference
+| full
+|
+
+| [[TELEM06-01]]TELEM06-01
+| Observability
+| Telemetry / Data Lakes
+| Verify storage performance metrics are available (bandwidth, IOPS, latency)
+| TELEM06
+| reference
+| full
+|
+
+| [[TELEM07-01]]TELEM07-01
+| Observability
+| Telemetry / Data Lakes
+| Verify NVLink metrics are available from the GPU perspective (per-link counters, bandwidth utilization)
+| TELEM07
+| reference
+| full
+|
+
+| [[TELEM08-01]]TELEM08-01
+| Observability
+| Telemetry / Data Lakes
+| Verify NVLink metrics are available from the switch perspective (port-level counters, error rates)
+| TELEM08
+| reference
+| full
+|
+
+| [[SEC12-01]]SEC12-01
+| Security & Identity
+| Network Security
+| Verify BMC management is on a dedicated, restricted network (physically separate or VLAN/VRF-isolated)
+| SEC12
+| offtake
+| full
+|
+
+| [[SEC12-02]]SEC12-02
+| Security & Identity
+| Network Security
+| Verify BMC interfaces are not reachable from tenant networks
+| SEC12
+| offtake
+| full
+|
+
+| [[CNP10-01]]CNP10-01
+| Security & Identity
+| Network Security
+| Verify IPMI is disabled; Redfish over TLS is used with AAA
+| CNP10
+| offtake
+| full
+|
+
+| [[SEC12-03]]SEC12-03
+| Security & Identity
+| Network Security
+| Verify BMC is only accessible via a hardened bastion (jumphost) server; direct public/corporate network access is blocked
+| SEC12
+| offtake
+| full
+|
+
+| [[SEC13-01]]SEC13-01
+| Security & Identity
+| Network Security
+| Verify mTLS (or equivalent) for all east-west and north-south traffic
+| SEC13
+| offtake
+| full
+|
+
+| [[SEC14-01]]SEC14-01
+| Security & Identity
+| Network Security
+| Verify no public internet access to API endpoints by default
+| SEC14
+| offtake
+| full
+|
+
+| [[SEC13-02]]SEC13-02
+| Security & Identity
+| Network Security
+| Verify insecure protocols (HTTP, SSLv3, TLSv1) are disabled
+| SEC13
+| offtake
+| full
+|
+
+| [[SDN04-04]]SDN04-04
+| Security & Identity
+| Network Security
+| Verify IB tenant isolation — compute dedicated to NVIDIA is isolated from other customers
+| SDN04
+| offtake
+| full
+|
+
+| [[SDN04-05]]SDN04-05
+| Security & Identity
+| Network Security
+| Verify IB keys are configured: P_Key, Management Key, Aggregation Management Key, VendorSpecific Key, CongestionControl Key, Node2Node Key, Manager2Node Key
+| SDN04
+| offtake
+| full
+|
+
+| [[SEC11-01]]SEC11-01
+| Security & Identity
+| Network Security
+| Verify hard physical or logical isolation between tenants for network, data, compute, and storage resources
+| SEC11
+| offtake
+| full
+|
+
+| [[SEC01-01]]SEC01-01
+| Security & Identity
+| Authentication
+| Verify user authentication via OIDC for platform services
+| SEC01
+| offtake
+| full
+|
+
+| [[SEC06-01]]SEC06-01
+| Security & Identity
+| Authentication
+| Verify workloads and nodes receive short-lived credentials/tokens
+| SEC06
+| offtake
+| full
+|
+
+| [[SEC03-01]]SEC03-01
+| Security & Identity
+| Authentication
+| Verify out-of-cluster service accounts can authenticate with long-lived credentials
+| SEC03
+| offtake
+| full
+|
+
+| [[SEC07-01]]SEC07-01
+| Security & Identity
+| Authentication
+| Verify all administrative interfaces (UI, CLI, API) are protected by Multi-Factor Authentication
+| SEC07
+| offtake
+| full
+|
+
+| [[SEC04-02]]SEC04-02
+| Security & Identity
+| Authorization
+| Assign a minimal role to a user; verify they cannot perform actions outside that role on Compute, Storage, and Network APIs
+| SEC04
+| offtake
+| full
+|
+
+| [[SEC08-01]]SEC08-01
+| Security & Identity
+| Audit & Logging
+| Perform a management API call; verify an audit log entry is generated with correct metadata
+| SEC08
+| offtake
+| full
+|
+
+| [[SEC08-02]]SEC08-02
+| Security & Identity
+| Audit & Logging
+| Verify audit logs are retained for at least 30 days
+| SEC08
+| offtake
+| full
+|
+
+| [[SEC21-04]]SEC21-04
+| Security & Identity
+| Hardware Security & Compliance
+| Verify memory sanitization between tenants
+| SEC21
+| offtake
+| full
+|
+
+| [[SEC21-05]]SEC21-05
+| Security & Identity
+| Hardware Security & Compliance
+| Verify SRAM/GPU memory is sanitized between tenants
+| SEC21
+| offtake
+| full
+|
+
+| [[SEC21-06]]SEC21-06
+| Security & Identity
+| Hardware Security & Compliance
+| Verify TPM and BIOS are reset during tenant transitions or hardware replacement
+| SEC21
+| offtake
+| full
+|
+
+| SEC21-06
+| Security & Identity
+| Hardware Security & Compliance
+| Verify TPM and BIOS are reset during tenant transitions or hardware replacement
+| SEC22
+| offtake
+| full
+|
+
+| [[SEC20-01]]SEC20-01
+| Security & Identity
+| Hardware Security & Compliance
+| Verify all data at rest is encrypted via SED on local NVMe/SSD and network-attached storage
+| SEC20
+| offtake
+| full
+|
+
+| [[SEC09-03]]SEC09-03
+| Security & Identity
+| Hardware Security & Compliance
+| Verify a centralized KMS is used for all encryption keys and secrets
+| SEC09
+| offtake
+| full
+|
+
+| SEC09-03
+| Security & Identity
+| Hardware Security & Compliance
+| Verify a centralized KMS is used for all encryption keys and secrets
+| SEC10
+| offtake
+| full
+|
+
+| [[SEC09-04]]SEC09-04
+| Security & Identity
+| Hardware Security & Compliance
+| Verify support for Customer Managed Keys (BYOK)
+| SEC09
+| offtake
+| full
+|
+
+| [[NET01-01]]NET01-01
+| Network Transport
+| Backend Switch Fabric API
+| Query the API for a compute node and verify it returns backend switch IDs (leaf, spine, core)
+| NET01
+| offtake
+| full
+|
+
+| [[NET02-02]]NET02-02
+| Network Transport
+| NVLink Domain API
+| Query the NVLink domain ID for a compute node supporting NVLink
+| NET02
+| offtake
+| full
+|
+
+| [[NET04-01]]NET04-01
+| Network Transport
+| Transport Connectivity
+| Verify Private Cloud Interconnect to NVIDIA CorpIT is operational
+| NET04
+| offtake
+| full
+|
+
+| [[NET05-01]]NET05-01
+| Network Transport
+| Transport Connectivity
+| Verify high-bandwidth Private Cloud Interconnect to DGXC on-prem object storage
+| NET05
+| offtake
+| full
+|
+
+| [[NET05-02]]NET05-02
+| Network Transport
+| Transport Connectivity
+| Verify end-to-end MACsec encryption (fail-closed)
+| NET05
+| offtake
+| full
+|
+
+| [[NET06-01]]NET06-01
+| Network Transport
+| Transport Connectivity
+| Verify egress NAT IPs are a static pool dedicated to NVIDIA
+| NET06
+| offtake
+| full
+|
+
+| [[NET06-02]]NET06-02
+| Network Transport
+| Transport Connectivity
+| Verify redundant upstream paths for internet connectivity
+| NET06
+| offtake
+| full
+|
+
+| [[CAP01-01]]CAP01-01
+| Capacity & Fleet Management
+| Governance Metrics
+| Query and verify governance API returns Delivered, Healthy, Reserved, and Active metrics for nodes/GPUs
+| CAP01
+| offtake
+| full
+|
+
+| [[CAP04-01]]CAP04-01
+| Capacity & Fleet Management
+| Capacity Reservations
+| Verify a set of resources can be logically grouped and pinned to an account
+| CAP04
+| offtake
+| full
+|
+
+| [[CAP04-02]]CAP04-02
+| Capacity & Fleet Management
+| Capacity Reservations
+| Verify atomic allocation of a topology block as a single unit
+| CAP04
+| offtake
+| full
+|
+
+| [[CAP05-01]]CAP05-01
+| Capacity & Fleet Management
+| Unified Health APIs
+| Verify per-host health API returns real-time GPU state, thermal status, memory health
+| CAP05
+| offtake
+| full
+|
+
+| [[CAP05-02]]CAP05-02
+| Capacity & Fleet Management
+| Unified Health APIs
+| Verify primitive-level health aggregation (cluster, nodegroup, or reservation level)
+| CAP05
+| offtake
+| full
+|
+
+| [[BM01-01]]BM01-01
+| Benchmarking
+| Exemplar
+| Simulate Exemplar across 512 GPU cluster using latest dgxc-benchmarking release
+| BM01
+| offtake
+| full
+|
+
+| [[BENCH01-01]]BENCH01-01
+| Benchmarking
+| Exemplar
+| NVMesh checks?
+| BENCH01
+| reference
+| full
+|
+
+| [[BENCH02-01]]BENCH02-01
+| Benchmarking
+| Exemplar
+| IPv4 and IPv6 checks?
+| BENCH02
+| reference
+| full
+|
+
+| [[BM01-02]]BM01-02
+| Benchmarking
+| Exemplar
+| Verify performance is within 5% of NVIDIA Reference
+| BM01
+| offtake
+| full
+|
+
+|===

--- a/docs/requirements/test-requirements-matrix.yaml
+++ b/docs/requirements/test-requirements-matrix.yaml
@@ -1,0 +1,2316 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Test <-> Requirement junction (reconciliation layer).
+#
+# Source of truth for which requirement(s) each test exercises, across
+# multiple requirement documents (`source`).
+#
+# Per mapping:
+#   test_id       - matches docs/test-plan.yaml
+#   requirements  - list of { req_id, source: offtake|reference, coverage: full|partial }
+#   annotations   - free-form (e.g. how this relationship was decided)
+#   notes         - free-form scratch
+#
+# Render to AsciiDoc with: make plan (scripts/requirements_matrix_to_adoc.py)
+
+version: 0.1.0
+mappings:
+  - test_id: BOOT01-01
+    requirements:
+      - req_id: BOOT01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BOOT01-02
+    requirements:
+      - req_id: BOOT01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BOOT03-01
+    requirements:
+      - req_id: BOOT03
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BOOT03-02
+    requirements:
+      - req_id: BOOT03
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BOOT01-03
+    requirements:
+      - req_id: BOOT01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BOOT01-04
+    requirements:
+      - req_id: BOOT01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BOOT01-05
+    requirements:
+      - req_id: BOOT01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: IMG01-01
+    requirements:
+      - req_id: IMG01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: IMG02-01
+    requirements:
+      - req_id: IMG02
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: IMG03-01
+    requirements:
+      - req_id: IMG03
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: AUTH01-01
+    requirements:
+      - req_id: AUTH01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: AUTH02-01
+    requirements:
+      - req_id: AUTH02
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: AUTH03-01
+    requirements:
+      - req_id: AUTH03
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: IAM01-01
+    requirements:
+      - req_id: IAM01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: IAM02-01
+    requirements:
+      - req_id: IAM02
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: IAM03-01
+    requirements:
+      - req_id: IAM03
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: IPAM01-01
+    requirements:
+      - req_id: IPAM01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: IPAM02-01
+    requirements:
+      - req_id: IPAM02
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: NETMGMT01-01
+    requirements:
+      - req_id: NETMGMT01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: RESDB01-01
+    requirements:
+      - req_id: RESDB01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CP03-01
+    requirements:
+      - req_id: CP03
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CP04-01
+    requirements:
+      - req_id: CP04
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CP05-01
+    requirements:
+      - req_id: CP05
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CP06-01
+    requirements:
+      - req_id: CP06
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CP07-01
+    requirements:
+      - req_id: CP07
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CP08-01
+    requirements:
+      - req_id: CP08
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CP09-01
+    requirements:
+      - req_id: CP09
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CP10-01
+    requirements:
+      - req_id: CP10
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CP11-01
+    requirements:
+      - req_id: CP11
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: HWING01-01
+    requirements:
+      - req_id: HWING01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: HWING02-01
+    requirements:
+      - req_id: HWING02
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC22-01
+    requirements:
+      - req_id: SEC22
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: ATTEST01-01
+    requirements:
+      - req_id: ATTEST01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC22-02
+    requirements:
+      - req_id: SEC22
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: ATTEST02-01
+    requirements:
+      - req_id: ATTEST02
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP09-01
+    requirements:
+      - req_id: CNP09
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP09-02
+    requirements:
+      - req_id: CNP09
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC22-03
+    requirements:
+      - req_id: SEC22
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP01-01
+    requirements:
+      - req_id: CNP01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP01-02
+    requirements:
+      - req_id: CNP01
+        source: offtake
+        coverage: full
+      - req_id: CNP04
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP01-03
+    requirements:
+      - req_id: CNP01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC21-01
+    requirements:
+      - req_id: SEC21
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC21-02
+    requirements:
+      - req_id: SEC21
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP01-04
+    requirements:
+      - req_id: CNP01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BMAAS01-01
+    requirements:
+      - req_id: BMAAS01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BMAAS02-01
+    requirements:
+      - req_id: BMAAS02
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BMAAS03-01
+    requirements:
+      - req_id: BMAAS03
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP01-05
+    requirements:
+      - req_id: CNP01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP01-06
+    requirements:
+      - req_id: CNP01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BMAAS04-01
+    requirements:
+      - req_id: BMAAS04
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP01-07
+    requirements:
+      - req_id: CNP01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BOOT02-01
+    requirements:
+      - req_id: BOOT02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP01-08
+    requirements:
+      - req_id: CNP01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP05-01
+    requirements:
+      - req_id: CNP05
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BMAAS05-01
+    requirements:
+      - req_id: BMAAS05
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BMAAS06-01
+    requirements:
+      - req_id: BMAAS06
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BMAAS07-01
+    requirements:
+      - req_id: BMAAS07
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP06-01
+    requirements:
+      - req_id: CNP06
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BMAAS08-01
+    requirements:
+      - req_id: BMAAS08
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BMAAS09-01
+    requirements:
+      - req_id: BMAAS09
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BMAAS10-01
+    requirements:
+      - req_id: BMAAS10
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BMAAS11-01
+    requirements:
+      - req_id: BMAAS11
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BMAAS12-01
+    requirements:
+      - req_id: BMAAS12
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP06-02
+    requirements:
+      - req_id: CNP06
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP08-01
+    requirements:
+      - req_id: CNP08
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP08-02
+    requirements:
+      - req_id: CNP08
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP01-09
+    requirements:
+      - req_id: CNP01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP01-10
+    requirements:
+      - req_id: CNP01
+        source: offtake
+        coverage: full
+      - req_id: CNP04
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP01-11
+    requirements:
+      - req_id: CNP01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP01-12
+    requirements:
+      - req_id: CNP01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC21-03
+    requirements:
+      - req_id: SEC21
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: VMAAS01-01
+    requirements:
+      - req_id: VMAAS01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP01-13
+    requirements:
+      - req_id: CNP01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: VMAAS02-01
+    requirements:
+      - req_id: VMAAS02
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP01-14
+    requirements:
+      - req_id: CNP01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP01-15
+    requirements:
+      - req_id: CNP01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP05-02
+    requirements:
+      - req_id: CNP05
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BOOT02-02
+    requirements:
+      - req_id: BOOT02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: VMAAS03-01
+    requirements:
+      - req_id: VMAAS03
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: VMAAS04-01
+    requirements:
+      - req_id: VMAAS04
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: VMAAS05-01
+    requirements:
+      - req_id: VMAAS05
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: VMAAS06-01
+    requirements:
+      - req_id: VMAAS06
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: VMAAS07-01
+    requirements:
+      - req_id: VMAAS07
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: VMAAS08-01
+    requirements:
+      - req_id: VMAAS08
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: VMAAS09-01
+    requirements:
+      - req_id: VMAAS09
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: VMAAS10-01
+    requirements:
+      - req_id: VMAAS10
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: VMAAS11-01
+    requirements:
+      - req_id: VMAAS11
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: VMAAS12-01
+    requirements:
+      - req_id: VMAAS12
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: VMAAS13-01
+    requirements:
+      - req_id: VMAAS13
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: VMAAS14-01
+    requirements:
+      - req_id: VMAAS14
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP06-03
+    requirements:
+      - req_id: CNP06
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP08-03
+    requirements:
+      - req_id: CNP08
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP08-04
+    requirements:
+      - req_id: CNP08
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP01-16
+    requirements:
+      - req_id: CNP01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP01-17
+    requirements:
+      - req_id: CNP01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN01-01
+    requirements:
+      - req_id: SDN01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN01-02
+    requirements:
+      - req_id: SDN01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN01-03
+    requirements:
+      - req_id: SDN01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN01-04
+    requirements:
+      - req_id: SDN01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN04-01
+    requirements:
+      - req_id: SDN04
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN04-02
+    requirements:
+      - req_id: SDN04
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN04-03
+    requirements:
+      - req_id: SDN04
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: NET03-01
+    requirements:
+      - req_id: NET03
+        source: offtake
+        coverage: full
+      - req_id: SDN01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN11-01
+    requirements:
+      - req_id: SDN11
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN05-01
+    requirements:
+      - req_id: SDN05
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN06-01
+    requirements:
+      - req_id: SDN06
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN07-01
+    requirements:
+      - req_id: SDN07
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN02-01
+    requirements:
+      - req_id: SDN02
+        source: offtake
+        coverage: full
+      - req_id: SDN03
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN02-02
+    requirements:
+      - req_id: SDN02
+        source: offtake
+        coverage: full
+      - req_id: SDN03
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN02-03
+    requirements:
+      - req_id: SDN02
+        source: offtake
+        coverage: full
+      - req_id: SDN03
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN02-04
+    requirements:
+      - req_id: SDN02
+        source: offtake
+        coverage: full
+      - req_id: SDN03
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP03-01
+    requirements:
+      - req_id: CNP03
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN12-01
+    requirements:
+      - req_id: SDN12
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN13-01
+    requirements:
+      - req_id: SDN13
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN14-01
+    requirements:
+      - req_id: SDN14
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN15-01
+    requirements:
+      - req_id: SDN15
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN16-01
+    requirements:
+      - req_id: SDN16
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN17-01
+    requirements:
+      - req_id: SDN17
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN18-01
+    requirements:
+      - req_id: SDN18
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN19-01
+    requirements:
+      - req_id: SDN19
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN20-01
+    requirements:
+      - req_id: SDN20
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN21-01
+    requirements:
+      - req_id: SDN21
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN22-01
+    requirements:
+      - req_id: SDN22
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN23-01
+    requirements:
+      - req_id: SDN23
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN24-01
+    requirements:
+      - req_id: SDN24
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN25-01
+    requirements:
+      - req_id: SDN25
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN26-01
+    requirements:
+      - req_id: SDN26
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN27-01
+    requirements:
+      - req_id: SDN27
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN28-01
+    requirements:
+      - req_id: SDN28
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN02-05
+    requirements:
+      - req_id: SDN02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN02-06
+    requirements:
+      - req_id: SDN02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN02-07
+    requirements:
+      - req_id: SDN02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN02-08
+    requirements:
+      - req_id: SDN02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN02-09
+    requirements:
+      - req_id: SDN02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN08-01
+    requirements:
+      - req_id: SDN08
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN02-10
+    requirements:
+      - req_id: SDN02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN09-01
+    requirements:
+      - req_id: SDN09
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN09-02
+    requirements:
+      - req_id: SDN09
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN09-03
+    requirements:
+      - req_id: SDN09
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: META01-01
+    requirements:
+      - req_id: META01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CTRL01-01
+    requirements:
+      - req_id: CTRL01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CAP02-01
+    requirements:
+      - req_id: CAP02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CAP03-01
+    requirements:
+      - req_id: CAP03
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP08-05
+    requirements:
+      - req_id: CNP08
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: LB01-01
+    requirements:
+      - req_id: LB01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: LB02-01
+    requirements:
+      - req_id: LB02
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: LB03-01
+    requirements:
+      - req_id: LB03
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: LB04-01
+    requirements:
+      - req_id: LB04
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BFX04-01
+    requirements:
+      - req_id: BFX04
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BFX05-01
+    requirements:
+      - req_id: BFX05
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BFX06-01
+    requirements:
+      - req_id: BFX06
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BFX01-01
+    requirements:
+      - req_id: BFX01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BFX01-02
+    requirements:
+      - req_id: BFX01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BFX01-03
+    requirements:
+      - req_id: BFX01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BFX01-04
+    requirements:
+      - req_id: BFX01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BFX01-05
+    requirements:
+      - req_id: BFX01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BFX02-01
+    requirements:
+      - req_id: BFX02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BFX02-02
+    requirements:
+      - req_id: BFX02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BFX02-03
+    requirements:
+      - req_id: BFX02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BFX03-01
+    requirements:
+      - req_id: BFX03
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BFX03-02
+    requirements:
+      - req_id: BFX03
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BFX03-03
+    requirements:
+      - req_id: BFX03
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: HSS01-01
+    requirements:
+      - req_id: HSS01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: HSS02-01
+    requirements:
+      - req_id: HSS02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: HSS03-01
+    requirements:
+      - req_id: HSS03
+        source: offtake
+        coverage: full
+      - req_id: K8S23
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: HSS04-01
+    requirements:
+      - req_id: HSS04
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: HSS05-01
+    requirements:
+      - req_id: HSS05
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: STOR01-01
+    requirements:
+      - req_id: STOR01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: DIR02-01
+    requirements:
+      - req_id: DIR02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: DIR01-01
+    requirements:
+      - req_id: DIR01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: DIR01-02
+    requirements:
+      - req_id: DIR01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: DMS01-01
+    requirements:
+      - req_id: DMS01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: DMS02-01
+    requirements:
+      - req_id: DMS02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: DMS03-01
+    requirements:
+      - req_id: DMS03
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: DMS05-01
+    requirements:
+      - req_id: DMS05
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: STG02-01
+    requirements:
+      - req_id: STG02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: STG03-01
+    requirements:
+      - req_id: STG03
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: STG04-01
+    requirements:
+      - req_id: STG04
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: STG05-01
+    requirements:
+      - req_id: STG05
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC04-01
+    requirements:
+      - req_id: SEC04
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: HSS06-01
+    requirements:
+      - req_id: HSS06
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: HSS07-01
+    requirements:
+      - req_id: HSS07
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: HSS09-01
+    requirements:
+      - req_id: HSS09
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: HSS10-01
+    requirements:
+      - req_id: HSS10
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: HSS12-01
+    requirements:
+      - req_id: HSS12
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: HSS13-01
+    requirements:
+      - req_id: HSS13
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: HSS14-01
+    requirements:
+      - req_id: HSS14
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: HSS15-01
+    requirements:
+      - req_id: HSS15
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: HSS18-01
+    requirements:
+      - req_id: HSS18
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: DATASVC01-01
+    requirements:
+      - req_id: DATASVC01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S23-01
+    requirements:
+      - req_id: K8S23
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: DATASVC02-01
+    requirements:
+      - req_id: DATASVC02
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: DATASVC03-01
+    requirements:
+      - req_id: DATASVC03
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: DATASVC04-01
+    requirements:
+      - req_id: DATASVC04
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: DATASVC05-01
+    requirements:
+      - req_id: DATASVC05
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: DATASVC06-01
+    requirements:
+      - req_id: DATASVC06
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: DATASVC07-01
+    requirements:
+      - req_id: DATASVC07
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: DATASVC08-01
+    requirements:
+      - req_id: DATASVC08
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: DATASVC09-01
+    requirements:
+      - req_id: DATASVC09
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SLURM01-01
+    requirements:
+      - req_id: SLURM01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SLURM02-01
+    requirements:
+      - req_id: SLURM02
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SLURM03-01
+    requirements:
+      - req_id: SLURM03
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SLURM04-01
+    requirements:
+      - req_id: SLURM04
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SLURM05-01
+    requirements:
+      - req_id: SLURM05
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SLURM06-01
+    requirements:
+      - req_id: SLURM06
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SLURM07-01
+    requirements:
+      - req_id: SLURM07
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SLURM08-01
+    requirements:
+      - req_id: SLURM08
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SLURM09-01
+    requirements:
+      - req_id: SLURM09
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SLURM10-01
+    requirements:
+      - req_id: SLURM10
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S05-01
+    requirements:
+      - req_id: K8S05
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S38-01
+    requirements:
+      - req_id: K8S38
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S41-01
+    requirements:
+      - req_id: K8S41
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S27-01
+    requirements:
+      - req_id: K8S27
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S14-01
+    requirements:
+      - req_id: K8S14
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S39-01
+    requirements:
+      - req_id: K8S39
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S40-01
+    requirements:
+      - req_id: K8S40
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S32-01
+    requirements:
+      - req_id: K8S32
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S33-01
+    requirements:
+      - req_id: K8S33
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S34-01
+    requirements:
+      - req_id: K8S34
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S24-01
+    requirements:
+      - req_id: K8S24
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S01-01
+    requirements:
+      - req_id: K8S01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S17-01
+    requirements:
+      - req_id: K8S17
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S21-01
+    requirements:
+      - req_id: K8S21
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S35-01
+    requirements:
+      - req_id: K8S35
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S22-01
+    requirements:
+      - req_id: K8S22
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S23-02
+    requirements:
+      - req_id: K8S23
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S23-03
+    requirements:
+      - req_id: K8S23
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S23-04
+    requirements:
+      - req_id: K8S23
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S23-05
+    requirements:
+      - req_id: K8S23
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S23-06
+    requirements:
+      - req_id: K8S23
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S23-07
+    requirements:
+      - req_id: K8S23
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S25-01
+    requirements:
+      - req_id: K8S25
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S25-02
+    requirements:
+      - req_id: K8S25
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S02-01
+    requirements:
+      - req_id: K8S02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S02-02
+    requirements:
+      - req_id: K8S02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S09-01
+    requirements:
+      - req_id: K8S09
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S10-01
+    requirements:
+      - req_id: K8S10
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S11-01
+    requirements:
+      - req_id: K8S11
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S12-01
+    requirements:
+      - req_id: K8S12
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S15-01
+    requirements:
+      - req_id: K8S15
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S19-01
+    requirements:
+      - req_id: K8S19
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC09-01
+    requirements:
+      - req_id: SEC09
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC09-02
+    requirements:
+      - req_id: SEC09
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S36-01
+    requirements:
+      - req_id: K8S36
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S04-01
+    requirements:
+      - req_id: K8S04
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S06-01
+    requirements:
+      - req_id: K8S06
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S06-02
+    requirements:
+      - req_id: K8S06
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S06-03
+    requirements:
+      - req_id: K8S06
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S06-04
+    requirements:
+      - req_id: K8S06
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S07-01
+    requirements:
+      - req_id: K8S07
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S17-02
+    requirements:
+      - req_id: K8S17
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S20-01
+    requirements:
+      - req_id: K8S20
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S37-01
+    requirements:
+      - req_id: K8S37
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: K8S26-01
+    requirements:
+      - req_id: K8S26
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: POWER01-01
+    requirements:
+      - req_id: POWER01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: APIGW01-01
+    requirements:
+      - req_id: APIGW01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: AICP01-01
+    requirements:
+      - req_id: AICP01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: WEBUI01-01
+    requirements:
+      - req_id: WEBUI01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS01-01
+    requirements:
+      - req_id: OBS01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS02-01
+    requirements:
+      - req_id: OBS02
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS03-01
+    requirements:
+      - req_id: OBS03
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS04-01
+    requirements:
+      - req_id: OBS04
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS05-01
+    requirements:
+      - req_id: OBS05
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS06-01
+    requirements:
+      - req_id: OBS06
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS07-01
+    requirements:
+      - req_id: OBS07
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS08-01
+    requirements:
+      - req_id: OBS08
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS09-01
+    requirements:
+      - req_id: OBS09
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS10-01
+    requirements:
+      - req_id: OBS10
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS11-01
+    requirements:
+      - req_id: OBS11
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS12-01
+    requirements:
+      - req_id: OBS12
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS13-01
+    requirements:
+      - req_id: OBS13
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS14-01
+    requirements:
+      - req_id: OBS14
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS15-01
+    requirements:
+      - req_id: OBS15
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS16-01
+    requirements:
+      - req_id: OBS16
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS17-01
+    requirements:
+      - req_id: OBS17
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS18-01
+    requirements:
+      - req_id: OBS18
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: OBS19-01
+    requirements:
+      - req_id: OBS19
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: TELEM01-01
+    requirements:
+      - req_id: TELEM01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: TELEM02-01
+    requirements:
+      - req_id: TELEM02
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: TELEM03-01
+    requirements:
+      - req_id: TELEM03
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: TELEM04-01
+    requirements:
+      - req_id: TELEM04
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: TELEM05-01
+    requirements:
+      - req_id: TELEM05
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: TELEM06-01
+    requirements:
+      - req_id: TELEM06
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: TELEM07-01
+    requirements:
+      - req_id: TELEM07
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: TELEM08-01
+    requirements:
+      - req_id: TELEM08
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC12-01
+    requirements:
+      - req_id: SEC12
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC12-02
+    requirements:
+      - req_id: SEC12
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CNP10-01
+    requirements:
+      - req_id: CNP10
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC12-03
+    requirements:
+      - req_id: SEC12
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC13-01
+    requirements:
+      - req_id: SEC13
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC14-01
+    requirements:
+      - req_id: SEC14
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC13-02
+    requirements:
+      - req_id: SEC13
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN04-04
+    requirements:
+      - req_id: SDN04
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SDN04-05
+    requirements:
+      - req_id: SDN04
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC11-01
+    requirements:
+      - req_id: SEC11
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC01-01
+    requirements:
+      - req_id: SEC01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC06-01
+    requirements:
+      - req_id: SEC06
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC03-01
+    requirements:
+      - req_id: SEC03
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC07-01
+    requirements:
+      - req_id: SEC07
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC04-02
+    requirements:
+      - req_id: SEC04
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC08-01
+    requirements:
+      - req_id: SEC08
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC08-02
+    requirements:
+      - req_id: SEC08
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC21-04
+    requirements:
+      - req_id: SEC21
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC21-05
+    requirements:
+      - req_id: SEC21
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC21-06
+    requirements:
+      - req_id: SEC21
+        source: offtake
+        coverage: full
+      - req_id: SEC22
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC20-01
+    requirements:
+      - req_id: SEC20
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC09-03
+    requirements:
+      - req_id: SEC09
+        source: offtake
+        coverage: full
+      - req_id: SEC10
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: SEC09-04
+    requirements:
+      - req_id: SEC09
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: NET01-01
+    requirements:
+      - req_id: NET01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: NET02-02
+    requirements:
+      - req_id: NET02
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: NET04-01
+    requirements:
+      - req_id: NET04
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: NET05-01
+    requirements:
+      - req_id: NET05
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: NET05-02
+    requirements:
+      - req_id: NET05
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: NET06-01
+    requirements:
+      - req_id: NET06
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: NET06-02
+    requirements:
+      - req_id: NET06
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CAP01-01
+    requirements:
+      - req_id: CAP01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CAP04-01
+    requirements:
+      - req_id: CAP04
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CAP04-02
+    requirements:
+      - req_id: CAP04
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CAP05-01
+    requirements:
+      - req_id: CAP05
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: CAP05-02
+    requirements:
+      - req_id: CAP05
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BM01-01
+    requirements:
+      - req_id: BM01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BENCH01-01
+    requirements:
+      - req_id: BENCH01
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BENCH02-01
+    requirements:
+      - req_id: BENCH02
+        source: reference
+        coverage: full
+    annotations: ''
+    notes: ''
+  - test_id: BM01-02
+    requirements:
+      - req_id: BM01
+        source: offtake
+        coverage: full
+    annotations: ''
+    notes: ''

--- a/scripts/reqtrace.py
+++ b/scripts/reqtrace.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integrity checks for the requirements reconciliation layer.
+
+Resolves the test <-> requirement graph against its sources of truth:
+
+* ``docs/test-plan.yaml`` - the canonical test catalog (test side)
+* ``docs/requirements/*-requirements.yaml`` - one structured listing per source
+  (offtake, reference, and any future team docs), auto-discovered
+* ``docs/requirements/test-requirements-matrix.yaml`` - the index joining them
+
+``validate`` checks that **both** endpoints of every mapping edge resolve: each
+``test_id`` exists in the test plan, and each ``req_id`` exists in the source
+listing it claims (``source``). It fails (non-zero) on dangling edges, unknown
+sources, duplicate/colliding ids, or an id used as both a test and a requirement.
+
+``coverage`` reports, per source, the requirements that no test maps to (gaps).
+
+Usage:
+    python3 scripts/reqtrace.py validate
+    python3 scripts/reqtrace.py coverage
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEST_PLAN = REPO_ROOT / "docs" / "test-plan.yaml"
+REQ_DIR = REPO_ROOT / "docs" / "requirements"
+MATRIX_DOC = REQ_DIR / "test-requirements-matrix.yaml"
+
+
+def _load(path: Path) -> Any:
+    """Parse a YAML file."""
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def load_plan_test_ids(path: Path) -> set[str]:
+    """Return the set of all ``test_id``s declared in the test plan."""
+    data = _load(path)
+    ids: set[str] = set()
+    for domain in data.get("domains", []):
+        for comp in domain.get("components", []):
+            for cap in comp.get("capabilities", []):
+                for test in cap.get("tests", []):
+                    tid = test.get("test_id")
+                    if tid:
+                        ids.add(tid)
+    return ids
+
+
+def discover_source_files() -> list[tuple[str, Path]]:
+    """Return ``(source_name, path)`` for every requirement listing, dups included.
+
+    A source listing is any ``*.yaml`` in the requirements dir with top-level
+    ``source`` and ``requirements`` keys (this excludes the mapping index).
+    New team docs are picked up automatically. Unlike :func:`discover_sources`,
+    this keeps every file so callers can detect source-name collisions.
+    """
+    out: list[tuple[str, Path]] = []
+    for p in sorted(REQ_DIR.glob("*.yaml")):
+        if p.name == MATRIX_DOC.name:
+            continue
+        data = _load(p)
+        if isinstance(data, dict) and "source" in data and "requirements" in data:
+            out.append((str(data["source"]), p))
+    return out
+
+
+def discover_sources() -> dict[str, Path]:
+    """Map each requirement source name to its YAML listing.
+
+    Convenience view over :func:`discover_source_files`. If two files declare
+    the same name the last one wins here, so callers that care about integrity
+    should also run :func:`duplicate_source_name_errors`.
+    """
+    return dict(discover_source_files())
+
+
+def duplicate_source_name_errors(source_files: list[tuple[str, Path]]) -> list[str]:
+    """Return an error per ``source`` name claimed by more than one listing.
+
+    The ``source`` name is the primary key for its requirement listing; two
+    files sharing one would silently shadow each other in
+    :func:`discover_sources` (dict overwrite), dropping a whole listing with no
+    signal. Fail loudly instead.
+    """
+    files_by_name: dict[str, list[str]] = {}
+    for name, path in source_files:
+        files_by_name.setdefault(name, []).append(path.name)
+    return [
+        f"source name {name!r} declared by multiple files: {', '.join(sorted(files))}"
+        for name, files in sorted(files_by_name.items())
+        if len(files) > 1
+    ]
+
+
+def source_req_ids(path: Path) -> tuple[list[str], list[str]]:
+    """Return ``(req_ids, duplicates)`` from a source listing YAML."""
+    seen: list[str] = []
+    dupes: list[str] = []
+    for r in _load(path).get("requirements", []):
+        rid = r.get("req_id")
+        if not rid:
+            continue
+        (dupes if rid in seen else seen).append(rid)
+    return seen, dupes
+
+
+def _mapping_edges(mapping: dict[str, Any]):
+    """Yield ``(test_id, req_id, source)`` for every edge in the index."""
+    for m in mapping.get("mappings", []):
+        tid = m.get("test_id", "")
+        for req in m.get("requirements") or []:
+            yield tid, req.get("req_id", ""), req.get("source", "")
+
+
+def validate() -> int:
+    """Resolve both endpoints of every mapping edge; return an exit code."""
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    plan_ids = load_plan_test_ids(TEST_PLAN)
+    source_files = discover_source_files()
+    if not source_files:
+        errors.append("no source requirement listings found in docs/requirements/")
+    errors.extend(duplicate_source_name_errors(source_files))
+    sources = dict(source_files)
+
+    # Per-source req ids, with within-source dup + cross-source ownership checks.
+    source_sets: dict[str, set[str]] = {}
+    owner: dict[str, str] = {}
+    for sname, path in sources.items():
+        ids, dupes = source_req_ids(path)
+        source_sets[sname] = set(ids)
+        for rid in dupes:
+            errors.append(f"{sname}: duplicate req_id {rid!r}")
+        for rid in set(ids):
+            if rid in owner:
+                errors.append(f"req_id {rid!r} defined in both {owner[rid]!r} and {sname!r} listings")
+            else:
+                owner[rid] = sname
+
+    all_req_ids = set(owner)
+    for x in sorted(all_req_ids & plan_ids):
+        errors.append(f"id {x!r} is used as both a test_id and a req_id (must be globally unique)")
+
+    mapping = _load(MATRIX_DOC)
+    mapped_test_ids: set[str] = set()
+    mapped_reqs: set[str] = set()
+    for m in mapping.get("mappings", []):
+        tid = m.get("test_id", "")
+        if not tid:
+            errors.append("mapping: entry with empty test_id")
+            continue
+        if tid in mapped_test_ids:
+            errors.append(f"mapping: duplicate test_id {tid!r}")
+        mapped_test_ids.add(tid)
+        if tid not in plan_ids:
+            errors.append(f"mapping: test_id {tid!r} not in test-plan.yaml")
+
+    for tid, rid, src in _mapping_edges(mapping):
+        if not rid:
+            continue
+        mapped_reqs.add(rid)
+        if src not in source_sets:
+            errors.append(f"mapping: test {tid!r} cites unknown source {src!r} for req {rid!r}")
+        elif rid not in source_sets[src]:
+            errors.append(f"mapping: req_id {rid!r} (test {tid!r}) not found in {src!r} listing")
+
+    for tid in sorted(plan_ids - mapped_test_ids):
+        warnings.append(f"test {tid!r} has no mapping entry")
+
+    if warnings:
+        print(f"{len(warnings)} warning(s):")
+        for w in warnings:
+            print(f"  - {w}")
+    if errors:
+        print(f"\nvalidate FAILED with {len(errors)} error(s):")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+
+    counts = ", ".join(f"{s}={len(source_sets[s])}" for s in sorted(source_sets))
+    print(f"\nvalidate OK: {len(mapped_test_ids)} tests; sources [{counts}]; {len(mapped_reqs)} reqs mapped.")
+    return 0
+
+
+def coverage() -> int:
+    """Report, per source, requirements that no test maps to."""
+    sources = discover_sources()
+    mapping = _load(MATRIX_DOC)
+    mapped_reqs = {rid for _, rid, _ in _mapping_edges(mapping) if rid}
+
+    for sname in sorted(sources):
+        ids, _ = source_req_ids(sources[sname])
+        gaps = [rid for rid in ids if rid not in mapped_reqs]
+        print(f"{sname}: {len(ids) - len(gaps)}/{len(ids)} mapped to a test; {len(gaps)} with no test")
+        for rid in gaps:
+            print(f"  - {rid}")
+    return 0
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("validate", help="cross-file integrity checks (both endpoints resolve)")
+    sub.add_parser("coverage", help="per-source requirements with no mapped test")
+    args = parser.parse_args()
+
+    if args.command == "validate":
+        sys.exit(validate())
+    if args.command == "coverage":
+        sys.exit(coverage())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/requirements_matrix_to_adoc.py
+++ b/scripts/requirements_matrix_to_adoc.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Render the test <-> requirement junction to an AsciiDoc table.
+
+Joins ``docs/requirements/test-requirements-matrix.yaml`` with metadata from
+``docs/test-plan.yaml`` and emits a **flat** traceability table (one row per
+test/requirement pair). Flat-on-purpose: no row-span merging, so the result
+pastes cleanly into Google Sheets.
+
+Usage:
+    python3 scripts/requirements_matrix_to_adoc.py [matrix.yaml]
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEST_PLAN = REPO_ROOT / "docs" / "test-plan.yaml"
+DEFAULT_MATRIX = REPO_ROOT / "docs" / "requirements" / "test-requirements-matrix.yaml"
+
+
+def esc_adoc(val: Any) -> str:
+    """Stringify `val` and escape the AsciiDoc cell delimiter; '' for None."""
+    if val is None:
+        return ""
+    return str(val).replace("|", "\\|")
+
+
+def cell(content: str) -> str:
+    """Emit a regular AsciiDoc cell with no trailing whitespace when empty."""
+    return f"| {content}" if content else "|"
+
+
+def load_test_index(data: dict[str, Any]) -> dict[str, dict[str, str]]:
+    """Map ``test_id`` -> useful test metadata from the test plan."""
+    index: dict[str, dict[str, str]] = {}
+    for domain in data.get("domains", []):
+        for comp in domain.get("components", []):
+            for cap in comp.get("capabilities", []):
+                for test in cap.get("tests", []):
+                    tid = test.get("test_id")
+                    if not tid:
+                        continue
+                    index[tid] = {
+                        "domain": domain.get("name", ""),
+                        "component": comp.get("name", ""),
+                        "summary": test.get("summary", ""),
+                        "status": test.get("status", ""),
+                    }
+    return index
+
+
+def generate_adoc(mapping: dict[str, Any], index: dict[str, dict[str, str]], outfile: Path) -> None:
+    """Write the flat traceability AsciiDoc table to `outfile`."""
+    lines = [
+        "////",
+        "GENERATED FILE - DO NOT EDIT BY HAND.",
+        "Produced by scripts/requirements_matrix_to_adoc.py from",
+        "docs/requirements/test-requirements-matrix.yaml. Run `make plan` to regenerate.",
+        "////",
+        "= Test \u2194 Requirement Traceability",
+        ":toc:",
+        ":icons: font",
+        ":max-width: none",
+        "",
+        '[cols="2,2,5,2,2,1,3,3",options="header"]',
+        "|===",
+        "| Test ID | Test Domain | Function | Test Summary | Req ID | Source | Coverage | Notes",
+        "",
+    ]
+
+    for m in mapping.get("mappings", []):
+        tid = m.get("test_id", "")
+        meta = index.get(tid, {})
+        reqs = m.get("requirements") or [{}]
+        notes = m.get("notes", "")
+        for i, req in enumerate(reqs):
+            # Anchor only on a test's first row; multi-req tests repeat the id
+            # text on later rows (sheet-friendly) without re-declaring the anchor.
+            if not tid:
+                id_cell = ""
+            elif i == 0:
+                id_cell = f"[[{tid}]]{tid}"
+            else:
+                id_cell = tid
+            parts = [
+                cell(id_cell),
+                cell(esc_adoc(meta.get("domain", ""))),
+                cell(esc_adoc(meta.get("component", ""))),
+                cell(esc_adoc(meta.get("summary", ""))),
+                cell(esc_adoc(req.get("req_id", ""))),
+                cell(esc_adoc(req.get("source", ""))),
+                cell(esc_adoc(req.get("coverage", ""))),
+                cell(esc_adoc(notes)),
+            ]
+            lines.append("\n".join(parts))
+            lines.append("")
+
+    lines.append("|===")
+    outfile.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"Wrote {outfile}")
+
+
+def main() -> None:
+    """Load the matrix + test plan and emit the traceability AsciiDoc."""
+    matrix_path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_MATRIX
+
+    with open(matrix_path, encoding="utf-8") as f:
+        mapping = yaml.safe_load(f)
+    with open(TEST_PLAN, encoding="utf-8") as f:
+        plan = yaml.safe_load(f)
+
+    index = load_test_index(plan)
+
+    # Warn on any mapping that references a test_id absent from the plan.
+    unknown = [m.get("test_id") for m in mapping.get("mappings", []) if m.get("test_id") not in index]
+    if unknown:
+        print(f"WARNING: {len(unknown)} mapping(s) reference unknown test_id(s): {unknown[:5]}...", file=sys.stderr)
+
+    out = Path(re.sub(r"\.(yaml|yml)$", "", str(matrix_path)) + ".adoc")
+    generate_adoc(mapping, index, out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/requirements_source_to_md.py
+++ b/scripts/requirements_source_to_md.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Render a source-requirements YAML to a publishable Markdown listing.
+
+YAML is the source of record (queryable, key-clean); Markdown is the published,
+Google-Docs-friendly view. Handles both the `offtake` and `reference` sources.
+
+Usage:
+    python3 scripts/requirements_source_to_md.py docs/requirements/offtake-requirements.yaml
+    python3 scripts/requirements_source_to_md.py            # render both known sources
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REQ_DIR = REPO_ROOT / "docs" / "requirements"
+DEFAULT_SOURCES = [REQ_DIR / "offtake-requirements.yaml", REQ_DIR / "software-reference-requirements.yaml"]
+
+GENERATED_BANNER = "<!-- GENERATED FILE - DO NOT EDIT BY HAND. Source: {src}. Run `make plan`. -->"
+
+
+def cell(val: Any) -> str:
+    """Escape a value for a Markdown table cell."""
+    return str(val if val is not None else "").replace("|", "\\|").replace("\n", " ").strip()
+
+
+def heading(out: list[str], text: str) -> None:
+    """Append a heading with a blank line before and after."""
+    if out and out[-1] != "":
+        out.append("")
+    out += [text, ""]
+
+
+def render_offtake(doc: dict[str, Any], src_name: str) -> str:
+    """Render the offtake listing, grouped by section -> subsection."""
+    out = [
+        GENERATED_BANNER.format(src=src_name),
+        "",
+        f"# {doc.get('title', 'Offtake Requirements')}",
+        "",
+        f"> Structured source of record: `{src_name}` (version {doc.get('version', 'n/a')}).",
+        "> Curated, in-repo copy of the publicly-published *NVIDIA Requirements Guide",
+        "> for AI Clouds*. Edit the YAML, not this file.",
+        "",
+    ]
+    section = subsection = None
+    for r in doc.get("requirements", []):
+        if r.get("section") != section:
+            section = r.get("section")
+            heading(out, f"## {section}")
+            subsection = None
+        if r.get("subsection") != subsection:
+            subsection = r.get("subsection")
+            if subsection:
+                heading(out, f"### {subsection}")
+            out += [
+                "| Req ID | Requirement Area | Description | Test details | Status |",
+                "| :----- | :--------------- | :---------- | :----------- | :----- |",
+            ]
+        out.append(
+            f"| {cell(r.get('req_id'))} | {cell(r.get('area'))} | {cell(r.get('description'))} "
+            f"| {cell(r.get('test_details'))} | {cell(r.get('status', 'active'))} |"
+        )
+    return "\n".join(out) + "\n"
+
+
+def render_reference(doc: dict[str, Any], src_name: str) -> str:
+    """Render the reference listing, grouped by domain -> component."""
+    out = [GENERATED_BANNER.format(src=src_name), "", f"# {doc.get('title', 'Software Reference Requirements')}", ""]
+    if doc.get("preamble"):
+        out += [doc["preamble"], ""]
+    domain = component = None
+    for r in doc.get("requirements", []):
+        if r.get("domain") != domain:
+            domain = r.get("domain")
+            heading(out, f"## {domain}")
+            component = None
+        if r.get("component") != component:
+            component = r.get("component")
+            heading(out, f"### {component}")
+            out += [
+                "| Req ID | Requirement Area | Description | Reference Mapping | Covers test | Status |",
+                "| :----- | :--------------- | :---------- | :---------------- | :---------- | :----- |",
+            ]
+        out.append(
+            f"| {cell(r.get('req_id'))} | {cell(r.get('component'))} | {cell(r.get('description'))} "
+            f"| {cell(r.get('reference_mapping'))} | `{cell(r.get('covers_test'))}` | {cell(r.get('status'))} |"
+        )
+    return "\n".join(out) + "\n"
+
+
+def render(path: Path) -> None:
+    """Render a single source YAML to its sibling `.md`."""
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    renderer = render_offtake if doc.get("source") == "offtake" else render_reference
+    out_path = path.with_suffix(".md")
+    out_path.write_text(renderer(doc, path.name), encoding="utf-8")
+    print(f"Wrote {out_path}")
+
+
+def main() -> None:
+    """Render the given source YAML(s), or both known sources by default."""
+    targets = [Path(a) for a in sys.argv[1:]] or DEFAULT_SOURCES
+    for t in targets:
+        if t.exists():
+            render(t)
+        else:
+            print(f"skip (not found): {t}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_reqtrace.py
+++ b/scripts/tests/test_reqtrace.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for reqtrace.py.
+
+Acts as the CI drift guard: the committed requirements layer
+(``test-plan.yaml`` + ``test-requirements-matrix.yaml`` +
+``software-reference-requirements.md``) must stay internally consistent.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "reqtrace.py"
+_spec = importlib.util.spec_from_file_location("reqtrace", _SCRIPT)
+assert _spec and _spec.loader
+reqtrace = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(reqtrace)
+
+
+def test_committed_requirements_layer_is_consistent() -> None:
+    """`reqtrace validate` must pass against the committed files (no drift)."""
+    assert reqtrace.validate() == 0
+
+
+def test_sources_and_ids_resolve() -> None:
+    """Sanity-check source discovery and id extraction."""
+    ids = reqtrace.load_plan_test_ids(reqtrace.TEST_PLAN)
+    assert "BOOT01-01" in ids
+
+    sources = reqtrace.discover_sources()
+    assert {"offtake", "reference"} <= set(sources)
+
+    ref_ids, ref_dupes = reqtrace.source_req_ids(sources["reference"])
+    assert "OBS03" in ref_ids and ref_dupes == []
+
+    off_ids, _ = reqtrace.source_req_ids(sources["offtake"])
+    assert "BOOT01" in off_ids
+
+
+def test_coverage_runs() -> None:
+    """`coverage` should execute cleanly."""
+    assert reqtrace.coverage() == 0
+
+
+def test_duplicate_source_name_is_rejected() -> None:
+    """Two listings claiming the same `source` name must be flagged, not shadowed."""
+    ok = [("offtake", Path("offtake-requirements.yaml")), ("reference", Path("software-reference-requirements.yaml"))]
+    assert reqtrace.duplicate_source_name_errors(ok) == []
+
+    clash = [
+        ("reference", Path("software-reference-requirements.yaml")),
+        ("reference", Path("team-x-requirements.yaml")),
+    ]
+    errs = reqtrace.duplicate_source_name_errors(clash)
+    assert len(errs) == 1
+    assert "reference" in errs[0]
+    assert "software-reference-requirements.yaml" in errs[0]
+    assert "team-x-requirements.yaml" in errs[0]


### PR DESCRIPTION
Adds a Requirements to Tests Matrix which will allow us to trace from various requirements sources (which we will consolidate more of over time) to our main test-plan.yaml, and then trace through that to the individual tests.

docs/requirements/
- offtake-requirements.yaml/.md: in-repo offtake listing
- software-reference-requirements.yaml/.md: backfills requirements from the NCP Software Reference Guide (NSRG).
- test-requirements-matrix.yaml: the junction index, rendered to a flat (sheet-friendly) AsciiDoc traceability matrix that can be viewed directly in the github UI.
- README.md: the reconciliation policy (canonical authority, ID/naming + prefix registry, continue-numbering collision policy, legacy_ids lifecycle, and a new-source onboarding runbook).

Tooling
- scripts/reqtrace.py: `validate` resolves both endpoints of every mapping edge (test in plan, req in its source listing) with uniqueness checks, plus a `coverage` report of untested requirements. Wired into `make reqcheck` + a unit test; `make plan` renders the listings and traceability matrix.