### PR TITLE
fix(test-plan): update legacy control-plane IDs

### DIFF
--- a/isvctl/configs/providers/nico/config/control-plane.yaml
+++ b/isvctl/configs/providers/nico/config/control-plane.yaml
@@ -63,7 +63,7 @@ tests:
           labels: ["control_plane"]
           fields: ["account_id", "tests"]
         FieldValueCheck:
-          test_id: "CP-XX-03"
+          test_id: "CP03-01"
           labels: ["control_plane"]
           field: "success"
           expected: true

--- a/isvctl/configs/suites/control-plane.yaml
+++ b/isvctl/configs/suites/control-plane.yaml
@@ -129,7 +129,7 @@ tests:
       checks:
         StepSuccessCheck-delete_access_key:
           # No dedicated "delete access key" plan item; access-key lifecycle is
-          # CP-XX-05 (create) and CP-XX-06 (disable).
+          # CP05-01 (create) and CP06-01 (disable).
           test_id: "N/A"
           labels: ["control_plane"]
           step: delete_access_key

--- a/scripts/tests/test_test_plan_coverage.py
+++ b/scripts/tests/test_test_plan_coverage.py
@@ -79,7 +79,7 @@ def test_consistency_errors_allows_cross_domain_and_unknown_prefix() -> None:
     """Cross-domain labels pass; prefixes without a rule are ignored."""
     entries = [
         {"name": "SgCheck", "labels": ["network", "security"], "test_ids": ["SDN02-05"]},
-        {"name": "TenantCheck", "labels": ["iam"], "test_ids": ["CP-XX-07"]},  # CP has no rule
+        {"name": "TenantCheck", "labels": ["iam"], "test_ids": ["CP07-01"]},  # CP has no rule
     ]
     assert test_plan_coverage.consistency_errors(entries) == []
 


### PR DESCRIPTION
## Summary
- Replace remaining legacy control-plane test IDs with stable catalog IDs in Nico wiring and coverage tests.
- Update the control-plane suite comment to reference the stable access-key lifecycle IDs.

## Test plan
- [x] Pre-commit hooks passed during commit, including test-plan coverage and suite checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified control-plane teardown notes for access-key lifecycle checks.
  * Standardized validation/test references to use consistent control-plane identifiers.
* **Tests**
  * Updated coverage checks to match the revised validation identifiers, keeping existing behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->