### PR TITLE
feat: labels and suites refactor WIP

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -100,13 +100,16 @@ directory, and JUnit/reporting context.
 Use `--dry-run` to inspect the plan before running any lifecycle:
 
 ```bash
+isvctl catalog labels --provider aws
 isvctl test run --provider aws --label network --dry-run
 ```
 
-The output lists the selected config files and the checks that matched. This is
-the runtime form of the matrix model: provider configs describe the service
-line or execution surface, while labels select requirement rows such as
-`network`, `security`, `iam`, `observability`, or `sanitization`.
+`catalog labels --provider` lists runnable labels across the provider's resolved
+configs, including config counts and optional config file paths with `--files`.
+The dry-run output lists the selected config files and the checks that matched.
+Together these are the runtime form of the matrix model: provider configs
+describe the service line or execution surface, while labels select requirement
+rows such as `network`, `security`, `iam`, `observability`, or `sanitization`.
 
 ## Config Structure
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -81,6 +81,33 @@ isvctl test run -f config.yaml --dry-run
 isvctl test run -f config.yaml -- -v -s -k "NodeCount"
 ```
 
+## Provider Label Discovery
+
+Explicit config mode and provider discovery mode are intentionally separate:
+
+- `isvctl test run -f config.yaml --label network` runs the supplied config and
+  filters validations inside it.
+- `isvctl test run --provider aws --label network` scans
+  `isvctl/configs/providers/aws/config/*.yaml`, resolves each config's imports,
+  and runs every provider config that contains at least one runnable check with
+  all requested labels.
+
+Discovery mode treats provider configs as independent lifecycle contexts. It
+does not merge matching configs into a super-config, so each selected config
+keeps its own platform, commands, step outputs, teardown behavior, working
+directory, and JUnit/reporting context.
+
+Use `--dry-run` to inspect the plan before running any lifecycle:
+
+```bash
+isvctl test run --provider aws --label network --dry-run
+```
+
+The output lists the selected config files and the checks that matched. This is
+the runtime form of the matrix model: provider configs describe the service
+line or execution surface, while labels select requirement rows such as
+`network`, `security`, `iam`, `observability`, or `sanitization`.
+
 ## Config Structure
 
 ### Complete Example
@@ -676,11 +703,22 @@ Filter tests using labels:
 # Run only specific tests
 isvctl test run -f config.yaml -- -k "vpc_crud"
 
-# Run by label
+# Filter a specific config by label
 isvctl test run -f config.yaml --label kubernetes
+
+# Discover provider configs by label, then filter each selected config
+isvctl test run --provider aws --label network
 ```
 
-Available labels: `bare_metal`, `vm`, `kubernetes`, `slurm`, `gpu`, `network`, `ssh`, `security`, `iam`, `workload`, `slow`
+Repeated labels use AND semantics: a check must carry every requested label to
+match. For example, `--label network --label security` selects checks that are
+both network-related and security-related.
+
+Common label groups:
+
+- Execution targets: `bare_metal`, `vm`, `kubernetes`, `slurm`
+- Requirement areas: `network`, `security`, `iam`, `observability`, `sanitization`
+- Traits: `min_req`, `gpu`, `ssh`, `workload`, `slow`
 
 ## Related Documentation
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -111,6 +111,21 @@ Together these are the runtime form of the matrix model: provider configs
 describe the service line or execution surface, while labels select requirement
 rows such as `network`, `security`, `iam`, `observability`, or `sanitization`.
 
+The label taxonomy is intentionally explicit:
+
+- Capability labels are execution columns: `native_cloud`, `vm` (VMaaS),
+  `bare_metal` (BMaaS), `slurm`, and `kubernetes` (K8s). Current configs also
+  expose `control_plane` and `image_registry` as capability labels while the
+  Native AI Cloud column naming settles.
+- Requirement labels are cross-cutting rows: `iam`, `security`, `network`
+  (Networking), `observability`, and `sanitization`.
+- Trait labels refine a query without defining a row or column: `min_req`,
+  `gpu`, `ssh`, `workload`, `slow`, and similar hardware or execution traits.
+
+Keep YAML suites and provider configs lifecycle-scoped while this taxonomy is
+settled. Rename or consolidate suite files only after the capability columns and
+requirement rows are stable enough to avoid config merge collisions.
+
 ## Config Structure
 
 ### Complete Example

--- a/docs/packages/isvctl.md
+++ b/docs/packages/isvctl.md
@@ -108,6 +108,7 @@ isvctl test run -f isvctl/configs/suites/k8s.yaml --dry-run
 
 # Discover provider configs with matching requirement labels, then run each
 # matching config as its own lifecycle
+# Label output classifies capabilities, requirements, and traits.
 isvctl catalog labels --provider aws
 isvctl test run --provider aws --label network
 isvctl test run --provider aws --label network --dry-run

--- a/docs/packages/isvctl.md
+++ b/docs/packages/isvctl.md
@@ -106,6 +106,11 @@ isvctl test run -f isvctl/configs/suites/k8s.yaml --phase teardown
 # Dry run - validate config without executing
 isvctl test run -f isvctl/configs/suites/k8s.yaml --dry-run
 
+# Discover provider configs with matching requirement labels, then run each
+# matching config as its own lifecycle
+isvctl test run --provider aws --label network
+isvctl test run --provider aws --label network --dry-run
+
 # Verbose with pytest options
 isvctl test run -f isvctl/configs/suites/k8s.yaml -- -v -s --tb=short
 ```

--- a/docs/packages/isvctl.md
+++ b/docs/packages/isvctl.md
@@ -108,6 +108,7 @@ isvctl test run -f isvctl/configs/suites/k8s.yaml --dry-run
 
 # Discover provider configs with matching requirement labels, then run each
 # matching config as its own lifecycle
+isvctl catalog labels --provider aws
 isvctl test run --provider aws --label network
 isvctl test run --provider aws --label network --dry-run
 

--- a/isvctl/src/isvctl/cli/catalog.py
+++ b/isvctl/src/isvctl/cli/catalog.py
@@ -33,6 +33,7 @@ from rich.table import Table
 from isvctl.cli import setup_logging
 from isvctl.cli.common import get_output_dir, print_error, print_progress
 from isvctl.config.label_discovery import list_providers, summarize_provider_labels
+from isvctl.config.label_taxonomy import label_metadata
 
 logger = logging.getLogger(__name__)
 CONFIGS_ROOT = Path(__file__).resolve().parents[3] / "configs"
@@ -151,15 +152,19 @@ def labels_cmd(
             return [path.relative_to(CONFIGS_ROOT).as_posix() for path in config_paths]
 
         if json_output:
-            labels = [
-                {
-                    "label": summary.label,
-                    "tests": len(summary.checks),
-                    "configs": len(summary.config_paths),
-                    **({"files": files_for_provider(summary.config_paths)} if show_files else {}),
-                }
-                for summary in summaries
-            ]
+            labels = []
+            for summary in summaries:
+                metadata = label_metadata(summary.label)
+                labels.append(
+                    {
+                        "label": summary.label,
+                        "display": metadata.display_name,
+                        "kind": metadata.kind,
+                        "tests": len(summary.checks),
+                        "configs": len(summary.config_paths),
+                        **({"files": files_for_provider(summary.config_paths)} if show_files else {}),
+                    }
+                )
             typer.echo(json.dumps({"provider": provider, "labels": labels}, indent=2))
             return
 
@@ -171,13 +176,22 @@ def labels_cmd(
             padding=(0, 1),
         )
         table.add_column("Label", style="green", no_wrap=True)
+        table.add_column("Display")
+        table.add_column("Kind", style="magenta")
         table.add_column("Tests", style="cyan", justify="right")
         table.add_column("Configs", style="cyan", justify="right")
         if show_files:
             table.add_column("Files", style="dim")
 
         for summary in summaries:
-            row = [summary.label, str(len(summary.checks)), str(len(summary.config_paths))]
+            metadata = label_metadata(summary.label)
+            row = [
+                summary.label,
+                metadata.display_name,
+                metadata.kind,
+                str(len(summary.checks)),
+                str(len(summary.config_paths)),
+            ]
             if show_files:
                 row.append("\n".join(files_for_provider(summary.config_paths)) or "-")
             table.add_row(*row)

--- a/isvctl/src/isvctl/cli/catalog.py
+++ b/isvctl/src/isvctl/cli/catalog.py
@@ -21,18 +21,21 @@ Manage the test catalog: build, save, and upload to ISV Lab Service.
 import json
 import logging
 from collections import Counter
+from pathlib import Path
 from typing import Annotated
 
 import typer
 from isvtest.catalog import build_catalog, build_label_file_map, get_catalog_version
-from isvtest.release_manifest import load_released_tests
+from isvtest.release_manifest import load_released_test_filter, load_released_tests
 from rich.console import Console
 from rich.table import Table
 
 from isvctl.cli import setup_logging
 from isvctl.cli.common import get_output_dir, print_error, print_progress
+from isvctl.config.label_discovery import list_providers, summarize_provider_labels
 
 logger = logging.getLogger(__name__)
+CONFIGS_ROOT = Path(__file__).resolve().parents[3] / "configs"
 
 app = typer.Typer(
     name="catalog",
@@ -112,6 +115,10 @@ def labels_cmd(
         bool,
         typer.Option("--json", help="Emit the labels as JSON instead of a table"),
     ] = False,
+    provider: Annotated[
+        str | None,
+        typer.Option("--provider", help="Limit labels to runnable checks in one provider's configs"),
+    ] = None,
     show_files: Annotated[
         bool,
         typer.Option("--files", help="Also show the config file(s) declaring each label"),
@@ -125,10 +132,59 @@ def labels_cmd(
 
     Examples:
         isvctl catalog labels
+        isvctl catalog labels --provider aws
         isvctl catalog labels --files
         isvctl catalog labels --json
         ISVTEST_INCLUDE_UNRELEASED=1 isvctl catalog labels
     """
+    if provider:
+        known_providers = list_providers(CONFIGS_ROOT)
+        if provider not in known_providers:
+            print_error(f"Unknown provider {provider!r}. Available providers: {', '.join(known_providers)}")
+            raise typer.Exit(code=1)
+
+        released_tests = load_released_test_filter()
+        summaries = summarize_provider_labels(provider, configs_root=CONFIGS_ROOT, released_tests=released_tests)
+
+        def files_for_provider(config_paths: tuple[Path, ...]) -> list[str]:
+            """Return provider config paths relative to the configs root."""
+            return [path.relative_to(CONFIGS_ROOT).as_posix() for path in config_paths]
+
+        if json_output:
+            labels = [
+                {
+                    "label": summary.label,
+                    "tests": len(summary.checks),
+                    "configs": len(summary.config_paths),
+                    **({"files": files_for_provider(summary.config_paths)} if show_files else {}),
+                }
+                for summary in summaries
+            ]
+            typer.echo(json.dumps({"provider": provider, "labels": labels}, indent=2))
+            return
+
+        table = Table(
+            title=f"Provider Catalog Labels: {provider} ({len(summaries)} labels)",
+            title_justify="left",
+            show_header=True,
+            header_style="bold",
+            padding=(0, 1),
+        )
+        table.add_column("Label", style="green", no_wrap=True)
+        table.add_column("Tests", style="cyan", justify="right")
+        table.add_column("Configs", style="cyan", justify="right")
+        if show_files:
+            table.add_column("Files", style="dim")
+
+        for summary in summaries:
+            row = [summary.label, str(len(summary.checks)), str(len(summary.config_paths))]
+            if show_files:
+                row.append("\n".join(files_for_provider(summary.config_paths)) or "-")
+            table.add_row(*row)
+
+        console.print(table)
+        return
+
     counts = Counter(label for entry in build_catalog() for label in (entry.get("labels") or []))
     sorted_counts = sorted(counts.items())
     label_files = build_label_file_map() if show_files else {}

--- a/isvctl/src/isvctl/cli/test.py
+++ b/isvctl/src/isvctl/cli/test.py
@@ -265,11 +265,12 @@ def run(
             print_error(f"Unknown provider {provider!r}. Available providers: {', '.join(known_providers)}")
             raise typer.Exit(code=1)
 
+        released_tests = load_released_test_filter()
         matches = discover_provider_label_configs(
-            provider, labels, configs_root=CONFIGS_ROOT, released_tests=load_released_test_filter()
+            provider, labels, configs_root=CONFIGS_ROOT, released_tests=released_tests
         )
         if not matches:
-            known_labels = available_labels(provider, configs_root=CONFIGS_ROOT)
+            known_labels = available_labels(provider, configs_root=CONFIGS_ROOT, released_tests=released_tests)
             print_error(
                 f"No {provider!r} provider configs match labels: {', '.join(labels)}. "
                 f"Available labels for {provider!r}: {', '.join(sorted(known_labels))}"

--- a/isvctl/src/isvctl/config/label_discovery.py
+++ b/isvctl/src/isvctl/config/label_discovery.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from isvtest.core.resolution import ValidationEntry, parse_validations, resolve_class_key
 
+from isvctl.config.label_taxonomy import label_sort_key
 from isvctl.config.merger import merge_yaml_files
 
 
@@ -101,7 +102,7 @@ def summarize_provider_labels(
             checks=tuple(sorted(label_checks[label])),
             config_paths=tuple(sorted(label_configs[label])),
         )
-        for label in sorted(label_checks)
+        for label in sorted(label_checks, key=label_sort_key)
     ]
 
 

--- a/isvctl/src/isvctl/config/label_discovery.py
+++ b/isvctl/src/isvctl/config/label_discovery.py
@@ -50,12 +50,19 @@ def list_providers(configs_root: Path) -> list[str]:
     )
 
 
-def available_labels(provider: str, *, configs_root: Path) -> set[str]:
-    """Return every label declared across a provider's resolved config wiring."""
+def available_labels(
+    provider: str,
+    *,
+    configs_root: Path,
+    released_tests: set[str] | None = None,
+) -> set[str]:
+    """Return labels declared by runnable checks across a provider's resolved configs."""
     provider_config_dir = configs_root / "providers" / provider / "config"
     labels: set[str] = set()
     for config_path in provider_config_dir.glob("*.yaml"):
         for entry in _iter_config_validations(config_path):
+            if released_tests is not None and resolve_class_key(entry.name, released_tests) is None:
+                continue
             labels.update(entry.labels)
     return labels
 

--- a/isvctl/src/isvctl/config/label_discovery.py
+++ b/isvctl/src/isvctl/config/label_discovery.py
@@ -38,6 +38,15 @@ class ProviderConfigMatch:
     matched_checks: tuple[MatchedCheck, ...]
 
 
+@dataclass(frozen=True)
+class ProviderLabelSummary:
+    """Provider-scoped label metadata for runnable checks."""
+
+    label: str
+    checks: tuple[str, ...]
+    config_paths: tuple[Path, ...]
+
+
 def list_providers(configs_root: Path) -> list[str]:
     """Return provider names that expose a discoverable ``config/*.yaml`` directory."""
     providers_dir = configs_root / "providers"
@@ -65,6 +74,35 @@ def available_labels(
                 continue
             labels.update(entry.labels)
     return labels
+
+
+def summarize_provider_labels(
+    provider: str,
+    *,
+    configs_root: Path,
+    released_tests: set[str] | None = None,
+) -> list[ProviderLabelSummary]:
+    """Return runnable label summaries across a provider's resolved configs."""
+    provider_config_dir = configs_root / "providers" / provider / "config"
+    label_checks: dict[str, set[str]] = {}
+    label_configs: dict[str, set[Path]] = {}
+
+    for config_path in sorted(provider_config_dir.glob("*.yaml")):
+        for entry in _iter_config_validations(config_path):
+            if released_tests is not None and resolve_class_key(entry.name, released_tests) is None:
+                continue
+            for label in entry.labels:
+                label_checks.setdefault(label, set()).add(entry.name)
+                label_configs.setdefault(label, set()).add(config_path)
+
+    return [
+        ProviderLabelSummary(
+            label=label,
+            checks=tuple(sorted(label_checks[label])),
+            config_paths=tuple(sorted(label_configs[label])),
+        )
+        for label in sorted(label_checks)
+    ]
 
 
 def discover_provider_label_configs(

--- a/isvctl/src/isvctl/config/label_taxonomy.py
+++ b/isvctl/src/isvctl/config/label_taxonomy.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical label taxonomy for matrix-style suite discovery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LabelMetadata:
+    """Human-facing metadata for a validation label."""
+
+    kind: str
+    display_name: str
+
+
+CAPABILITY_LABELS: dict[str, str] = {
+    "native_cloud": "Native AI Cloud",
+    "vm": "VMaaS",
+    "bare_metal": "BMaaS",
+    "slurm": "SLURM",
+    "kubernetes": "K8s",
+    "control_plane": "Native AI Cloud",
+    "image_registry": "Image Registry",
+}
+
+REQUIREMENT_LABELS: dict[str, str] = {
+    "iam": "IAM",
+    "security": "Security",
+    "network": "Networking",
+    "observability": "Observability",
+    "sanitization": "Sanitization",
+}
+
+TRAIT_LABELS: dict[str, str] = {
+    "min_req": "Minimum Requirement",
+    "gpu": "GPU",
+    "ssh": "SSH",
+    "workload": "Workload",
+    "slow": "Slow",
+    "attestation": "Attestation",
+    "capacity": "Capacity",
+    "disk": "Disk",
+    "dpu": "DPU",
+    "firmware": "Firmware",
+    "governance": "Governance",
+    "health": "Health",
+    "infiniband": "InfiniBand",
+    "ingestion": "Ingestion",
+    "l2": "Layer 2",
+}
+
+_KIND_ORDER = {
+    "capability": 0,
+    "requirement": 1,
+    "trait": 2,
+    "uncategorized": 3,
+}
+
+_LABEL_ORDER = {
+    label: index
+    for index, label in enumerate(
+        [
+            "native_cloud",
+            "control_plane",
+            "vm",
+            "bare_metal",
+            "slurm",
+            "kubernetes",
+            "image_registry",
+            "iam",
+            "security",
+            "network",
+            "observability",
+            "sanitization",
+        ]
+    )
+}
+
+
+def label_metadata(label: str) -> LabelMetadata:
+    """Return taxonomy metadata for ``label``."""
+    if label in CAPABILITY_LABELS:
+        return LabelMetadata(kind="capability", display_name=CAPABILITY_LABELS[label])
+    if label in REQUIREMENT_LABELS:
+        return LabelMetadata(kind="requirement", display_name=REQUIREMENT_LABELS[label])
+    if label in TRAIT_LABELS:
+        return LabelMetadata(kind="trait", display_name=TRAIT_LABELS[label])
+    return LabelMetadata(kind="uncategorized", display_name=label.replace("_", " ").title())
+
+
+def label_sort_key(label: str) -> tuple[int, str, str]:
+    """Sort labels by matrix taxonomy, then display name, then raw label."""
+    metadata = label_metadata(label)
+    order = _LABEL_ORDER.get(label, len(_LABEL_ORDER))
+    return (_KIND_ORDER[metadata.kind], f"{order:04d}:{metadata.display_name.casefold()}", label)

--- a/isvctl/tests/test_catalog_cli.py
+++ b/isvctl/tests/test_catalog_cli.py
@@ -16,10 +16,13 @@
 """Unit tests for the catalog CLI subcommand."""
 
 import json
+from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from typer.testing import CliRunner
 
+import isvctl.cli.catalog as catalog_cli
 from isvctl.cli.catalog import app
 
 runner = CliRunner()
@@ -40,6 +43,45 @@ _FAKE_ENTRIES = [
         "platforms": [],
     },
 ]
+
+
+def _write_provider_config(root: Path, provider: str, name: str, suite: str) -> Path:
+    """Write a provider config importing one suite."""
+    config_path = root / "providers" / provider / "config" / name
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        f"""\
+import:
+  - ../../../suites/{suite}
+commands:
+  demo:
+    phases: [test]
+    steps: []
+tests:
+  platform: demo
+""",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def _write_suite(root: Path, name: str, labels: list[str], check_name: str) -> None:
+    """Write a suite with one labelled validation check."""
+    labels_yaml = ", ".join(f'"{label}"' for label in labels)
+    suite_path = root / "suites" / name
+    suite_path.parent.mkdir(parents=True, exist_ok=True)
+    suite_path.write_text(
+        f"""\
+tests:
+  validations:
+    sample:
+      checks:
+        {check_name}:
+          test_id: "N/A"
+          labels: [{labels_yaml}]
+""",
+        encoding="utf-8",
+    )
 
 
 def test_catalog_help() -> None:
@@ -138,6 +180,56 @@ def test_catalog_labels_files_option_adds_files() -> None:
         },
         {"label": "security", "tests": 1, "files": ["suites/security.yaml"]},
     ]
+
+
+def test_catalog_labels_provider_json_honors_release_filter(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """`catalog labels --provider --json` lists runnable provider labels only."""
+    configs_root = tmp_path / "configs"
+    _write_suite(configs_root, "network.yaml", ["network"], "NetworkCheck")
+    _write_suite(configs_root, "observability.yaml", ["network", "observability"], "VpcFlowLogsCheck")
+    _write_suite(configs_root, "future.yaml", ["future"], "UnreleasedCheck")
+    _write_provider_config(configs_root, "aws", "network.yaml", "network.yaml")
+    _write_provider_config(configs_root, "aws", "observability.yaml", "observability.yaml")
+    _write_provider_config(configs_root, "aws", "future.yaml", "future.yaml")
+    monkeypatch.setattr(catalog_cli, "CONFIGS_ROOT", configs_root)
+    monkeypatch.setattr(catalog_cli, "load_released_test_filter", lambda: {"NetworkCheck", "VpcFlowLogsCheck"})
+
+    result = runner.invoke(app, ["labels", "--provider", "aws", "--files", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["provider"] == "aws"
+    assert payload["labels"] == [
+        {
+            "label": "network",
+            "tests": 2,
+            "configs": 2,
+            "files": [
+                "providers/aws/config/network.yaml",
+                "providers/aws/config/observability.yaml",
+            ],
+        },
+        {
+            "label": "observability",
+            "tests": 1,
+            "configs": 1,
+            "files": ["providers/aws/config/observability.yaml"],
+        },
+    ]
+
+
+def test_catalog_labels_provider_unknown_lists_available(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """An unknown provider reports discoverable providers for label inspection."""
+    configs_root = tmp_path / "configs"
+    _write_suite(configs_root, "network.yaml", ["network"], "NetworkCheck")
+    _write_provider_config(configs_root, "aws", "network.yaml", "network.yaml")
+    monkeypatch.setattr(catalog_cli, "CONFIGS_ROOT", configs_root)
+
+    result = runner.invoke(app, ["labels", "--provider", "gcp", "--json"])
+
+    assert result.exit_code == 1, result.output
+    assert "Unknown provider 'gcp'" in result.output
+    assert "aws" in result.output
 
 
 def test_catalog_list_unreleased_json() -> None:

--- a/isvctl/tests/test_catalog_cli.py
+++ b/isvctl/tests/test_catalog_cli.py
@@ -185,14 +185,22 @@ def test_catalog_labels_files_option_adds_files() -> None:
 def test_catalog_labels_provider_json_honors_release_filter(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """`catalog labels --provider --json` lists runnable provider labels only."""
     configs_root = tmp_path / "configs"
+    _write_suite(configs_root, "vm.yaml", ["vm"], "VmCheck")
     _write_suite(configs_root, "network.yaml", ["network"], "NetworkCheck")
     _write_suite(configs_root, "observability.yaml", ["network", "observability"], "VpcFlowLogsCheck")
+    _write_suite(configs_root, "gpu.yaml", ["gpu"], "GpuCheck")
     _write_suite(configs_root, "future.yaml", ["future"], "UnreleasedCheck")
+    _write_provider_config(configs_root, "aws", "vm.yaml", "vm.yaml")
     _write_provider_config(configs_root, "aws", "network.yaml", "network.yaml")
     _write_provider_config(configs_root, "aws", "observability.yaml", "observability.yaml")
+    _write_provider_config(configs_root, "aws", "gpu.yaml", "gpu.yaml")
     _write_provider_config(configs_root, "aws", "future.yaml", "future.yaml")
     monkeypatch.setattr(catalog_cli, "CONFIGS_ROOT", configs_root)
-    monkeypatch.setattr(catalog_cli, "load_released_test_filter", lambda: {"NetworkCheck", "VpcFlowLogsCheck"})
+    monkeypatch.setattr(
+        catalog_cli,
+        "load_released_test_filter",
+        lambda: {"VmCheck", "NetworkCheck", "VpcFlowLogsCheck", "GpuCheck"},
+    )
 
     result = runner.invoke(app, ["labels", "--provider", "aws", "--files", "--json"])
 
@@ -201,7 +209,17 @@ def test_catalog_labels_provider_json_honors_release_filter(monkeypatch: pytest.
     assert payload["provider"] == "aws"
     assert payload["labels"] == [
         {
+            "label": "vm",
+            "display": "VMaaS",
+            "kind": "capability",
+            "tests": 1,
+            "configs": 1,
+            "files": ["providers/aws/config/vm.yaml"],
+        },
+        {
             "label": "network",
+            "display": "Networking",
+            "kind": "requirement",
             "tests": 2,
             "configs": 2,
             "files": [
@@ -211,9 +229,19 @@ def test_catalog_labels_provider_json_honors_release_filter(monkeypatch: pytest.
         },
         {
             "label": "observability",
+            "display": "Observability",
+            "kind": "requirement",
             "tests": 1,
             "configs": 1,
             "files": ["providers/aws/config/observability.yaml"],
+        },
+        {
+            "label": "gpu",
+            "display": "GPU",
+            "kind": "trait",
+            "tests": 1,
+            "configs": 1,
+            "files": ["providers/aws/config/gpu.yaml"],
         },
     ]
 

--- a/isvctl/tests/test_provider_label_discovery.py
+++ b/isvctl/tests/test_provider_label_discovery.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from isvctl.config.label_discovery import discover_provider_label_configs
+from isvctl.config.label_discovery import available_labels, discover_provider_label_configs
 
 
 def _write_provider_config(root: Path, provider: str, name: str, suite: str) -> Path:
@@ -80,6 +80,19 @@ def test_discovery_excludes_configs_matched_only_by_unreleased_checks(tmp_path: 
 
     assert [match.config_path.name for match in matches] == ["network.yaml"]
     assert [check.name for check in matches[0].matched_checks] == ["NetworkCheck"]
+
+
+def test_available_labels_honors_release_filter(tmp_path: Path) -> None:
+    """Provider label suggestions only include labels from checks that can run."""
+    configs_root = tmp_path / "configs"
+    _write_suite(configs_root, "network.yaml", ["network"], "NetworkCheck")
+    _write_suite(configs_root, "future.yaml", ["future"], "UnreleasedCheck")
+    _write_provider_config(configs_root, "aws", "network.yaml", "network.yaml")
+    _write_provider_config(configs_root, "aws", "future.yaml", "future.yaml")
+
+    labels = available_labels("aws", configs_root=configs_root, released_tests={"NetworkCheck"})
+
+    assert labels == {"network"}
 
 
 def test_discovery_requires_all_requested_labels(tmp_path: Path) -> None:

--- a/isvctl/tests/test_test_cli_labels.py
+++ b/isvctl/tests/test_test_cli_labels.py
@@ -187,6 +187,7 @@ def test_provider_discovery_no_label_match_lists_available_labels(
     _write_suite(configs_root, "network.yaml", ["network"], "NetworkCheck")
     _write_provider_config(configs_root, "aws", "network.yaml", "network.yaml", "network")
     _FakeOrchestrator.calls = []
+    monkeypatch.setenv("ISVTEST_INCLUDE_UNRELEASED", "1")
     monkeypatch.setattr(test_cli, "CONFIGS_ROOT", configs_root)
     monkeypatch.setattr(test_cli, "Orchestrator", _FakeOrchestrator)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- document provider-scoped label discovery as the lifecycle-safe matrix workflow for requirement labels across provider configs
- clarify explicit config label filtering versus provider discovery mode
- align provider available-label suggestions with the same release filter used by discovery
- add `isvctl catalog labels --provider <name>` so users can inspect runnable provider labels, config counts, and optional config files before running a label row
- define the first matrix label taxonomy: capabilities as execution columns, requirements as rows, and traits as query refinements
- surface taxonomy metadata (`display`, `kind`) in provider label catalog output without renaming raw labels yet

## Validation
- `PATH="$HOME/.local/bin:$PATH" uv run pytest isvctl/tests/test_provider_label_discovery.py isvctl/tests/test_test_cli_labels.py isvctl/tests/test_catalog_cli.py`
- `PATH="$HOME/.local/bin:$PATH" uvx pre-commit run -a`
- `PATH="$HOME/.local/bin:$PATH" uv run isvctl catalog labels --provider aws --json`
- `PATH="$HOME/.local/bin:$PATH" uv run isvctl catalog labels --provider aws --files --json`
- `PATH="$HOME/.local/bin:$PATH" uv run isvctl test run --provider aws --label network --dry-run --no-upload`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-336de977-bc97-4ed1-badf-af27af3bcc13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-336de977-bc97-4ed1-badf-af27af3bcc13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

