### PR TITLE
fix(labels): declare check labels only in suites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,9 +95,15 @@ configs to pytest format, runs native pytest, and returns rich in-memory results
 Validation classes live in `isvtest/src/isvtest/validations/` grouped by domain
 (`generic.py`, `cluster.py`, `instance.py`, `network.py`, `iam.py`, `security.py`,
 `host.py`, `k8s_*.py`, `slurm_*.py`, `bm_*.py`). Each subclass is auto-discovered.
-Filtering labels live on the YAML wiring (`labels: [...]` per check in the suite/
-provider configs), not on the class; the catalog, pytest marks, `isvctl docs`,
-and the orchestrator's include/exclude-label filtering all read them from there.
+Filtering labels live on the YAML wiring (`labels: [...]` per check), not on the
+class; the catalog, pytest marks, `isvctl docs`, and the orchestrator's
+include/exclude-label filtering all read them from there. Declare labels ONLY in
+`isvctl/configs/suites/*.yaml` - never add `labels:` to per-check wiring under
+`isvctl/configs/providers/**`; provider configs inherit labels from the suites
+they import (top-level `exclude.labels:` filtering blocks are fine). Sole
+exception: the single-node local providers
+`isvctl/configs/providers/{k3s,microk8s,minikube}.yaml`, which wire host-level
+checks that exist in no suite.
 
 Workloads (`isvtest/src/isvtest/workloads/`) are long-running tests (NIM, NCCL,
 stress) labelled `("workload", "slow", ...)` with manifests and helper scripts

--- a/isvctl/configs/providers/nico/config/control-plane.yaml
+++ b/isvctl/configs/providers/nico/config/control-plane.yaml
@@ -60,11 +60,9 @@ tests:
       checks:
         FieldExistsCheck:
           test_id: "N/A"
-          labels: ["control_plane"]
           fields: ["account_id", "tests"]
         FieldValueCheck:
           test_id: "CP03-01"
-          labels: ["control_plane"]
           field: "success"
           expected: true
 

--- a/isvctl/configs/providers/nico/config/iam.yaml
+++ b/isvctl/configs/providers/nico/config/iam.yaml
@@ -59,11 +59,9 @@ tests:
       checks:
         FieldExistsCheck:
           test_id: "N/A"
-          labels: ["iam"]
           fields: ["account_id", "authenticated", "tests"]
         StepSuccessCheck:
           test_id: "N/A"
-          labels: ["iam"]
 
   exclude:
     labels: []

--- a/isvctl/configs/providers/nico/config/network.yaml
+++ b/isvctl/configs/providers/nico/config/network.yaml
@@ -109,24 +109,20 @@ tests:
       checks:
         TenantListedCheck:
           test_id: "N/A"
-          labels: ["network"]
 
     vpc_info:
       step: get_vpc
       checks:
         TenantInfoCheck:
-          test_id: "SDN01-02"
-          labels: ["min_req", "network"]
+          test_id: "N/A"
 
     network_connectivity:
       step: network_connectivity
       checks:
         StepSuccessCheck:
           test_id: "N/A"
-          labels: ["network"]
         FieldValueCheck:
           test_id: "N/A"
-          labels: ["network"]
           field: "tests.network_assigned.passed"
           expected: true
 
@@ -135,10 +131,8 @@ tests:
       checks:
         StepSuccessCheck:
           test_id: "N/A"
-          labels: ["network"]
         FieldValueCheck:
           test_id: "N/A"
-          labels: ["network"]
           field: "tests.network_setup.passed"
           expected: true
 


### PR DESCRIPTION
## Summary
- Remove per-check `labels:` from the Nico provider configs (`control-plane.yaml`, `iam.yaml`, `network.yaml`) so labels are declared only in `isvctl/configs/suites/*.yaml`; `isvctl catalog labels --files` now attributes every label to suite files, with the single-node local providers (`k3s`/`microk8s`/`minikube`) as the only allowed exception.
- Change Nico's `TenantInfoCheck` test_id `SDN01-02` to the `"N/A"` sentinel: `SDN01-02` is owned by `VpcCrudCheck-read` in `suites/network.yaml`, and the provider-local attribution trips the plan-coverage domain guardrail once the `network` label is gone.
- Document the rule in AGENTS.md so agents never reintroduce provider labels (top-level `exclude.labels:` filtering blocks remain fine).

Accepted behavior change: `isvctl test run --provider nico --label <x>` no longer discovers these standalone configs (they carry no labels and import no suite); direct `-f <file>` runs are unaffected.

## Test plan
- [x] `uv run isvctl catalog labels --files` lists only `suites/*.yaml` (plus the exempted `providers/{k3s,microk8s,minikube}.yaml`) for every label
- [x] `make test` (all packages + scripts)
- [x] `make demo-test`
- [x] `uvx pre-commit run -a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how label-based filtering works, including where labels should be defined and when provider-level exclusions are allowed.

* **Bug Fixes**
  * Cleaned up several validation configurations so checks use a more consistent label setup.
  * Kept existing validation behavior intact while simplifying how checks are classified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->