### PR TITLE
feat(nico): support configurable API path segment for updated sites

### DIFF
--- a/isvctl/configs/providers/nico/scripts/common/nico_client.py
+++ b/isvctl/configs/providers/nico/scripts/common/nico_client.py
@@ -28,6 +28,7 @@ from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 DEFAULT_PAGE_SIZE = 100
+DEFAULT_API_NAME = "carbide"
 OIDC_TOKEN_TIMEOUT_SECONDS = 30
 
 
@@ -45,6 +46,11 @@ class NicoAuth(NamedTuple):
 def _env(name: str) -> str:
     """Return a stripped environment value or an empty string."""
     return os.environ.get(name, "").strip()
+
+
+def nico_api_name() -> str:
+    """Return the NICo API path segment (``carbide`` or ``nico``)."""
+    return _env("NICO_API_NAME") or DEFAULT_API_NAME
 
 
 def resolve_auth(*, timeout: int = OIDC_TOKEN_TIMEOUT_SECONDS) -> NicoAuth:
@@ -179,7 +185,7 @@ def forge_get(
 
     Args:
         org: NGC org name.
-        path: API path relative to /carbide/ (e.g., "machine", "expected-machine").
+        path: API path relative to the API name segment (e.g., "machine", "expected-machine").
         token: Bearer token.
         base_url: NICo API base URL.
         params: Query parameters (will be URL-encoded).
@@ -191,7 +197,7 @@ def forge_get(
     Raises:
         HTTPError: On non-2xx response.
     """
-    url = f"{base_url}/{org}/carbide/{path}"
+    url = f"{base_url}/{org}/{nico_api_name()}/{path}"
     if params:
         url = f"{url}?{urlencode(params)}"
 
@@ -221,7 +227,7 @@ def forge_get_all(
 
     Args:
         org: NGC org name.
-        path: API path relative to /carbide/ (e.g., "machine", "expected-machine").
+        path: API path relative to the API name segment (e.g., "machine", "expected-machine").
         token: Bearer token.
         base_url: NICo API base URL.
         params: Additional query parameters.

--- a/isvctl/src/isvctl/config/env_catalog.py
+++ b/isvctl/src/isvctl/config/env_catalog.py
@@ -148,6 +148,12 @@ ENV_VARS: tuple[EnvVar, ...] = (
         "NICo API base URL",
     ),
     EnvVar(
+        "NICO_API_NAME",
+        "NICo",
+        Requirement.OPTIONAL,
+        "NICo API path segment (carbide or nico); defaults to carbide",
+    ),
+    EnvVar(
         "NICO_ORGANIZATION",
         "NICo",
         Requirement.OPTIONAL,

--- a/isvctl/src/isvctl/doctor/checks/env.py
+++ b/isvctl/src/isvctl/doctor/checks/env.py
@@ -33,6 +33,7 @@ from isvctl.doctor.result import CategoryReport, CheckResult, Status
 from isvctl.redaction import redact_text
 
 _NICO_TOKEN_TIMEOUT_SECONDS = 30
+_NICO_DEFAULT_API_NAME = "carbide"
 
 # The variable catalog lives in `isvctl.config.env_catalog` so `doctor` and
 # `isvctl configure` share one source of truth.
@@ -210,9 +211,14 @@ def _resolve_nico_doctor_token() -> tuple[str, str]:
     return token, "OIDC client_credentials configured"
 
 
+def _nico_api_name() -> str:
+    """Return the NICo API path segment (``carbide`` or ``nico``)."""
+    return _env_value("NICO_API_NAME") or _NICO_DEFAULT_API_NAME
+
+
 def _probe_nico_api(organization: str, site_id: str, api_base: str, token: str) -> bool:
     """Probe the NICo site endpoint with the resolved token."""
-    url = f"{api_base.rstrip('/')}/{organization}/carbide/site/{site_id}"
+    url = f"{api_base.rstrip('/')}/{organization}/{_nico_api_name()}/site/{site_id}"
     request = Request(url, headers={"Authorization": f"Bearer {token}"})
     with urlopen(request, timeout=10) as response:
         response.read()
@@ -294,7 +300,7 @@ def _check_nico_provider() -> list[CheckResult]:
                 status=Status.FAIL,
                 message="unreachable or unauthorized",
                 detail=str(exc),
-                remediation="check NICO_API_BASE, NICO_ORGANIZATION, NICO_SITE_ID, credentials, and any port-forward",
+                remediation="check NICO_API_BASE, NICO_API_NAME, NICO_ORGANIZATION, NICO_SITE_ID, credentials, and any port-forward",
                 group="NICo",
             )
         )

--- a/isvctl/tests/providers/nico/test_nico_provider.py
+++ b/isvctl/tests/providers/nico/test_nico_provider.py
@@ -317,6 +317,60 @@ def test_forge_get_all_extracts_result_key_from_wrapped_response(monkeypatch: py
     assert items == [{"id": "m-1"}]
 
 
+def test_forge_get_defaults_to_carbide_api_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Legacy NICo sites expose REST paths under /carbide/."""
+    module = _load_nico_client()
+    seen: dict[str, str] = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b"{}"
+
+    def fake_urlopen(request, timeout: int = 30):
+        seen["url"] = request.full_url
+        return _Response()
+
+    monkeypatch.delenv("NICO_API_NAME", raising=False)
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+
+    module.forge_get("ncx", "machine", "tok", base_url="http://127.0.0.1:8080/v2/org")
+
+    assert seen["url"] == "http://127.0.0.1:8080/v2/org/ncx/carbide/machine"
+
+
+def test_forge_get_honors_nico_api_name_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Updated NICo sites expose REST paths under /nico/."""
+    module = _load_nico_client()
+    seen: dict[str, str] = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b"{}"
+
+    def fake_urlopen(request, timeout: int = 30):
+        seen["url"] = request.full_url
+        return _Response()
+
+    monkeypatch.setenv("NICO_API_NAME", "nico")
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+
+    module.forge_get("ncx", "site/site-1", "tok", base_url="http://127.0.0.1:8080/v2/org")
+
+    assert seen["url"] == "http://127.0.0.1:8080/v2/org/ncx/nico/site/site-1"
+
+
 @pytest.mark.parametrize(
     "step_name",
     [

--- a/isvctl/tests/test_doctor_cli.py
+++ b/isvctl/tests/test_doctor_cli.py
@@ -351,6 +351,56 @@ def test_nico_oidc_token_request_reports_http_error_body(monkeypatch: pytest.Mon
         )
 
 
+def test_probe_nico_api_defaults_to_carbide_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Doctor should probe legacy /carbide/ site paths by default."""
+    seen: dict[str, str] = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b"{}"
+
+    def fake_urlopen(request, timeout: int = 10):
+        seen["url"] = request.full_url
+        return _Response()
+
+    monkeypatch.delenv("NICO_API_NAME", raising=False)
+    monkeypatch.setattr(env_checks, "urlopen", fake_urlopen)
+
+    assert env_checks._probe_nico_api("ncx", "site-1", "http://127.0.0.1:8080/v2/org", "tok") is True
+    assert seen["url"] == "http://127.0.0.1:8080/v2/org/ncx/carbide/site/site-1"
+
+
+def test_probe_nico_api_honors_nico_api_name_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Doctor should probe /nico/ site paths when NICO_API_NAME is set."""
+    seen: dict[str, str] = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b"{}"
+
+    def fake_urlopen(request, timeout: int = 10):
+        seen["url"] = request.full_url
+        return _Response()
+
+    monkeypatch.setenv("NICO_API_NAME", "nico")
+    monkeypatch.setattr(env_checks, "urlopen", fake_urlopen)
+
+    assert env_checks._probe_nico_api("ncx", "site-1", "http://127.0.0.1:8080/v2/org", "tok") is True
+    assert seen["url"] == "http://127.0.0.1:8080/v2/org/ncx/nico/site/site-1"
+
+
 def test_doctor_strict_flips_warnings_to_failure(all_tools_present: None, all_env_unset: None) -> None:
     """Without --strict, recommended-but-missing env vars only WARN."""
     result = runner.invoke(app, ["--check", "env"])

--- a/isvctl/tests/test_env_catalog.py
+++ b/isvctl/tests/test_env_catalog.py
@@ -56,6 +56,7 @@ def test_vars_for_provider_nico_scopes_to_group() -> None:
     assert all(var.group == "NICo" for var in nico_vars)
     names = {var.name for var in nico_vars}
     assert "NICO_API_BASE" in names
+    assert "NICO_API_NAME" in names
     assert "NICO_CLIENT_SECRET" in names
     assert "AWS_REGION" not in names
 


### PR DESCRIPTION
## Summary

- Updated NICo deployments expose REST routes under `/nico/` instead of `/carbide/`.
- Adds `NICO_API_NAME` so `doctor` and the NICo provider scripts can target either path, keeping `carbide` as the default for legacy sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting the NICo API path segment via a new optional environment setting, with a default fallback to the existing path.
  * Improved NICo connectivity checks to use the configured API path segment and surface it in guidance when checks fail.

* **Tests**
  * Added coverage for both default and custom API path behavior in request building and endpoint probing.
  * Expanded environment catalog validation to include the new NICo setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->