### PR TITLE
feat: add catalog schema version and platform axis

### DIFF
--- a/isvctl/src/isvctl/cli/catalog.py
+++ b/isvctl/src/isvctl/cli/catalog.py
@@ -24,7 +24,7 @@ from collections import Counter
 from typing import Annotated
 
 import typer
-from isvtest.catalog import build_catalog, build_label_file_map, get_catalog_version
+from isvtest.catalog import build_catalog, build_label_file_map, catalog_document, get_catalog_version
 from isvtest.release_manifest import load_released_tests
 from rich.console import Console
 from rich.table import Table
@@ -74,7 +74,7 @@ def list_cmd(
     catalog_version = get_catalog_version()
 
     if json_output:
-        typer.echo(json.dumps({"isvTestVersion": catalog_version, "entries": catalog_entries}, indent=2))
+        typer.echo(json.dumps(catalog_document(catalog_entries, catalog_version), indent=2))
         return
 
     table = Table(
@@ -193,11 +193,12 @@ def push(
     print_progress("Building test catalog...")
     catalog_entries = build_catalog()
     catalog_version = get_catalog_version()
+    document = catalog_document(catalog_entries, catalog_version)
     print_progress(f"  {len(catalog_entries)} tests (version: {catalog_version})")
 
     output_dir = get_output_dir()
     catalog_path = output_dir / "test_catalog.json"
-    catalog_path.write_text(json.dumps({"isvTestVersion": catalog_version, "entries": catalog_entries}, indent=2))
+    catalog_path.write_text(json.dumps(document, indent=2))
     print_progress(f"  Saved to: {catalog_path}")
 
     if no_upload:
@@ -225,6 +226,8 @@ def push(
         jwt_token=jwt_token,
         isv_test_version=catalog_version,
         entries=catalog_entries,
+        schema_version=document["schemaVersion"],
+        platforms=document["platforms"],
     ):
         print_progress(typer.style("[OK]", fg=typer.colors.GREEN) + " Catalog push complete")
     else:

--- a/isvctl/tests/test_catalog_cli.py
+++ b/isvctl/tests/test_catalog_cli.py
@@ -73,8 +73,11 @@ def test_catalog_list_json() -> None:
 
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
+    assert payload["schemaVersion"] == 1
     assert payload["isvTestVersion"] == "1.2.3"
     assert payload["entries"] == _FAKE_ENTRIES
+    # The platform axis is derived from the real configs and drives the UI matrix.
+    assert "KUBERNETES" in payload["platforms"]
 
 
 def test_catalog_labels_table() -> None:

--- a/isvreporter/src/isvreporter/client.py
+++ b/isvreporter/src/isvreporter/client.py
@@ -281,6 +281,9 @@ def upload_test_catalog(
     jwt_token: str,
     isv_test_version: str,
     entries: list[dict[str, Any]],
+    *,
+    schema_version: int = 1,
+    platforms: list[str] | None = None,
 ) -> bool:
     """Upload test catalog for a suite version (idempotent per version).
 
@@ -294,6 +297,9 @@ def upload_test_catalog(
         isv_test_version: Test suite version string (e.g. "1.2.3")
         entries: List of catalog entry dicts with keys:
             name, description, labels, module, platforms, test_ids
+        schema_version: Catalog document schema version.
+        platforms: Platform axis labels (e.g. ["KUBERNETES", "VM"]) - the
+            matrix columns; empty list when unknown.
 
     Returns:
         True if catalog was uploaded or already exists, False on error
@@ -313,7 +319,9 @@ def upload_test_catalog(
     url = f"{endpoint}/v1/test-catalog"
 
     payload = {
+        "schemaVersion": schema_version,
         "isvTestVersion": isv_test_version,
+        "platforms": platforms or [],
         "entries": [
             {
                 "name": e["name"],

--- a/isvreporter/tests/test_catalog_upload.py
+++ b/isvreporter/tests/test_catalog_upload.py
@@ -70,6 +70,9 @@ class TestUploadTestCatalog:
 
         payload = json.loads(request.data.decode())
         assert payload["isvTestVersion"] == "1.2.3"
+        # Envelope defaults when axis metadata is not supplied.
+        assert payload["schemaVersion"] == 1
+        assert payload["platforms"] == []
         assert len(payload["entries"]) == 2
         assert payload["entries"][0]["name"] == "TestA"
         assert payload["entries"][0]["labels"] == ["k8s"]
@@ -180,6 +183,33 @@ class TestUploadTestCatalog:
         assert "markers" not in entry
         assert entry["module"] == ""
         assert entry["test_ids"] == []
+
+    @patch("isvreporter.client.urlopen")
+    def test_forwards_platform_axis_metadata(self, mock_urlopen: MagicMock) -> None:
+        """schema_version/platforms are sent in the top-level envelope."""
+        get_response = MagicMock()
+        get_response.read.return_value = json.dumps([]).encode()
+        get_response.__enter__ = MagicMock(return_value=get_response)
+        get_response.__exit__ = MagicMock(return_value=False)
+        post_response = MagicMock()
+        post_response.read.return_value = json.dumps({"status": "created"}).encode()
+        post_response.__enter__ = MagicMock(return_value=post_response)
+        post_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.side_effect = [get_response, post_response]
+
+        upload_test_catalog(
+            endpoint="https://api.example.com",
+            jwt_token="test-token",
+            isv_test_version="1.2.3",
+            entries=[{"name": "TestA"}],
+            schema_version=1,
+            platforms=["KUBERNETES", "VM"],
+        )
+
+        request = mock_urlopen.call_args_list[1][0][0]
+        payload = json.loads(request.data.decode())
+        assert payload["schemaVersion"] == 1
+        assert payload["platforms"] == ["KUBERNETES", "VM"]
 
     @patch("isvreporter.client.urlopen")
     def test_markers_field_is_not_forwarded(self, mock_urlopen: MagicMock) -> None:

--- a/isvtest/src/isvtest/catalog.py
+++ b/isvtest/src/isvtest/catalog.py
@@ -73,6 +73,11 @@ LABEL_TO_PLATFORM: dict[str, str] = {
     "vm": "VM",
 }
 
+# Version of the catalog document envelope (schemaVersion field), bumped only
+# when the top-level shape changes - independent of the isvtest package version
+# (isvTestVersion), which tracks the test content.
+CATALOG_SCHEMA_VERSION = 1
+
 
 def _find_configs_dir() -> Path | None:
     """Locate the isvctl/configs/ directory."""
@@ -356,6 +361,33 @@ def build_catalog(*, released_only: bool = True) -> list[dict[str, Any]]:
 
     logger.info("Built test catalog with %d entries", len(catalog))
     return catalog
+
+
+def build_platform_axis() -> list[str]:
+    """Return the sorted platform-axis labels (the catalog's capability columns).
+
+    Derived from :data:`PLATFORM_CONFIGS`, the canonical per-platform suite
+    mapping, so adding a platform there extends the axis automatically. The
+    values match each entry's ``platforms`` field (e.g. ``KUBERNETES``), so a
+    consumer can build the platform matrix straight from the catalog.
+    """
+    return sorted(PLATFORM_CONFIGS.keys())
+
+
+def catalog_document(entries: list[dict[str, Any]], version: str) -> dict[str, Any]:
+    """Wrap catalog ``entries`` in the versioned upload/artifact envelope.
+
+    Adds the schema version, the isvtest package version, and the platform axis
+    list (see :func:`build_platform_axis`). The per-entry ``labels`` are
+    intentionally not summarized at the top level - a consumer can derive the
+    label universe from the entries when needed.
+    """
+    return {
+        "schemaVersion": CATALOG_SCHEMA_VERSION,
+        "isvTestVersion": version,
+        "platforms": build_platform_axis(),
+        "entries": entries,
+    }
 
 
 def get_catalog_version() -> str:

--- a/isvtest/tests/test_catalog.py
+++ b/isvtest/tests/test_catalog.py
@@ -17,7 +17,13 @@
 
 from unittest.mock import patch
 
-from isvtest.catalog import build_catalog, get_catalog_version
+from isvtest.catalog import (
+    CATALOG_SCHEMA_VERSION,
+    build_catalog,
+    build_platform_axis,
+    catalog_document,
+    get_catalog_version,
+)
 from isvtest.core.validation import BaseValidation
 
 
@@ -29,6 +35,36 @@ class ExplicitLabelCatalogCheck(BaseValidation):
     def run(self) -> None:
         """Mark the validation passed."""
         self.set_passed()
+
+
+class TestCatalogDocument:
+    """Tests for the platform axis and the versioned catalog envelope."""
+
+    def test_derives_platform_axis_from_configs(self) -> None:
+        """The platform axis lists every platform in PLATFORM_CONFIGS, sorted."""
+        assert build_platform_axis() == [
+            "BARE_METAL",
+            "CONTROL_PLANE",
+            "IAM",
+            "IMAGE_REGISTRY",
+            "KUBERNETES",
+            "NETWORK",
+            "OBSERVABILITY",
+            "SECURITY",
+            "SLURM",
+            "VM",
+        ]
+
+    def test_catalog_document_wraps_entries_with_metadata(self) -> None:
+        """The envelope carries schema version, package version, and the platform axis."""
+        entries = [{"name": "X", "labels": ["iam"]}]
+        doc = catalog_document(entries, "1.2.3")
+        assert doc["schemaVersion"] == CATALOG_SCHEMA_VERSION
+        assert doc["isvTestVersion"] == "1.2.3"
+        assert doc["entries"] == entries
+        assert doc["platforms"] == build_platform_axis()
+        # The label universe is intentionally not summarized at the top level.
+        assert "labels" not in doc
 
 
 class TestBuildCatalog:


### PR DESCRIPTION
## Summary
- Add a versioned test catalog envelope with `schemaVersion`, `isvTestVersion`, and top-level catalog platform axis metadata.
- Forward catalog axis metadata during upload so downstream services can drive capability/platform UI from the client-provided catalog.
- Cover catalog generation, CLI output, and reporter upload payload behavior with tests.

## Test plan
- `uv run pytest isvtest/tests/test_catalog.py isvctl/tests/test_catalog_cli.py isvreporter/tests/test_catalog_upload.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Catalog output now includes a full document envelope with schema version and platform information.
  * Uploads now send the same richer catalog metadata for better consistency.

* **Bug Fixes**
  * `catalog list --json` now returns the complete catalog structure instead of a reduced wrapper.
  * `catalog push` now uses the same document format when preparing uploads.

* **Tests**
  * Expanded coverage to verify schema version, platform data, and upload payload fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->