### PR TITLE
feat(storage): filesystem/posix semantics tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ ai-cloud-validation*.tar.gz
 
 # Trivy local / CI artifact (default output name)
 *.sarif
+
+# Vendored sources
+isvtest/vendor/

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,18 @@ MY_ISV_DOMAINS := bare_metal control-plane iam image-registry network observabil
 DEMO_TARGETS := $(addprefix demo-,$(MY_ISV_DOMAINS))
 
 .PHONY: help pre-commit build test coverage clean lint format install bump-patch bump-fix bump-minor bump-feat bump-major bump bump-check \
-	security-trivy security-trivy-detail security-trufflehog ci-security demo-test demo-all $(DEMO_TARGETS) plan plan-coverage validate-suites reqcheck
+	security-trivy security-trivy-detail security-trufflehog ci-security demo-test demo-all $(DEMO_TARGETS) plan plan-coverage validate-suites \
+	reqcheck vendor-pjdfstest
 
 PACKAGES := isvctl isvreporter isvtest
 BUMP_SCRIPT := scripts/bump-version.py
 RUFF_VERSION := 0.15.12
 RUFF := uvx --from ruff==$(RUFF_VERSION) ruff
+
+# Vendored pjdfstest
+PJDFSTEST_REPO := https://github.com/pjd/pjdfstest.git
+PJDFSTEST_REV := ededbeb2b44929972898afb87474b0937f78a877
+PJDFSTEST_DIR := isvtest/vendor/pjdfstest
 
 # DISABLED (2026-03-24): Trivy supply chain compromise - see GHSA-69fq-xp46-6x23.
 # Do NOT pull aquasec/trivy images from Docker Hub until Aqua Security regains control.
@@ -197,6 +203,12 @@ plan-coverage: ## Report test-plan coverage + gaps via wired test_ids (CHECK=1 f
 
 validate-suites: ## Require test_id and labels on every suite check (CHECK=1 for CI/pre-commit)
 	@uv run python scripts/validate_suite_wiring.py $(if $(CHECK),--check,)
+
+vendor-pjdfstest: ## Download pinned pjdfstest source into isvtest/vendor/ (gitignored; required by K8sPosixComplianceCheck)
+	@rm -rf $(PJDFSTEST_DIR)
+	@git clone --quiet $(PJDFSTEST_REPO) $(PJDFSTEST_DIR)
+	@git -C $(PJDFSTEST_DIR) checkout --quiet $(PJDFSTEST_REV)
+	@echo "✅ Vendored pjdfstest @ $(PJDFSTEST_REV) -> $(PJDFSTEST_DIR)"
 
 .PHONY: changelog-fill
 changelog-fill: ## Fill CHANGELOG.md gaps via an LLM CLI (CLI=auto|cursor|codex|claude)

--- a/docs/guides/remote-deployment.md
+++ b/docs/guides/remote-deployment.md
@@ -101,6 +101,8 @@ sudo -E env "PATH=$PATH" isvctl test run -f isvctl/configs/suites/slurm.yaml
 
 Ensure the remote user has `kubectl` access configured (e.g., `~/.kube/config` exists and is valid).
 
+**Filesystem POSIX tests:** The pjdfstest source is downloaded at build time via the make command (`make vendor-pjdfstest`) which must be run on the remote host.
+
 ## Troubleshooting
 
 **Connection refused:**

--- a/isvctl/configs/suites/k8s.yaml
+++ b/isvctl/configs/suites/k8s.yaml
@@ -341,6 +341,81 @@ tests:
           expand_timeout_s: 180
           namespace_prefix: "isvtest-csi-expand"
 
+    k8s_filesystem:
+      checks:
+        # Shared-filesystem POSIX-semantics checks (multi-pod, RWX PVC).
+        K8sFileLockingCheck:
+          test_id: "N/A"
+          labels: ["kubernetes"]
+          shared_fs_storage_class: "{{ steps.setup.csi.shared_fs_storage_class | default('', true) }}"
+          nfs_storage_class: "{{ steps.setup.csi.nfs_storage_class | default('', true) }}"
+          image: "busybox:1.36"
+          node_selector: {}
+          pvc_size: "1Gi"
+          bind_timeout_s: 120
+          release_timeout_s: 60
+          namespace_prefix: "isvtest-fs-lock"
+        K8sCrossNodeWriteVisibilityCheck:
+          test_id: "N/A"
+          labels: ["kubernetes"]
+          shared_fs_storage_class: "{{ steps.setup.csi.shared_fs_storage_class | default('', true) }}"
+          nfs_storage_class: "{{ steps.setup.csi.nfs_storage_class | default('', true) }}"
+          image: "busybox:1.36"
+          node_selector: {}
+          pvc_size: "1Gi"
+          bind_timeout_s: 120
+          visibility_window_s: 5.0
+          namespace_prefix: "isvtest-fs-vis"
+        K8sCrossNodeAttrConsistencyCheck:
+          test_id: "N/A"
+          labels: ["kubernetes"]
+          shared_fs_storage_class: "{{ steps.setup.csi.shared_fs_storage_class | default('', true) }}"
+          nfs_storage_class: "{{ steps.setup.csi.nfs_storage_class | default('', true) }}"
+          image: "busybox:1.36"
+          node_selector: {}
+          pvc_size: "1Gi"
+          bind_timeout_s: 120
+          attr_cache_window_s: 30.0
+          extend_bytes: 1024
+          namespace_prefix: "isvtest-fs-attr"
+        K8sLargeDirListingFilesCheck:
+          test_id: "N/A"
+          labels: ["kubernetes"]
+          shared_fs_storage_class: "{{ steps.setup.csi.shared_fs_storage_class | default('', true) }}"
+          nfs_storage_class: "{{ steps.setup.csi.nfs_storage_class | default('', true) }}"
+          image: "busybox:1.36"
+          node_selector: {}
+          files_count: 10000
+          pvc_size: "10Gi"
+          bind_timeout_s: 120
+          namespace_prefix: "isvtest-fs-bigdir"
+          timeout: 3600
+        K8sLargeDirListingDirsCheck:
+          test_id: "N/A"
+          labels: ["kubernetes"]
+          shared_fs_storage_class: "{{ steps.setup.csi.shared_fs_storage_class | default('', true) }}"
+          nfs_storage_class: "{{ steps.setup.csi.nfs_storage_class | default('', true) }}"
+          image: "busybox:1.36"
+          node_selector: {}
+          dirs_count: 500
+          pvc_size: "10Gi"
+          bind_timeout_s: 120
+          namespace_prefix: "isvtest-fs-bigdir"
+          timeout: 3600
+        K8sPosixComplianceCheck:
+          test_id: "N/A"
+          labels: ["kubernetes", "slow"]
+          shared_fs_storage_class: "{{ steps.setup.csi.shared_fs_storage_class | default('', true) }}"
+          nfs_storage_class: "{{ steps.setup.csi.nfs_storage_class | default('', true) }}"
+          image: "gcc:12"
+          node_selector: {}
+          pvc_size: "5Gi"
+          bind_timeout_s: 120
+          build_timeout_s: 600
+          # tests_subdir: ""  # optional: scope to a single tests/ subdir (e.g. "chmod")
+          namespace_prefix: "isvtest-fs-posix"
+          timeout: 3600
+
     k8s_identity:
       checks:
         K8sOidcIssuerCheck:

--- a/isvtest/src/isvtest/validations/k8s_filesystem.py
+++ b/isvtest/src/isvtest/validations/k8s_filesystem.py
@@ -110,7 +110,7 @@ _DEFAULT_NOEXECUTE_TAINT_KEYS: frozenset[str] = frozenset(
 
 
 def _taint_is_tolerated(taint: dict[str, Any], tolerations: list[dict[str, Any]]) -> bool:
-    """Return True when any entry in ``tolerations`` covers ``taint``. """
+    """Return True when any entry in ``tolerations`` covers ``taint``."""
     taint_key = taint.get("key", "")
     taint_value = taint.get("value", "")
     taint_effect = taint.get("effect", "")
@@ -456,7 +456,9 @@ class _K8sSharedFsCheck(BaseValidation):
         return ok, err
 
     def _wait_pvc_bound(self, pvc_name: str, timeout_s: int) -> bool:
-        return _poll_pvc_bound(self.run_command, self._kubectl_base, self._namespace, pvc_name, timeout_s, poll_interval_s=60.0)
+        return _poll_pvc_bound(
+            self.run_command, self._kubectl_base, self._namespace, pvc_name, timeout_s, poll_interval_s=60.0
+        )
 
     def _exec(self, pod_name: str, inner: str, timeout: int | None = None) -> CommandResult:
         cmd = f"{self._kubectl_base} exec -n {self._ns_quoted} {shlex.quote(pod_name)} -- sh -c {shlex.quote(inner)}"
@@ -996,8 +998,7 @@ class _K8sLargeDirListingBase(_K8sSharedFsCheck):
             create = self._exec(pod, self._create_cmd(target_dir, count), timeout=self.timeout)
             if create.exit_code != 0:
                 self.set_failed(
-                    f"Creating {count} {self._ENTRY_KIND} failed: "
-                    f"{_fmt_err(create.stderr or create.stdout)}"
+                    f"Creating {count} {self._ENTRY_KIND} failed: {_fmt_err(create.stderr or create.stdout)}"
                 )
                 return
 
@@ -1112,9 +1113,7 @@ class K8sPosixComplianceCheck(_K8sSharedFsCheck):
         timeout: Per-command timeout, also bounds the prove run (default 3600).
     """
 
-    description: ClassVar[str] = (
-        "Run the pjdfstest POSIX filesystem test suite against the cluster filesystem storage."
-    )
+    description: ClassVar[str] = "Run the pjdfstest POSIX filesystem test suite against the cluster filesystem storage."
     timeout: ClassVar[int] = 3600
 
     _DEFAULT_NS_PREFIX = "isvtest-fs-posix"
@@ -1164,10 +1163,7 @@ class K8sPosixComplianceCheck(_K8sSharedFsCheck):
             self.set_passed("Skipped: no shared-fs/nfs StorageClass configured")
             return
         if not _PJDFSTEST_SRC_DIR.is_dir():
-            self.set_failed(
-                f"Vendored pjdfstest source not found at {_PJDFSTEST_SRC_DIR}; "
-                "run `make vendor-pjdfstest`"
-            )
+            self.set_failed(f"Vendored pjdfstest source not found at {_PJDFSTEST_SRC_DIR}; run `make vendor-pjdfstest`")
             return
 
         bind_timeout = int(self.config.get("bind_timeout_s", self._DEFAULT_BIND_TIMEOUT_S))
@@ -1218,9 +1214,7 @@ class K8sPosixComplianceCheck(_K8sSharedFsCheck):
 
             copied = self._copy_source(pod)
             if copied.exit_code != 0:
-                self.set_failed(
-                    f"Copying pjdfstest source into pod failed: {_fmt_err(copied.stderr or copied.stdout)}"
-                )
+                self.set_failed(f"Copying pjdfstest source into pod failed: {_fmt_err(copied.stderr or copied.stdout)}")
                 return
 
             build = self._exec(
@@ -1257,9 +1251,7 @@ class K8sPosixComplianceCheck(_K8sSharedFsCheck):
                 if fname in failed_map:
                     nfailed = failed_map[fname]
                     message = (
-                        f"{nfailed} POSIX subtest(s) failed"
-                        if nfailed
-                        else "non-zero exit status (crashed / dubious)"
+                        f"{nfailed} POSIX subtest(s) failed" if nfailed else "non-zero exit status (crashed / dubious)"
                     )
                     self.report_subtest(fname, passed=False, message=message)
                 else:

--- a/isvtest/src/isvtest/validations/k8s_filesystem.py
+++ b/isvtest/src/isvtest/validations/k8s_filesystem.py
@@ -208,9 +208,10 @@ _RE_PROVE_RESULT = re.compile(r"^Result:\s*(PASS|FAIL)\s*$", re.MULTILINE)
 # prove footer: "Files=238, Tests=12345, 30 wallclock secs (...)".
 _RE_PROVE_FILES_TESTS = re.compile(r"^Files=(\d+),\s*Tests=(\d+)", re.MULTILINE)
 # Per-file failure lines in the "Test Summary Report" block, e.g.
-# "tests/chmod/12.t (Wstat: 0 Tests: 203 Failed: 1)".
+# "tests/chmod/12.t (Wstat: 0 Tests: 203 Failed: 1)". A non-zero Wstat marks a
+# file prove deemed "Dubious" (crashed / exited non-zero) even when Failed is 0.
 _RE_PROVE_FAILED_FILE = re.compile(
-    r"^(\S+\.t)\s+\(Wstat:\s*\d+\s+Tests:\s*(\d+)\s+Failed:\s*(\d+)\)",
+    r"^(\S+\.t)\s+\(Wstat:\s*(\d+)\s+Tests:\s*(\d+)\s+Failed:\s*(\d+)\)",
     re.MULTILINE,
 )
 # Per-file lines: progress lines ("<path>.t ..... ok") during the run and the
@@ -232,6 +233,8 @@ class PjdfstestResult:
     success: bool
     files_total: int = 0
     tests_total: int = 0
+    # (file, failed_subtest_count). A count of 0 means the file failed only by a
+    # non-zero Wstat (crashed / dubious exit), not by a failing subtest.
     failed_files: list[tuple[str, int]] = field(default_factory=list)
     all_files: list[str] = field(default_factory=list)
     result: str = ""  # "PASS" | "FAIL" | ""
@@ -252,8 +255,15 @@ def parse_pjdfstest_output(output: str) -> PjdfstestResult:
         A :class:`PjdfstestResult`. ``success`` is False (with ``error`` set)
         when no recognizable prove summary is present.
     """
+    # A Test Summary Report entry is a failure when subtests failed OR when the
+    # file exited non-zero / died from a signal (non-zero Wstat), which prove
+    # flags as "Dubious" even with Failed: 0. Record the failed-subtest count
+    # (0 for a Wstat-only failure); the presence in this list, not the count,
+    # is what marks the file failed.
     failed_files = [
-        (name, int(failed)) for name, _tests, failed in _RE_PROVE_FAILED_FILE.findall(output) if int(failed) > 0
+        (name, int(failed))
+        for name, wstat, _tests, failed in _RE_PROVE_FAILED_FILE.findall(output)
+        if int(failed) > 0 or int(wstat) != 0
     ]
 
     # Enumerate every test file (progress + summary lines), preserving first-seen
@@ -1115,9 +1125,11 @@ class K8sPosixComplianceCheck(_K8sSharedFsCheck):
     def _is_podsecurity_denial(text: str) -> bool:
         """Return True when ``text`` looks like a Pod Security admission rejection."""
         low = (text or "").lower()
-        if "podsecurity" in low or "violates" in low:
+        if "podsecurity" in low or "pod security" in low:
             return True
-        return "privileged" in low and ("forbidden" in low or "not allowed" in low or "denied" in low)
+        return "privileged" in low and (
+            "forbidden" in low or "not allowed" in low or "denied" in low or "violates" in low
+        )
 
     def _apply_posix_pod(self, name: str, pvc_name: str) -> tuple[int, str]:
         image = str(self.config.get("image") or _DEFAULT_BUILD_IMAGE)
@@ -1242,9 +1254,14 @@ class K8sPosixComplianceCheck(_K8sSharedFsCheck):
             # complete per-file POSIX-compliance record, not just the failures.
             failed_map = dict(result.failed_files)
             for fname in result.all_files:
-                nfailed = failed_map.get(fname, 0)
-                if nfailed:
-                    self.report_subtest(fname, passed=False, message=f"{nfailed} POSIX subtest(s) failed")
+                if fname in failed_map:
+                    nfailed = failed_map[fname]
+                    message = (
+                        f"{nfailed} POSIX subtest(s) failed"
+                        if nfailed
+                        else "non-zero exit status (crashed / dubious)"
+                    )
+                    self.report_subtest(fname, passed=False, message=message)
                 else:
                     self.report_subtest(fname, passed=True)
 

--- a/isvtest/src/isvtest/validations/k8s_filesystem.py
+++ b/isvtest/src/isvtest/validations/k8s_filesystem.py
@@ -1,0 +1,1263 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared-filesystem POSIX-semantics validations (multi-pod, RWX PVC).
+
+These checks exercise filesystem behavior that a shared (RWX) volume must
+provide for home-directory / scratch use cases, by mounting one PVC from two
+BusyBox pods and driving real syscalls through ``kubectl exec``:
+
+* :class:`K8sFileLockingCheck` - ``flock`` acquired from pod A blocks
+  or EAGAINs pod B on the same PVC, and releases cleanly.
+* :class:`K8sCrossNodeWriteVisibilityCheck` - a file written from a
+  pod on node A is readable with correct content from a pod on node B.
+* :class:`K8sCrossNodeAttrConsistencyCheck` - extending a file on
+  node A is reflected in ``stat`` size + mtime from node B within the
+  vendor-documented attribute-cache window.
+* :class:`K8sLargeDirListingFilesCheck` - create a large number of
+  files in one directory and list them without error or truncation.
+* :class:`K8sLargeDirListingDirsCheck` - same for subdirectories.
+* :class:`K8sPosixComplianceCheck` - build and run the upstream
+  pjdfstest POSIX suite (chmod/chown/link/rename/...) in a privileged
+  root pod against the mounted volume.
+
+The per-operation logic is factored into transport-neutral shell-snippet
+helpers (``write_payload_cmd``, ``flock_nonblock_cmd``, ``stat_size_mtime_cmd``,
+``create_files_cmd``, ...). The k8s checks wrap them in ``kubectl exec``; a
+future bare-metal sibling can run the same snippets over an SSH/local runner
+against two hosts sharing the mount.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import time
+import uuid
+from abc import abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, ClassVar
+
+from isvtest.config.settings import (
+    get_k8s_csi_nfs_storage_class,
+    get_k8s_csi_shared_fs_storage_class,
+)
+from isvtest.core.k8s import (
+    get_kubectl_base_shell,
+    get_kubectl_command,
+    kubectl_items_or_empty,
+    render_k8s_manifest,
+    run_kubectl,
+)
+from isvtest.core.runners import CommandResult
+from isvtest.core.validation import BaseValidation
+
+# Reuse the stable PVC manifest + apply/poll helpers from the CSI checks so
+# the two storage modules stay consistent on manifest shape
+from isvtest.validations.k8s_storage import (
+    _MOUNT_POD_MANIFEST,
+    _PVC_MANIFEST,
+    _apply_manifest,
+    _poll_pvc_bound,
+    _set_fs_pod_fields,
+    _set_pvc_fields,
+    _wait_pod_ready,
+)
+
+_MANIFEST_DIR = Path(__file__).parent / "manifests" / "k8s"
+_PJDFSTEST_POD_MANIFEST = _MANIFEST_DIR / "pjdfstest_pod.yaml"
+
+# Vendored pjdfstest source, if not present, run `make vendor-pjdfstest`
+_PJDFSTEST_SRC_DIR = Path(__file__).resolve().parents[3] / "vendor" / "pjdfstest"
+# Where the source is copied (and built) inside the probe pod.
+_PJDFSTEST_DEST = "/opt/pjdfstest"
+
+# Default probe image for the POSIX-compliance check. A stock public toolchain
+# image (buildpack-deps based) that already ships cc/make/autoconf/automake,
+# perl (prove), git and tar - so building pjdfstest and running prove need
+# nothing from the network beyond pulling the image. Override via the ``image``
+# config key to point at a registry mirror on air-gapped clusters.
+_DEFAULT_BUILD_IMAGE = "gcc:12"
+
+_DATA_DIR = "/data"
+
+# BusyBox provides flock/stat/ls/mkdir/awk/seq; override via the ``image``
+# config key for air-gapped clusters that mirror to a private registry.
+_DEFAULT_IMAGE = "busybox:1.36"
+
+# Exclude nodes with these taints from scheduling
+# unless the user supplies matching tolerations via the ``tolerations`` config key.
+_DEFAULT_NOEXECUTE_TAINT_KEYS: frozenset[str] = frozenset(
+    {
+        "node.kubernetes.io/not-ready",
+        "node.kubernetes.io/unreachable",
+    }
+)
+
+
+def _taint_is_tolerated(taint: dict[str, Any], tolerations: list[dict[str, Any]]) -> bool:
+    """Return True when any entry in ``tolerations`` covers ``taint``. """
+    taint_key = taint.get("key", "")
+    taint_value = taint.get("value", "")
+    taint_effect = taint.get("effect", "")
+    for t in tolerations:
+        if not isinstance(t, dict):
+            continue
+        t_effect = t.get("effect", "")
+        if t_effect and t_effect != taint_effect:
+            continue
+        t_op = t.get("operator", "Equal")
+        t_key = t.get("key")
+        if t_op == "Exists":
+            if t_key is None or t_key == "" or t_key == taint_key:
+                return True
+        else:  # Equal
+            if (t_key is None or t_key == taint_key) and t.get("value", "") == taint_value:
+                return True
+    return False
+
+
+def _fmt_err(text: str, max_len: int = 200) -> str:
+    """Strip whitespace and truncate ``text`` to ``max_len`` characters."""
+    return text.strip()[:max_len]
+
+
+# --------------------------------------------------------------------------
+# Transport-neutral shell-snippet helpers.
+#
+# Each returns an ``sh -c``-ready command string operating on a mounted path.
+# They are deliberately free of any kubectl/SSH coupling so the same snippet
+# can be wrapped by whichever transport a provider uses.
+# --------------------------------------------------------------------------
+
+
+def write_payload_cmd(path: str, payload: str) -> str:
+    """Truncate ``path`` and write ``payload`` verbatim (no trailing newline)."""
+    return f"printf %s {shlex.quote(payload)} > {shlex.quote(path)}"
+
+
+def append_payload_cmd(path: str, payload: str) -> str:
+    """Append ``payload`` to ``path`` verbatim (no trailing newline)."""
+    return f"printf %s {shlex.quote(payload)} >> {shlex.quote(path)}"
+
+
+def read_file_cmd(path: str) -> str:
+    """Read ``path`` to stdout."""
+    return f"cat {shlex.quote(path)}"
+
+
+def stat_size_mtime_cmd(path: str) -> str:
+    """Print ``<size_bytes> <mtime_epoch_seconds>`` for ``path``."""
+    return f"stat -c '%s %Y' {shlex.quote(path)}"
+
+
+def flock_hold_command(lock_path: str) -> list[str]:
+    """Container command that grabs an exclusive ``flock`` and holds it for the
+    pod's lifetime (released only when the pod is deleted).
+    """
+    return ["flock", "-x", lock_path, "sh", "-c", "while true; do sleep 3600; done"]
+
+
+def flock_nonblock_cmd(lock_path: str) -> str:
+    """Try to grab an exclusive ``flock`` without blocking; non-zero on EAGAIN."""
+    return f"flock -xn {shlex.quote(lock_path)} true"
+
+
+def create_files_cmd(directory: str, count: int, prefix: str = "f") -> str:
+    """Create ``count`` empty files ``<prefix>1..<prefix>count`` under ``directory``."""
+    names = f"seq 1 {int(count)} | awk -v d={shlex.quote(directory)} -v p={shlex.quote(prefix)} '{{print d\"/\"p$0}}'"
+    return f"mkdir -p {shlex.quote(directory)} && {names} | xargs touch"
+
+
+def create_dirs_cmd(directory: str, count: int, prefix: str = "d") -> str:
+    """Create ``count`` subdirectories ``<prefix>1..<prefix>count`` under ``directory``."""
+    names = f"seq 1 {int(count)} | awk -v d={shlex.quote(directory)} -v p={shlex.quote(prefix)} '{{print d\"/\"p$0}}'"
+    return f"mkdir -p {shlex.quote(directory)} && {names} | xargs mkdir"
+
+
+def list_dir_quiet_cmd(directory: str) -> str:
+    """List ``directory`` discarding output; non-zero exit means ``ls`` errored."""
+    return f"ls -1A {shlex.quote(directory)} >/dev/null"
+
+
+def count_entries_cmd(directory: str) -> str:
+    """Count immediate entries under ``directory`` (excludes ``.`` and ``..``)."""
+    return f"find {shlex.quote(directory)} -mindepth 1 -maxdepth 1 | wc -l"
+
+
+# --------------------------------------------------------------------------
+# pjdfstest (prove/TAP) output parsing.
+# --------------------------------------------------------------------------
+
+# prove footer: "Result: PASS" / "Result: FAIL".
+_RE_PROVE_RESULT = re.compile(r"^Result:\s*(PASS|FAIL)\s*$", re.MULTILINE)
+# prove footer: "Files=238, Tests=12345, 30 wallclock secs (...)".
+_RE_PROVE_FILES_TESTS = re.compile(r"^Files=(\d+),\s*Tests=(\d+)", re.MULTILINE)
+# Per-file failure lines in the "Test Summary Report" block, e.g.
+# "tests/chmod/12.t (Wstat: 0 Tests: 203 Failed: 1)".
+_RE_PROVE_FAILED_FILE = re.compile(
+    r"^(\S+\.t)\s+\(Wstat:\s*\d+\s+Tests:\s*(\d+)\s+Failed:\s*(\d+)\)",
+    re.MULTILINE,
+)
+# Per-file lines: progress lines ("<path>.t ..... ok") during the run and the
+# "Test Summary Report" lines both start with the file path at column 0, so a
+# deduped scan of these enumerates every test file prove executed.
+_RE_PROVE_FILE = re.compile(r"^(\S+\.t)\b", re.MULTILINE)
+_PROVE_ALL_OK = "All tests successful."
+
+
+@dataclass
+class PjdfstestResult:
+    """Parsed result of a ``prove -r <pjdfstest>/tests`` run.
+
+    ``success`` is True only when prove reported PASS (or "All tests
+    successful." with no failing files). ``error`` is set when the output
+    could not be interpreted as a prove summary at all.
+    """
+
+    success: bool
+    files_total: int = 0
+    tests_total: int = 0
+    failed_files: list[tuple[str, int]] = field(default_factory=list)
+    all_files: list[str] = field(default_factory=list)
+    result: str = ""  # "PASS" | "FAIL" | ""
+    error: str = ""
+
+
+def parse_pjdfstest_output(output: str) -> PjdfstestResult:
+    """Parse prove's summary for the pjdfstest suite.
+
+    Extracts the PASS/FAIL verdict, file/test totals, and the per-file
+    failure list from prove's "Test Summary Report". Mirrors the shape of
+    :func:`isvtest.workloads.nccl_common.parse_nccl_output`.
+
+    Args:
+        output: Combined stdout/stderr from a ``prove`` invocation.
+
+    Returns:
+        A :class:`PjdfstestResult`. ``success`` is False (with ``error`` set)
+        when no recognizable prove summary is present.
+    """
+    failed_files = [
+        (name, int(failed)) for name, _tests, failed in _RE_PROVE_FAILED_FILE.findall(output) if int(failed) > 0
+    ]
+
+    # Enumerate every test file (progress + summary lines), preserving first-seen
+    # (execution) order, so callers can emit a per-file subtest for all of them.
+    all_files: list[str] = []
+    seen: set[str] = set()
+    for name in _RE_PROVE_FILE.findall(output):
+        if name not in seen:
+            seen.add(name)
+            all_files.append(name)
+
+    files_total = tests_total = 0
+    ft = _RE_PROVE_FILES_TESTS.search(output)
+    if ft:
+        files_total, tests_total = int(ft.group(1)), int(ft.group(2))
+
+    verdict_match = _RE_PROVE_RESULT.search(output)
+    verdict = verdict_match.group(1) if verdict_match else ""
+    all_ok = _PROVE_ALL_OK in output
+
+    if not verdict and not all_ok:
+        return PjdfstestResult(
+            success=False,
+            files_total=files_total,
+            tests_total=tests_total,
+            failed_files=failed_files,
+            all_files=all_files,
+            error="Could not parse prove summary from pjdfstest output",
+        )
+
+    success = (verdict == "PASS" or (all_ok and not verdict)) and not failed_files
+    return PjdfstestResult(
+        success=success,
+        files_total=files_total,
+        tests_total=tests_total,
+        failed_files=failed_files,
+        all_files=all_files,
+        result=verdict or ("PASS" if all_ok else "FAIL"),
+    )
+
+
+# --------------------------------------------------------------------------
+# Shared harness.
+# --------------------------------------------------------------------------
+
+
+def _coerce_maybe_json(value: Any) -> Any:
+    """Return structured config, JSON-parsing the value when it is a string.
+
+    Native YAML config supplies ``node_selector`` / ``kernel_modules`` as a
+    dict / list. When the values are instead injected as a Jinja-rendered JSON
+    string (e.g. from a setup step's output), parse those back into the
+    underlying structure. Empty / blank strings become ``None`` (the caller's
+    "unset" sentinel); unparseable strings pass through untouched.
+    """
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    if not stripped:
+        return None
+    try:
+        return json.loads(stripped)
+    except (ValueError, TypeError):
+        return value
+
+
+class _K8sSharedFsCheck(BaseValidation):
+    """Common harness for shared-filesystem checks: namespace + RWX PVC + pods.
+
+    Concrete subclasses implement :meth:`run`. This base is abstract (no
+    ``run``) so it is skipped by validation discovery.
+
+    Common config keys (in addition to each subclass's own):
+        image: Container image for the probe pods (default: ``busybox:1.36``).
+            Override to point at a mirror on air-gapped clusters; it must
+            provide ``sh``/``flock``/``stat``/``ls``/``mkdir``/``awk``/``seq``.
+        node_selector: Optional dict of label key/value pairs added to
+            ``spec.nodeSelector`` on every probe pod. Use this to restrict
+            scheduling to nodes where the CSI driver is installed, e.g.
+            ``{scd.vastdata.com/node: "true"}`` or ``{kubernetes.io/os: linux}``.
+            For cross-node checks the selector also filters which
+            nodes are considered when picking two distinct Ready nodes.
+        tolerations: Optional list of Kubernetes toleration objects appended to
+            ``spec.tolerations`` on every probe pod.
+    """
+
+    # Subclasses may override these config-key defaults.
+    _DEFAULT_NS_PREFIX: ClassVar[str] = "isvtest-fs"
+    _DEFAULT_PVC_SIZE: ClassVar[str] = "1Gi"
+    _DEFAULT_BIND_TIMEOUT_S: ClassVar[int] = 180
+
+    def _setup_kubectl(self) -> None:
+        self._kubectl_parts = get_kubectl_command()
+        self._kubectl_base = get_kubectl_base_shell()
+
+    def _resolve_shared_sc(self) -> str:
+        """Resolve the RWX StorageClass: shared-fs, then NFS, then env fallbacks."""
+        return str(
+            self.config.get("shared_fs_storage_class")
+            or self.config.get("nfs_storage_class")
+            or get_k8s_csi_shared_fs_storage_class()
+            or get_k8s_csi_nfs_storage_class()
+            or ""
+        )
+
+    def _create_namespace(self) -> bool:
+        prefix = self.config.get("namespace_prefix", self._DEFAULT_NS_PREFIX)
+        self._namespace = f"{prefix}-{uuid.uuid4().hex[:8]}"
+        self._ns_quoted = shlex.quote(self._namespace)
+        result = self.run_command(f"{self._kubectl_base} create namespace {self._ns_quoted}")
+        if result.exit_code != 0:
+            self.set_failed(f"Failed to create namespace {self._namespace}: {result.stderr}")
+            return False
+        return True
+
+    def _cleanup_namespace(self, created: bool) -> None:
+        if not created:
+            return
+        cleanup = self.run_command(
+            f"{self._kubectl_base} delete namespace {self._ns_quoted} --wait=false --ignore-not-found=true"
+        )
+        if cleanup.exit_code != 0:
+            self.log.warning("Namespace cleanup failed for %s: %s", self._namespace, cleanup.stderr)
+
+    def _apply_pvc(self, name: str, sc: str, size: str) -> tuple[int, str]:
+        def _mutate(doc: dict[str, Any]) -> dict[str, Any]:
+            return _set_pvc_fields(doc, namespace=self._namespace, name=name, sc=sc, mode="ReadWriteMany", size=size)
+
+        return _apply_manifest(self._kubectl_parts, render_k8s_manifest(_PVC_MANIFEST, _mutate), self.timeout)
+
+    def _image(self) -> str:
+        return str(self.config.get("image") or _DEFAULT_IMAGE)
+
+    def _node_selector(self) -> dict[str, str]:
+        """Return ``node_selector`` from config as a ``{label: value}`` dict.
+
+        Accepts either a native dict or the JSON-string form emitted by the
+        storage manifest's ``manifest_to_steps`` setup step.
+        """
+        raw = _coerce_maybe_json(self.config.get("node_selector")) or {}
+        if not isinstance(raw, dict):
+            return {}
+        return {str(k): str(v) for k, v in raw.items()}
+
+    def _tolerations(self) -> list[dict[str, Any]]:
+        """Return ``tolerations`` from config as a list of toleration dicts."""
+        raw = self.config.get("tolerations") or []
+        if not isinstance(raw, list):
+            return []
+        return [t for t in raw if isinstance(t, dict)]
+
+    def _apply_pod(
+        self,
+        name: str,
+        pvc_name: str,
+        *,
+        node_name: str | None = None,
+        command: list[str] | None = None,
+    ) -> tuple[int, str]:
+        image = self._image()
+        node_selector = self._node_selector() or None
+        tolerations = self._tolerations() or None
+
+        def _mutate(doc: dict[str, Any]) -> dict[str, Any]:
+            return _set_fs_pod_fields(
+                doc,
+                namespace=self._namespace,
+                name=name,
+                pvc_name=pvc_name,
+                image=image,
+                node_name=node_name,
+                node_selector=node_selector,
+                tolerations=tolerations,
+                command=command,
+            )
+
+        return _apply_manifest(self._kubectl_parts, render_k8s_manifest(_MOUNT_POD_MANIFEST, _mutate), self.timeout)
+
+    def _wait_ready(self, pod_name: str, timeout_s: int) -> tuple[bool, str]:
+        ok, err = _wait_pod_ready(self.run_command, self._kubectl_base, self._namespace, pod_name, timeout_s)
+        if not ok:
+            # Append container logs so the failure message contains the actual
+            # error (e.g. "flock: Operation not supported") rather than just
+            # "did not become Ready".
+            logs = self.run_command(
+                f"{self._kubectl_base} logs -n {self._ns_quoted} {shlex.quote(pod_name)} --tail=20 2>&1"
+            )
+            if logs.stdout.strip():
+                err = f"{err}\nContainer logs:\n{logs.stdout.strip()}"
+        return ok, err
+
+    def _wait_pvc_bound(self, pvc_name: str, timeout_s: int) -> bool:
+        return _poll_pvc_bound(self.run_command, self._kubectl_base, self._namespace, pvc_name, timeout_s, poll_interval_s=60.0)
+
+    def _exec(self, pod_name: str, inner: str, timeout: int | None = None) -> CommandResult:
+        cmd = f"{self._kubectl_base} exec -n {self._ns_quoted} {shlex.quote(pod_name)} -- sh -c {shlex.quote(inner)}"
+        # Log the un-double-quoted form; shlex.quote's nested '"'"' escaping of
+        # the inner snippet is correct but unreadable in logs.
+        display_cmd = f"{self._kubectl_base} exec -n {self._namespace} {pod_name} -- sh -c {inner!r}"
+        return self.run_command(cmd, timeout=timeout, display_cmd=display_cmd)
+
+    def _delete_pod(self, pod_name: str, *, wait: bool) -> None:
+        wait_flag = "true" if wait else "false"
+        self.run_command(
+            f"{self._kubectl_base} delete pod {shlex.quote(pod_name)} -n {self._ns_quoted} "
+            f"--wait={wait_flag} --ignore-not-found=true"
+        )
+
+    @staticmethod
+    def _item_is_ready(node_item: dict[str, Any]) -> bool:
+        """Return True when a node item's ``Ready`` condition has ``status == "True"``."""
+        for condition in (node_item.get("status") or {}).get("conditions") or []:
+            if isinstance(condition, dict) and condition.get("type") == "Ready":
+                return condition.get("status") == "True"
+        return False
+
+    @staticmethod
+    def _has_untolerated_noexecute_taint(
+        node_item: dict[str, Any],
+        user_tolerations: list[dict[str, Any]],
+    ) -> bool:
+        """Return True when the node has a NoExecute taint our pods won't tolerate.
+
+        Checks against the two default Kubernetes tolerations (``not-ready`` /
+        ``unreachable``) plus any user-supplied ``tolerations`` from config.
+        """
+        for taint in (node_item.get("spec") or {}).get("taints") or []:
+            if not isinstance(taint, dict) or taint.get("effect") != "NoExecute":
+                continue
+            if taint.get("key") in _DEFAULT_NOEXECUTE_TAINT_KEYS:
+                continue
+            if _taint_is_tolerated(taint, user_tolerations):
+                continue
+            return True
+        return False
+
+    def _ready_nodes(self) -> list[str]:
+        """Return schedulable node matching node_selector (if set), sorted for determinism."""
+        selector = self._node_selector()
+        extra_args = ["-l", ",".join(f"{k}={v}" for k, v in sorted(selector.items()))] if selector else []
+        result = run_kubectl(["get", "nodes", *extra_args, "-o", "json"])
+        if result.returncode != 0:
+            self.log.warning(
+                "kubectl get nodes%s failed (rc=%s): %s",
+                f" -l {extra_args[1]}" if extra_args else "",
+                result.returncode,
+                _fmt_err(result.stderr or ""),
+            )
+            return []
+        user_tolerations = self._tolerations()
+        return sorted(
+            str(name)
+            for item in kubectl_items_or_empty(result)
+            if self._item_is_ready(item)
+            and not self._has_untolerated_noexecute_taint(item, user_tolerations)
+            and (name := (item.get("metadata") or {}).get("name"))
+        )
+
+
+# --------------------------------------------------------------------------
+# Cross-node base.
+# --------------------------------------------------------------------------
+
+
+class _K8sCrossNodeCheck(_K8sSharedFsCheck):
+    """Shared setup for two pods pinned to distinct nodes on one RWX PVC."""
+
+    def _two_nodes(self) -> list[str] | None:
+        """Return two distinct Ready node names, or ``None`` (after skipping)."""
+        nodes = self._ready_nodes()
+        if len(nodes) < 2:
+            self.set_passed(f"Skipped: cross-node test requires >= 2 Ready nodes, found {len(nodes)}")
+            return None
+        return nodes[:2]
+
+    def _provision(
+        self,
+        pvc_name: str,
+        sc: str,
+        pvc_size: str,
+        pod_a: str,
+        pod_b: str,
+        nodes: list[str],
+        bind_timeout: int,
+        *,
+        cmd_a: list[str] | None = None,
+        cmd_b: list[str] | None = None,
+    ) -> bool:
+        """Create the PVC and both node-pinned pods, then wait for Ready."""
+        rc, err = self._apply_pvc(pvc_name, sc, pvc_size)
+        if rc != 0:
+            self.set_failed(f"kubectl apply failed for PVC {pvc_name!r}: {_fmt_err(err)}")
+            return False
+        if not self._wait_pvc_bound(pvc_name, bind_timeout):
+            self.set_failed(f"PVC {pvc_name!r} did not reach Bound within {bind_timeout}s")
+            return False
+        still_ready = set(self._ready_nodes())
+        stale = [n for n in nodes if n not in still_ready]
+        if stale:
+            self.set_failed(
+                f"Node(s) {stale} are no longer schedulable after PVC binding; "
+                "retry or investigate node health before re-running"
+            )
+            return False
+        rc, err = self._apply_pod(pod_a, pvc_name, node_name=nodes[0], command=cmd_a)
+        if rc != 0:
+            self.set_failed(f"kubectl apply failed for pod {pod_a!r} on {nodes[0]!r}: {_fmt_err(err)}")
+            return False
+        rc, err = self._apply_pod(pod_b, pvc_name, node_name=nodes[1], command=cmd_b)
+        if rc != 0:
+            self.set_failed(f"kubectl apply failed for pod {pod_b!r} on {nodes[1]!r}: {_fmt_err(err)}")
+            return False
+        for pod, node in ((pod_a, nodes[0]), (pod_b, nodes[1])):
+            ready, wait_err = self._wait_ready(pod, bind_timeout)
+            if not ready:
+                self.set_failed(
+                    f"Pod {pod!r} on node {node!r} did not become Ready within {bind_timeout}s: {_fmt_err(wait_err)}"
+                )
+                return False
+        return True
+
+
+# --------------------------------------------------------------------------
+# File locking across pods.
+# --------------------------------------------------------------------------
+
+
+class K8sFileLockingCheck(_K8sCrossNodeCheck):
+    """Verify ``flock`` is honoured across pods on distinct nodes.
+
+    Pod A (node A) holds an exclusive ``flock`` on a file on a shared RWX PVC
+    for its lifetime. While A holds the lock, pod B (node B) on the same PVC
+    must be denied by a non-blocking ``flock -xn`` (EAGAIN). After pod A is
+    deleted, pod B's ``flock -xn`` must succeed. Pinning the pods to distinct
+    nodes is what makes this exercise *distributed* lock arbitration rather
+    than local-kernel enforcement, so the check is skipped on single-node
+    clusters.
+
+    Config keys (with defaults):
+        shared_fs_storage_class / nfs_storage_class: RWX StorageClass; the
+            check is skipped when neither (nor the env fallbacks) is set.
+        pvc_size: PVC request size (default: ``1Gi``).
+        bind_timeout_s: Max wait for PVCs to bind / pods to become Ready
+            (default: 180).
+        release_timeout_s: Max wait for pod B to acquire after A is deleted
+            (default: 60).
+        namespace_prefix: Ephemeral namespace prefix (default:
+            ``isvtest-fs-lock``).
+        timeout: Per-command timeout (default: 300).
+    """
+
+    description: ClassVar[str] = "Verify flock locking is honoured across pods on distinct nodes on one RWX PVC."
+    timeout: ClassVar[int] = 300
+
+    _DEFAULT_NS_PREFIX = "isvtest-fs-lock"
+
+    def run(self) -> None:
+        self._setup_kubectl()
+        sc = self._resolve_shared_sc()
+        if not sc:
+            self.set_passed("Skipped: no shared-fs/nfs StorageClass configured")
+            return
+
+        nodes = self._two_nodes()
+        if nodes is None:
+            return
+
+        bind_timeout = int(self.config.get("bind_timeout_s", self._DEFAULT_BIND_TIMEOUT_S))
+        pvc_size = str(self.config.get("pvc_size", self._DEFAULT_PVC_SIZE))
+        release_timeout = int(self.config.get("release_timeout_s", 60))
+        lock_path = f"{_DATA_DIR}/lockfile"
+
+        created = False
+        try:
+            created = self._create_namespace()
+            if not created:
+                return
+
+            pvc_name = f"fs-lock-{uuid.uuid4().hex[:6]}"
+            pod_a = f"fs-lock-holder-{uuid.uuid4().hex[:6]}"
+            pod_b = f"fs-lock-waiter-{uuid.uuid4().hex[:6]}"
+
+            # Pod A holds the lock for its whole lifetime (released only by the
+            # explicit delete below); pod B uses the default keepalive command.
+            if not self._provision(
+                pvc_name,
+                sc,
+                pvc_size,
+                pod_a,
+                pod_b,
+                nodes,
+                bind_timeout,
+                cmd_a=flock_hold_command(lock_path),
+            ):
+                return
+
+            # Give pod A a moment to actually acquire the lock after its
+            # container starts running.
+            time.sleep(2.0)
+
+            # Subtest 1: pod B must NOT be able to acquire while A holds.
+            contend = self._exec(pod_b, flock_nonblock_cmd(lock_path))
+            if contend.exit_code == 1:
+                contention_ok = True
+                contention_msg = "Pod B was correctly denied the lock (EAGAIN) while pod A held it"
+            elif contend.exit_code == 0:
+                contention_ok = False
+                contention_msg = "Pod B acquired the lock while pod A still held it (locking not enforced across pods)"
+            else:
+                contention_ok = False
+                contention_msg = (
+                    f"flock on pod B errored (exit {contend.exit_code}); could not evaluate contention: "
+                    f"{_fmt_err(contend.stderr or contend.stdout)}"
+                )
+            self.report_subtest("lock-contention", passed=contention_ok, message=contention_msg)
+
+            # Subtest 2: after A releases (pod deleted), B must be able to acquire.
+            self._delete_pod(pod_a, wait=True)
+            release_ok = False
+            deadline = time.time() + release_timeout
+            while time.time() < deadline:
+                acquired = self._exec(pod_b, flock_nonblock_cmd(lock_path))
+                if acquired.exit_code == 0:
+                    release_ok = True
+                    break
+                time.sleep(2.0)
+            self.report_subtest(
+                "lock-release",
+                passed=release_ok,
+                message=(
+                    "Pod B acquired the lock after pod A was deleted"
+                    if release_ok
+                    else f"Pod B could not acquire the lock within {release_timeout}s after pod A was deleted"
+                ),
+            )
+
+            if contention_ok and release_ok:
+                self.set_passed("flock locking enforced across pods on the shared PVC")
+            else:
+                self.set_failed("Cross-pod flock locking did not behave correctly; see subtest details")
+        finally:
+            self._cleanup_namespace(created)
+
+
+# --------------------------------------------------------------------------
+# Cross-node write visibility.
+# --------------------------------------------------------------------------
+
+
+class K8sCrossNodeWriteVisibilityCheck(_K8sCrossNodeCheck):
+    """Verify a file written on node A is visible+correct on node B.
+
+    Pod A (node A) writes a unique payload to a file on the shared PVC; pod B
+    (node B) reads it back. Passes when the content matches within
+    ``visibility_window_s``.
+
+    Config keys (with defaults):
+        shared_fs_storage_class / nfs_storage_class: RWX StorageClass; skipped
+            when neither (nor the env fallbacks) is set.
+        pvc_size: PVC request size (default: ``1Gi``).
+        bind_timeout_s: Max wait for PVC bind / pod Ready (default: 180).
+        visibility_window_s: Max seconds for the write to become visible on
+            node B. The spec target is 1s; defaults to 5.0 to absorb
+            ``kubectl exec`` round-trip overhead - tighten per vendor SLA.
+        namespace_prefix: Ephemeral namespace prefix (default:
+            ``isvtest-fs-vis``).
+        timeout: Per-command timeout (default: 300).
+    """
+
+    description: ClassVar[str] = "Verify a file written from a pod on node A is readable+correct from node B."
+    timeout: ClassVar[int] = 300
+
+    _DEFAULT_NS_PREFIX = "isvtest-fs-vis"
+
+    def run(self) -> None:
+        self._setup_kubectl()
+        sc = self._resolve_shared_sc()
+        if not sc:
+            self.set_passed("Skipped: no shared-fs/nfs StorageClass configured")
+            return
+
+        nodes = self._two_nodes()
+        if nodes is None:
+            return
+
+        bind_timeout = int(self.config.get("bind_timeout_s", self._DEFAULT_BIND_TIMEOUT_S))
+        pvc_size = str(self.config.get("pvc_size", self._DEFAULT_PVC_SIZE))
+        window_s = float(self.config.get("visibility_window_s", 5.0))
+        file_path = f"{_DATA_DIR}/visfile"
+
+        created = False
+        try:
+            created = self._create_namespace()
+            if not created:
+                return
+
+            suffix = uuid.uuid4().hex[:6]
+            pvc_name = f"fs-vis-{suffix}"
+            pod_a = f"fs-vis-writer-{suffix}"
+            pod_b = f"fs-vis-reader-{suffix}"
+
+            ok = self._provision(pvc_name, sc, pvc_size, pod_a, pod_b, nodes, bind_timeout)
+            if not ok:
+                return
+
+            payload = uuid.uuid4().hex
+            write = self._exec(pod_a, write_payload_cmd(file_path, payload))
+            if write.exit_code != 0:
+                self.set_failed(f"Write from node {nodes[0]!r} failed: {_fmt_err(write.stderr or write.stdout)}")
+                return
+
+            start = time.time()
+            elapsed = 0.0
+            visible = False
+            while True:
+                read = self._exec(pod_b, read_file_cmd(file_path))
+                elapsed = time.time() - start
+                if read.exit_code == 0 and read.stdout.strip() == payload:
+                    visible = True
+                    break
+                if elapsed >= window_s:
+                    break
+                time.sleep(0.1)
+
+            if visible:
+                self.set_passed(
+                    f"File written on node {nodes[0]!r} was readable with correct content on node {nodes[1]!r} "
+                    f"in {elapsed:.2f}s (window {window_s:.2f}s)"
+                )
+            else:
+                self.set_failed(
+                    f"File written on node {nodes[0]!r} was not visible with correct content on node {nodes[1]!r} "
+                    f"within {window_s:.2f}s"
+                )
+        finally:
+            self._cleanup_namespace(created)
+
+
+# --------------------------------------------------------------------------
+# Cross-node attribute consistency.
+# --------------------------------------------------------------------------
+
+
+class K8sCrossNodeAttrConsistencyCheck(_K8sCrossNodeCheck):
+    """Verify extending a file on node A is reflected in stat on node B.
+
+    Pod A (node A) creates then extends a file; pod B (node B) ``stat``s it and
+    must observe the updated size and mtime within ``attr_cache_window_s``
+    (the vendor-documented attribute-cache window).
+
+    Config keys (with defaults):
+        shared_fs_storage_class / nfs_storage_class: RWX StorageClass; skipped
+            when neither (nor the env fallbacks) is set.
+        pvc_size: PVC request size (default: ``1Gi``).
+        bind_timeout_s: Max wait for PVC bind / pod Ready (default: 180).
+        attr_cache_window_s: Max seconds for size+mtime to propagate to node B
+            (default: 30.0).
+        extend_bytes: Bytes appended on node A to grow the file (default: 1024).
+        namespace_prefix: Ephemeral namespace prefix (default:
+            ``isvtest-fs-attr``).
+        timeout: Per-command timeout (default: 300).
+    """
+
+    description: ClassVar[str] = "Verify extending a file on node A is reflected in stat size+mtime on node B."
+    timeout: ClassVar[int] = 300
+
+    _DEFAULT_NS_PREFIX = "isvtest-fs-attr"
+
+    def run(self) -> None:
+        self._setup_kubectl()
+        sc = self._resolve_shared_sc()
+        if not sc:
+            self.set_passed("Skipped: no shared-fs/nfs StorageClass configured")
+            return
+
+        nodes = self._two_nodes()
+        if nodes is None:
+            return
+
+        bind_timeout = int(self.config.get("bind_timeout_s", self._DEFAULT_BIND_TIMEOUT_S))
+        pvc_size = str(self.config.get("pvc_size", self._DEFAULT_PVC_SIZE))
+        window_s = float(self.config.get("attr_cache_window_s", 30.0))
+        extend_bytes = int(self.config.get("extend_bytes", 1024))
+        file_path = f"{_DATA_DIR}/attrfile"
+
+        created = False
+        try:
+            created = self._create_namespace()
+            if not created:
+                return
+
+            suffix = uuid.uuid4().hex[:6]
+            pvc_name = f"fs-attr-{suffix}"
+            pod_a = f"fs-attr-writer-{suffix}"
+            pod_b = f"fs-attr-reader-{suffix}"
+
+            if not self._provision(pvc_name, sc, pvc_size, pod_a, pod_b, nodes, bind_timeout):
+                return
+
+            # Initial small file, then prime node B's attribute cache by
+            # stat-ing it before the extend.
+            init = self._exec(pod_a, write_payload_cmd(file_path, "x"))
+            if init.exit_code != 0:
+                self.set_failed(f"Initial write on node {nodes[0]!r} failed: {_fmt_err(init.stderr)}")
+                return
+            self._exec(pod_b, stat_size_mtime_cmd(file_path))
+
+            # Ensure mtime can advance by at least a whole second (stat %Y is
+            # second-granular), then extend the file on node A.
+            time.sleep(1.1)
+            extend = self._exec(pod_a, append_payload_cmd(file_path, "x" * extend_bytes))
+            if extend.exit_code != 0:
+                self.set_failed(f"Extend on node {nodes[0]!r} failed: {_fmt_err(extend.stderr)}")
+                return
+
+            src = self._exec(pod_a, stat_size_mtime_cmd(file_path))
+            expected = self._parse_stat(src)
+            if expected is None:
+                self.set_failed(f"Could not parse stat output on node {nodes[0]!r}: {_fmt_err(src.stdout)!r}")
+                return
+            expected_size, expected_mtime = expected
+
+            start = time.time()
+            elapsed = 0.0
+            consistent = False
+            observed: tuple[int, int] | None = None
+            while True:
+                dst = self._exec(pod_b, stat_size_mtime_cmd(file_path))
+                observed = self._parse_stat(dst)
+                elapsed = time.time() - start
+                if observed is not None and observed[0] == expected_size and observed[1] >= expected_mtime:
+                    consistent = True
+                    break
+                if elapsed >= window_s:
+                    break
+                time.sleep(0.2)
+
+            if consistent:
+                self.set_passed(
+                    f"stat on node {nodes[1]!r} reflected size={expected_size} and updated mtime "
+                    f"in {elapsed:.2f}s (window {window_s:.2f}s)"
+                )
+            else:
+                self.set_failed(
+                    f"stat on node {nodes[1]!r} did not reflect size={expected_size}/mtime>={expected_mtime} "
+                    f"within {window_s:.2f}s (last observed {observed!r})"
+                )
+        finally:
+            self._cleanup_namespace(created)
+
+    @staticmethod
+    def _parse_stat(result: CommandResult) -> tuple[int, int] | None:
+        """Parse ``"<size> <mtime>"`` stat output into ``(size, mtime)``."""
+        if result.exit_code != 0:
+            return None
+        parts = result.stdout.split()
+        if len(parts) != 2:
+            return None
+        try:
+            return int(parts[0]), int(parts[1])
+        except ValueError:
+            return None
+
+
+# --------------------------------------------------------------------------
+# Large directory listing.
+# --------------------------------------------------------------------------
+
+
+class _K8sLargeDirListingBase(_K8sSharedFsCheck):
+    """Create many entries in one directory and list them without truncation.
+
+    Subclasses set :attr:`_ENTRY_KIND` (``files`` / ``dirs``), the config key
+    for the count, its default, and the creation snippet.
+    """
+
+    timeout: ClassVar[int] = 3600
+
+    _DEFAULT_PVC_SIZE = "10Gi"
+    _DEFAULT_BIND_TIMEOUT_S = 300
+    _ENTRY_KIND: ClassVar[str] = ""
+    _COUNT_KEY: ClassVar[str] = ""
+    _DEFAULT_COUNT: ClassVar[int] = 0
+
+    @abstractmethod
+    def _create_cmd(self, directory: str, count: int) -> str:
+        """Return the shell snippet that creates ``count`` entries under ``directory``."""
+
+    def run(self) -> None:
+        self._setup_kubectl()
+        sc = self._resolve_shared_sc()
+        if not sc:
+            self.set_passed("Skipped: no shared-fs/nfs StorageClass configured")
+            return
+
+        count = self._parse_positive_int(self._COUNT_KEY, default=self._DEFAULT_COUNT)
+        if count is None:
+            return
+
+        bind_timeout = int(self.config.get("bind_timeout_s", self._DEFAULT_BIND_TIMEOUT_S))
+        pvc_size = str(self.config.get("pvc_size", self._DEFAULT_PVC_SIZE))
+        target_dir = f"{_DATA_DIR}/bigdir"
+
+        created = False
+        try:
+            created = self._create_namespace()
+            if not created:
+                return
+
+            suffix = uuid.uuid4().hex[:6]
+            pvc_name = f"fs-bigdir-{suffix}"
+            pod = f"fs-bigdir-{suffix}"
+
+            rc, err = self._apply_pvc(pvc_name, sc, pvc_size)
+            if rc != 0:
+                self.set_failed(f"kubectl apply failed for PVC {pvc_name!r}: {_fmt_err(err)}")
+                return
+            if not self._wait_pvc_bound(pvc_name, bind_timeout):
+                self.set_failed(f"PVC {pvc_name!r} did not reach Bound within {bind_timeout}s")
+                return
+            rc, err = self._apply_pod(pod, pvc_name)
+            if rc != 0:
+                self.set_failed(f"kubectl apply failed for pod {pod!r}: {_fmt_err(err)}")
+                return
+            ready, wait_err = self._wait_ready(pod, bind_timeout)
+            if not ready:
+                self.set_failed(f"Pod {pod!r} did not become Ready within {bind_timeout}s: {_fmt_err(wait_err)}")
+                return
+
+            create = self._exec(pod, self._create_cmd(target_dir, count), timeout=self.timeout)
+            if create.exit_code != 0:
+                self.set_failed(
+                    f"Creating {count} {self._ENTRY_KIND} failed: "
+                    f"{_fmt_err(create.stderr or create.stdout)}"
+                )
+                return
+
+            listing = self._exec(pod, list_dir_quiet_cmd(target_dir), timeout=self.timeout)
+            if listing.exit_code != 0:
+                self.set_failed(
+                    f"ls of directory with {count} {self._ENTRY_KIND} errored: "
+                    f"{_fmt_err(listing.stderr or listing.stdout)}"
+                )
+                return
+
+            counted = self._exec(pod, count_entries_cmd(target_dir), timeout=self.timeout)
+            if counted.exit_code != 0:
+                self.set_failed(f"Counting entries failed: {_fmt_err(counted.stderr)}")
+                return
+            try:
+                observed = int(counted.stdout.strip())
+            except ValueError:
+                self.set_failed(f"Could not parse entry count: {_fmt_err(counted.stdout)!r}")
+                return
+
+            if observed == count:
+                self.set_passed(f"Listed all {count} {self._ENTRY_KIND} without error or truncation")
+            else:
+                self.set_failed(
+                    f"Expected {count} {self._ENTRY_KIND} but listing found {observed} (possible truncation)"
+                )
+        finally:
+            self._cleanup_namespace(created)
+
+
+class K8sLargeDirListingFilesCheck(_K8sLargeDirListingBase):
+    """List a directory holding a very large number of files.
+
+    Config keys (with defaults):
+        files_count: Number of files to create (default: 1,000,000).
+        shared_fs_storage_class / nfs_storage_class: RWX StorageClass; skipped
+            when neither (nor the env fallbacks) is set.
+        pvc_size: PVC request size (default: ``10Gi``).
+        bind_timeout_s: Max wait for PVC bind / pod Ready (default: 300).
+        namespace_prefix: Ephemeral namespace prefix (default:
+            ``isvtest-fs-bigdir``).
+        timeout: Per-command timeout, also bounds creation (default: 3600).
+    """
+
+    description: ClassVar[str] = "Create a large number of files in one directory and list them without truncation."
+    _DEFAULT_NS_PREFIX = "isvtest-fs-bigdir"
+    _ENTRY_KIND = "files"
+    _COUNT_KEY = "files_count"
+    _DEFAULT_COUNT = 1_000_000
+
+    def _create_cmd(self, directory: str, count: int) -> str:
+        return create_files_cmd(directory, count, prefix="f")
+
+
+class K8sLargeDirListingDirsCheck(_K8sLargeDirListingBase):
+    """List a directory holding a very large number of subdirectories.
+
+    Config keys (with defaults):
+        dirs_count: Number of subdirectories to create (default: 500,000).
+        shared_fs_storage_class / nfs_storage_class: RWX StorageClass; skipped
+            when neither (nor the env fallbacks) is set.
+        pvc_size: PVC request size (default: ``10Gi``).
+        bind_timeout_s: Max wait for PVC bind / pod Ready (default: 300).
+        namespace_prefix: Ephemeral namespace prefix (default:
+            ``isvtest-fs-bigdir``).
+        timeout: Per-command timeout, also bounds creation (default: 3600).
+    """
+
+    description: ClassVar[str] = (
+        "Create a large number of subdirectories in one directory and list them without truncation."
+    )
+    _DEFAULT_NS_PREFIX = "isvtest-fs-bigdir"
+    _ENTRY_KIND = "subdirectories"
+    _COUNT_KEY = "dirs_count"
+    _DEFAULT_COUNT = 500_000
+
+    def _create_cmd(self, directory: str, count: int) -> str:
+        return create_dirs_cmd(directory, count, prefix="d")
+
+
+# --------------------------------------------------------------------------
+# POSIX compliance (pjdfstest).
+# --------------------------------------------------------------------------
+
+
+class K8sPosixComplianceCheck(_K8sSharedFsCheck):
+    """Run the upstream pjdfstest POSIX suite against the filesystem storage.
+
+    pjdfstest (https://github.com/pjd/pjdfstest) exercises POSIX system-call
+    semantics (chmod/chown/link/rename/mknod/truncate/...). This check
+    provisions a PVC on the filesystem StorageClass, mounts it at ``/data`` in
+    a single root pod, copies the vendored pjdfstest source into the pod,
+    builds the ``pjdfstest`` helper, and runs ``prove`` against the
+    mounted volume.
+
+    pjdfstest must run as root, so the probe pod is privileged. On clusters
+    that enforce a restrictive Pod Security Standard the pod is rejected and
+    the check skips (passes with a skip message) rather than failing.
+
+    Config keys (with defaults):
+        shared_fs_storage_class / nfs_storage_class: filesystem StorageClass;
+            the check is skipped when neither (nor the env fallbacks) is set.
+        image: probe/toolchain image (default ``gcc:12``). Must provide
+            cc/make/autoconf/automake, perl (``prove``) and tar.
+        pvc_size: PVC request size (default ``5Gi``).
+        bind_timeout_s: Max wait for PVC bind / pod Ready (default 300).
+        build_timeout_s: Max wait for autoreconf+configure+make (default 600).
+        tests_subdir: Optional ``tests/`` subdirectory to scope the run to a
+            subset (e.g. ``chmod``); default runs the full suite.
+        node_selector / tolerations: optional pod scheduling controls.
+        timeout: Per-command timeout, also bounds the prove run (default 3600).
+    """
+
+    description: ClassVar[str] = (
+        "Run the pjdfstest POSIX filesystem test suite against the cluster filesystem storage."
+    )
+    timeout: ClassVar[int] = 3600
+
+    _DEFAULT_NS_PREFIX = "isvtest-fs-posix"
+    _DEFAULT_PVC_SIZE = "5Gi"
+    _DEFAULT_BIND_TIMEOUT_S = 300
+
+    @staticmethod
+    def _is_podsecurity_denial(text: str) -> bool:
+        """Return True when ``text`` looks like a Pod Security admission rejection."""
+        low = (text or "").lower()
+        if "podsecurity" in low or "violates" in low:
+            return True
+        return "privileged" in low and ("forbidden" in low or "not allowed" in low or "denied" in low)
+
+    def _apply_posix_pod(self, name: str, pvc_name: str) -> tuple[int, str]:
+        image = str(self.config.get("image") or _DEFAULT_BUILD_IMAGE)
+        node_selector = self._node_selector() or None
+        tolerations = self._tolerations() or None
+
+        def _mutate(doc: dict[str, Any]) -> dict[str, Any]:
+            return _set_fs_pod_fields(
+                doc,
+                namespace=self._namespace,
+                name=name,
+                pvc_name=pvc_name,
+                image=image,
+                node_selector=node_selector,
+                tolerations=tolerations,
+                # Keep the manifest's sleep-infinity keepalive command.
+                command=None,
+            )
+
+        return _apply_manifest(self._kubectl_parts, render_k8s_manifest(_PJDFSTEST_POD_MANIFEST, _mutate), self.timeout)
+
+    def _copy_source(self, pod: str) -> CommandResult:
+        """``kubectl cp`` the vendored pjdfstest tree into ``pod`` at _PJDFSTEST_DEST."""
+        src = shlex.quote(str(_PJDFSTEST_SRC_DIR))
+        dest = shlex.quote(f"{self._namespace}/{pod}:{_PJDFSTEST_DEST}")
+        return self.run_command(f"{self._kubectl_base} cp {src} {dest} -c probe", timeout=self.timeout)
+
+    def run(self) -> None:
+        self._setup_kubectl()
+        sc = self._resolve_shared_sc()
+        if not sc:
+            self.set_passed("Skipped: no shared-fs/nfs StorageClass configured")
+            return
+        if not _PJDFSTEST_SRC_DIR.is_dir():
+            self.set_failed(
+                f"Vendored pjdfstest source not found at {_PJDFSTEST_SRC_DIR}; "
+                "run `make vendor-pjdfstest`"
+            )
+            return
+
+        bind_timeout = int(self.config.get("bind_timeout_s", self._DEFAULT_BIND_TIMEOUT_S))
+        pvc_size = str(self.config.get("pvc_size", self._DEFAULT_PVC_SIZE))
+        build_timeout = int(self.config.get("build_timeout_s", 600))
+        subdir = str(self.config.get("tests_subdir", "")).strip().strip("/")
+        tests_path = f"{_PJDFSTEST_DEST}/tests" + (f"/{subdir}" if subdir else "")
+
+        created = False
+        try:
+            created = self._create_namespace()
+            if not created:
+                return
+
+            suffix = uuid.uuid4().hex[:6]
+            pvc_name = f"fs-posix-{suffix}"
+            pod = f"fs-posix-{suffix}"
+
+            rc, err = self._apply_pvc(pvc_name, sc, pvc_size)
+            if rc != 0:
+                self.set_failed(f"kubectl apply failed for PVC {pvc_name!r}: {_fmt_err(err)}")
+                return
+            if not self._wait_pvc_bound(pvc_name, bind_timeout):
+                self.set_failed(f"PVC {pvc_name!r} did not reach Bound within {bind_timeout}s")
+                return
+
+            rc, err = self._apply_posix_pod(pod, pvc_name)
+            if rc != 0:
+                if self._is_podsecurity_denial(err):
+                    self.set_passed(
+                        "Skipped: cluster Pod Security admission blocked the privileged pjdfstest "
+                        f"pod (pjdfstest must run as root): {_fmt_err(err)}"
+                    )
+                    return
+                self.set_failed(f"kubectl apply failed for pod {pod!r}: {_fmt_err(err)}")
+                return
+
+            ready, wait_err = self._wait_ready(pod, bind_timeout)
+            if not ready:
+                if self._is_podsecurity_denial(wait_err):
+                    self.set_passed(
+                        "Skipped: cluster Pod Security admission blocked the privileged pjdfstest "
+                        f"pod (pjdfstest must run as root): {_fmt_err(wait_err)}"
+                    )
+                    return
+                self.set_failed(f"Pod {pod!r} did not become Ready within {bind_timeout}s: {_fmt_err(wait_err)}")
+                return
+
+            copied = self._copy_source(pod)
+            if copied.exit_code != 0:
+                self.set_failed(
+                    f"Copying pjdfstest source into pod failed: {_fmt_err(copied.stderr or copied.stdout)}"
+                )
+                return
+
+            build = self._exec(
+                pod,
+                f"cd {_PJDFSTEST_DEST} && autoreconf -ifs && ./configure && make",
+                timeout=build_timeout,
+            )
+            if build.exit_code != 0:
+                build_output = f"{build.stdout}\n{build.stderr}".strip()
+                last_line = next((ln for ln in reversed(build_output.splitlines()) if ln.strip()), "")
+                self.set_failed(
+                    f"Building pjdfstest in the probe pod failed (autoreconf/configure/make, "
+                    f"exit {build.exit_code}): {_fmt_err(last_line)}",
+                    output=build_output[-4000:],
+                )
+                return
+
+            run_cmd = f"cd {_DATA_DIR} && prove -r {shlex.quote(tests_path)}"
+            proven = self._exec(pod, run_cmd, timeout=self.timeout)
+            combined = f"{proven.stdout}\n{proven.stderr}"
+            result = parse_pjdfstest_output(combined)
+
+            if result.error:
+                self.set_failed(
+                    f"Could not parse pjdfstest results (prove exit {proven.exit_code}): {_fmt_err(result.error)}",
+                    output=combined[-2000:],
+                )
+                return
+
+            # Emit a subtest per file (pass and fail) so the JUnit export is a
+            # complete per-file POSIX-compliance record, not just the failures.
+            failed_map = dict(result.failed_files)
+            for fname in result.all_files:
+                nfailed = failed_map.get(fname, 0)
+                if nfailed:
+                    self.report_subtest(fname, passed=False, message=f"{nfailed} POSIX subtest(s) failed")
+                else:
+                    self.report_subtest(fname, passed=True)
+
+            if result.success and proven.exit_code == 0:
+                self.set_passed(
+                    f"pjdfstest POSIX compliance passed: {result.tests_total} tests across "
+                    f"{result.files_total} files, 0 failures"
+                )
+            else:
+                self.set_failed(
+                    f"pjdfstest reported failures ({len(result.failed_files)} test file(s) with failures, "
+                    f"prove result {result.result or 'FAIL'}); see subtests",
+                    output=combined[-2000:],
+                )
+        finally:
+            self._cleanup_namespace(created)

--- a/isvtest/src/isvtest/validations/k8s_storage.py
+++ b/isvtest/src/isvtest/validations/k8s_storage.py
@@ -67,6 +67,10 @@ _RESOURCEQUOTA_MANIFEST = _MANIFEST_DIR / "storage_resourcequota.yaml"
 _PV_MANIFEST = _MANIFEST_DIR / "storage_pv.yaml"
 _MOUNT_POD_MANIFEST = _MANIFEST_DIR / "storage_mount_pod.yaml"
 
+# BusyBox provides flock/stat/ls/mkdir/awk/seq; override via the ``image``
+# config key for air-gapped clusters that mirror to a private registry.
+_DEFAULT_IMAGE = "busybox:1.36"
+
 _STORAGE_TYPES: tuple[tuple[str, str], ...] = (
     ("block", "ReadWriteOnce"),
     ("shared-fs", "ReadWriteMany"),
@@ -142,7 +146,7 @@ def _apply_mount_pod_manifest(
     """
 
     def _mutate(doc: dict[str, Any]) -> dict[str, Any]:
-        return _set_mount_pod_fields(doc, namespace=namespace, name=pod_name, pvc_name=pvc_name)
+        return _set_fs_pod_fields(doc, namespace=namespace, name=pod_name, pvc_name=pvc_name)
 
     return _apply_manifest(kubectl_parts, render_k8s_manifest(_MOUNT_POD_MANIFEST, _mutate), timeout)
 
@@ -1821,7 +1825,7 @@ class K8sCsiProvisioningModesCheck(BaseValidation):
         """Render the BusyBox mount pod and apply it."""
 
         def _mutate(doc: dict[str, Any]) -> dict[str, Any]:
-            return _set_mount_pod_fields(doc, namespace=self._namespace, name=pod_name, pvc_name=pvc_name)
+            return _set_fs_pod_fields(doc, namespace=self._namespace, name=pod_name, pvc_name=pvc_name)
 
         return self._run_kubectl_apply(render_k8s_manifest(_MOUNT_POD_MANIFEST, _mutate))
 
@@ -2483,22 +2487,38 @@ def _apply_pvc_manifest(
     return _apply_manifest(kubectl_parts, render_k8s_manifest(_PVC_MANIFEST, _mutate), timeout)
 
 
-def _set_mount_pod_fields(
+def _set_fs_pod_fields(
     doc: dict[str, Any],
     *,
     namespace: str,
     name: str,
     pvc_name: str,
+    image: str = _DEFAULT_IMAGE,
+    node_name: str | None = None,
+    node_selector: dict[str, str] | None = None,
+    tolerations: list[dict[str, Any]] | None = None,
+    command: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Mutate a parsed mount-pod manifest in place, binding its single PVC volume.
+    """Mutate a parsed probe-pod manifest in place, binding its single PVC volume.
 
-    The pod is kept off transient test-provisioning node pools (nodes carrying
-    the ``isv.ncp.validation/pool`` marker). Those pools are created/scaled/
-    deleted within the same run by node-pool CRUD checks, so a freshly joined
-    node may not yet have the CSI node-plugin DaemonSet pod running - a probe
-    pod landing there hangs at mount until the bind timeout. Baseline cluster
-    nodes never carry the marker, so this is a no-op for providers that do not
-    provision test pools (single-node k3s/minikube/microk8s included).
+    Sets the container ``image``, optionally pins the pod to ``node_name`` or
+    restricts scheduling via ``node_selector`` (``spec.nodeSelector``), and
+    overrides the container command. ``command`` must be a full argv list
+    (e.g. ``["sh", "-c", "sleep 3600"]``). ``node_name`` and ``node_selector``
+    may both be set (nodeName takes precedence in the scheduler, nodeSelector
+    is still recorded). ``tolerations`` is appended to any existing
+    ``spec.tolerations``. The CSI provisioning checks call this with only
+    ``namespace``/``name``/``pvc_name`` (the manifest defaults cover image and
+    command); the shared-filesystem checks additionally supply
+    image/command/node placement.
+
+    The pod is also kept off transient test-provisioning node pools (nodes
+    carrying the ``isv.ncp.validation/pool`` marker). Those pools are created/
+    scaled/deleted within the same run by node-pool CRUD checks, so a freshly
+    joined node may not yet have the CSI node-plugin DaemonSet pod running - a
+    probe pod landing there hangs at mount until the bind timeout. Baseline
+    cluster nodes never carry the marker, so this is a no-op for providers that
+    do not provision test pools (single-node k3s/minikube/microk8s included).
     """
     metadata = doc.setdefault("metadata", {})
     metadata["name"] = name
@@ -2521,12 +2541,33 @@ def _set_mount_pod_fields(
             }
         }
     }
+    if node_name:
+        spec["nodeName"] = node_name
+    if node_selector:
+        spec["nodeSelector"] = node_selector
+    if tolerations:
+        existing = spec.setdefault("tolerations", [])
+        existing.extend(tolerations)
+    # Force the kubelet to always apply fsGroup ownership to the mount point.
+    # Without this, kubelets configured with FSGroupChangePolicy=OnRootMismatch
+    # may skip the chown on a fresh volume whose root is owned by root:root,
+    # leaving /data unwritable by the non-root container user.
+    sc = spec.setdefault("securityContext", {})
+    sc.setdefault("fsGroupChangePolicy", "Always")
+
     volumes = spec.setdefault("volumes", [])
     if not volumes:
         volumes.append({"name": "data"})
     volumes[0]["name"] = "data"
     volumes[0].pop("emptyDir", None)
     volumes[0]["persistentVolumeClaim"] = {"claimName": pvc_name}
+
+    containers = spec.setdefault("containers", [])
+    if not containers:
+        containers.append({"name": "probe"})
+    containers[0]["image"] = image
+    if command is not None:
+        containers[0]["command"] = command
     return doc
 
 

--- a/isvtest/src/isvtest/validations/manifests/k8s/pjdfstest_pod.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/pjdfstest_pod.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Parameterisable pjdfstest POSIX-compliance pod for K8sPosixComplianceCheck.
+#
+# Loaded by isvtest.core.k8s.render_k8s_manifest and mutated in-memory at
+# runtime by _set_fs_pod_fields (metadata.{name,namespace}, the container
+# image and command, the persistentVolumeClaim.claimName, and optional
+# nodeSelector/tolerations are overridden before apply).
+#
+# Unlike storage_mount_pod.yaml this pod runs as **root** and **privileged**:
+# pjdfstest exercises chown/mknod/setuid/special-file semantics that require
+# a full set of capabilities, so a cap-dropped non-root container cannot run
+# it. On clusters that enforce a restrictive Pod Security Standard the apply
+# is rejected; K8sPosixComplianceCheck detects that and skips rather than
+# failing. The default keepalive command sleeps so the harness can kubectl cp
+# the vendored source in and exec the build + prove run; the harness deletes
+# the pod (via the namespace) when done.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: placeholder
+  namespace: placeholder
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    fsGroup: 0
+  containers:
+    - name: probe
+      image: placeholder
+      command: ["sh", "-c", "sleep infinity"]
+      securityContext:
+        privileged: true
+        runAsNonRoot: false
+        runAsUser: 0
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: placeholder

--- a/isvtest/src/isvtest/validations/manifests/k8s/storage_mount_pod.yaml
+++ b/isvtest/src/isvtest/validations/manifests/k8s/storage_mount_pod.yaml
@@ -13,14 +13,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Parameterisable BusyBox mount pod for CSI provisioning validations.
+# Parameterisable BusyBox probe pod for PVC-mount validations.
 #
 # Loaded by isvtest.core.k8s.render_k8s_manifest and mutated in-memory at
-# runtime. The placeholder values below exist only to keep the file valid
-# YAML; metadata.{name,namespace} and the persistentVolumeClaim.claimName
-# are overridden by the caller before apply. The container sleeps so the
-# caller can kubectl exec into it to write and read back a canary file on
-# the mounted PVC.
+# runtime by _set_fs_pod_fields (isvtest.validations.k8s_storage). It serves
+# two callers:
+#   * CSI provisioning checks (k8s_storage) that just need a consumer to bind a
+#     PVC and exec in to write/read a canary file - they override only
+#     metadata.{name,namespace} and the persistentVolumeClaim.claimName (the
+#     mutator supplies the default busybox:1.36 image).
+#   * Shared-filesystem checks (k8s_filesystem) that additionally override the
+#     container image (default busybox:1.36, so air-gapped clusters can point at
+#     a mirror), the container command (e.g. to hold a flock or a write loop)
+#     and optionally spec.nodeName / spec.nodeSelector so two pods can be pinned
+#     to distinct nodes for cross-node tests.
+# The placeholder metadata/image/claimName values below exist only to keep the
+# file valid YAML; they are always overridden before apply.
+#
+# It needs no extra privileges - flock/echo/stat/ls/mkdir all run as the
+# unprivileged nobody user against the mounted PVC. The default keepalive
+# command loops forever rather than `sleep N` so the pod never self-terminates
+# mid-test (BusyBox `sleep` has no `infinity`); the harness deletes pods
+# explicitly when done.
 apiVersion: v1
 kind: Pod
 metadata:
@@ -37,8 +51,8 @@ spec:
       type: RuntimeDefault
   containers:
     - name: probe
-      image: busybox:1.36
-      command: ["sh", "-c", "sleep 3600"]
+      image: placeholder
+      command: ["sh", "-c", "while true; do sleep 3600; done"]
       securityContext:
         allowPrivilegeEscalation: false
         capabilities:

--- a/isvtest/tests/test_k8s_filesystem.py
+++ b/isvtest/tests/test_k8s_filesystem.py
@@ -635,8 +635,9 @@ class TestPosixSkipBehaviour:
         assert check.passed
         assert "Skipped" in check._output
 
-    def test_podsecurity_denial_skips(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_podsecurity_denial_skips(self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
         _clear_sc_env(monkeypatch)
+        monkeypatch.setattr("isvtest.validations.k8s_filesystem._PJDFSTEST_SRC_DIR", tmp_path)
         check = K8sPosixComplianceCheck(config={"shared_fs_storage_class": "sc-rwx", "bind_timeout_s": 5})
         denial = 'pods "x" is forbidden: violates PodSecurity "restricted:latest": privileged (container ...)'
         with (

--- a/isvtest/tests/test_k8s_filesystem.py
+++ b/isvtest/tests/test_k8s_filesystem.py
@@ -544,6 +544,22 @@ _PROVE_FAIL = (
     "Result: FAIL\n"
 )
 
+# A file whose subtests all pass but that exits non-zero: prove flags it
+# "Dubious" and reports a non-zero Wstat with Failed: 0. It must still be
+# treated as a failed file.
+_PROVE_FAIL_WSTAT = (
+    "tests/open/00.t .. ok\n"
+    "tests/chmod/01.t .. Dubious, test returned 1 (wstat 256, 0x100)\n"
+    "All 5 subtests passed\n"
+    "\n"
+    "Test Summary Report\n"
+    "-------------------\n"
+    "tests/chmod/01.t (Wstat: 256 Tests: 5 Failed: 0)\n"
+    "  Non-zero exit status: 1\n"
+    "Files=238, Tests=8000, 50 wallclock secs ( ... )\n"
+    "Result: FAIL\n"
+)
+
 
 class TestParsePjdfstest:
     def test_pass_output(self) -> None:
@@ -568,6 +584,16 @@ class TestParsePjdfstest:
         # Every file is enumerated once (progress + summary lines deduped),
         # preserving execution order, including the passing file.
         assert r.all_files == ["tests/open/00.t", "tests/chmod/12.t", "tests/open/05.t"]
+
+    def test_nonzero_wstat_with_zero_failed_is_a_failure(self) -> None:
+        # A file that prove marks "Dubious" (non-zero Wstat, Failed: 0) must be
+        # recorded as a failed file (with a 0 subtest count) so its per-file
+        # subtest is reported failing rather than passing.
+        r = parse_pjdfstest_output(_PROVE_FAIL_WSTAT)
+        assert not r.success
+        assert r.result == "FAIL"
+        assert r.failed_files == [("tests/chmod/01.t", 0)]
+        assert r.all_files == ["tests/open/00.t", "tests/chmod/01.t"]
 
     def test_unparseable_output_is_error(self) -> None:
         r = parse_pjdfstest_output("bash: prove: command not found\n")

--- a/isvtest/tests/test_k8s_filesystem.py
+++ b/isvtest/tests/test_k8s_filesystem.py
@@ -1,0 +1,706 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``isvtest.validations.k8s_filesystem``."""
+
+from __future__ import annotations
+
+import json
+import re
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from isvtest.core.k8s import render_k8s_manifest
+from isvtest.core.runners import CommandResult
+from isvtest.validations.k8s_filesystem import (
+    _PJDFSTEST_POD_MANIFEST,
+    K8sCrossNodeWriteVisibilityCheck,
+    K8sFileLockingCheck,
+    K8sLargeDirListingFilesCheck,
+    K8sPosixComplianceCheck,
+    _set_fs_pod_fields,
+    append_payload_cmd,
+    count_entries_cmd,
+    create_dirs_cmd,
+    create_files_cmd,
+    flock_hold_command,
+    flock_nonblock_cmd,
+    list_dir_quiet_cmd,
+    parse_pjdfstest_output,
+    read_file_cmd,
+    stat_size_mtime_cmd,
+    write_payload_cmd,
+)
+
+_SC_ENV_VARS = ("K8S_CSI_SHARED_FS_SC", "K8S_CSI_NFS_SC")
+
+
+def _ok(stdout: str = "", stderr: str = "") -> CommandResult:
+    return CommandResult(exit_code=0, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+def _fail(stdout: str = "", stderr: str = "", exit_code: int = 1) -> CommandResult:
+    return CommandResult(exit_code=exit_code, stdout=stdout, stderr=stderr, duration=0.0)
+
+
+class _FakeProc:
+    """Stand-in for ``subprocess.CompletedProcess`` returned by ``kubectl apply``."""
+
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _fake_kubectl_get_nodes_result(nodes: dict[str, str]) -> Any:
+    """Build a fake ``run_kubectl`` result for ``kubectl get nodes -o json``.
+
+    ``nodes`` maps node-name -> "Ready"|"NotReady"; the returned object has
+    the ``returncode``, ``stdout``, ``stderr`` attributes ``run_kubectl``
+    callers consume.
+    """
+    items = [
+        {
+            "metadata": {"name": name},
+            "status": {"conditions": [{"type": "Ready", "status": "True" if status == "Ready" else "False"}]},
+        }
+        for name, status in nodes.items()
+    ]
+    return _FakeProc(returncode=0, stdout=json.dumps({"items": items}), stderr="")
+
+
+_BOUND_PVC_JSON = '{"status":{"phase":"Bound"}}'
+
+
+class _FakeClock:
+    def __init__(self, start: float = 0.0) -> None:
+        self._now = float(start)
+
+    def time(self) -> float:
+        return self._now
+
+    def sleep(self, seconds: float) -> None:
+        self._now += float(seconds)
+
+
+@contextmanager
+def _patched_clock() -> Any:
+    """Patch ``k8s_filesystem`` time + the ``kubectl apply`` subprocess in one place."""
+    clock = _FakeClock()
+    with (
+        patch("isvtest.validations.k8s_filesystem.time.sleep", side_effect=clock.sleep),
+        patch("isvtest.validations.k8s_filesystem.time.time", side_effect=clock.time),
+        patch("isvtest.validations.k8s_storage.subprocess.run", return_value=_FakeProc(0)),
+    ):
+        yield clock
+
+
+def _clear_sc_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in _SC_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+# --------------------------------------------------------------------------
+# Snippet helpers.
+# --------------------------------------------------------------------------
+
+
+class TestSnippets:
+    def test_write_and_append_payload(self) -> None:
+        assert write_payload_cmd("/data/f", "abc") == "printf %s abc > /data/f"
+        assert append_payload_cmd("/data/f", "abc") == "printf %s abc >> /data/f"
+
+    def test_write_payload_quotes_special_chars(self) -> None:
+        # A payload with a space must be shell-quoted so it is one argument.
+        assert write_payload_cmd("/data/f", "a b") == "printf %s 'a b' > /data/f"
+
+    def test_read_and_stat(self) -> None:
+        assert read_file_cmd("/data/f") == "cat /data/f"
+        assert stat_size_mtime_cmd("/data/f") == "stat -c '%s %Y' /data/f"
+
+    def test_flock_helpers(self) -> None:
+        assert flock_nonblock_cmd("/data/lock") == "flock -xn /data/lock true"
+        assert flock_hold_command("/data/lock") == [
+            "flock",
+            "-x",
+            "/data/lock",
+            "sh",
+            "-c",
+            "while true; do sleep 3600; done",
+        ]
+
+    def test_create_files_cmd(self) -> None:
+        cmd = create_files_cmd("/data/big", 1000, prefix="f")
+        assert cmd.startswith("mkdir -p /data/big &&")
+        assert "seq 1 1000" in cmd
+        assert "xargs touch" in cmd
+
+    def test_create_dirs_cmd(self) -> None:
+        cmd = create_dirs_cmd("/data/big", 500, prefix="d")
+        assert "seq 1 500" in cmd
+        assert "xargs mkdir" in cmd
+
+    def test_list_and_count(self) -> None:
+        assert list_dir_quiet_cmd("/data/big") == "ls -1A /data/big >/dev/null"
+        assert count_entries_cmd("/data/big") == "find /data/big -mindepth 1 -maxdepth 1 | wc -l"
+
+
+# --------------------------------------------------------------------------
+# Manifest mutator.
+# --------------------------------------------------------------------------
+
+
+class TestSetFsPodFields:
+    def _base_doc(self) -> dict[str, Any]:
+        return {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {"name": "placeholder", "namespace": "placeholder"},
+            "spec": {
+                "containers": [{"name": "probe", "image": "placeholder", "command": ["sh", "-c", "sleep 3600"]}],
+                "volumes": [{"name": "data", "persistentVolumeClaim": {"claimName": "placeholder"}}],
+            },
+        }
+
+    def test_binds_pvc_and_sets_metadata(self) -> None:
+        out = _set_fs_pod_fields(self._base_doc(), namespace="ns1", name="pod1", pvc_name="pvc1", image="busybox:1.36")
+        assert out["metadata"]["name"] == "pod1"
+        assert out["metadata"]["namespace"] == "ns1"
+        assert out["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] == "pvc1"
+        assert out["spec"]["containers"][0]["image"] == "busybox:1.36"
+        assert "nodeName" not in out["spec"]
+
+    def test_pins_node_and_overrides_command_and_image(self) -> None:
+        out = _set_fs_pod_fields(
+            self._base_doc(),
+            namespace="ns1",
+            name="pod1",
+            pvc_name="pvc1",
+            image="mirror.local/busybox:1.36",
+            node_name="node-a",
+            command=["sh", "-c", "flock -x /data/lock -c 'sleep 10'"],
+        )
+        assert out["spec"]["nodeName"] == "node-a"
+        assert out["spec"]["containers"][0]["image"] == "mirror.local/busybox:1.36"
+        assert out["spec"]["containers"][0]["command"] == ["sh", "-c", "flock -x /data/lock -c 'sleep 10'"]
+
+    def test_sets_node_selector(self) -> None:
+        out = _set_fs_pod_fields(
+            self._base_doc(),
+            namespace="ns1",
+            name="pod1",
+            pvc_name="pvc1",
+            image="busybox:1.36",
+            node_selector={"scd.vastdata.com/node": "true", "kubernetes.io/os": "linux"},
+        )
+        assert out["spec"]["nodeSelector"] == {
+            "scd.vastdata.com/node": "true",
+            "kubernetes.io/os": "linux",
+        }
+        assert "nodeName" not in out["spec"]
+
+    def test_no_node_selector_omitted(self) -> None:
+        out = _set_fs_pod_fields(self._base_doc(), namespace="ns1", name="pod1", pvc_name="pvc1", image="busybox:1.36")
+        assert "nodeSelector" not in out["spec"]
+
+
+# --------------------------------------------------------------------------
+# Skip behaviour.
+# --------------------------------------------------------------------------
+
+
+class TestSkipBehaviour:
+    def test_no_storage_class_skips_without_work(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_sc_env(monkeypatch)
+        check = K8sFileLockingCheck(config={})
+        with patch.object(check, "run_command") as mock_run:
+            check.run()
+        mock_run.assert_not_called()
+        assert check.passed
+        assert "Skipped" in check._output
+
+    def test_cross_node_skips_when_fewer_than_two_ready_nodes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_sc_env(monkeypatch)
+        check = K8sCrossNodeWriteVisibilityCheck(config={"shared_fs_storage_class": "sc-rwx"})
+        with (
+            patch(
+                "isvtest.validations.k8s_filesystem.run_kubectl",
+                return_value=_fake_kubectl_get_nodes_result({"node-a": "Ready", "node-b": "NotReady"}),
+            ),
+            patch.object(check, "run_command") as mock_run,
+        ):
+            check.run()
+        # Skipped before any namespace/pod work.
+        mock_run.assert_not_called()
+        assert check.passed
+        assert "2 Ready nodes" in check._output
+
+    def test_ready_nodes_filters_and_sorts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_sc_env(monkeypatch)
+        check = K8sCrossNodeWriteVisibilityCheck(config={})
+        with patch(
+            "isvtest.validations.k8s_filesystem.run_kubectl",
+            return_value=_fake_kubectl_get_nodes_result({"b": "Ready", "a": "Ready", "c": "NotReady"}),
+        ):
+            assert check._ready_nodes() == ["a", "b"]
+
+
+class TestNodeSelector:
+    """Unit tests for _node_selector() and its effect on _ready_nodes()."""
+
+    def test_absent_returns_empty_dict(self) -> None:
+        check = K8sFileLockingCheck(config={})
+        assert check._node_selector() == {}
+
+    def test_empty_dict_returns_empty_dict(self) -> None:
+        check = K8sFileLockingCheck(config={"node_selector": {}})
+        assert check._node_selector() == {}
+
+    def test_non_dict_returns_empty_dict(self) -> None:
+        check = K8sFileLockingCheck(config={"node_selector": "bad-value"})
+        assert check._node_selector() == {}
+
+    def test_selector_returned_as_str_dict(self) -> None:
+        check = K8sFileLockingCheck(
+            config={"node_selector": {"scd.vastdata.com/node": "true", "kubernetes.io/os": "linux"}}
+        )
+        assert check._node_selector() == {"scd.vastdata.com/node": "true", "kubernetes.io/os": "linux"}
+
+    def test_json_string_selector_parsed(self) -> None:
+        """Manifest-driven node_selector arrives as a JSON string via the setup step."""
+        check = K8sFileLockingCheck(config={"node_selector": '{"csi.acme.com/node": "true"}'})
+        assert check._node_selector() == {"csi.acme.com/node": "true"}
+
+    def test_empty_json_string_returns_empty_dict(self) -> None:
+        check = K8sFileLockingCheck(config={"node_selector": ""})
+        assert check._node_selector() == {}
+
+    def _node_item(self, name: str, ready: bool) -> dict[str, Any]:
+        status = "True" if ready else "False"
+        return {"metadata": {"name": name}, "status": {"conditions": [{"type": "Ready", "status": status}]}}
+
+    def test_ready_nodes_uses_run_kubectl_with_label_arg(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When node_selector is set, _ready_nodes() filters via kubectl -l and the items' Ready condition."""
+        check = K8sCrossNodeWriteVisibilityCheck(
+            config={"shared_fs_storage_class": "sc-rwx", "node_selector": {"foo": "bar"}}
+        )
+        fake_nodes_json = json.dumps(
+            {
+                "items": [
+                    self._node_item("node-y", ready=True),
+                    self._node_item("node-x", ready=True),
+                    self._node_item("node-z", ready=False),  # filtered out: NotReady
+                ]
+            }
+        )
+
+        class _FakeResult:
+            returncode = 0
+            stdout = fake_nodes_json
+            stderr = ""
+
+        calls: list[list[str]] = []
+
+        def _fake_run_kubectl(args: list[str]) -> _FakeResult:
+            calls.append(args)
+            return _FakeResult()
+
+        monkeypatch.setattr("isvtest.validations.k8s_filesystem.run_kubectl", _fake_run_kubectl)
+
+        result = check._ready_nodes()
+
+        assert len(calls) == 1
+        assert "-l" in calls[0]
+        assert "foo=bar" in calls[0]
+        # Only Ready nodes, sorted; node-z dropped.
+        assert result == ["node-x", "node-y"]
+
+    def test_ready_nodes_returns_empty_when_kubectl_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        check = K8sCrossNodeWriteVisibilityCheck(
+            config={"shared_fs_storage_class": "sc-rwx", "node_selector": {"foo": "bar"}}
+        )
+
+        class _FailResult:
+            returncode = 1
+            stdout = ""
+            stderr = "boom"
+
+        monkeypatch.setattr("isvtest.validations.k8s_filesystem.run_kubectl", lambda args: _FailResult())
+        assert check._ready_nodes() == []
+
+
+# --------------------------------------------------------------------------
+# Happy-path flows (mocked kubectl).
+# --------------------------------------------------------------------------
+
+
+class TestFileLockingFlow:
+    def _router(self) -> Any:
+        """Answer the kubectl commands K8sFileLockingCheck issues.
+
+        First flock exec (contention while pod A holds) fails; the second
+        (after pod A is deleted) succeeds.
+        """
+        state = {"flock_calls": 0}
+
+        def _side_effect(cmd: str, *args: Any, **kwargs: Any) -> CommandResult:
+            if "create namespace" in cmd or "delete namespace" in cmd or "delete pod" in cmd:
+                return _ok()
+            if "wait --for=condition=Ready" in cmd:
+                return _ok()
+            if "get pvc" in cmd:
+                return _ok(stdout=_BOUND_PVC_JSON)
+            if "flock -xn" in cmd:
+                state["flock_calls"] += 1
+                return _fail() if state["flock_calls"] == 1 else _ok()
+            return _ok()
+
+        return _side_effect
+
+    def test_locking_enforced_then_released(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_sc_env(monkeypatch)
+        check = K8sFileLockingCheck(
+            config={"shared_fs_storage_class": "sc-rwx", "bind_timeout_s": 5, "release_timeout_s": 10}
+        )
+        with (
+            _patched_clock(),
+            patch.object(check, "_ready_nodes", return_value=["node-a", "node-b"]),
+            patch.object(check, "run_command", side_effect=self._router()),
+        ):
+            check.run()
+        assert check.passed, check._error
+        names = {s["name"]: s for s in check._subtest_results}
+        assert names["lock-contention"]["passed"]
+        assert names["lock-release"]["passed"]
+
+    def test_locking_fails_when_contention_not_enforced(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_sc_env(monkeypatch)
+        check = K8sFileLockingCheck(config={"shared_fs_storage_class": "sc-rwx", "bind_timeout_s": 5})
+
+        def _side_effect(cmd: str, *args: Any, **kwargs: Any) -> CommandResult:
+            if "get pvc" in cmd:
+                return _ok(stdout=_BOUND_PVC_JSON)
+            if "flock -xn" in cmd:
+                return _ok()  # pod B always acquires - locking NOT enforced
+            return _ok()
+
+        with (
+            _patched_clock(),
+            patch.object(check, "_ready_nodes", return_value=["node-a", "node-b"]),
+            patch.object(check, "run_command", side_effect=_side_effect),
+        ):
+            check.run()
+        assert not check.passed
+        names = {s["name"]: s for s in check._subtest_results}
+        assert not names["lock-contention"]["passed"]
+
+    def test_contention_flock_error_does_not_pass(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A flock failure that is not EAGAIN (exit != 0/1) must not count as 'denied'."""
+        _clear_sc_env(monkeypatch)
+        check = K8sFileLockingCheck(config={"shared_fs_storage_class": "sc-rwx", "bind_timeout_s": 5})
+
+        def _side_effect(cmd: str, *args: Any, **kwargs: Any) -> CommandResult:
+            if "get pvc" in cmd:
+                return _ok(stdout=_BOUND_PVC_JSON)
+            if "flock -xn" in cmd:
+                return _fail(stderr="flock: applet not found", exit_code=127)
+            return _ok()
+
+        with (
+            _patched_clock(),
+            patch.object(check, "_ready_nodes", return_value=["node-a", "node-b"]),
+            patch.object(check, "run_command", side_effect=_side_effect),
+        ):
+            check.run()
+        assert not check.passed
+        names = {s["name"]: s for s in check._subtest_results}
+        assert not names["lock-contention"]["passed"]
+        assert "errored" in names["lock-contention"]["message"]
+
+
+class TestCrossNodeVisibilityFlow:
+    def _router(self) -> Any:
+        """Echo back whatever payload pod A wrote when pod B reads visfile."""
+        state = {"payload": ""}
+
+        def _side_effect(cmd: str, *args: Any, **kwargs: Any) -> CommandResult:
+            if "create namespace" in cmd or "delete namespace" in cmd:
+                return _ok()
+            if "wait --for=condition=Ready" in cmd:
+                return _ok()
+            if "get pvc" in cmd:
+                return _ok(stdout=_BOUND_PVC_JSON)
+            if "printf %s" in cmd and "visfile" in cmd:
+                match = re.search(r"printf %s (\S+) >", cmd)
+                if match:
+                    state["payload"] = match.group(1)
+                return _ok()
+            if "cat /data/visfile" in cmd:
+                return _ok(stdout=state["payload"] + "\n")
+            return _ok()
+
+        return _side_effect
+
+    def test_visible_within_window(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_sc_env(monkeypatch)
+        check = K8sCrossNodeWriteVisibilityCheck(
+            config={"shared_fs_storage_class": "sc-rwx", "bind_timeout_s": 5, "visibility_window_s": 5.0}
+        )
+        with (
+            _patched_clock(),
+            patch.object(check, "_ready_nodes", return_value=["node-a", "node-b"]),
+            patch.object(check, "run_command", side_effect=self._router()),
+        ):
+            check.run()
+        assert check.passed, check._error
+
+
+class TestLargeDirListingFlow:
+    def test_lists_all_entries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_sc_env(monkeypatch)
+        check = K8sLargeDirListingFilesCheck(
+            config={"shared_fs_storage_class": "sc-rwx", "files_count": 1000, "bind_timeout_s": 5}
+        )
+
+        def _side_effect(cmd: str, *args: Any, **kwargs: Any) -> CommandResult:
+            if "create namespace" in cmd or "delete namespace" in cmd:
+                return _ok()
+            if "wait --for=condition=Ready" in cmd:
+                return _ok()
+            if "get pvc" in cmd:
+                return _ok(stdout=_BOUND_PVC_JSON)
+            if "xargs touch" in cmd:
+                return _ok()
+            if "ls -1A" in cmd:
+                return _ok()
+            if "wc -l" in cmd:
+                return _ok(stdout="1000\n")
+            return _ok()
+
+        with _patched_clock(), patch.object(check, "run_command", side_effect=_side_effect):
+            check.run()
+        assert check.passed, check._error
+
+    def test_truncated_listing_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_sc_env(monkeypatch)
+        check = K8sLargeDirListingFilesCheck(
+            config={"shared_fs_storage_class": "sc-rwx", "files_count": 1000, "bind_timeout_s": 5}
+        )
+
+        def _side_effect(cmd: str, *args: Any, **kwargs: Any) -> CommandResult:
+            if "get pvc" in cmd:
+                return _ok(stdout=_BOUND_PVC_JSON)
+            if "wc -l" in cmd:
+                return _ok(stdout="999\n")  # one short - truncation
+            return _ok()
+
+        with _patched_clock(), patch.object(check, "run_command", side_effect=_side_effect):
+            check.run()
+        assert not check.passed
+        assert "truncation" in check._error
+
+
+# --------------------------------------------------------------------------
+# pjdfstest (prove/TAP) parsing.
+# --------------------------------------------------------------------------
+
+
+_PROVE_PASS = (
+    "tests/chmod/00.t .. ok\n"
+    "tests/open/00.t .. ok\n"
+    "All tests successful.\n"
+    "Files=238, Tests=8000, 42 wallclock secs ( 1.20 usr  0.30 sys + ... )\n"
+    "Result: PASS\n"
+)
+
+_PROVE_FAIL = (
+    "tests/open/00.t .. ok\n"
+    "tests/chmod/12.t .. 1/203 Failed 1/203 subtests\n"
+    "tests/open/05.t .. Failed 2/30 subtests\n"
+    "\n"
+    "Test Summary Report\n"
+    "-------------------\n"
+    "tests/chmod/12.t (Wstat: 0 Tests: 203 Failed: 1)\n"
+    "  Failed tests:  57\n"
+    "tests/open/05.t (Wstat: 0 Tests: 30 Failed: 2)\n"
+    "  Failed tests:  3, 7\n"
+    "Files=238, Tests=8000, 50 wallclock secs ( ... )\n"
+    "Result: FAIL\n"
+)
+
+
+class TestParsePjdfstest:
+    def test_pass_output(self) -> None:
+        r = parse_pjdfstest_output(_PROVE_PASS)
+        assert r.success
+        assert r.result == "PASS"
+        assert r.files_total == 238
+        assert r.tests_total == 8000
+        assert r.failed_files == []
+        assert r.all_files == ["tests/chmod/00.t", "tests/open/00.t"]
+
+    def test_all_ok_without_result_line(self) -> None:
+        r = parse_pjdfstest_output("tests/x.t .. ok\nAll tests successful.\nFiles=1, Tests=5, 1 wallclock secs\n")
+        assert r.success
+        assert r.result == "PASS"
+
+    def test_fail_output_lists_failed_files(self) -> None:
+        r = parse_pjdfstest_output(_PROVE_FAIL)
+        assert not r.success
+        assert r.result == "FAIL"
+        assert r.failed_files == [("tests/chmod/12.t", 1), ("tests/open/05.t", 2)]
+        # Every file is enumerated once (progress + summary lines deduped),
+        # preserving execution order, including the passing file.
+        assert r.all_files == ["tests/open/00.t", "tests/chmod/12.t", "tests/open/05.t"]
+
+    def test_unparseable_output_is_error(self) -> None:
+        r = parse_pjdfstest_output("bash: prove: command not found\n")
+        assert not r.success
+        assert r.error
+        assert r.result == ""
+
+
+# --------------------------------------------------------------------------
+# POSIX-compliance manifest + flow.
+# --------------------------------------------------------------------------
+
+
+class TestPosixManifest:
+    def test_rendered_pod_is_root_and_privileged(self) -> None:
+        rendered = render_k8s_manifest(
+            _PJDFSTEST_POD_MANIFEST,
+            lambda d: _set_fs_pod_fields(
+                d, namespace="ns1", name="posix-pod", pvc_name="pvc1", image="gcc:12", command=None
+            ),
+        )
+        doc = yaml.safe_load(rendered)
+        container = doc["spec"]["containers"][0]
+        assert doc["spec"]["securityContext"]["runAsUser"] == 0
+        assert container["securityContext"]["privileged"] is True
+        assert container["image"] == "gcc:12"
+        # The manifest's sleep-infinity keepalive is preserved when command=None.
+        assert container["command"] == ["sh", "-c", "sleep infinity"]
+        assert doc["spec"]["volumes"][0]["persistentVolumeClaim"]["claimName"] == "pvc1"
+
+
+class TestPosixSkipBehaviour:
+    def test_no_storage_class_skips_without_work(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_sc_env(monkeypatch)
+        check = K8sPosixComplianceCheck(config={})
+        with patch.object(check, "run_command") as mock_run:
+            check.run()
+        mock_run.assert_not_called()
+        assert check.passed
+        assert "Skipped" in check._output
+
+    def test_podsecurity_denial_skips(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_sc_env(monkeypatch)
+        check = K8sPosixComplianceCheck(config={"shared_fs_storage_class": "sc-rwx", "bind_timeout_s": 5})
+        denial = 'pods "x" is forbidden: violates PodSecurity "restricted:latest": privileged (container ...)'
+        with (
+            patch.object(check, "run_command", return_value=_ok()),
+            patch.object(check, "_apply_pvc", return_value=(0, "")),
+            patch.object(check, "_wait_pvc_bound", return_value=True),
+            patch.object(check, "_apply_posix_pod", return_value=(1, denial)),
+        ):
+            check.run()
+        assert check.passed
+        assert "Skipped" in check._output
+
+    def test_is_podsecurity_denial_detection(self) -> None:
+        assert K8sPosixComplianceCheck._is_podsecurity_denial("violates PodSecurity ...")
+        assert K8sPosixComplianceCheck._is_podsecurity_denial("privileged is forbidden")
+        assert not K8sPosixComplianceCheck._is_podsecurity_denial("ImagePullBackOff")
+        assert not K8sPosixComplianceCheck._is_podsecurity_denial("")
+
+
+class TestPosixComplianceFlow:
+    @pytest.fixture(autouse=True)
+    def _stub_vendored_src(self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("isvtest.validations.k8s_filesystem._PJDFSTEST_SRC_DIR", tmp_path)
+
+    def test_passes_when_prove_reports_pass(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_sc_env(monkeypatch)
+        check = K8sPosixComplianceCheck(config={"shared_fs_storage_class": "sc-rwx", "bind_timeout_s": 5})
+
+        def _route(cmd: str, *a: Any, **k: Any) -> CommandResult:
+            if "prove -r" in cmd:
+                return _ok(stdout=_PROVE_PASS)
+            return _ok()
+
+        with (
+            patch.object(check, "_apply_pvc", return_value=(0, "")),
+            patch.object(check, "_wait_pvc_bound", return_value=True),
+            patch.object(check, "_apply_posix_pod", return_value=(0, "")),
+            patch.object(check, "_wait_ready", return_value=(True, "")),
+            patch.object(check, "run_command", side_effect=_route),
+        ):
+            check.run()
+        assert check.passed, check._error
+        assert "0 failures" in check._output
+        # Passing files are still reported as subtests for a complete export.
+        passed_subtests = {s["name"] for s in check._subtest_results if s["passed"]}
+        assert {"tests/chmod/00.t", "tests/open/00.t"} <= passed_subtests
+
+    def test_fails_and_reports_subtests(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_sc_env(monkeypatch)
+        check = K8sPosixComplianceCheck(config={"shared_fs_storage_class": "sc-rwx", "bind_timeout_s": 5})
+
+        def _route(cmd: str, *a: Any, **k: Any) -> CommandResult:
+            if "prove -r" in cmd:
+                return _fail(stdout=_PROVE_FAIL)
+            return _ok()
+
+        with (
+            patch.object(check, "_apply_pvc", return_value=(0, "")),
+            patch.object(check, "_wait_pvc_bound", return_value=True),
+            patch.object(check, "_apply_posix_pod", return_value=(0, "")),
+            patch.object(check, "_wait_ready", return_value=(True, "")),
+            patch.object(check, "run_command", side_effect=_route),
+        ):
+            check.run()
+        assert not check.passed
+        names = {s["name"]: s for s in check._subtest_results}
+        assert "tests/chmod/12.t" in names
+        assert "tests/open/05.t" in names
+        assert not names["tests/chmod/12.t"]["passed"]
+        # Passing files in a failing run are still reported (complete export).
+        assert names["tests/open/00.t"]["passed"]
+
+    def test_build_failure_fails_cleanly(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _clear_sc_env(monkeypatch)
+        check = K8sPosixComplianceCheck(config={"shared_fs_storage_class": "sc-rwx", "bind_timeout_s": 5})
+
+        def _route(cmd: str, *a: Any, **k: Any) -> CommandResult:
+            if "autoreconf" in cmd:
+                return _fail(stderr="autoreconf: command not found")
+            if "prove -r" in cmd:
+                raise AssertionError("prove must not run when the build fails")
+            return _ok()
+
+        with (
+            patch.object(check, "_apply_pvc", return_value=(0, "")),
+            patch.object(check, "_wait_pvc_bound", return_value=True),
+            patch.object(check, "_apply_posix_pod", return_value=(0, "")),
+            patch.object(check, "_wait_ready", return_value=(True, "")),
+            patch.object(check, "run_command", side_effect=_route),
+        ):
+            check.run()
+        assert not check.passed
+        assert "Building pjdfstest" in check._error

--- a/isvtest/tests/test_k8s_storage.py
+++ b/isvtest/tests/test_k8s_storage.py
@@ -1977,7 +1977,7 @@ class TestSetMountPodFields:
 
     def test_excludes_test_pool_nodes(self) -> None:
         """Probe pods must avoid transient test-pool nodes via node anti-affinity."""
-        out = _set_mount_pod_fields(self._base_doc(), namespace="ns1", name="probe-1", pvc_name="pvc-1")
+        out = _set_fs_pod_fields(self._base_doc(), namespace="ns1", name="probe-1", pvc_name="pvc-1")
         terms = out["spec"]["affinity"]["nodeAffinity"]["requiredDuringSchedulingIgnoredDuringExecution"][
             "nodeSelectorTerms"
         ]

--- a/isvtest/tests/test_k8s_storage.py
+++ b/isvtest/tests/test_k8s_storage.py
@@ -38,7 +38,7 @@ from isvtest.validations.k8s_storage import (
     _find_cluster_secret_grants,
     _find_shared_cluster_marker,
     _rule_grants_unrestricted_secrets,
-    _set_mount_pod_fields,
+    _set_fs_pod_fields,
     _set_pv_fields,
     _set_pvc_fields,
     _set_resourcequota_fields,
@@ -1944,7 +1944,8 @@ class TestSetPvFields:
 
 
 class TestSetMountPodFields:
-    """Tests for ``_set_mount_pod_fields`` - the BusyBox mount-pod mutator."""
+    """Tests for ``_set_fs_pod_fields`` - the shared BusyBox probe-pod mutator,
+    exercised here with only the CSI mount-pod fields (name/namespace/pvc)."""
 
     def _base_doc(self) -> dict[str, Any]:
         return {
@@ -1966,7 +1967,7 @@ class TestSetMountPodFields:
         }
 
     def test_sets_name_namespace_and_pvc(self) -> None:
-        out = _set_mount_pod_fields(self._base_doc(), namespace="ns1", name="probe-1", pvc_name="pvc-1")
+        out = _set_fs_pod_fields(self._base_doc(), namespace="ns1", name="probe-1", pvc_name="pvc-1")
         assert out["metadata"]["name"] == "probe-1"
         assert out["metadata"]["namespace"] == "ns1"
         assert out["spec"]["volumes"][0]["persistentVolumeClaim"] == {"claimName": "pvc-1"}


### PR DESCRIPTION
Add shared-filesystem POSIX-semantics validations for Kubernetes RWX volumes: cross-pod flock locking, cross-node write visibility, cross-node attribute (size/mtime) consistency, large-directory listing for files and subdirectories, and a pjdfstest-based POSIX compliance suite.

### K8sFileLockingCheck

**What it tests:** Verifies advisory `flock` locking is arbitrated correctly across pods on *distinct nodes* sharing one RWX PVC (distributed lock arbitration, not local-kernel enforcement). Pod A (node A) holds an exclusive `flock` for its lifetime; pod B (node B) contends on the same lockfile. Skipped on single-node clusters.

| Subtest | What it checks | Acceptance test |
| ------- | -------------- | --------------- |
| `lock-contention` | While pod A holds the lock, pod B's non-blocking `flock -xn` is denied (EAGAIN, exit 1) | NVIDIA/ai-cloud-validation#495 |
| `lock-release` | After pod A is deleted, pod B's `flock -xn` succeeds within `release_timeout_s` | NVIDIA/ai-cloud-validation#495 |

**Success criteria:** Both subtests pass — B is denied while A holds, then acquires after A is gone. Skips (passes) when no shared-fs/NFS StorageClass is configured or fewer than 2 Ready nodes exist.

**Configuration notes:**
- `shared_fs_storage_class` / `nfs_storage_class` select the RWX StorageClass (env fallbacks `K8S_CSI_SHARED_FS_SC` / `K8S_CSI_NFS_SC`).
- `node_selector` / `tolerations` restrict probe pods to nodes where the CSI driver is installed and filter the candidate node pool for the cross-node pairing.
- `pvc_size` (default `1Gi`), `bind_timeout_s` (default 180), `release_timeout_s` (default 60).

---

### K8sCrossNodeWriteVisibilityCheck

**What it tests:** Pod A (node A) writes a unique payload to a file on the shared RWX PVC; pod B (node B) reads it back. Passes when the content matches within `visibility_window_s`.

| Subtest | What it checks | Acceptance test |
| ------- | -------------- | --------------- |
| (single check) | Payload written on node A is read back byte-identical on node B within the visibility window | NVIDIA/ai-cloud-validation#496 |

**Success criteria:** Pod B reads the exact payload within `visibility_window_s` (spec target 1s; default 5s to absorb `kubectl exec` round-trip). Skips when no StorageClass or <2 Ready nodes.

**Configuration notes:**
- `visibility_window_s` (default `5.0`) — tighten to the vendor SLA.
- Same StorageClass / scheduling / `pvc_size` / `bind_timeout_s` keys as above.

---

### K8sCrossNodeAttrConsistencyCheck

**What it tests:** Pod A (node A) creates a small file, node B `stat`s it to prime its attribute cache, then pod A extends the file. Pod B must observe the new size and an advanced mtime within `attr_cache_window_s`.

| Subtest | What it checks | Acceptance test |
| ------- | -------------- | --------------- |
| (single check) | `stat` on node B reflects `size == expected` and `mtime >= expected` within the attribute-cache window | NVIDIA/ai-cloud-validation#497|

**Success criteria:** Node B's `stat` converges to node A's size+mtime within `attr_cache_window_s`. Skips when no StorageClass or <2 Ready nodes.

**Configuration notes:**
- `attr_cache_window_s` (default `30.0`), `extend_bytes` (default `1024`).
- mtime is compared at second granularity (`stat %Y`), so the check sleeps ≥1.1s between create and extend.

---

### K8sLargeDirListingFilesCheck

**What it tests:** Single pod creates `files_count` empty files in one directory, lists them (`ls -1A`), and counts entries (`find … | wc -l`). Passes only when the listing succeeds and the observed count exactly equals the created count.

| Subtest | What it checks | Acceptance test |
| ------- | -------------- | --------------- |
| (single check) | `ls` exits 0 and `find` counts exactly `files_count` entries (no truncation) | NVIDIA/ai-cloud-validation#498 |

**Success criteria:** No `ls` error and `observed == files_count`.

**Configuration notes:**
- `files_count` (default `10_000`), `pvc_size` (default `10Gi`), `bind_timeout_s` (default 300), `timeout` (default 3600, also bounds creation).

---

### K8sLargeDirListingDirsCheck

**What it tests:** Same harness as the files variant, but creates `dirs_count` subdirectories.

| Subtest | What it checks | Acceptance test |
| ------- | -------------- | --------------- |
| (single check) | `ls` exits 0 and `find` counts exactly `dirs_count` subdirectories (no truncation) | NVIDIA/ai-cloud-validation#499 |

**Success criteria:** No `ls` error and `observed == dirs_count`.

**Configuration notes:**
- `dirs_count` (default `500`); other keys identical to the files variant.

---

### K8sPosixComplianceCheck

**What it tests:** Provisions a PVC on the filesystem StorageClass, mounts it at `/data` in a single privileged root pod, copies the vendored [pjdfstest](https://github.com/pjd/pjdfstest) tree into the pod, builds it (`autoreconf -ifs && ./configure && make`), and runs `prove -r tests/` against the mounted volume. One subtest is emitted per `.t` file (pass and fail) so the JUnit export is a complete per-file POSIX record.

| Subtest | What it checks | Acceptance test |
| ------- | -------------- | --------------- |
| `<tests/...>.t` (one per file, 238 total) | The pjdfstest file passed all its POSIX assertions | NVIDIA/ai-cloud-validation#494 |

**Success criteria:** `prove` reports PASS (or "All tests successful.") with zero failing files. Skips (passes) when no StorageClass is configured, or when the cluster's Pod Security admission rejects the privileged root pod pjdfstest requires.

**Configuration notes:**
- Requires the vendored source (`make vendor-pjdfstest`); fails fast if `isvtest/vendor/pjdfstest` is missing.
- `image` (default `gcc:12`, must ship cc/make/autoconf/automake/perl/tar), `build_timeout_s` (default 600), `tests_subdir` (scope to a subset, e.g. `chmod`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added Kubernetes `k8s_filesystem` shared-filesystem POSIX validations for RWX volumes (flock locking, cross-node write visibility, cross-node attribute consistency, and large directory listing).
  * Added `pjdfstest`-based POSIX compliance coverage with structured subtest results.
* **Bug Fixes**
  * Improved storage/probe pod customization for filesystem validations, including consistent PVC mounting and scheduling overrides.
* **Documentation**
  * Updated remote deployment guidance to download `pjdfstest` via `make vendor-pjdfstest`.
* **Chores**
  * Added a pinned `make vendor-pjdfstest` target and ignored vendored sources in version control.
* **Tests**
  * Added extensive unit tests for filesystem validations and `pjdfstest` output parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->